### PR TITLE
gear3: transform case `set` into `ranges`

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -665,6 +665,8 @@ proc traverseCase(e: var EContext; c: var Cursor) =
         while c.kind != ParRi:
           traverseExpr e, c
         wantParRi e, c
+      else:
+        traverseExpr e, c
       traverseStmt e, c
       wantParRi e, c
     of ElseS:

--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -519,9 +519,7 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         e.dest.add c
         inc nested
         inc c
-    of ParRi: # TODO: refactoring: take the whole statement into consideration
-      if nested == 0:
-        break
+    of ParRi:
       e.dest.add c
       dec nested
       if nested == 0:
@@ -539,6 +537,9 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
     of UnknownToken, DotToken, Ident, StringLit, CharLit, IntLit, UIntLit, FloatLit:
       e.dest.add c
       inc c
+
+    if nested == 0:
+      break
 
 proc traverseLocal(e: var EContext; c: var Cursor; tag: string; mode: TraverseMode) =
   let toPatch = e.dest.len
@@ -658,7 +659,12 @@ proc traverseCase(e: var EContext; c: var Cursor) =
     of OfS:
       e.dest.add c
       inc c
-      traverseExpr e, c
+      if c.kind == ParLe and pool.tags[c.tag] == $SetX:
+        inc c
+        e.add "ranges", c.info
+        while c.kind != ParRi:
+          traverseExpr e, c
+        wantParRi e, c
       traverseStmt e, c
       wantParRi e, c
     of ElseS:

--- a/src/nifc/genstmts.nim
+++ b/src/nifc/genstmts.nim
@@ -109,6 +109,8 @@ proc genCaseCond(c: var GeneratedCode; t: Tree; n: NodePos) =
         genBranchValue c, t, b
       else:
         genBranchValue c, t, ch
+      c.add ":"
+      c.add NewLine
   else:
     error c.m, "no `ranges` expected but got: ", t, n
 
@@ -153,7 +155,6 @@ proc genSwitch(c: var GeneratedCode; t: Tree; caseStmt: NodePos) =
       else:
         let (cond, action) = sons2(t, n)
         c.genCaseCond t, cond
-        c.add Colon
         c.add CurlyLe
         genStmt c, t, action
         c.add CurlyRi
@@ -166,6 +167,7 @@ proc genSwitch(c: var GeneratedCode; t: Tree; caseStmt: NodePos) =
         error c.m, "no `of` before `else` but got: ", t, n
       else:
         c.add DefaultKeyword
+        c.add NewLine
         c.add CurlyLe
         genStmt c, t, n.firstSon
         c.add CurlyRi

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -133,11 +133,11 @@
     (var :m.c . . (bool) (true))
     (case m.c
     (of
-     (ranges (true))
+     (set (true))
      (stmts
       (call foo.c +1 +2)))
     (of
-     (ranges (false))
+     (set (false))
      (stmts
       (call foo.c +2 +2))))
 

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -64,6 +64,33 @@
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) ,12
+ 
+ 
+ (proc 5 :foo222.0.tesg7afhq1 . . . 9
+  (params) . . . 2,1
+  (stmts 4
+   (var :global.0 . .
+    (i -1) 9 +12) 7,2
+   (asgn ~7 global.0 2 +1) ,3
+   (case 5 global.0 ,1
+    (of 
+     (set 3 +11 7 +12 11 +13 15
+      (range +8 3 +9)) 2,1
+     (stmts 
+      (discard 8 +1))) ,3
+    (of 
+     (set 3 +2) 2,1
+     (stmts 
+      (discard 8 +2))) ,5
+    (of 
+     (set 3 +3) 2,1
+     (stmts 
+      (discard 8 +3))) ,7
+    (else 2,1
+     (stmts 
+      (discard 8 +4))))))
+ 
+ 
  (proc 5 :ifExpr.0.tesg7afhq1 . . . 11
   (params) . . . 2,1
   (stmts 4


### PR DESCRIPTION
transforms
```
(case 5 global.0 ,1
    (of 
     (set 3 +11 7 +12 11 +13 15
      (range +8 3 +9)) 2,1
     (stmts 
      (discard 8 +1))) ,3
```
into
```
   (case 5 global.0 ,1
    (of 3
     (ranges +11 4 +12 8 +13 12
      (range +8 3 +9) ~3) 2,1
     (stmts 
      (discard 8 +1))) ,3
```

TODO:
- [x] fixes nifc for switch ranges