### PR TITLE
add range types to use for array index types

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -246,6 +246,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
         skipParRi e, c
         e.dest.addIntLit(last - first + 1, c.info)
       else:
+        # should not be possible, but assume length anyway
         traverseExpr e, c
       wantParRi e, c
     of RangeT:

--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -234,7 +234,26 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
       e.dest.add c
       inc c
       traverseType e, c
-      traverseExpr e, c
+      if c.typeKind == RangeT:
+        inc c
+        skip c
+        expectIntLit e, c
+        let first = pool.integers[c.intId]
+        inc c
+        expectIntLit e, c
+        let last = pool.integers[c.intId]
+        inc c
+        skipParRi e, c
+        e.dest.addIntLit(last - first + 1, c.info)
+      else:
+        traverseExpr e, c
+      wantParRi e, c
+    of RangeT:
+      # skip to base type
+      inc c
+      traverseType e, c
+      skip c
+      skip c
       wantParRi e, c
     of UncheckedArrayT:
       if IsPointerOf in flags:

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -127,6 +127,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mLow: res LowX
   of mHigh: res HighX
   of mArray: res ArrayT
+  of mRange: res RangeT
   of mSet: res SetT
   of mVarargs: res VarargsT
   of mRef: res RefT

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -166,6 +166,7 @@ type
     IterT = "itertype"
     InvokeT = "at" # might not be the best idea to do it this way...
     ArrayT = "array"
+    RangeT = "rangetype"
     UncheckedArrayT = "uarray"
     SetT = "sett"
     AutoT = "auto"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1617,7 +1617,9 @@ proc maybeInlineMagic(c: var SemContext; res: LoadResult) =
           if n.kind == ParRi: break
           inc n
 
-proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; context: TypeDeclContext) =
+proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[SemFlag])
+
+proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; start: int; context: TypeDeclContext) =
   if s.kind in {TypeY, TypevarY}:
     let res = tryLoadSym(s.name)
     let beforeMagic = c.dest.len
@@ -1640,6 +1642,11 @@ proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; context: TypeDe
         c.dest.shrink c.dest.len-1
         var t = typ.body
         semLocalTypeImpl c, t, context
+  elif context == AllowValues:
+    var dummyBuf = createTokenBuf(1)
+    dummyBuf.add dotToken(info)
+    var it = Item(n: cursorAt(dummyBuf, 0), typ: c.types.autoType)
+    semExprSym c, it, s, start, {}
   elif s.kind != NoSym:
     var orig = createTokenBuf(1)
     orig.add c.dest[c.dest.len-1]
@@ -1774,6 +1781,48 @@ proc instGenericType(c: var SemContext; dest: var TokenBuf; info: PackedLineInfo
     else:
       dest.buildLocalErr info, "too many generic arguments provided"
 
+proc isRangeExpr(n: Cursor): bool =
+  var n = n
+  if n.exprKind notin {CallX, InfixX}:
+    return false
+  inc n
+  let name = getIdent(n)
+  result = name != StrId(0) and pool.strings[name] == ".."
+
+proc addRangeValues(c: var SemContext; n: var Cursor) =
+  # XXX should consider unresolved values
+  var err: bool = false
+  let first = asSigned(evalOrdinal(c, n), err)
+  if err:
+    c.buildErr n.info, "could not evaluate as ordinal", n
+    err = false
+  else:
+    c.dest.addIntLit(first, n.info)
+  skip n
+  let last = asSigned(evalOrdinal(c, n), err)
+  if err:
+    c.buildErr n.info, "could not evaluate as ordinal", n
+    err = false
+  else:
+    c.dest.addIntLit(last, n.info)
+
+proc semRangeTypeFromExpr(c: var SemContext; n: var Cursor; info: PackedLineInfo) =
+  inc n # call tag
+  skip n # `..`
+  c.dest.addParLe(RangeT, info)
+  var it = Item(n: n, typ: c.types.autoType)
+  var valuesBuf = createTokenBuf(4)
+  swap c.dest, valuesBuf
+  semExpr c, it
+  semExpr c, it
+  swap c.dest, valuesBuf
+  n = it.n
+  # insert base type:
+  c.dest.addSubtree it.typ
+  var values = cursorAt(valuesBuf, 0)
+  addRangeValues c, values
+  wantParRi c, n
+
 proc semInvoke(c: var SemContext; n: var Cursor) =
   let typeStart = c.dest.len
   let info = n.info
@@ -1798,7 +1847,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     let head = cursorAt(c.dest, typeStart+1)
     let kind = head.typeKind
     endRead(c.dest)
-    if kind in {ArrayT, VarargsT,
+    if kind in {ArrayT, RangeT, VarargsT,
       PtrT, RefT, UncheckedArrayT, SetT, StaticT, TypedescT}:
       # magics that can be invoked
       magicKind = kind
@@ -1833,6 +1882,21 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
           magicExpr.takeTree args # element type
           magicExpr.addSubtree indexPart
           skipParRi args
+        of RangeT:
+          # range types are invoked as `range[a..b]`
+          if isRangeExpr(args):
+            # don't bother calling semLocalTypeImpl, fully build type here
+            magicExpr.shrink 0
+            swap c.dest, magicExpr
+            semRangeTypeFromExpr c, args, info
+            swap c.dest, magicExpr
+            c.dest.endRead()
+            c.dest.shrink typeStart
+            c.dest.add magicExpr
+            return
+          else:
+            # error?
+            discard
         of PtrT, RefT, UncheckedArrayT, SetT, StaticT, TypedescT:
           # unary invocations
           magicExpr.takeTree args
@@ -1899,23 +1963,30 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
   let info = n.info
   case n.kind
   of Ident:
+    let start = c.dest.len
     let s = semIdent(c, n)
-    semTypeSym c, s, info, context
+    semTypeSym c, s, info, start, context
   of Symbol:
+    let start = c.dest.len
     let s = fetchSym(c, n.symId)
     c.dest.add n
     inc n
-    semTypeSym c, s, info, context
+    semTypeSym c, s, info, start, context
   of ParLe:
     case typeKind(n)
     of NoType:
       if exprKind(n) == QuotedX:
+        let start = c.dest.len
         let s = semQuoted(c, n)
-        semTypeSym c, s, info, context
+        semTypeSym c, s, info, start, context
       elif context == AllowValues:
         var it = Item(n: n, typ: c.types.autoType)
         semExpr c, it
         n = it.n
+      elif false and isRangeExpr(n):
+        # a..b, interpret as range type but only without AllowValues
+        # to prevent conflict with HSlice
+        semRangeTypeFromExpr c, n, info
       else:
         c.buildErr info, "not a type", n
         skip n
@@ -1950,7 +2021,50 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
     of ArrayT:
       takeToken c, n
       semLocalTypeImpl c, n, context
+      # index type, possibilities are:
+      # 1. length as integer
+      # 2. range expression i.e. `a..b`
+      # 3. full ordinal type i.e. `uint8`, `Enum`, `range[a..b]`
+      # 4. standalone unresolved expression/type variable, could resolve to 1 or 3
+      if isRangeExpr(n):
+        semRangeTypeFromExpr c, n, info
+      else:
+        var indexBuf = createTokenBuf(4)
+        swap c.dest, indexBuf
+        semLocalTypeImpl c, n, AllowValues
+        swap c.dest, indexBuf
+        var index = cursorAt(indexBuf, 0)
+        if index.typeKind == RangeT:
+          # range expression
+          c.dest.addSubtree index
+        elif index.kind == Symbol and fetchSym(c, index.symId).kind == TypevarY: # or index.typeKind in {UnresolvedT, InvokeT]
+          # unresolved types are left alone
+          # check for invocations would need earlier ordinal type check
+          c.dest.addSubtree index
+        elif index.typeKind != NoType:
+          # XXX should check for ordinal type, then turn it into range type
+          c.dest.addSubtree index
+        else:
+          # length expression
+          var err = false # ignore for now
+          let length = asSigned(evalOrdinal(c, index), err)
+          c.dest.addParLe(RangeT, info)
+          c.dest.addSubtree c.types.intType
+          c.dest.addIntLit 0, info
+          c.dest.addIntLit length - 1, info
+          c.dest.addParRi()
+      wantParRi c, n
+    of RangeT:
+      takeToken c, n
+      let baseTypeStart = c.dest.len
+      semLocalTypeImpl c, n, context
+      var valuesBuf = createTokenBuf(4)
+      swap c.dest, valuesBuf
       semLocalTypeImpl c, n, AllowValues
+      semLocalTypeImpl c, n, AllowValues
+      swap c.dest, valuesBuf
+      var values = cursorAt(valuesBuf, 0)
+      addRangeValues c, values
       wantParRi c, n
     of VarargsT:
       takeToken c, n
@@ -2314,8 +2428,9 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
   elif s.kind in {TypeY, TypevarY}:
     let typeStart = c.dest.len
     c.dest.buildTree TypedescT, it.n.info:
+      let symStart = c.dest.len
       c.dest.add symToken(s.name, it.n.info)
-      semTypeSym c, s, it.n.info, InLocalDecl
+      semTypeSym c, s, it.n.info, symStart, InLocalDecl
     it.typ = typeToCursor(c, typeStart)
     c.dest.shrink typeStart
     commonType c, it, start, expected
@@ -2470,21 +2585,13 @@ proc semWhen(c: var SemContext; it: var Item) =
     # none of the branches evaluated, output nothing
     c.dest.shrink start
 
-proc isRangeNode(c: var SemContext; n: Cursor): bool =
-  var n = n
-  if n.exprKind notin {CallX, InfixX}:
-    return false
-  inc n
-  let name = getIdent(n)
-  result = name != StrId(0) and pool.strings[name] == ".."
-
 proc semCaseOfValue(c: var SemContext; it: var Item; selectorType: TypeCursor;
                     seen: var seq[(xint, xint)]) =
   if it.n == "set":
     takeToken c, it.n
     while it.n.kind != ParRi:
       let info = it.n.info
-      if isRangeNode(c, it.n):
+      if isRangeExpr(it.n):
         inc it.n # call tag
         skip it.n # `..`
         c.dest.buildTree RangeX, it.n.info:
@@ -2769,7 +2876,11 @@ proc semArrayConstr(c: var SemContext, it: var Item) =
   let typeStart = c.dest.len
   c.dest.buildTree ArrayT, it.n.info:
     c.dest.addSubtree elem.typ
-    c.dest.add intToken(pool.integers.getOrIncl(count), it.n.info)
+    c.dest.addParLe(RangeT, it.n.info)
+    c.dest.addSubtree c.types.intType
+    c.dest.addIntLit(0, it.n.info)
+    c.dest.addIntLit(count - 1, it.n.info)
+    c.dest.addParRi()
   let expected = it.typ
   it.typ = typeToCursor(c, typeStart)
   c.dest.shrink typeStart
@@ -2796,7 +2907,7 @@ proc semSetConstr(c: var SemContext, it: var Item) =
   var elemStart = c.dest.len
   var elemInfo = elem.n.info
   while elem.n.kind != ParRi:
-    if isRangeNode(c, elem.n):
+    if isRangeExpr(elem.n):
       inc elem.n # call tag
       skip elem.n # `..`
       c.dest.buildTree RangeX, elem.n.info:
@@ -3129,7 +3240,7 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
           skip it.n
         of IntT, FloatT, CharT, BoolT, UIntT, VoidT, StringT, NilT, AutoT, SymKindT,
             PtrT, RefT, MutT, OutT, LentT, SinkT, UncheckedArrayT, SetT, StaticT, TypedescT,
-            TupleT, ArrayT, VarargsT, ProcT, IterT, UntypedT, TypedT, CstringT, PointerT:
+            TupleT, ArrayT, RangeT, VarargsT, ProcT, IterT, UntypedT, TypedT, CstringT, PointerT:
           # every valid local type expression
           semLocalTypeExpr c, it
         of OrT, AndT, NotT, InvokeT:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1617,8 +1617,6 @@ proc maybeInlineMagic(c: var SemContext; res: LoadResult) =
           if n.kind == ParRi: break
           inc n
 
-proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[SemFlag])
-
 proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; start: int; context: TypeDeclContext) =
   if s.kind in {TypeY, TypevarY}:
     let res = tryLoadSym(s.name)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1643,6 +1643,8 @@ proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; start: int; con
         var t = typ.body
         semLocalTypeImpl c, t, context
   elif context == AllowValues:
+    # non type symbol, treat as expression
+    # XXX should skip TypedescT and become StaticT/UnresolvedT otherwise
     var dummyBuf = createTokenBuf(1)
     dummyBuf.add dotToken(info)
     var it = Item(n: cursorAt(dummyBuf, 0), typ: c.types.autoType)
@@ -1790,7 +1792,7 @@ proc isRangeExpr(n: Cursor): bool =
   result = name != StrId(0) and pool.strings[name] == ".."
 
 proc addRangeValues(c: var SemContext; n: var Cursor) =
-  # XXX should consider unresolved values
+  # XXX AllowValues refactor would need this to handle StaticT/UnresolvedT
   var err: bool = false
   let first = asSigned(evalOrdinal(c, n), err)
   if err:
@@ -1980,6 +1982,7 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
         let s = semQuoted(c, n)
         semTypeSym c, s, info, start, context
       elif context == AllowValues:
+        # XXX should skip TypedescT and become StaticT/UnresolvedT otherwise
         var it = Item(n: n, typ: c.types.autoType)
         semExpr c, it
         n = it.n
@@ -2146,6 +2149,7 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
       inc n
   else:
     if context == AllowValues:
+      # XXX should skip TypedescT and become StaticT/UnresolvedT otherwise
       var it = Item(n: n, typ: c.types.autoType)
       semExpr c, it
       n = it.n

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2058,8 +2058,7 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
           else:
             c.dest.addIntLit(last, index.info)
           c.dest.addParRi()
-        elif index.typeKind == InvokeT or (index.kind == Symbol and
-            fetchSym(c, index.symId).kind == TypevarY): # or UnresolvedT
+        elif containsGenericParams(index):
           # unresolved types are left alone
           c.dest.addSubtree index
         elif index.typeKind != NoType:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -393,6 +393,11 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
       else:
         linearMatch m, f, a
       expectParRi m, f
+    of RangeT:
+      # XXX see nim sigmatch
+      var a = skipModifier(arg.typ)
+      linearMatch m, f, a
+      expectParRi m, f
     of ArrayT, SetT, UncheckedArrayT:
       var a = skipModifier(arg.typ)
       linearMatch m, f, a

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -394,9 +394,12 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
         linearMatch m, f, a
       expectParRi m, f
     of RangeT:
-      # XXX see nim sigmatch
+      # for now acts the same as base type
       var a = skipModifier(arg.typ)
+      inc f # skip to base type
       linearMatch m, f, a
+      skip f
+      skip f
       expectParRi m, f
     of ArrayT, SetT, UncheckedArrayT:
       var a = skipModifier(arg.typ)

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -65,7 +65,7 @@ proc isOrdinalType*(typ: TypeCursor; allowEnumWithHoles: bool = false): bool =
       result = isOrdinalType(decl.body)
   of ParLe:
     case typ.typeKind
-    of IntT, UIntT, CharT, BoolT:
+    of IntT, UIntT, CharT, BoolT, RangeT:
       result = true
     of InvokeT:
       # check base type
@@ -120,6 +120,16 @@ proc firstOrd*(c: var SemContext; typ: TypeCursor): xint =
       else: result = createNaN()
     of UIntT, CharT, BoolT:
       result = zero()
+    of RangeT:
+      var first = typ
+      skip first # base type
+      case first.kind
+      of IntLit:
+        result = createXint pool.integers[first.intId]
+      of UIntLit:
+        result = createXint pool.uintegers[first.uintId]
+      else:
+        result = createNaN()
     of InvokeT:
       # check base type
       var base = typ
@@ -185,6 +195,17 @@ proc lastOrd*(c: var SemContext; typ: TypeCursor): xint =
       of 32: result = createXint high(uint32).uint64
       of 64: result = createXint high(uint64)
       else: result = createNaN()
+    of RangeT:
+      var last = typ
+      skip last # base type
+      skip last # first
+      case last.kind
+      of IntLit:
+        result = createXint pool.integers[last.intId]
+      of UIntLit:
+        result = createXint pool.uintegers[last.uintId]
+      else:
+        result = createNaN()
     of BoolT:
       result = createXint 1.uint64
     of InvokeT:

--- a/tests/nimony/basics/tgeneric_obj.nif
+++ b/tests/nimony/basics/tgeneric_obj.nif
@@ -34,7 +34,9 @@
    (u +8)) .) 4,11
  (var :myarr.0.tgekp9q4q1 . . 12
   (array ~14,~10
-   (i -1) 1 +3) .) 4,12
+   (i -1) 
+   (rangetype
+    (i -1) +0 +2)) .) 4,12
  (let :u8.0.tgekp9q4q1 . .
   (u +8) 5
   (suf +3u "u8")) 6,13

--- a/tests/nimony/basics/tgeneric_obj.nif
+++ b/tests/nimony/basics/tgeneric_obj.nif
@@ -99,7 +99,38 @@
    (discard 11
     (call ~3 foo.0.tgekp9q4q1 3
      (add
-      (i -1) ~2 +34 1 +56) 8 "xyz")))) 19,21
+      (i -1) ~2 +34 1 +56) 8 "xyz")))) 16,42
+ (type ~14 :HSlice.0.tgekp9q4q1 x ~7
+  (typevars 1
+   (typevar :T.3 . . . .) 4
+   (typevar :U.0 . . . .)) . 2
+  (object . ~14,1
+   (fld :a.0.tgekp9q4q1 . . 3 T.3 .) ~14,2
+   (fld :b.0.tgekp9q4q1 . . 3 U.0 .))) 12,45
+ (type ~10 :Slice.0.tgekp9q4q1 x ~4
+  (typevars 1
+   (typevar :T.4 . . . .)) . 8
+  (at ~6 HSlice.0.tgekp9q4q1 1 T.4 4 T.4)) ,47
+ (proc 5 :\2E..0.tgekp9q4q1 x . 10
+  (typevars 1
+   (typevar :T.5 . . . .) 4
+   (typevar :U.1 . . . .)) 16
+  (params 1
+   (param :a.0 . . 3 T.5 .) 7
+   (param :b.0 . . 3 U.1 .)) 20
+  (at ~6 HSlice.0.tgekp9q4q1 1 U.1 4 T.5) . . 45
+  (stmts 
+   (result :result.1 . . ~25
+    (at ~6 HSlice.0.tgekp9q4q1 1 U.1 4 T.5) .) 
+   (discard .) ~45
+   (ret result.1))) 4,50
+ (var :myarr2.0.tgekp9q4q1 . . 12,~39
+  (array ~14,~10
+   (i -1) 
+   (rangetype
+    (i -1) +0 +2)) 27 myarr.0.tgekp9q4q1) 7,51
+ (asgn ~7 myarr2.0.tgekp9q4q1 2
+  (arr 1 +4 4 +5 7 +6)) 19,21
  (type :MyGeneric.1.tgekp9q4q1 . 
   (at MyGeneric.0.tgekp9q4q1 ~17,~20
    (i -1)) ~4,~4 . ~2,~4

--- a/tests/nimony/basics/tgeneric_obj.nim
+++ b/tests/nimony/basics/tgeneric_obj.nim
@@ -39,3 +39,15 @@ proc foo(x: int; y: string): int =
 proc overloaded() =
   let someInt = `+`(23, 90)
   discard foo(34+56, "xyz")
+
+type
+  HSlice*[T, U] = object
+    a: T
+    b: U
+  Slice*[T] = HSlice[T, T]
+
+proc `..`*[T, U](a: T, b: U): HSlice[U, T] = discard
+
+# needs `..` to compile for now:
+var myarr2: array[0..2, int] = myarr
+myarr2 = [4, 5, 6]

--- a/tests/nimony/basics/timportfromexcept.nif
+++ b/tests/nimony/basics/timportfromexcept.nif
@@ -2,18 +2,24 @@
 ,1,tests/nimony/basics/timportfromexcept.nim(stmts 4,4
  (let :allImported.0.timkmpki51 . . 
   (array 11,~2,tests/nimony/basics/deps/modexcept.nim
-   (i -1) +3) 14
+   (i -1) 
+   (rangetype
+    (i -1) +0 +2)) 14
   (arr 1 exceptB.0.modq349xg1 10 fromA.0.mod50uygs 17 fromC.0.mod50uygs)) 4,5
  (let :exceptDeclared.0.timkmpki51 . . 
   (array
-   (bool) +3) 17
+   (bool) 
+   (rangetype
+    (i -1) +0 +2)) 17
   (arr
    (false)
    (true)
    (false))) 4,6
  (let :fromDeclared.0.timkmpki51 . . ,~1
   (array
-   (bool) +3) 15
+   (bool) 
+   (rangetype
+    (i -1) +0 +2)) 15
   (arr
    (true)
    (false)


### PR DESCRIPTION
Range types are added so that we can implement custom index types for arrays as well as the `array[0..2, ...]` syntax. Now, fully resolved array types always have a range type as their index type, but unresolved array types do not, as the unresolved index type can either resolve to a range type or might have to be converted to one. 

Outside of array indexes, range types themselves don't have much functionality, in sigmatch they match their base type but their base types don't match them yet. Float ranges also aren't implemented.

Range types have the representation `(rangetype Type IntLit IntLit)` where its children are the base type followed by the bounds which are always integer literals. They may need to allow unsigned integer literals in the future as well but for array indexes this isn't a concern. In the expander, array types will convert their index range type to a length integer to pass to NIFC.

Followup PRs would implement explicit/inferred index types in array constructors, test/implement array index type inference in generics (`proc foo[I, T](x: array[I, T])`), and implement indexing for custom index types.