### PR TITLE
fix & test import/include lists

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -278,7 +278,8 @@ proc semImport(c: var SemContext; it: var Item) =
 
   var files: seq[ImportedFilename] = @[]
   var hasError = false
-  filenameVal(x, files, hasError, allowAs = true)
+  while x.kind != ParRi:
+    filenameVal(x, files, hasError, allowAs = true)
   if hasError:
     c.buildErr info, "wrong `import` statement"
   else:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -190,7 +190,8 @@ proc semInclude(c: var SemContext; it: var Item) =
   var x = it.n
   skip it.n
   inc x # skip the `include`
-  filenameVal(x, files, hasError, allowAs = false)
+  while x.kind != ParRi:
+    filenameVal(x, files, hasError, allowAs = false)
 
   if hasError:
     c.buildErr info, "wrong `include` statement"

--- a/tests/nimony/basics/timportlist1.nim
+++ b/tests/nimony/basics/timportlist1.nim
@@ -1,0 +1,5 @@
+import deps/modb, deps/modexcept, deps/modfrom
+
+use(4)
+let x = fromA
+let y = exceptB

--- a/tests/nimony/basics/timportlist2.nim
+++ b/tests/nimony/basics/timportlist2.nim
@@ -1,0 +1,5 @@
+import deps/[modb, modfrom, modexcept]
+
+use(4)
+let x = fromA
+let y = exceptB

--- a/tests/nimony/basics/tincludelist.nim
+++ b/tests/nimony/basics/tincludelist.nim
@@ -1,0 +1,5 @@
+include deps/modb, deps/modexcept, deps/modfrom
+
+use(4)
+let x = fromA
+let y = exceptB


### PR DESCRIPTION
The `import a, b, c` syntax was not implemented, although `import foo/[a, b, c]` was, both are tested