### PR TITLE
fix cached invocation types

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1897,6 +1897,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     # can do its job properly:
     let key = typeToCanon(c.dest, typeStart)
     if c.instantiatedTypes.hasKey(key):
+      c.dest.shrink typeStart
       c.dest.add symToken(c.instantiatedTypes[key], info)
     else:
       var args = cursorAt(c.dest, beforeArgs)

--- a/tests/nimony/basics/tgeneric_obj.nif
+++ b/tests/nimony/basics/tgeneric_obj.nif
@@ -117,12 +117,12 @@
    (typevar :U.1 . . . .)) 16
   (params 1
    (param :a.0 . . 3 T.5 .) 7
-   (param :b.0 . . 3 U.1 .)) 2,~46
-  (i -1) . . 36
+   (param :b.0 . . 3 U.1 .)) 20
+  (at ~6 HSlice.0.tgekp9q4q1 1 T.5 4 U.1) . . 45
   (stmts 
-   (result :result.1 . . ~34,~46
-    (i -1) .) 
-   (discard .) ~36
+   (result :result.1 . . ~25
+    (at ~6 HSlice.0.tgekp9q4q1 1 T.5 4 U.1) .) 
+   (discard .) ~45
    (ret result.1))) 4,50
  (var :myarr2.0.tgekp9q4q1 . . 12,~39
   (array ~14,~10
@@ -164,12 +164,10 @@
    (param :a.2 . .
     (i -1) .) 7
    (param :b.2 . .
-    (i -1) .)) ~17,~49
-  (i -1) ~19,~3 . ~19,~3 . 17,~3
+    (i -1) .)) 1,~3 HSlice.1.tgekp9q4q1 ~19,~3 . ~19,~3 . 26,~3
   (stmts 
-   (result :result.3 . . ~34,~46
-    (i -1) .) 
-   (discard .) ~36
+   (result :result.3 . . ~25 HSlice.1.tgekp9q4q1 .) 
+   (discard .) ~45
    (ret result.3))) 3,54
  (proc :foo.2.tgekp9q4q1 . ~3,~1 . 
   (at foo.1.tgekp9q4q1 13,~43
@@ -218,4 +216,13 @@
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
    (fld :x.2.tgekp9q4q1 . . ~2,~15
-    (f +64) .))))
+    (f +64) .))) 20,47
+ (type :HSlice.1.tgekp9q4q1 . 
+  (at HSlice.0.tgekp9q4q1
+   (i -1)
+   (i -1)) ~4,~5 . ~2,~5
+  (object . ~14,1
+   (fld :a.1.tgekp9q4q1 . .
+    (i -1) .) ~14,2
+   (fld :b.1.tgekp9q4q1 . .
+    (i -1) .))))

--- a/tests/nimony/basics/tgeneric_obj.nim
+++ b/tests/nimony/basics/tgeneric_obj.nim
@@ -46,7 +46,7 @@ type
     b: U
   Slice*[T] = HSlice[T, T]
 
-proc `..`*[T, U](a: T, b: U): int = discard # : HSlice[T, U]
+proc `..`*[T, U](a: T, b: U): HSlice[T, U] = discard
 
 # needs `..` to compile for now:
 var myarr2: array[0..2, int] = myarr


### PR DESCRIPTION
Brings back disabled test from #274, cached invocation types outputted `(at BaseType ...) InstType` rather than just `InstType`

Every single call to `typeToCursor` uses a cursor that is supposed to contain a single type and nothing after, maybe we can enforce that `typeToCursor` consumes a single tree and nothing else is left in the buffer to catch these bugs.