### PR TITLE
fix unused import warnings

### DIFF
--- a/src/lib/nifprelude.nim
+++ b/src/lib/nifprelude.nim
@@ -1,3 +1,7 @@
 ## imports the set of NIF related modules that have won
 
+{.push warning[UnusedImport]: off.}
+
 import bitabs, nifcursors, nifstreams, lineinfos, nifreader, nifbuilder
+
+{.pop.}

--- a/src/nifler/nifler.nim
+++ b/src/nifler/nifler.nim
@@ -7,7 +7,7 @@
 ## Nifler is a simple tool that parses Nim code and outputs NIF code.
 ## No semantic checking is done and no symbol lookups are performed.
 
-import std / [parseopt, strutils, os, syncio, assertions, times]
+import std / [parseopt, strutils, os, assertions, times]
 import bridge, configcmd
 
 const

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1,6 +1,6 @@
 
 import std / [os, strutils]
-import "../src/lib" / [nifreader, nifbuilder, nif_linkedtree, treemangler]
+import "../src/lib" / [nifreader, nifbuilder, nif_linkedtree]
 
 const
   ExpectedOutput = """


### PR DESCRIPTION
`{.push warning[UnusedImport].}` only suppresses the warning since recent PR https://github.com/nim-lang/Nim/pull/24554 but we test for devel anyway