### PR TITLE
fix expression return, set result symbol for current routine

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -276,6 +276,7 @@ proc declareResult(c: var SemContext; info: PackedLineInfo): SymId =
     let s = Sym(kind: ResultY, name: result,
                 pos: c.dest.len)
     discard c.currentScope.addNonOverloadable(name, s)
+    c.routine.resId = result
 
     let declStart = c.dest.len
     buildTree c.dest, ResultS, info:

--- a/tests/nimony/basics/t2.nif
+++ b/tests/nimony/basics/t2.nif
@@ -32,10 +32,10 @@
   (stmts 4
    (result :result.0 . . ~4,~9
     (i -1) .) 4
-   (var :x.2 . .
+   (var :x.3 . .
     (string) 4 "abc") 7,1
    (asgn ~7 result.0 2 +4) 2,2
-   (asgn ~2 x.2 2 "34") ~2,~1
+   (asgn ~2 x.3 2 "34") ~2,~1
    (ret result.0))) ,14
  (proc 5 :overloaded.0.t277k7ei1 . . . 15
   (params) . . . 2,1
@@ -47,4 +47,14 @@
    (discard 11
     (call ~3 foo.0.t277k7ei1 3
      (add
-      (i -1) ~2 +34 1 +56) 8 "xyz")))))
+      (i -1) ~2 +34 1 +56) 8 "xyz")))) ,18
+ (proc 5 :exprReturn.0.t277k7ei1 . . . 15
+  (params 1
+   (param :x.2 . . ~14,~17
+    (i -1) .)) 2,~17
+  (i -1) . . 31
+  (stmts 
+   (result :result.1 . . ~29,~17
+    (i -1) .) 
+   (asgn result.1 x.2) ~31
+   (ret result.1))))

--- a/tests/nimony/basics/t2.nim
+++ b/tests/nimony/basics/t2.nim
@@ -16,3 +16,5 @@ proc foo(x: int; y: string): int =
 proc overloaded() =
   let someInt = `+`(23, 90)
   discard foo(34+56, "xyz")
+
+proc exprReturn(x: int): int = x


### PR DESCRIPTION
refs https://github.com/nim-lang/nimony/pull/250#discussion_r1894131519

Previously `resId` was never set and [this condition](https://github.com/nim-lang/nimony/blob/0d019e7d867265ad02f25b7748abae915f059ccc/src/nimony/sem.nim#L579) was always false.