### PR TITLE
fix issues with generic proc matching

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2793,6 +2793,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
 
   if c.phase == SemcheckSignatures or (delayed.status == OkNew and c.phase != SemcheckTopLevelSyms):
     var isGeneric: bool
+    let prevGeneric = c.routine.inGeneric
     if n.kind == DotToken:
       takeToken c, n
       isGeneric = false
@@ -2813,7 +2814,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
         semLocalTypeImpl c, n, InTypeSection
     if isGeneric:
       closeScope c
-      dec c.routine.inGeneric # increased by semGenericParams
+      c.routine.inGeneric = prevGeneric # revert increase by semGenericParams
   else:
     c.takeTree n # generics
     semTypePragmas c, n, beforeExportMarker

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -864,7 +864,7 @@ proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; candidates: FnCa
 proc requestRoutineInstance(c: var SemContext; origin: SymId; m: var Match;
                             info: PackedLineInfo): ProcInstance =
   let key = typeToCanon(m.typeArgs, 0)
-  var targetSym = c.instantiatedProcs.getOrDefault(key)
+  var targetSym = c.instantiatedProcs.mgetOrPut(origin).getOrDefault(key)
   if targetSym == SymId(0):
     let targetSym = newSymId(c, origin)
     var signature = createTokenBuf(30)
@@ -890,7 +890,7 @@ proc requestRoutineInstance(c: var SemContext; origin: SymId; m: var Match;
       returnType: cursorAt(signature, beforeRetType))
     publish targetSym, ensureMove signature
 
-    c.instantiatedProcs[key] = targetSym
+    c.instantiatedProcs[origin][key] = targetSym
     var req = InstRequest(
       origin: origin,
       targetSym: targetSym,
@@ -1120,8 +1120,7 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
       semExpr c, magicExpr
       it.typ = magicExpr.typ
     elif c.routine.inGeneric == 0 and m[idx].inferred.len > 0 and isMagic == NonMagicCall:
-      assert cs.fn.n.kind == Symbol
-      let inst = c.requestRoutineInstance(cs.fn.n.symId, m[idx], cs.callNode.info)
+      let inst = c.requestRoutineInstance(finalFn.sym, m[idx], cs.callNode.info)
       c.dest[cs.beforeCall+1].setSymId inst.targetSym
       typeofCallIs c, it, cs.beforeCall, inst.returnType
     else:
@@ -1865,7 +1864,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     semLocalTypeImpl c, n, AllowValues
   swap c.usedTypevars, genericArgs
   wantParRi c, n
-  if genericArgs == 0 and ok:
+  if (genericArgs == 0 or magicKind != NoType) and ok:
     # we have to be eager in generic type instantiations so that type-checking
     # can do its job properly:
     let key = typeToCanon(c.dest, typeStart)
@@ -2311,6 +2310,7 @@ proc semGenericParams(c: var SemContext; n: var Cursor) =
     while n.kind != ParRi:
       semGenericParam c, n
     wantParRi c, n
+    dec c.routine.inGeneric
   elif n == $InvokeT:
     takeTree c, n
   else:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -864,7 +864,7 @@ proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; candidates: FnCa
 proc requestRoutineInstance(c: var SemContext; origin: SymId; m: var Match;
                             info: PackedLineInfo): ProcInstance =
   let key = typeToCanon(m.typeArgs, 0)
-  var targetSym = c.instantiatedProcs.mgetOrPut(origin).getOrDefault(key)
+  var targetSym = c.instantiatedProcs.getOrDefault((origin, key))
   if targetSym == SymId(0):
     let targetSym = newSymId(c, origin)
     var signature = createTokenBuf(30)
@@ -890,7 +890,7 @@ proc requestRoutineInstance(c: var SemContext; origin: SymId; m: var Match;
       returnType: cursorAt(signature, beforeRetType))
     publish targetSym, ensureMove signature
 
-    c.instantiatedProcs[origin][key] = targetSym
+    c.instantiatedProcs[(origin, key)] = targetSym
     var req = InstRequest(
       origin: origin,
       targetSym: targetSym,

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -842,9 +842,7 @@ proc maybeAddConceptMethods(c: var SemContext; fn: StrId; typevar: SymId; cands:
     inc ops  # (concept
     skip ops # .
     skip ops # .
-    inc ops # (typevar
-    let self = ops.symId # Self
-    skipToEnd ops # ...)
+    skip ops #   (typevar Self ...)
     if ops == "stmts":
       inc ops
       while ops.kind != ParRi:
@@ -855,7 +853,7 @@ proc maybeAddConceptMethods(c: var SemContext; fn: StrId; typevar: SymId; cands:
           if prc.kind == SymbolDef and sameIdent(prc.symId, fn):
             var d = ops
             skipToParams d
-            cands.addUnique FnCandidate(kind: ConceptProcY, sym: prc.symId, typ: d, selfType: self)
+            cands.addUnique FnCandidate(kind: ConceptProcY, sym: prc.symId, typ: d)
         skip ops
 
 proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; candidates: FnCandidates; args: openArray[Item], genericArgs: Cursor) =
@@ -1121,12 +1119,6 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
       var magicExpr = Item(n: cursorAt(magicExprBuf, 0), typ: it.typ)
       semExpr c, magicExpr
       it.typ = magicExpr.typ
-    elif false and finalFn.kind == ConceptProcY:
-      # substitute the Self in the return type
-      var sc = SubsContext(params: addr m[idx].inferred)
-      var buf = createTokenBuf(4)
-      subs(c, buf, sc, m[idx].returnType)
-      typeofCallIs c, it, cs.beforeCall, typeToCursor(c, buf, 0)
     elif c.routine.inGeneric == 0 and m[idx].inferred.len > 0 and isMagic == NonMagicCall:
       let inst = c.requestRoutineInstance(finalFn.sym, m[idx], cs.callNode.info)
       c.dest[cs.beforeCall+1].setSymId inst.targetSym

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2813,7 +2813,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
         semLocalTypeImpl c, n, InTypeSection
     if isGeneric:
       closeScope c
-      dec c.routine.inGeneric
+      dec c.routine.inGeneric # increased by semGenericParams
   else:
     c.takeTree n # generics
     semTypePragmas c, n, beforeExportMarker

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -842,7 +842,9 @@ proc maybeAddConceptMethods(c: var SemContext; fn: StrId; typevar: SymId; cands:
     inc ops  # (concept
     skip ops # .
     skip ops # .
-    skip ops #   (typevar Self ...)
+    inc ops # (typevar
+    let self = ops.symId # Self
+    skipToEnd ops # ...)
     if ops == "stmts":
       inc ops
       while ops.kind != ParRi:
@@ -853,7 +855,7 @@ proc maybeAddConceptMethods(c: var SemContext; fn: StrId; typevar: SymId; cands:
           if prc.kind == SymbolDef and sameIdent(prc.symId, fn):
             var d = ops
             skipToParams d
-            cands.addUnique FnCandidate(kind: ConceptProcY, sym: prc.symId, typ: d)
+            cands.addUnique FnCandidate(kind: ConceptProcY, sym: prc.symId, typ: d, selfType: self)
         skip ops
 
 proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; candidates: FnCandidates; args: openArray[Item], genericArgs: Cursor) =
@@ -1119,6 +1121,12 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
       var magicExpr = Item(n: cursorAt(magicExprBuf, 0), typ: it.typ)
       semExpr c, magicExpr
       it.typ = magicExpr.typ
+    elif false and finalFn.kind == ConceptProcY:
+      # substitute the Self in the return type
+      var sc = SubsContext(params: addr m[idx].inferred)
+      var buf = createTokenBuf(4)
+      subs(c, buf, sc, m[idx].returnType)
+      typeofCallIs c, it, cs.beforeCall, typeToCursor(c, buf, 0)
     elif c.routine.inGeneric == 0 and m[idx].inferred.len > 0 and isMagic == NonMagicCall:
       let inst = c.requestRoutineInstance(finalFn.sym, m[idx], cs.callNode.info)
       c.dest[cs.beforeCall+1].setSymId inst.targetSym
@@ -2310,7 +2318,6 @@ proc semGenericParams(c: var SemContext; n: var Cursor) =
     while n.kind != ParRi:
       semGenericParam c, n
     wantParRi c, n
-    dec c.routine.inGeneric
   elif n == $InvokeT:
     takeTree c, n
   else:
@@ -2814,6 +2821,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
         semLocalTypeImpl c, n, InTypeSection
     if isGeneric:
       closeScope c
+      dec c.routine.inGeneric
   else:
     c.takeTree n # generics
     semTypePragmas c, n, beforeExportMarker

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -79,7 +79,7 @@ type
     types*: BuiltinTypes
     typeMem*: Table[string, TokenBuf]
     instantiatedTypes*: OrderedTable[string, SymId]
-    instantiatedProcs*: OrderedTable[string, SymId]
+    instantiatedProcs*: OrderedTable[SymId, OrderedTable[string, SymId]]
     thisModuleSuffix*: string
     moduleFlags*: set[ModuleFlag]
     processedModules*: HashSet[string]

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -79,7 +79,7 @@ type
     types*: BuiltinTypes
     typeMem*: Table[string, TokenBuf]
     instantiatedTypes*: OrderedTable[string, SymId]
-    instantiatedProcs*: OrderedTable[SymId, OrderedTable[string, SymId]]
+    instantiatedProcs*: OrderedTable[(SymId, string), SymId]
     thisModuleSuffix*: string
     moduleFlags*: set[ModuleFlag]
     processedModules*: HashSet[string]

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -207,6 +207,9 @@ proc linearMatch(m: var Match; f, a: var Cursor, containsStartTag = true) =
         if m.err: break
       elif matchesConstraint(m, fs, a):
         m.inferred[fs] = a # NOTICE: Can introduce modifiers for a type var!
+        inc f
+        skip a
+        continue
       else:
         m.error concat(typeToString(a), " does not match constraint ", typeToString(f))
         break

--- a/tests/nimony/basics/tgeneric_obj.nif
+++ b/tests/nimony/basics/tgeneric_obj.nif
@@ -84,10 +84,10 @@
   (stmts 4
    (result :result.0 . . ~4,~32
     (i -1) .) 4
-   (var :x.2 . .
+   (var :x.4 . .
     (string) 4 "abc") 7,1
    (asgn ~7 result.0 2 +4) 2,2
-   (asgn ~2 x.2 2 "34") ~2,~1
+   (asgn ~2 x.4 2 "34") ~2,~1
    (ret result.0))) ,37
  (proc 5 :overloaded.0.tgekp9q4q1 . . . 15
   (params) . . . 2,1
@@ -117,12 +117,12 @@
    (typevar :U.1 . . . .)) 16
   (params 1
    (param :a.0 . . 3 T.5 .) 7
-   (param :b.0 . . 3 U.1 .)) 20
-  (at ~6 HSlice.0.tgekp9q4q1 1 U.1 4 T.5) . . 45
+   (param :b.0 . . 3 U.1 .)) 2,~46
+  (i -1) . . 36
   (stmts 
-   (result :result.1 . . ~25
-    (at ~6 HSlice.0.tgekp9q4q1 1 U.1 4 T.5) .) 
-   (discard .) ~45
+   (result :result.1 . . ~34,~46
+    (i -1) .) 
+   (discard .) ~36
    (ret result.1))) 4,50
  (var :myarr2.0.tgekp9q4q1 . . 12,~39
   (array ~14,~10
@@ -130,7 +130,83 @@
    (rangetype
     (i -1) +0 +2)) 27 myarr.0.tgekp9q4q1) 7,51
  (asgn ~7 myarr2.0.tgekp9q4q1 2
-  (arr 1 +4 4 +5 7 +6)) 19,21
+  (arr 1 +4 4 +5 7 +6)) ,53
+ (proc 5 :foo.1.tgekp9q4q1 . . 8
+  (typevars 1
+   (typevar :I.0 . . . .) 4
+   (typevar :T.6 . . . .)) 14
+  (params 1
+   (param :x.2 . . 8
+    (array 4 T.6 1 I.0) .)) . . . 33
+  (stmts 
+   (discard .))) 3,54
+ (call ~3 foo.2.tgekp9q4q1 1 myarr2.0.tgekp9q4q1) ,56
+ (proc 5 :identity.0.tgekp9q4q1 . . 13
+  (typevars 1
+   (typevar :I.1 . . . .) 4
+   (typevar :T.7 . . . .)) 19
+  (params 1
+   (param :x.3 . . 8
+    (array 4 T.7 1 I.1) .)) 23
+  (array 4 T.7 1 I.1) . . 2,1
+  (stmts 7
+   (result :result.2 . . 19,~1
+    (array 4 T.7 1 I.1) .) 7
+   (asgn ~7 result.2 2 x.3) ~2,~1
+   (ret result.2))) 7,58
+ (asgn ~7 myarr2.0.tgekp9q4q1 10
+  (call ~8 identity.1.tgekp9q4q1 1 myarr2.0.tgekp9q4q1)) 19,50
+ (proc :\2E..1.tgekp9q4q1 . ~19,~3 . 
+  (at \2E..0.tgekp9q4q1
+   (i -1)
+   (i -1)) ~3,~3
+  (params 1
+   (param :a.2 . .
+    (i -1) .) 7
+   (param :b.2 . .
+    (i -1) .)) ~17,~49
+  (i -1) ~19,~3 . ~19,~3 . 17,~3
+  (stmts 
+   (result :result.3 . . ~34,~46
+    (i -1) .) 
+   (discard .) ~36
+   (ret result.3))) 3,54
+ (proc :foo.2.tgekp9q4q1 . ~3,~1 . 
+  (at foo.1.tgekp9q4q1 13,~43
+   (rangetype
+    (i -1) +0 +2) ~1,~53
+   (i -1)) 11,~1
+  (params 1
+   (param :x.7 . . 8
+    (array ~21,~52
+     (i -1) ~7,~42
+     (rangetype
+      (i -1) +0 +2)) .)) ~3,~1 . ~3,~1 . ~3,~1 . 30,~1
+  (stmts 
+   (discard .))) 17,58
+ (proc :identity.1.tgekp9q4q1 . ~17,~2 . 
+  (at identity.0.tgekp9q4q1 ~1,~47
+   (rangetype
+    (i -1) +0 +2) ~15,~57
+   (i -1)) 2,~2
+  (params 1
+   (param :x.8 . . 8
+    (array ~26,~55
+     (i -1) ~12,~45
+     (rangetype
+      (i -1) +0 +2)) .)) 6,~2
+  (array ~21,~55
+   (i -1) ~7,~45
+   (rangetype
+    (i -1) +0 +2)) ~17,~2 . ~17,~2 . ~15,~1
+  (stmts 7
+   (result :result.4 . . 19,~1
+    (array ~26,~55
+     (i -1) ~12,~45
+     (rangetype
+      (i -1) +0 +2)) .) 7
+   (asgn ~7 result.4 2 x.8) ~2,~1
+   (ret result.4))) 19,21
  (type :MyGeneric.1.tgekp9q4q1 . 
   (at MyGeneric.0.tgekp9q4q1 ~17,~20
    (i -1)) ~4,~4 . ~2,~4

--- a/tests/nimony/basics/tgeneric_obj.nim
+++ b/tests/nimony/basics/tgeneric_obj.nim
@@ -46,8 +46,15 @@ type
     b: U
   Slice*[T] = HSlice[T, T]
 
-proc `..`*[T, U](a: T, b: U): HSlice[U, T] = discard
+proc `..`*[T, U](a: T, b: U): int = discard # : HSlice[T, U]
 
 # needs `..` to compile for now:
 var myarr2: array[0..2, int] = myarr
 myarr2 = [4, 5, 6]
+
+proc foo[I, T](x: array[I, T]) = discard
+foo(myarr2)
+
+proc identity[I, T](x: array[I, T]): array[I, T] =
+  result = x
+myarr2 = identity(myarr2)


### PR DESCRIPTION
1. Instantiated procs were only mapped to the types of their parameters, not which routine symbols they were instantiated from
2. Magic type invocations (i.e. `array[I, T]`) were left as `(at (array) I T)` in generics
3. `inc inGeneric` leaked in `semGenericParams` for type sections since they did not push a new routine
4. `linearMatch` matching a generic parameter only skipped a single token after doing so, i.e. `(array T I)` matching `(array (i -1) ...)` would match `T` to `(i -1)` then move to the next token after `(i`, matching `I` to `-1`

`inc inGeneric` leaking means procs were not instantiated in some of the tests, the `HSlice[T, U]` return type of `..` remains as `InvokeT` after instantiation rather becoming a symbol which causes issues, probably `semLocalType` isn't called on the return type during instantiation or whatever has to be done