### PR TITLE
implement `isMainModule` as magic, fix `not` and expreval

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -145,7 +145,7 @@ proc generatedFile(orig, ext: string): string =
 
 proc testFile(c: var TestCounters; file: string; overwrite, useTrack: bool) =
   inc c.total
-  var nimonycmd = "m"
+  var nimonycmd = "m --isMain"
   if useTrack:
     nimonycmd.add markersToCmdLine extractMarkers(readFile(file))
   let (compilerOutput, compilerExitCode) = execNimony(nimonycmd & " " & quoteShell(file))

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -70,9 +70,9 @@ proc eval*(c: var EvalContext, n: var Cursor): Cursor =
   template propagateError(r: Cursor): Cursor =
     let val = r
     if val.kind == ParLe and val.tagId == ErrT:
-      val
-    else:
       return val
+    else:
+      val
   case n.kind
   of Ident:
     error "cannot evaluate undeclared ident: " & pool.strings[n.litId], n.info

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -148,10 +148,12 @@ proc eval*(c: var EvalContext, n: var Cursor): Cursor =
       result = n
       skipToEnd n
     of IsMainModuleX:
+      inc n
+      skipParRi n
       if IsMain in c.c.moduleFlags:
-        return c.getTrueValue()
+        result = c.getTrueValue()
       else:
-        return c.getFalseValue()
+        result = c.getFalseValue()
     else:
       if n.tagId == ErrT:
         result = n

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -98,6 +98,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   case m
   of mDefined: res DefinedX
   of mDeclared: res DeclaredX
+  of mIsMainModule: res IsMainModuleX
   of mCompiles: res CompilesX
   of mArrGet: res AtX
   of mArrPut: res AtX

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -10,7 +10,7 @@ import std / [parseopt, sets, strutils, os, assertions, syncio]
 
 import ".." / gear3 / gear3 # only imported to ensure it keeps compiling
 import ".." / gear2 / modnames
-import sem, nifconfig, semos
+import sem, nifconfig, semos, semdata
 
 const
   Version = "0.2"

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -130,6 +130,7 @@ type
     LowX = "low"
     TypeofX = "typeof"
     UnpackX = "unpack"
+    IsMainModuleX = "ismainmodule"
 
   TypeKind* = enum
     NoType

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2919,7 +2919,6 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
       semBoolExpr c, it.n
       wantParRi c, it.n
     of NotX:
-      c.dest.add it.n
       takeToken c, it.n
       semBoolExpr c, it.n
       wantParRi c, it.n

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1819,7 +1819,7 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
       # no explicit type given:
       inc n # 3
       var it = Item(n: n, typ: c.types.autoType)
-      if kind == ConstY:
+      if false and kind == ConstY:
         withNewScope c:
           semConstExpr c, it # 4
       else:
@@ -1833,7 +1833,7 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
         takeToken c, n
       else:
         var it = Item(n: n, typ: typ)
-        if kind == ConstY:
+        if false and kind == ConstY:
           withNewScope c:
             semConstExpr c, it # 4
         else:

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -62,6 +62,9 @@ type
     includedFiles*: seq[string] # will become part of the index file
     importedFiles*: seq[string] # likewise
 
+  ModuleFlag* = enum
+    IsSystem, IsMain, SkipSystem
+
   SemContext* = object
     dest*: TokenBuf
     routine*: SemRoutine
@@ -78,6 +81,7 @@ type
     instantiatedTypes*: OrderedTable[string, SymId]
     instantiatedProcs*: OrderedTable[string, SymId]
     thisModuleSuffix*: string
+    moduleFlags*: set[ModuleFlag]
     processedModules*: HashSet[string]
     usedTypevars*: int
     phase*: SemPhase

--- a/tests/nimony/basics/deps/mwhen.nim
+++ b/tests/nimony/basics/deps/mwhen.nim
@@ -1,0 +1,12 @@
+type
+  bool* {.magic: Bool.} = enum ## Built-in boolean type.
+    false = 0, true = 1
+
+const isMainModule* {.magic: IsMainModule.} = false
+
+when isMainModule:
+  const isImportedMain1* = true
+else:
+  const isImportedMain1* = false
+
+const isImportedMain2* = isMainModule

--- a/tests/nimony/basics/deps/mwhen.nim
+++ b/tests/nimony/basics/deps/mwhen.nim
@@ -9,4 +9,6 @@ when isMainModule:
 else:
   const isImportedMain1* = false
 
-const isImportedMain2* = isMainModule
+when false:
+  # needs `const`s to evaluate their values
+  const isImportedMain2* = isMainModule

--- a/tests/nimony/basics/twhen.nif
+++ b/tests/nimony/basics/twhen.nif
@@ -7,18 +7,14 @@
  (stmts 
   (discard 8 "good")) 2,20
  (stmts 
-  (discard 8 "good")) 2,25
- (stmts 
-  (discard 8 "good")) ,27
+  (discard 8 "good")) ,28
  (proc 5 :not.0.twh0750pd 
   (not) . . 11
   (params 1
-   (param :x.0 . . 14,~25,tests/nimony/basics/deps/mwhen.nim
-    (bool) .)) 26,~25,tests/nimony/basics/deps/mwhen.nim
+   (param :x.0 . . 14,~26,tests/nimony/basics/deps/mwhen.nim
+    (bool) .)) 26,~26,tests/nimony/basics/deps/mwhen.nim
   (bool) 27
   (pragmas 2
-   (magic 7 Not)) . .) 2,32
- (stmts 
-  (discard 8 "good")) 2,35
+   (magic 7 Not)) . .) 2,33
  (stmts 
   (discard 8 "good")))

--- a/tests/nimony/basics/twhen.nif
+++ b/tests/nimony/basics/twhen.nif
@@ -14,4 +14,12 @@
  (stmts 
   (discard 8 "good")) 2,12
  (stmts 
+  (discard 8 "good")) 20,14
+ (const ~14 :isMainModule.0.twh0750pd 
+  (ismainmodule) 
+  (pragmas 2
+   (magic 7 IsMainModule)) ~8,~12
+  (bool) ~8,~12
+  (false)) 2,17
+ (stmts 
   (discard 8 "good")))

--- a/tests/nimony/basics/twhen.nif
+++ b/tests/nimony/basics/twhen.nif
@@ -1,25 +1,24 @@
 (.nif24)
-,1,tests/nimony/basics/twhen.nim(stmts 24,1
- (type ~22 :bool.0.twh0750pd 
-  (bool) . ~16
-  (pragmas 2
-   (magic 7 Bool)) 2
-  (enum ~14,1
-   (efld ~8 :false.0.twh0750pd 
-    (false) . 
-    (bool) +0) ~4,1
-   (efld ~7 :true.0.twh0750pd 
-    (true) . 
-    (bool) +1))) 2,5
+,1,tests/nimony/basics/twhen.nim(stmts 2,3
  (stmts 
-  (discard 8 "good")) 2,12
+  (discard 8 "good")) 2,10
  (stmts 
-  (discard 8 "good")) 20,14
- (const ~14 :isMainModule.0.twh0750pd 
-  (ismainmodule) 
+  (discard 8 "good")) 2,13
+ (stmts 
+  (discard 8 "good")) 2,20
+ (stmts 
+  (discard 8 "good")) 2,25
+ (stmts 
+  (discard 8 "good")) ,27
+ (proc 5 :not.0.twh0750pd 
+  (not) . . 11
+  (params 1
+   (param :x.0 . . 14,~25,tests/nimony/basics/deps/mwhen.nim
+    (bool) .)) 26,~25,tests/nimony/basics/deps/mwhen.nim
+  (bool) 27
   (pragmas 2
-   (magic 7 IsMainModule)) ~8,~12
-  (bool) ~8,~12
-  (false)) 2,17
+   (magic 7 Not)) . .) 2,32
+ (stmts 
+  (discard 8 "good")) 2,35
  (stmts 
   (discard 8 "good")))

--- a/tests/nimony/basics/twhen.nim
+++ b/tests/nimony/basics/twhen.nim
@@ -12,6 +12,13 @@ when false:
 else:
   discard "good"
 
+const isMainModule* {.magic: IsMainModule.} = false
+
+when isMainModule:
+  discard "good"
+else:
+  discard "bad"
+
 when false:
   proc defined*(x: untyped): bool {.magic: Defined.}
 

--- a/tests/nimony/basics/twhen.nim
+++ b/tests/nimony/basics/twhen.nim
@@ -20,10 +20,11 @@ when isImportedMain1:
 else:
   discard "good"
 
-when isImportedMain2:
-  discard "bad"
-else:
-  discard "good"
+when false: # enable when `isImportedMain2` works
+  when isImportedMain2:
+    discard "bad"
+  else:
+    discard "good"
 
 proc `not`*(x: bool): bool {.magic: Not.}
 
@@ -32,10 +33,11 @@ when not true:
 else:
   discard "good"
 
-when not isImportedMain2:
-  discard "good"
-else:
-  discard "bad"
+when false: # enable when `isImportedMain2` works
+  when not isImportedMain2:
+    discard "good"
+  else:
+    discard "bad"
 
 when false:
   proc defined*(x: untyped): bool {.magic: Defined.}

--- a/tests/nimony/basics/twhen.nim
+++ b/tests/nimony/basics/twhen.nim
@@ -1,6 +1,4 @@
-type
-  bool* {.magic: Bool.} = enum ## Built-in boolean type.
-    false = 0, true = 1
+import deps/mwhen
 
 when true:
   discard "good"
@@ -12,9 +10,29 @@ when false:
 else:
   discard "good"
 
-const isMainModule* {.magic: IsMainModule.} = false
-
 when isMainModule:
+  discard "good"
+else:
+  discard "bad"
+
+when isImportedMain1:
+  discard "bad"
+else:
+  discard "good"
+
+when isImportedMain2:
+  discard "bad"
+else:
+  discard "good"
+
+proc `not`*(x: bool): bool {.magic: Not.}
+
+when not true:
+  discard "bad"
+else:
+  discard "good"
+
+when not isImportedMain2:
   discard "good"
 else:
   discard "bad"


### PR DESCRIPTION
Hastur also adds `--isMain` to the arguments for every test, maybe this could be restricted to files starting with `t`.

Also adds disabled behavior that makes `const` definitions evaluate their values.