### PR TITLE
nimony: patches types of enum fields 

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1988,6 +1988,7 @@ proc semEnumField(c: var SemContext; n: var Cursor; enumType: SymId) =
       var it = Item(n: n, typ: c.types.autoType)
       semExpr c, it # 4
       n = it.n
+      patchType c, it.typ, beforeType
       # XXX check that it.typ is an ordinal!
   else:
     let typ = semLocalType(c, n) # 3

--- a/src/nimony/tests/basics/t1.nim
+++ b/src/nimony/tests/basics/t1.nim
@@ -114,3 +114,5 @@ var mt: Data = (1, "abc")
 const Inf* = 0x7FF0000000000000'f64
 
 let s: float = Inf
+
+var enum_s = red


### PR DESCRIPTION
patches types of enum fields instead of using enum identifier


before:

```
(efld ~8 :false.0.tesg7afhq1 . . :bool.0.tesg7afhq1 +0)
```

after:

```
(efld ~8 :false.0.tesg7afhq1 . . (i -1) +0)
```