### PR TITLE
add original AST to recoverable error tokens

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -214,7 +214,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
     inc c
   of ParLe:
     case c.typeKind
-    of NoType, OrT, AndT, NotT, TypedescT:
+    of NoType, OrT, AndT, NotT, TypedescT, UntypedT, TypedT:
       error e, "type expected but got: ", c
     of IntT, UIntT, FloatT, CharT, BoolT, AutoT, SymKindT:
       e.loop c:

--- a/src/nimony/asthelpers.nim
+++ b/src/nimony/asthelpers.nim
@@ -41,6 +41,9 @@ proc addWithoutErrorsImpl(result: var TokenBuf; c: var Cursor) =
           result.add item
           inc nested
           inc c
+      else:
+        result.add item
+        inc c
 
 proc addWithoutErrors*(result: var TokenBuf, c: Cursor) =
   var c = c

--- a/src/nimony/asthelpers.nim
+++ b/src/nimony/asthelpers.nim
@@ -1,0 +1,42 @@
+## helpers specific to nimony AST
+
+import std/assertions
+include nifprelude
+
+proc addWithoutErrorsImpl(result: var TokenBuf; c: var Cursor) =
+  assert c.kind != ParRi, "cursor at end?"
+  if c.kind != ParLe:
+    # atom:
+    result.add c.load
+    inc c
+  elif c.tagId == ErrT:
+    var last = c
+    inc c
+    if c.kind == ParRi:
+      inc c
+      return
+    while c.kind != ParRi:
+      last = c
+      skip c
+    addWithoutErrorsImpl(result, last)
+    assert last == c
+    inc c
+  else:
+    var nested = 0
+    while true:
+      let item = c.load
+      result.add item
+      if item.kind == ParRi:
+        dec nested
+        inc c
+        if nested == 0: break
+      elif item.kind == ParLe:
+        if item.tagId == ErrT:
+          addWithoutErrorsImpl(result, c)
+        else:
+          inc nested
+          inc c
+
+proc addWithoutErrors*(result: var TokenBuf, c: Cursor) =
+  var c = c
+  addWithoutErrorsImpl(result, c)

--- a/src/nimony/asthelpers.nim
+++ b/src/nimony/asthelpers.nim
@@ -29,8 +29,8 @@ proc addWithoutErrorsImpl(result: var TokenBuf; c: var Cursor) =
     var nested = 0
     while true:
       let item = c.load
-      result.add item
       if item.kind == ParRi:
+        result.add item
         dec nested
         inc c
         if nested == 0: break
@@ -38,6 +38,7 @@ proc addWithoutErrorsImpl(result: var TokenBuf; c: var Cursor) =
         if item.tagId == ErrT:
           addWithoutErrorsImpl(result, c)
         else:
+          result.add item
           inc nested
           inc c
 

--- a/src/nimony/asthelpers.nim
+++ b/src/nimony/asthelpers.nim
@@ -10,6 +10,7 @@ proc addWithoutErrorsImpl(result: var TokenBuf; c: var Cursor) =
     result.add c.load
     inc c
   elif c.tagId == ErrT:
+    # only add final child unless final child is `.`, in which case delete completely
     var last = c
     inc c
     if c.kind == ParRi:
@@ -18,7 +19,10 @@ proc addWithoutErrorsImpl(result: var TokenBuf; c: var Cursor) =
     while c.kind != ParRi:
       last = c
       skip c
-    addWithoutErrorsImpl(result, last)
+    if last.kind == DotToken:
+      inc last
+    else:
+      addWithoutErrorsImpl(result, last)
     assert last == c
     inc c
   else:

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -43,6 +43,7 @@ proc error(c: var EvalContext, msg: string, info: PackedLineInfo): Cursor =
   c.values.add createTokenBuf(3)
   c.values[i].addParLe ErrT, info
   c.values[i].addStrLit msg
+  c.values[i].addDotToken()
   c.values[i].addParRi()
   result = cursorAt(c.values[i], 0)
 

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -155,6 +155,8 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mTypeDesc: res TypedescT
   of mVoidType: res VoidT
   of mUnpack: res UnpackX
+  of mExpr: res UntypedT
+  of mStmt: res TypedT
   else: ("", 0)
 
 when isMainModule:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -165,6 +165,8 @@ type
     AutoT = "auto"
     SymKindT = "symkind"
     TypedescT = "typedesc"
+    UntypedT = "untyped"
+    TypedT = "typed"
 
   PragmaKind* = enum
     NoPragma

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -945,6 +945,7 @@ proc semCall(c: var SemContext; it: var Item) =
       addErrorMsg errorMsg, m[i]
     c.dest.addParLe ErrT, callNode.info
     c.dest.addStrLit errorMsg
+    c.dest.addDotToken()
     c.dest.addParRi()
   else:
     buildErr c, callNode.info, "undeclared identifier"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1552,7 +1552,7 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
       else:
         c.buildErr info, "not a type", n
         skip n
-    of IntT, FloatT, CharT, BoolT, UIntT, VoidT, StringT, NilT, AutoT, SymKindT:
+    of IntT, FloatT, CharT, BoolT, UIntT, VoidT, StringT, NilT, AutoT, SymKindT, UntypedT, TypedT:
       takeTree c, n
     of PtrT, RefT, MutT, OutT, LentT, SinkT, NotT, UncheckedArrayT, SetT, StaticT, TypedescT:
       takeToken c, n
@@ -2532,7 +2532,7 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
           skip it.n
         of IntT, FloatT, CharT, BoolT, UIntT, VoidT, StringT, NilT, AutoT, SymKindT,
             PtrT, RefT, MutT, OutT, LentT, SinkT, UncheckedArrayT, SetT, StaticT, TypedescT,
-            TupleT, ArrayT, VarargsT, ProcT, IterT:
+            TupleT, ArrayT, VarargsT, ProcT, IterT, UntypedT, TypedT:
           # every valid local type expression
           semLocalTypeExpr c, it
         of OrT, AndT, NotT, InvokeT:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -414,10 +414,6 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
       discard "do not even advance f here"
       if m.firstVarargPosition < 0:
         m.firstVarargPosition = m.args.len
-    of UntypedT:
-      # `varargs` and `untyped` simply match everything:
-      inc f
-      expectParRi m, f
     of TupleT:
       let fOrig = f
       let aOrig = arg.typ

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -63,6 +63,7 @@ proc addErrorMsg*(dest: var TokenBuf; m: Match) =
   let str = "For type " & typeToString(m.fn.typ) & " mismatch at position\n" &
     "[" & $(m.pos+1) & "] " & m.error.msg
   dest.addStrLit str
+  dest.addDotToken()
   dest.addParRi()
 
 proc expected(f, a: Cursor): string =

--- a/tests/nimony/basics/tundeclaredarg.msgs
+++ b/tests/nimony/basics/tundeclaredarg.msgs
@@ -2,3 +2,4 @@ tests/nimony/basics/tundeclaredarg.nim(1, 13) Error: not a type
 tests/nimony/basics/tundeclaredarg.nim(1, 13) Error: unknown type name
 tests/nimony/basics/tundeclaredarg.nim(3, 4) Error: Type mismatch at [position]
 [1] BUG: unhandled type: err
+tests/nimony/basics/tundeclaredarg.nim(3, 4) Error: undeclared identifier

--- a/tests/nimony/basics/tundeclaredarg.msgs
+++ b/tests/nimony/basics/tundeclaredarg.msgs
@@ -1,4 +1,4 @@
-tests/nimony/basics/tundeclaredarg.nif(1, 13) Error: not a type
-tests/nimony/basics/tundeclaredarg.nif(1, 13) Error: unknown type name
-tests/nimony/basics/tundeclaredarg.nif(3, 4) Error: Type mismatch at [position]
+tests/nimony/basics/tundeclaredarg.nim(1, 13) Error: not a type
+tests/nimony/basics/tundeclaredarg.nim(1, 13) Error: unknown type name
+tests/nimony/basics/tundeclaredarg.nim(3, 4) Error: Type mismatch at [position]
 [1] BUG: unhandled type: err

--- a/tests/nimony/basics/tundeclaredarg.msgs
+++ b/tests/nimony/basics/tundeclaredarg.msgs
@@ -1,5 +1,1 @@
-tests/nimony/basics/tundeclaredarg.nim(1, 13) Error: not a type
-tests/nimony/basics/tundeclaredarg.nim(1, 13) Error: unknown type name
-tests/nimony/basics/tundeclaredarg.nim(3, 4) Error: Type mismatch at [position]
-[1] BUG: unhandled type: err
-tests/nimony/basics/tundeclaredarg.nim(3, 4) Error: undeclared identifier
+tests/nimony/basics/tundeclaredarg.nim(5, 4) Error: undeclared identifier

--- a/tests/nimony/basics/tundeclaredarg.msgs
+++ b/tests/nimony/basics/tundeclaredarg.msgs
@@ -1,0 +1,4 @@
+tests/nimony/basics/tundeclaredarg.nif(1, 13) Error: not a type
+tests/nimony/basics/tundeclaredarg.nif(1, 13) Error: unknown type name
+tests/nimony/basics/tundeclaredarg.nif(3, 4) Error: Type mismatch at [position]
+[1] BUG: unhandled type: err

--- a/tests/nimony/basics/tundeclaredarg.nim
+++ b/tests/nimony/basics/tundeclaredarg.nim
@@ -1,3 +1,5 @@
-proc foo(x: int) = discard
+type typed* {.magic: Stmt.}
+
+proc foo(x: typed) = discard
 
 foo(abc)

--- a/tests/nimony/basics/tundeclaredarg.nim
+++ b/tests/nimony/basics/tundeclaredarg.nim
@@ -1,0 +1,3 @@
+proc foo(x: int) = discard
+
+foo(abc)

--- a/tests/nimony/basics/tuntypedarg.nif
+++ b/tests/nimony/basics/tuntypedarg.nif
@@ -1,0 +1,17 @@
+(.nif24)
+,1,tests/nimony/basics/tuntypedarg.nim(stmts 5
+ (type :untyped.0.tunl4m78c1 
+  (untyped) . 9
+  (pragmas 2
+   (magic 7 Expr)) .) ,2
+ (proc 5 :defined.0.tunl4m78c1 
+  (defined) . . 12
+  (params 1
+   (param :x.0 . . ~8,~2
+    (untyped) .)) . 25
+  (pragmas 2
+   (magic 7 Defined)) . .) 4,4
+ (let :x.0.tunl4m78c1 . . ~4,~2 . 11
+  (defined 1 abc)) 4,5
+ (let :y.0.tunl4m78c1 . . ~4,~3 . 11
+  (defined 1 nimony)))

--- a/tests/nimony/basics/tuntypedarg.nif
+++ b/tests/nimony/basics/tuntypedarg.nif
@@ -14,4 +14,7 @@
  (let :x.0.tunl4m78c1 . . ~4,~2 . 11
   (defined 1 abc)) 4,5
  (let :y.0.tunl4m78c1 . . ~4,~3 . 11
-  (defined 1 nimony)))
+  (defined 1 nimony)) 4,6
+ (let :z.0.tunl4m78c1 . . ~4,~4 . 11
+  (defined 4
+   (call))))

--- a/tests/nimony/basics/tuntypedarg.nif
+++ b/tests/nimony/basics/tuntypedarg.nif
@@ -11,10 +11,9 @@
     (untyped) .)) . 25
   (pragmas 2
    (magic 7 Defined)) . .) 4,4
- (let :x.0.tunl4m78c1 . . ~4,~2 . 11
-  (defined 1 abc)) 4,5
- (let :y.0.tunl4m78c1 . . ~4,~3 . 11
-  (defined 1 nimony)) 4,6
- (let :z.0.tunl4m78c1 . . ~4,~4 . 11
-  (defined 4
-   (call))))
+ (let :x.0.tunl4m78c1 . .
+  (bool)
+  (false)) 4,5
+ (let :y.0.tunl4m78c1 . .
+  (bool)
+  (true)))

--- a/tests/nimony/basics/tuntypedarg.nim
+++ b/tests/nimony/basics/tuntypedarg.nim
@@ -4,4 +4,4 @@ proc defined(x: untyped) {.magic: Defined.}
 
 let x = defined(abc)
 let y = defined(nimony)
-let z = defined(abc.def)
+#let z = defined(abc.def)

--- a/tests/nimony/basics/tuntypedarg.nim
+++ b/tests/nimony/basics/tuntypedarg.nim
@@ -4,3 +4,4 @@ proc defined(x: untyped) {.magic: Defined.}
 
 let x = defined(abc)
 let y = defined(nimony)
+let z = defined(abc.def)

--- a/tests/nimony/basics/tuntypedarg.nim
+++ b/tests/nimony/basics/tuntypedarg.nim
@@ -1,0 +1,6 @@
+type untyped* {.magic: Expr.}
+
+proc defined(x: untyped) {.magic: Defined.}
+
+let x = defined(abc)
+let y = defined(nimony)


### PR DESCRIPTION
I'm not sure if this is the right way to do this, but the idea is that matching `untyped` arguments would remove all error tokens from semchecked AST so that it can be semchecked again in another context. For this to be possible and ideally to prevent cascading errors, the last child of error token trees is now either a dot for when it's meant to be completely removed, and any other tree if it's meant to be replaced by that tree. It's not clear if this would work, I haven't implemented untyped arguments with this yet.