### PR TITLE
optional original AST after error tokens, make `defined` work with typed args

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -214,7 +214,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
     inc c
   of ParLe:
     case c.typeKind
-    of NoType, OrT, AndT, NotT, TypedescT, UntypedT:
+    of NoType, OrT, AndT, NotT, TypedescT, UntypedT, TypedT:
       error e, "type expected but got: ", c
     of IntT, UIntT, FloatT, CharT, BoolT, AutoT, SymKindT:
       e.loop c:

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -40,8 +40,9 @@ proc skipParRi(n: var Cursor) =
 
 proc error(c: var EvalContext, msg: string, info: PackedLineInfo): Cursor =
   let i = c.values.len
-  c.values.add createTokenBuf(3)
+  c.values.add createTokenBuf(4)
   c.values[i].addParLe ErrT, info
+  c.values[i].addDotToken()
   c.values[i].addStrLit msg
   c.values[i].addParRi()
   result = cursorAt(c.values[i], 0)

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -156,6 +156,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mVoidType: res VoidT
   of mUnpack: res UnpackX
   of mExpr: res UntypedT
+  of mStmt: res TypedT
   of mCstring: res CstringT
   of mPointer: res PointerT
   else: ("", 0)

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -168,6 +168,7 @@ type
     SymKindT = "symkind"
     TypedescT = "typedesc"
     UntypedT = "untyped"
+    TypedT = "typed"
     CstringT = "cstring"
     PointerT = "pointer"
 

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -244,45 +244,6 @@ proc buildLocalErr*(dest: var TokenBuf; info: PackedLineInfo; msg: string) =
   orig.addDotToken()
   dest.buildLocalErr info, msg, cursorAt(orig, 0)
 
-proc takeWithoutErrors*(result: var TokenBuf; c: var Cursor) =
-  assert c.kind != ParRi, "cursor at end?"
-  if c.kind != ParLe:
-    # atom:
-    result.add c.load
-    inc c
-  elif c.tagId == ErrT:
-    # only add original expression except if `.`, in which case delete completely
-    inc c
-    if c.kind != DotToken:
-      takeWithoutErrors(result, c)
-    while c.kind != ParRi:
-      # only other possible tokens in error are `.` and string literal
-      inc c
-    inc c
-  else:
-    var nested = 0
-    while true:
-      let item = c.load
-      if item.kind == ParRi:
-        result.add item
-        dec nested
-        inc c
-        if nested == 0: break
-      elif item.kind == ParLe:
-        if item.tagId == ErrT:
-          takeWithoutErrors(result, c)
-        else:
-          result.add item
-          inc nested
-          inc c
-      else:
-        result.add item
-        inc c
-
-proc addWithoutErrors*(result: var TokenBuf, c: Cursor) =
-  var c = c
-  takeWithoutErrors(result, c)
-
 # -------------------------- type handling ---------------------------
 
 proc typeToCanon*(buf: TokenBuf; start: int): string =

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -61,6 +61,7 @@ proc addErrorMsg*(dest: var string; m: Match) =
 proc addErrorMsg*(dest: var TokenBuf; m: Match) =
   assert m.err
   dest.addParLe ErrT, m.argInfo
+  dest.addDotToken()
   let str = "For type " & typeToString(m.fn.typ) & " mismatch at position\n" &
     "[" & $(m.pos+1) & "] " & m.error.msg
   dest.addStrLit str
@@ -437,8 +438,8 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
       discard "do not even advance f here"
       if m.firstVarargPosition < 0:
         m.firstVarargPosition = m.args.len
-    of UntypedT:
-      # `varargs` and `untyped` simply match everything:
+    of UntypedT, TypedT:
+      # `typed` and `untyped` simply match everything:
       inc f
       expectParRi m, f
     of TupleT:

--- a/tests/nimony/basics/tdefinedarg.nif
+++ b/tests/nimony/basics/tdefinedarg.nif
@@ -1,22 +1,22 @@
 (.nif24)
-,1,tests/nimony/basics/tdefinedarg.nif(stmts 5
- (type :untyped.0.tdeqc1axk1 
+,1,tests/nimony/basics/tdefinedarg.nim(stmts 5
+ (type :untyped.0.tdetxkbxo 
   (untyped) . 9
   (pragmas 2
    (magic 7 Expr)) .) ,2
- (proc 5 :defined.0.tdeqc1axk1 
+ (proc 5 :defined.0.tdetxkbxo 
   (defined) . . 12
   (params 1
    (param :x.0 . . ~8,~2
     (untyped) .)) . 25
   (pragmas 2
    (magic 7 Defined)) . .) 4,4
- (let :x.0.tdeqc1axk1 . .
+ (let :x.0.tdetxkbxo . .
   (bool)
   (false)) 4,5
- (let :y.0.tdeqc1axk1 . .
+ (let :y.0.tdetxkbxo . .
   (bool)
   (true)) 4,6
- (let :z.0.tdeqc1axk1 . .
+ (let :z.0.tdetxkbxo . .
   (bool)
   (false)))

--- a/tests/nimony/basics/tdefinedarg.nif
+++ b/tests/nimony/basics/tdefinedarg.nif
@@ -1,0 +1,22 @@
+(.nif24)
+,1,tests/nimony/basics/tdefinedarg.nif(stmts 5
+ (type :untyped.0.tdeqc1axk1 
+  (untyped) . 9
+  (pragmas 2
+   (magic 7 Expr)) .) ,2
+ (proc 5 :defined.0.tdeqc1axk1 
+  (defined) . . 12
+  (params 1
+   (param :x.0 . . ~8,~2
+    (untyped) .)) . 25
+  (pragmas 2
+   (magic 7 Defined)) . .) 4,4
+ (let :x.0.tdeqc1axk1 . .
+  (bool)
+  (false)) 4,5
+ (let :y.0.tdeqc1axk1 . .
+  (bool)
+  (true)) 4,6
+ (let :z.0.tdeqc1axk1 . .
+  (bool)
+  (false)))

--- a/tests/nimony/basics/tdefinedarg.nim
+++ b/tests/nimony/basics/tdefinedarg.nim
@@ -1,0 +1,7 @@
+type untyped* {.magic: Expr.}
+
+proc defined(x: untyped) {.magic: Defined.}
+
+let x = defined(abc)
+let y = defined(nimony)
+let z = defined(abc.def)

--- a/tests/nimony/basics/tundeclaredarg.msgs
+++ b/tests/nimony/basics/tundeclaredarg.msgs
@@ -1,0 +1,1 @@
+tests/nimony/basics/tundeclaredarg.nim(5, 4) Error: undeclared identifier

--- a/tests/nimony/basics/tundeclaredarg.nim
+++ b/tests/nimony/basics/tundeclaredarg.nim
@@ -1,0 +1,5 @@
+type typed* {.magic: Stmt.}
+
+proc foo(x: typed) = discard
+
+foo(abc)


### PR DESCRIPTION
closes #242

Similar to #221 except that `untyped` now acts the same as `typed` (which is now added), the original AST is at the start of the error tokens and not at the end, and only the errors described in #242 keep the original AST for now.

`defined` and for now `declared` manually strip all errors from the AST they receive and build strings from them, with `defined` now also supporting dotted identifiers. In the future `declared` could fully type its argument and check for specific errors instead of looking up an identifier based off of the raw AST.

`AllowUndeclared` is added that keeps identifier tokens as is instead of wrapping them in error tokens when they are undeclared. `semCall` uses this for the callee part so that we don't have to specifically strip undeclared identifier errors for now.

Unfortunately the code is not very pretty between the intermediate buffers/cursors and recursion in `takeWithoutErrors`/`getDottedIdent`, will apply any suggestions.