### PR TITLE
special handling for `true`/`false` as fields of magic enum `bool`

### DIFF
--- a/tests/nimony/basics/tbool.nif
+++ b/tests/nimony/basics/tbool.nif
@@ -1,0 +1,16 @@
+(.nif24)
+,1,tests/nimony/basics/tbool.nim(stmts 26
+ (type ~21 :bool.0.tbojn1uzv 
+  (bool) . ~16
+  (pragmas 2
+   (magic 7 Bool)) 2
+  (enum ~18,1
+   (efld ~8 :false.0.tbojn1uzv 
+    (false) . 
+    (bool) +0) ~8,1
+   (efld ~7 :true.0.tbojn1uzv 
+    (true) . 
+    (bool) +1))) 4,3
+ (let :x.0.tbojn1uzv . . 22,~3
+  (bool) 16,~2
+  (true)))

--- a/tests/nimony/basics/tbool.nim
+++ b/tests/nimony/basics/tbool.nim
@@ -1,0 +1,4 @@
+type bool {.magic: Bool.} = enum
+  false = 0, true = 1
+
+let x: bool = true # Error: expected `bool` but got: bool.0.abcdefgh


### PR DESCRIPTION
fixes #223

Not very elegantly written but works well enough, a prettier version might have a `magic: TypeKind` field in `EnumTypeState` instead but this would require parsing the magic tag, then again this is the only occurence where an enum has a magic tag