### PR TITLE
semcheck some magics after overloading

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -666,9 +666,9 @@ proc addFn(c: var SemContext; fn: FnCandidate; fnOrig: Cursor; args: openArray[I
       if n.kind == SymbolDef:
         inc n # skip the SymbolDef
         if n.kind == ParLe:
-          if n.exprKind notin {AtX}:
+          if n.exprKind in {DefinedX, DeclaredX, CompilesX, TypeofX,
+              SizeofX, LowX, HighX, AddrX}:
             # magic needs semchecking after overloading
-            # (at) currently produces itself so it needs to opt out
             result = MagicCallNeedsSemcheck
           else:
             result = MagicCall


### PR DESCRIPTION
Magic expressions produced by overload resolution may need to be semchecked. However this doesn't make sense for all magics, so a whitelist is used.

`semCmp` and `semTypedArithmetic` are not included in the semchecked magics but they are fixed so that semchecking those magics works regardless: The comparison magics are now typed so `semCmp` is updated accordingly, also it erroneously recursed over `it` rather than using a new item for the operands which expect a different type than the comparison expression itself (which expects `bool`). Typed arithmetic magics are also adapted to `commonType`.