### PR TITLE
nimony: support explicit generic arguments in calls

### DIFF
--- a/tests/nimony/basics/tfib2.nif
+++ b/tests/nimony/basics/tfib2.nif
@@ -111,7 +111,9 @@
          (infix \2D ~1 a.1 1 +2))))))) ~2,~1
    (ret result.0))) ,28
  (discard 11
-  (call ~3 fib.1.tfie0imm3 1 +8)) 11,28
+  (call ~3 fib.1.tfie0imm3 1 +8)) ,29
+ (discard 16
+  (call ~8 fib.1.tfie0imm3 1 +8)) 11,28
  (proc :fib.1.tfie0imm3 . ~11,~6 . 
   (at fib.0.tfie0imm3
    (i -1)) 9,~6

--- a/tests/nimony/basics/tfib2.nim
+++ b/tests/nimony/basics/tfib2.nim
@@ -28,5 +28,6 @@ proc fib[T: Fibable](a: T): T =
     result = fib(a-1) + fib(a-2)
 
 discard fib(8)
+discard fib[int](8)
 
 #discard fib(8.0)


### PR DESCRIPTION
Constraints are now checked for the matched generic parameters but missing/extra arguments are still ignored. Standalone instantiations of generic procs are also still not implemented.

`genericArgs` is expected to be a cursor to a stream of types, so when `semLocalType` receives values with `AllowValues`, it should wrap them in a `static` type that also contains the type of the expression, so that it can be matched in sigmatch. This is also not done yet because the representation of arrays would need to change accordingly, currently it just stores an integer.