### PR TITLE
nimony: fixes enum fields

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -200,7 +200,11 @@ proc traverseEnumField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}
   traverseType e, c, flags
   swap(result, e.dest)
 
+  inc c # skips TupleConstr
   traverseExpr e, c
+  skip c
+  skipParRi e, c
+
   wantParRi e, c
 
 proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =

--- a/src/nifgram/nifgram.nim
+++ b/src/nifgram/nifgram.nim
@@ -666,7 +666,6 @@ proc compile(c: var Context) =
           c.t = next(c.r)
           if c.t.tk == EofToken:
             error c, "')' expected, but got " & $c.t
-            break
           if c.t.tk == ParLe: inc nested
           elif c.t.tk == ParRi:
             dec nested

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -85,9 +85,12 @@ proc eval*(c: var EvalContext, n: var Cursor): Cursor =
     inc n
     let sym = tryLoadSym(symId)
     if sym.status == LacksNothing:
-      let local = asLocal(sym.decl)
+      var local = asLocal(sym.decl)
       case local.kind
-      of ConstY, EfldY:
+      of ConstY:
+        return local.val
+      of EfldY:
+        inc local.val # takes the first counter field
         return local.val
       else: discard
     error "cannot evaluate symbol at compile time: " & pool.syms[symId], info

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2285,23 +2285,40 @@ proc semEnumField(c: var SemContext; n: var Cursor; state: var EnumTypeState) =
 
   if n.kind == DotToken:
     # empty value
-    c.addXint state.thisValue, c.dest[declStart].info
+    let info = c.dest[declStart].info
+    c.dest.add parLeToken(pool.tags.getOrIncl($TupleConstrX), info)
+    c.addXint state.thisValue, info
+    c.dest.add strToken(delayed.lit, info)
+    c.dest.addParRi()
     inc n
   else:
-    var ec = initEvalContext(addr c)
-    var valueCursor = n
-    let fieldValue = eval(ec, valueCursor)
-    if fieldValue.kind == StringLit:
-      c.dest.add parLeToken(pool.tags.getOrIncl($TupleConstrX), n.info)
-      c.addXint state.thisValue, n.info
-      c.dest.add fieldValue
-      c.dest.addParRi()
-      n = valueCursor
-    else:
+    if n.kind == ParLe and n.exprKind == TupleConstrX:
+      c.dest.add n
+      inc n
       let explicitValue = evalConstIntExpr(c, n, c.types.autoType) # 4
       if explicitValue != state.thisValue:
         state.hasHole = true
         state.thisValue = explicitValue
+      c.dest.add evalExpr(c, n)
+      wantParRi c, n
+    else:
+      var ec = initEvalContext(addr c)
+      var valueCursor = n
+      let fieldValue = eval(ec, valueCursor)
+      if fieldValue.kind == StringLit:
+        c.dest.add parLeToken(pool.tags.getOrIncl($TupleConstrX), n.info)
+        c.addXint state.thisValue, n.info
+        c.dest.add fieldValue
+        c.dest.addParRi()
+        n = valueCursor
+      else:
+        c.dest.add parLeToken(pool.tags.getOrIncl($TupleConstrX), n.info)
+        let explicitValue = evalConstIntExpr(c, n, c.types.autoType) # 4
+        if explicitValue != state.thisValue:
+          state.hasHole = true
+          state.thisValue = explicitValue
+        c.dest.add strToken(delayed.lit, n.info)
+        c.dest.addParRi()
   c.addSym delayed
   wantParRi c, n
   publish c, delayed.s.name, declStart

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -12,11 +12,11 @@
  (type ~6 :Color.0.tesg7afhq1 . . . 2
   (enum ,1
    (efld ~6 :Red.0.tesg7afhq1 . .
-    (i -1) +0) 10,1
+    (i -1) (tup +0 "r1")) 10,1
    (efld ~7 :Blue.0.tesg7afhq1 . .
-    (i -1) +1) 21,1
+    (i -1) (tup +1 "r2")) 21,1
    (efld ~8 :Green.0.tesg7afhq1 . .
-    (i -1) +2)))
+    (i -1) (tup +2 "r3"))))
 
 
 (type ~21 :bool.0.tesg7afhq1
@@ -26,10 +26,10 @@
   (enum ~18,1
    (efld ~8 :false.0.tesg7afhq1 
     (false) . 
-    (bool) +0) ~8,1
+    (bool) (tup +0 "false")) ~8,1
    (efld ~7 :true.0.tesg7afhq1 
     (true) . 
-    (bool) +1))) 4,3
+    (bool) (tup +1 "true")))) 4,3
 
   (type ~7 :Parent.0.tesg7afhq1 . . . 2
   (object . ~7,1

--- a/tests/nimony/basics/t1.nim
+++ b/tests/nimony/basics/t1.nim
@@ -133,3 +133,30 @@ proc `[]`*[I;T](a: T; i: I): T {.magic: "ArrGet".}
 proc foo2 =
   var x = [1, 2, 3]
   let m = x[1]
+
+type
+  Color1 = enum
+    Red1, Blue1, Green1
+
+  Color2 = enum
+    Red2 = 0, Blue2 = 1, Green2 = 2
+
+  Color3 = enum
+    Red3 = "r1", Blue3 = "r2", Green3 = "r3"
+
+  Color4 = enum
+    Red4 = (0, "r1"), Blue4 = (1, "r2"), Green4 = (2, "r3")
+
+  Color5 = enum
+    Red5 = "456", Blue5 = 5, Green5 = (7, "r3")
+
+
+proc fooColor =
+  var x = Red1
+  case x
+  of Red1:
+    let s = 1
+  of Blue1:
+    let s2 = 3
+  of Green1:
+    let s3 = 4

--- a/tests/nimony/basics/tbool.nif
+++ b/tests/nimony/basics/tbool.nif
@@ -7,10 +7,12 @@
   (enum ~18,1
    (efld ~8 :false.0.tbojn1uzv 
     (false) . 
-    (bool) +0) ~8,1
+    (bool) 
+    (tup +0 "false")) ~8,1
    (efld ~7 :true.0.tbojn1uzv 
     (true) . 
-    (bool) +1))) 4,3
+    (bool) 
+    (tup +1 "true")))) 4,3
  (let :x.0.tbojn1uzv . . 22,~3
   (bool) 16,~2
   (true)))


### PR DESCRIPTION
```nim
type
  Color = enum
    Red = "r1", Green = "r12", Blue = "r3"
```
Transform into `(0, "r1")` pairs.

TODO：

- [x] fixes enums with tuple fields: (int, string)
- [x] fixes `ord(enums)` and case statements with enums