### PR TITLE
implement default, object & tuple as magics, full object constructors

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -525,7 +525,8 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
       toNif(n[i], n, c)
     # n.len-3: pragmas: must be empty (it is deprecated anyway)
     if n.len == 0:
-      c.b.addEmpty 2 # pragmas, body
+      # object typeclass, has no children
+      discard
     else:
       if n[n.len-3].kind != nkEmpty:
         c.b.addTree "err"
@@ -540,7 +541,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
         toNif(last, n, c)
     c.b.endTree()
 
-  of nkTupleTy:
+  of nkTupleTy, nkTupleClassTy:
     c.section = "fld"
     relLineInfo(n, parent, c)
     c.b.addTree(nodeKindTranslation(n.kind))

--- a/src/nimony/lib/std/system.nim
+++ b/src/nimony/lib/std/system.nim
@@ -348,3 +348,26 @@ template `>=`*(x, y: untyped): untyped =
 template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
+
+template default*(x: typedesc[bool]): bool = false
+template default*(x: typedesc[char]): char = '\0'
+template default*(x: typedesc[int]): int = 0
+template default*(x: typedesc[uint]): uint = 0'u
+template default*(x: typedesc[int8]): int8 = 0'i8
+template default*(x: typedesc[uint8]): uint8 = 0'u8
+template default*(x: typedesc[int16]): int16 = 0'i16
+template default*(x: typedesc[uint16]): uint16 = 0'u16
+template default*(x: typedesc[int32]): int32 = 0'i32
+template default*(x: typedesc[uint32]): uint32 = 0'u32
+template default*(x: typedesc[int64]): int64 = 0'i64
+template default*(x: typedesc[uint64]): uint64 = 0'u64
+template default*(x: typedesc[float32]): float32 = 0.0'f32
+template default*(x: typedesc[float64]): float64 = 0.0'f64
+template default*(x: typedesc[string]): string = ""
+template default*[T: enum](x: typedesc[T]): T = T(0)
+
+template default*[T: ptr](x: typedesc[T]): T = T(nil)
+template default*[T: ref](x: typedesc[T]): T = T(nil)
+
+proc default*[T: object](x: typedesc[T]): T {.magic: DefaultObj.}
+proc default*[T: tuple](x: typedesc[T]): T {.magic: DefaultTup.}

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -85,7 +85,9 @@ type
     mNimvm, mIntDefine, mStrDefine, mBoolDefine, mGenericDefine, mRunnableExamples,
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
     mSymIsInstantiationOf, mNodeId, mPrivateAccess, mZeroDefault,
-    mUnpack # not in Nim 2
+    # not in Nim 2:
+    mUnpack
+    mDefaultObj, mDefaultTup
 
 declareMatcher parseMagic, TMagic, 1, 1
 
@@ -161,6 +163,8 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mStmt: res TypedT
   of mCstring: res CstringT
   of mPointer: res PointerT
+  of mDefaultObj: res DefaultObjX
+  of mDefaultTup: res DefaultTupX
   else: ("", 0)
 
 when isMainModule:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -136,6 +136,8 @@ type
     TypeofX = "typeof"
     UnpackX = "unpack"
     IsMainModuleX = "ismainmodule"
+    DefaultObjX = "defaultobj"
+    DefaultTupX = "defaulttup"
 
   TypeKind* = enum
     NoType

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -763,7 +763,7 @@ proc addFn(c: var SemContext; fn: FnCandidate; fnOrig: Cursor; args: openArray[I
         inc n # skip the SymbolDef
         if n.kind == ParLe:
           if n.exprKind in {DefinedX, DeclaredX, CompilesX, TypeofX,
-              SizeofX, LowX, HighX, AddrX}:
+              SizeofX, LowX, HighX, AddrX, DefaultObjX, DefaultTupX}:
             # magic needs semchecking after overloading
             result = MagicCallNeedsSemcheck
           else:
@@ -3235,25 +3235,81 @@ proc semTupleConstr(c: var SemContext, it: var Item) =
   c.dest.shrink typeStart
   commonType c, it, exprStart, origExpected
 
+proc callDefault(c: var SemContext; typ: Cursor; info: PackedLineInfo) =
+  var callBuf = createTokenBuf(16)
+  callBuf.addParLe(CallX, info)
+  swap c.dest, callBuf
+  discard buildSymChoice(c, pool.strings.getOrIncl("default"), info, FindAll)
+  swap c.dest, callBuf
+  callBuf.addSubtree typ
+  callBuf.addParRi()
+  var it = Item(n: cursorAt(callBuf, 0), typ: c.types.autoType)
+  semCall c, it
+
+proc buildObjConstrField(c: var SemContext; field: Local; setFields: Table[SymId, Cursor]; info: PackedLineInfo) =
+  let fieldSym = field.name.symId
+  if fieldSym in setFields:
+    c.dest.addSubtree setFields[fieldSym]
+  else:
+    c.dest.addParLe(KvX, info)
+    c.dest.add(field.name)
+    callDefault c, field.typ, info
+    c.dest.addParRi()
+
+proc buildDefaultObjConstr(c: var SemContext; typ: Cursor; setFields: Table[SymId, Cursor]; info: PackedLineInfo) =
+  c.dest.addParLe(OconstrX, info)
+  c.dest.addSubtree typ
+  var objImpl = typ
+  if objImpl.kind == Symbol:
+    objImpl = objtypeImpl(objImpl.symId)
+  var obj = asObjectDecl(objImpl)
+  # same field order as old nim VM: starting with most shallow base type
+  while obj.parentType.kind != DotToken:
+    var parentImpl = obj.parentType
+    if parentImpl.kind == Symbol:
+      parentImpl = objtypeImpl(parentImpl.symId)
+    elif parentImpl.typeKind == InvokeT:
+      inc parentImpl # get to symbol
+      parentImpl = objtypeImpl(parentImpl.symId)
+    else:
+      # should not be possible
+      discard
+    let parent = asObjectDecl(parentImpl)
+    obj.parentType = parent.parentType
+    var currentField = parent.firstField
+    while currentField.kind != ParRi:
+      let field = asLocal(currentField)
+      buildObjConstrField(c, field, setFields, info)
+      skip currentField
+  var currentField = obj.firstField
+  while currentField.kind != ParRi:
+    let field = asLocal(currentField)
+    buildObjConstrField(c, field, setFields, info)
+    skip currentField
+  c.dest.addParRi()
+
 proc semObjConstr(c: var SemContext, it: var Item) =
   let exprStart = c.dest.len
   let expected = it.typ
   let info = it.n.info
-  takeToken c, it.n
+  inc it.n
   it.typ = semLocalType(c, it.n)
+  c.dest.shrink exprStart
   var objType = it.typ
   if objType.kind == Symbol:
     objType = objtypeImpl(objType.symId)
     if objType.typeKind != ObjectT:
-      c.dest.shrink exprStart
       c.buildErr info, "expected object type for object constructor"
       return
-  var setFields = initHashSet[SymId]()
+  var fieldBuf = createTokenBuf(16)
+  var setFieldPositions = initTable[SymId, int]()
   while it.n.kind != ParRi:
     if it.n.exprKind != KvX:
       c.buildErr it.n.info, "expected key/value pair in object constructor"
     else:
-      takeToken c, it.n
+      let fieldStart = fieldBuf.len
+      fieldBuf.add it.n
+      inc it.n
       let fieldInfo = it.n.info
       let fieldName = getIdent(it.n)
       if fieldName == StrId(0):
@@ -3262,20 +3318,60 @@ proc semObjConstr(c: var SemContext, it: var Item) =
       else:
         let field = findObjField(objType, fieldName)
         if field.level >= 0:
-          if setFields.containsOrIncl(field.sym):
+          if field.sym in setFieldPositions:
             c.buildErr fieldInfo, "field already set: " & pool.strings[fieldName]
             skip it.n
           else:
-            c.dest.add symToken(field.sym, info)
+            setFieldPositions[field.sym] = fieldStart
+            fieldBuf.add symToken(field.sym, info)
             # maybe add inheritance depth too somehow?
             var val = Item(n: it.n, typ: field.typ)
+            swap c.dest, fieldBuf
             semExpr c, val
+            swap c.dest, fieldBuf
             it.n = val.n
         else:
           c.buildErr fieldInfo, "undeclared field: " & pool.strings[fieldName]
           skip it.n
-      wantParRi c, it.n
-  wantParRi c, it.n
+      fieldBuf.addParRi()
+      skipParRi it.n
+  skipParRi it.n
+  var setFields = initTable[SymId, Cursor]()
+  for field, pos in setFieldPositions:
+    setFields[field] = cursorAt(fieldBuf, pos)
+  buildDefaultObjConstr(c, it.typ, setFields, info)
+  commonType c, it, exprStart, expected
+
+proc semObjDefault(c: var SemContext; it: var Item) =
+  let exprStart = c.dest.len
+  let expected = it.typ
+  let info = it.n.info
+  inc it.n
+  it.typ = semLocalType(c, it.n)
+  c.dest.shrink exprStart
+  skipParRi it.n
+  buildDefaultObjConstr(c, it.typ, initTable[SymId, Cursor](), info)
+  commonType c, it, exprStart, expected
+
+proc buildDefaultTuple(c: var SemContext; typ: Cursor; info: PackedLineInfo) =
+  c.dest.addParLe(TupleConstrX, info)
+  var currentField = typ
+  inc currentField # skip tuple tag
+  while currentField.kind != ParRi:
+    let field = asLocal(currentField)
+    callDefault c, field.typ, info
+    skip currentField
+  c.dest.addParRi()
+
+proc semTupleDefault(c: var SemContext; it: var Item) =
+  let exprStart = c.dest.len
+  let expected = it.typ
+  let info = it.n.info
+  inc it.n
+  it.typ = semLocalType(c, it.n)
+  c.dest.shrink exprStart
+  skipParRi it.n
+  buildDefaultTuple(c, it.typ, info)
   commonType c, it, exprStart, expected
 
 proc getDottedIdent(n: var Cursor): string =
@@ -3680,6 +3776,10 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
       semNil c, it
     of ConvX:
       semConv c, it
+    of DefaultObjX:
+      semObjDefault c, it
+    of DefaultTupX:
+      semTupleDefault c, it
     of DerefX, PatX, AddrX, SizeofX, KvX,
        RangeX, RangesX,
        OconvX, HconvX,

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -318,7 +318,7 @@ type
 
 proc identToSym*(c: var SemContext; lit: StrId; kind: SymKind): SymId =
   var name = pool.strings[lit]
-  if c.currentScope.kind == ToplevelScope or kind in {FldY, EfldY}:
+  if c.currentScope.kind == ToplevelScope or kind in {FldY, EfldY, TypevarY}:
     c.makeGlobalSym(name)
   else:
     c.makeLocalSym(name)

--- a/tests/nimony/basics/t1.nim
+++ b/tests/nimony/basics/t1.nim
@@ -40,8 +40,6 @@ var global: MyObject
 global.x = 45
 discard foo(global.x, "123")
 discard global.x.foo("123")
-global = MyObject(x: 123)
-global = MyObject(x: 123, y: 456)
 
 overloaded()
 overloaded("abc")

--- a/tests/nimony/basics/tfib2.nif
+++ b/tests/nimony/basics/tfib2.nif
@@ -91,11 +91,11 @@
       (param :y.7 . . 3 Self.0.tfie0imm3 .)) 14 Self.0.tfie0imm3 . . .)))) ,22
  (proc 5 :fib.0.tfie0imm3 . . 8
   (typevars 1
-   (typevar :T.0 . . 3 Fibable.0.tfie0imm3 .)) 20
+   (typevar :T.0.tfie0imm3 . . 3 Fibable.0.tfie0imm3 .)) 20
   (params 1
-   (param :a.1 . . 3 T.0 .)) 8 T.0 . . 2,1
+   (param :a.1 . . 3 T.0.tfie0imm3 .)) 8 T.0.tfie0imm3 . . 2,1
   (stmts 
-   (result :result.0 . . 22,~1 T.0 .) 
+   (result :result.0 . . 22,~1 T.0.tfie0imm3 .) 
    (if 3
     (elif 2
      (infix <= ~2 a.1 3 +2) ~1,1

--- a/tests/nimony/basics/tgeneric_obj.nif
+++ b/tests/nimony/basics/tgeneric_obj.nif
@@ -19,14 +19,14 @@
  (type :set.0.tgekp9q4q1 
   (sett) 4
   (typevars 1
-   (typevar :T.0 . . . .)) 8
+   (typevar :T.0.tgekp9q4q1 . . . .)) 8
   (pragmas 2
    (magic 7 Set)) .) 2,8
  (type :array.0.tgekp9q4q1 
   (array) 7
   (typevars 1
-   (typevar :Index.0 . . . .) 8
-   (typevar :T.1 . . . .)) 18
+   (typevar :Index.0.tgekp9q4q1 . . . .) 8
+   (typevar :T.1.tgekp9q4q1 . . . .)) 18
   (pragmas 2
    (magic 7 Array)) .) 4,10
  (var :myset.0.tgekp9q4q1 . . 10
@@ -51,9 +51,9 @@
   (arr 1 +1 4 +2 7 +3)) 15,17
  (type ~13 :MyGeneric.0.tgekp9q4q1 . ~4
   (typevars 1
-   (typevar :T.2 . . . .)) . 2
+   (typevar :T.2.tgekp9q4q1 . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tgekp9q4q1 . . 3 T.2 .))) 2,21
+   (fld :x.0.tgekp9q4q1 . . 3 T.2.tgekp9q4q1 .))) 2,21
  (var :myglob.0.tgekp9q4q1 . . 17 MyGeneric.1.tgekp9q4q1 .) 2,22
  (var :other.0.tgekp9q4q1 . . 16 MyGeneric.2.tgekp9q4q1 .) 9,24
  (asgn ~3
@@ -102,26 +102,26 @@
       (i -1) ~2 +34 1 +56) 8 "xyz")))) 16,42
  (type ~14 :HSlice.0.tgekp9q4q1 x ~7
   (typevars 1
-   (typevar :T.3 . . . .) 4
-   (typevar :U.0 . . . .)) . 2
+   (typevar :T.3.tgekp9q4q1 . . . .) 4
+   (typevar :U.0.tgekp9q4q1 . . . .)) . 2
   (object . ~14,1
-   (fld :a.0.tgekp9q4q1 . . 3 T.3 .) ~14,2
-   (fld :b.0.tgekp9q4q1 . . 3 U.0 .))) 12,45
+   (fld :a.0.tgekp9q4q1 . . 3 T.3.tgekp9q4q1 .) ~14,2
+   (fld :b.0.tgekp9q4q1 . . 3 U.0.tgekp9q4q1 .))) 12,45
  (type ~10 :Slice.0.tgekp9q4q1 x ~4
   (typevars 1
-   (typevar :T.4 . . . .)) . 8
-  (at ~6 HSlice.0.tgekp9q4q1 1 T.4 4 T.4)) ,47
+   (typevar :T.4.tgekp9q4q1 . . . .)) . 8
+  (at ~6 HSlice.0.tgekp9q4q1 1 T.4.tgekp9q4q1 4 T.4.tgekp9q4q1)) ,47
  (proc 5 :\2E..0.tgekp9q4q1 x . 10
   (typevars 1
-   (typevar :T.5 . . . .) 4
-   (typevar :U.1 . . . .)) 16
+   (typevar :T.5.tgekp9q4q1 . . . .) 4
+   (typevar :U.1.tgekp9q4q1 . . . .)) 16
   (params 1
-   (param :a.0 . . 3 T.5 .) 7
-   (param :b.0 . . 3 U.1 .)) 20
-  (at ~6 HSlice.0.tgekp9q4q1 1 T.5 4 U.1) . . 45
+   (param :a.0 . . 3 T.5.tgekp9q4q1 .) 7
+   (param :b.0 . . 3 U.1.tgekp9q4q1 .)) 20
+  (at ~6 HSlice.0.tgekp9q4q1 1 T.5.tgekp9q4q1 4 U.1.tgekp9q4q1) . . 45
   (stmts 
    (result :result.1 . . ~25
-    (at ~6 HSlice.0.tgekp9q4q1 1 T.5 4 U.1) .) 
+    (at ~6 HSlice.0.tgekp9q4q1 1 T.5.tgekp9q4q1 4 U.1.tgekp9q4q1) .) 
    (discard .) ~45
    (ret result.1))) 4,50
  (var :myarr2.0.tgekp9q4q1 . . 12,~39
@@ -133,25 +133,25 @@
   (arr 1 +4 4 +5 7 +6)) ,53
  (proc 5 :foo.1.tgekp9q4q1 . . 8
   (typevars 1
-   (typevar :I.0 . . . .) 4
-   (typevar :T.6 . . . .)) 14
+   (typevar :I.0.tgekp9q4q1 . . . .) 4
+   (typevar :T.6.tgekp9q4q1 . . . .)) 14
   (params 1
    (param :x.2 . . 8
-    (array 4 T.6 1 I.0) .)) . . . 33
+    (array 4 T.6.tgekp9q4q1 1 I.0.tgekp9q4q1) .)) . . . 33
   (stmts 
    (discard .))) 3,54
  (call ~3 foo.2.tgekp9q4q1 1 myarr2.0.tgekp9q4q1) ,56
  (proc 5 :identity.0.tgekp9q4q1 . . 13
   (typevars 1
-   (typevar :I.1 . . . .) 4
-   (typevar :T.7 . . . .)) 19
+   (typevar :I.1.tgekp9q4q1 . . . .) 4
+   (typevar :T.7.tgekp9q4q1 . . . .)) 19
   (params 1
    (param :x.3 . . 8
-    (array 4 T.7 1 I.1) .)) 23
-  (array 4 T.7 1 I.1) . . 2,1
+    (array 4 T.7.tgekp9q4q1 1 I.1.tgekp9q4q1) .)) 23
+  (array 4 T.7.tgekp9q4q1 1 I.1.tgekp9q4q1) . . 2,1
   (stmts 7
    (result :result.2 . . 19,~1
-    (array 4 T.7 1 I.1) .) 7
+    (array 4 T.7.tgekp9q4q1 1 I.1.tgekp9q4q1) .) 7
    (asgn ~7 result.2 2 x.3) ~2,~1
    (ret result.2))) 7,58
  (asgn ~7 myarr2.0.tgekp9q4q1 10

--- a/tests/nimony/basics/ttemplate.nif
+++ b/tests/nimony/basics/ttemplate.nif
@@ -15,15 +15,15 @@
  (type :array.0.tte6j7czy 
   (array) 7
   (typevars 1
-   (typevar :Index.0 . . . .) 8
-   (typevar :T.0 . . . .)) 18
+   (typevar :Index.0.tte6j7czy . . . .) 8
+   (typevar :T.0.tte6j7czy . . . .)) 18
   (pragmas 2
    (magic 7 Array)) .) 15,9
  (type ~13 :MyGeneric.0.tte6j7czy . ~4
   (typevars 1
-   (typevar :T.1 . . . .)) . 2
+   (typevar :T.1.tte6j7czy . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tte6j7czy . . 3 T.1 .))) 2,13
+   (fld :x.0.tte6j7czy . . 3 T.1.tte6j7czy .))) 2,13
  (var :myglob.0.tte6j7czy . . 17 MyGeneric.1.tte6j7czy .) 2,14
  (var :other.0.tte6j7czy . . 16 MyGeneric.2.tte6j7czy .) 9,16
  (asgn ~3
@@ -88,12 +88,12 @@
    (magic 7 UInt)) .) ,34
  (template 9 :conv.0.tte6j7czy . . 13
   (typevars 1
-   (typevar :T.2 . . . .)) 16
+   (typevar :T.2.tte6j7czy . . . .)) 16
   (params 1
    (param :x.3 . . ~15,~33
-    (i -1) .)) 10 T.2 . . 30
+    (i -1) .)) 10 T.2.tte6j7czy . . 30
   (stmts 1
-   (conv 1 T.2 1 x.3))) 4,36
+   (conv 1 T.2.tte6j7czy 1 x.3))) 4,36
  (let :val.0.tte6j7czy . .
   (i -1) 6 +123) ,37
  (discard 30,~3

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -147,17 +147,39 @@
     (typedesc 1 T.2) .)) 18 T.2 . . 47
   (stmts 1
    (conv ~10 T.2 1
-    (nil)))) ,19
- (discard 49,~5
-  (stmts "")) ,20
- (discard 43,~18
-  (stmts +0)) ,22
- (discard 47,~5
+    (nil)))) ,20
+ (proc 5 :default.18.tde837gue 
+  (defaultobj) . 13
+  (typevars 1
+   (typevar :T.3 . . 3
+    (typekind 
+     (object)) .)) 24
+  (params 1
+   (param :x.18 . . 11
+    (typedesc 1 T.3) .)) 18 T.3 44
+  (pragmas 2
+   (magic 7 DefaultObj)) . .) ,21
+ (proc 5 :default.19.tde837gue 
+  (defaulttup) . 13
+  (typevars 1
+   (typevar :T.4 . . 8
+    (typekind 
+     (tuple)) .)) 23
+  (params 1
+   (param :x.19 . . 11
+    (typedesc 1 T.4) .)) 18 T.4 43
+  (pragmas 2
+   (magic 7 DefaultTup)) . .) ,23
+ (discard 49,~9
+  (stmts "")) ,24
+ (discard 43,~22
+  (stmts +0)) ,26
+ (discard 47,~9
   (stmts 1
-   (conv ~32,5
-    (ptr ~12,~16,src/nimony/lib/std/system.nim
+   (conv ~32,9
+    (ptr ~12,~20,src/nimony/lib/std/system.nim
      (i -1)) 1
-    (nil)))) 10,23
+    (nil)))) 10,27
  (type ~5 :Enum.0.tde837gue . . . 2
   (enum 5
    (efld :a.0.tde837gue . . Enum.0.tde837gue 
@@ -165,7 +187,30 @@
    (efld :b.0.tde837gue . . Enum.0.tde837gue 
     (tup +1 "b")) 11
    (efld :c.0.tde837gue . . Enum.0.tde837gue 
-    (tup +2 "c")))) ,24
- (discard 48,~9
+    (tup +2 "c")))) ,28
+ (discard 48,~13
   (stmts 1
-   (conv ~34,9 Enum.0.tde837gue 1 +0))))
+   (conv ~34,13 Enum.0.tde837gue 1 +0))) 9,30
+ (type ~4 :Obj.0.tde837gue . . . 2
+  (object . ~9,1
+   (fld :x.0.tde837gue . . 2,~25,src/nimony/lib/std/system.nim
+    (i -1) .) ~9,2
+   (fld :y.0.tde837gue . . 2,12,src/nimony/lib/std/system.nim
+    (string) .) ~9,3
+   (fld :z.0.tde837gue . . 3
+    (tuple 6
+     (fld :a.1.tde837gue . . 17,27,src/nimony/lib/std/system.nim
+      (bool) .) 15
+     (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,35
+ (discard 15
+  (obj 1 Obj.0.tde837gue 
+   (kv ~13,~4 :x.0.tde837gue 28,~33
+    (stmts +0)) 
+   (kv ~13,~3 :y.0.tde837gue 34,~21
+    (stmts "")) 
+   (kv ~13,~2 :z.0.tde837gue 
+    (tup 30,~35
+     (stmts ~45,32,src/nimony/lib/std/system.nim
+      (false)) 33,~20
+     (stmts 1
+      (conv ~34,13 Enum.0.tde837gue 1 +0)))))))

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -81,4 +81,26 @@
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~6 MyObject.0.tde837gue 2
    (kv ~2 x.1.tde837gue 2 +123) 10
-   (kv ~10 y.1.tde837gue 2 +456))))
+   (kv ~10 y.1.tde837gue 2 +456))) ,29
+ (template 9 :resem.0.tde837gue . . . 14
+  (params) . . . 2,1
+  (stmts 7
+   (asgn ~7 global.0.tde837gue 10
+    (obj ~7,~8 MyObject.0.tde837gue 2
+     (kv ~2 x.1.tde837gue 2 +123) 
+     (kv ~12,~10 :y.1.tde837gue 33,676,src/nimony/lib/std/system.nim
+      (stmts +0)))) 7,1
+   (asgn ~7 global.0.tde837gue 10
+    (obj ~7,~9 MyObject.0.tde837gue 2
+     (kv ~2 x.1.tde837gue 2 +123) 10
+     (kv ~10 y.1.tde837gue 2 +456))))) 2,30
+ (stmts 7
+  (asgn ~7 global.0.tde837gue 10
+   (obj ~7,~8 MyObject.0.tde837gue 2
+    (kv ~2 x.1.tde837gue 2 +123) 
+    (kv y.1.tde837gue 33,676,src/nimony/lib/std/system.nim
+     (stmts +0)))) 7,1
+  (asgn ~7 global.0.tde837gue 10
+   (obj ~7,~9 MyObject.0.tde837gue 2
+    (kv ~2 x.1.tde837gue 2 +123) 10
+    (kv ~10 y.1.tde837gue 2 +456)))))

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -1,185 +1,15 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tdefault.nim(stmts 
- (template 9 :default.0.tde837gue x . . 17
-  (params 1
-   (param :x.0 . . 11
-    (typedesc ~1,60,src/nimony/lib/std/system.nim
-     (bool)) .)) 28,60,src/nimony/lib/std/system.nim
-  (bool) . . 45
-  (stmts ~45,32,src/nimony/lib/std/system.nim
-   (false))) ,1
- (template 9 :default.1.tde837gue x . . 17
-  (params 1
-   (param :x.1 . . 11
-    (typedesc ~25,41,src/nimony/lib/std/system.nim
-     (c +8)) .)) 4,41,src/nimony/lib/std/system.nim
-  (c +8) . . 45
-  (stmts '\00')) ,2
- (template 9 :default.2.tde837gue x . . 17
-  (params 1
-   (param :x.2 . . 11
-    (typedesc ~25,4,src/nimony/lib/std/system.nim
-     (i -1)) .)) 4,4,src/nimony/lib/std/system.nim
-  (i -1) . . 43
+ (discard 58,730,src/nimony/lib/std/system.nim
+  (stmts "")) ,1
+ (discard 52,705,src/nimony/lib/std/system.nim
   (stmts +0)) ,3
- (template 9 :default.3.tde837gue x . . 17
-  (params 1
-   (param :x.3 . . 11
-    (typedesc ~25,15,src/nimony/lib/std/system.nim
-     (u -1)) .)) 4,15,src/nimony/lib/std/system.nim
-  (u -1) . . 45
-  (stmts +0u)) ,4
- (template 9 :default.4.tde837gue x . . 17
-  (params 1
-   (param :x.4 . . 11
-    (typedesc ~25,6,src/nimony/lib/std/system.nim
-     (i +8)) .)) 4,6,src/nimony/lib/std/system.nim
-  (i +8) . . 45
-  (stmts 
-   (suf +0 "i8"))) ,5
- (template 9 :default.5.tde837gue x . . 17
-  (params 1
-   (param :x.5 . . 11
-    (typedesc ~25,15,src/nimony/lib/std/system.nim
-     (u +8)) .)) 4,15,src/nimony/lib/std/system.nim
-  (u +8) . . 47
-  (stmts 
-   (suf +0u "u8"))) ,6
- (template 9 :default.6.tde837gue x . . 17
-  (params 1
-   (param :x.6 . . 11
-    (typedesc ~25,6,src/nimony/lib/std/system.nim
-     (i +16)) .)) 4,6,src/nimony/lib/std/system.nim
-  (i +16) . . 47
-  (stmts 
-   (suf +0 "i16"))) ,7
- (template 9 :default.7.tde837gue x . . 17
-  (params 1
-   (param :x.7 . . 11
-    (typedesc ~25,15,src/nimony/lib/std/system.nim
-     (u +16)) .)) 4,15,src/nimony/lib/std/system.nim
-  (u +16) . . 49
-  (stmts 
-   (suf +0u "u16"))) ,8
- (template 9 :default.8.tde837gue x . . 17
-  (params 1
-   (param :x.8 . . 11
-    (typedesc ~25,6,src/nimony/lib/std/system.nim
-     (i +32)) .)) 4,6,src/nimony/lib/std/system.nim
-  (i +32) . . 47
-  (stmts 
-   (suf +0 "i32"))) ,9
- (template 9 :default.9.tde837gue x . . 17
-  (params 1
-   (param :x.9 . . 11
-    (typedesc ~25,15,src/nimony/lib/std/system.nim
-     (u +32)) .)) 4,15,src/nimony/lib/std/system.nim
-  (u +32) . . 49
-  (stmts 
-   (suf +0u "u32"))) ,10
- (template 9 :default.10.tde837gue x . . 17
-  (params 1
-   (param :x.10 . . 11
-    (typedesc ~25,6,src/nimony/lib/std/system.nim
-     (i +64)) .)) 4,6,src/nimony/lib/std/system.nim
-  (i +64) . . 47
-  (stmts 
-   (suf +0 "i64"))) ,11
- (template 9 :default.11.tde837gue x . . 17
-  (params 1
-   (param :x.11 . . 11
-    (typedesc ~25,15,src/nimony/lib/std/system.nim
-     (u +64)) .)) 4,15,src/nimony/lib/std/system.nim
-  (u +64) . . 49
-  (stmts 
-   (suf +0u "u64"))) ,12
- (template 9 :default.12.tde837gue x . . 17
-  (params 1
-   (param :x.12 . . 11
-    (typedesc ~25,22,src/nimony/lib/std/system.nim
-     (f +32)) .)) 4,22,src/nimony/lib/std/system.nim
-  (f +32) . . 51
-  (stmts 
-   (suf +0.0 "f32"))) ,13
- (template 9 :default.13.tde837gue x . . 17
-  (params 1
-   (param :x.13 . . 11
-    (typedesc ~25,23,src/nimony/lib/std/system.nim
-     (f +64)) .)) 4,23,src/nimony/lib/std/system.nim
-  (f +64) . . 51
-  (stmts 
-   (suf +0.0 "f64"))) ,14
- (template 9 :default.14.tde837gue x . . 17
-  (params 1
-   (param :x.14 . . 11
-    (typedesc ~25,30,src/nimony/lib/std/system.nim
-     (string)) .)) 4,30,src/nimony/lib/std/system.nim
-  (string) . . 49
-  (stmts "")) ,15
- (template 9 :default.15.tde837gue x . 17
-  (typevars 1
-   (typevar :T.0 . . 3
-    (typekind 
-     (enum)) .)) 26
-  (params 1
-   (param :x.15 . . 11
-    (typedesc 1 T.0) .)) 18 T.0 . . 48
+ (discard 56,733,src/nimony/lib/std/system.nim
   (stmts 1
-   (conv ~10 T.0 1 +0))) ,17
- (template 9 :default.16.tde837gue x . 17
-  (typevars 1
-   (typevar :T.1 . . 3
-    (typekind 
-     (ptr)) .)) 25
-  (params 1
-   (param :x.16 . . 11
-    (typedesc 1 T.1) .)) 18 T.1 . . 47
-  (stmts 1
-   (conv ~10 T.1 1
-    (nil)))) ,18
- (template 9 :default.17.tde837gue x . 17
-  (typevars 1
-   (typevar :T.2 . . 3
-    (typekind 
-     (ref)) .)) 25
-  (params 1
-   (param :x.17 . . 11
-    (typedesc 1 T.2) .)) 18 T.2 . . 47
-  (stmts 1
-   (conv ~10 T.2 1
-    (nil)))) ,20
- (proc 5 :default.18.tde837gue 
-  (defaultobj) . 13
-  (typevars 1
-   (typevar :T.3 . . 3
-    (typekind 
-     (object)) .)) 24
-  (params 1
-   (param :x.18 . . 11
-    (typedesc 1 T.3) .)) 18 T.3 44
-  (pragmas 2
-   (magic 7 DefaultObj)) . .) ,21
- (proc 5 :default.19.tde837gue 
-  (defaulttup) . 13
-  (typevars 1
-   (typevar :T.4 . . 8
-    (typekind 
-     (tuple)) .)) 23
-  (params 1
-   (param :x.19 . . 11
-    (typedesc 1 T.4) .)) 18 T.4 43
-  (pragmas 2
-   (magic 7 DefaultTup)) . .) ,23
- (discard 49,~9
-  (stmts "")) ,24
- (discard 43,~22
-  (stmts +0)) ,26
- (discard 47,~9
-  (stmts 1
-   (conv ~32,9
-    (ptr ~12,~20,src/nimony/lib/std/system.nim
+   (conv ~41,~733,tests/nimony/sysbasics/tdefault.nim
+    (ptr ~12,3,src/nimony/lib/std/system.nim
      (i -1)) 1
-    (nil)))) 10,27
+    (nil)))) 10,4
  (type ~5 :Enum.0.tde837gue . . . 2
   (enum 5
    (efld :a.0.tde837gue . . Enum.0.tde837gue 
@@ -187,30 +17,68 @@
    (efld :b.0.tde837gue . . Enum.0.tde837gue 
     (tup +1 "b")) 11
    (efld :c.0.tde837gue . . Enum.0.tde837gue 
-    (tup +2 "c")))) ,28
- (discard 48,~13
+    (tup +2 "c")))) ,5
+ (discard 57,727,src/nimony/lib/std/system.nim
   (stmts 1
-   (conv ~34,13 Enum.0.tde837gue 1 +0))) 9,30
+   (conv ~43,~727,tests/nimony/sysbasics/tdefault.nim Enum.0.tde837gue 1 +0))) 9,7
  (type ~4 :Obj.0.tde837gue . . . 2
   (object . ~9,1
-   (fld :x.0.tde837gue . . 2,~25,src/nimony/lib/std/system.nim
+   (fld :x.0.tde837gue . . 2,~2,src/nimony/lib/std/system.nim
     (i -1) .) ~9,2
-   (fld :y.0.tde837gue . . 2,12,src/nimony/lib/std/system.nim
+   (fld :y.0.tde837gue . . 2,35,src/nimony/lib/std/system.nim
     (string) .) ~9,3
    (fld :z.0.tde837gue . . 3
     (tuple 6
-     (fld :a.1.tde837gue . . 17,27,src/nimony/lib/std/system.nim
+     (fld :a.1.tde837gue . . 17,50,src/nimony/lib/std/system.nim
       (bool) .) 15
-     (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,35
+     (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,12
  (discard 15
   (obj 1 Obj.0.tde837gue 
-   (kv ~13,~4 :x.0.tde837gue 28,~33
+   (kv ~13,~4 :x.0.tde837gue 37,694,src/nimony/lib/std/system.nim
     (stmts +0)) 
-   (kv ~13,~3 :y.0.tde837gue 34,~21
+   (kv ~13,~3 :y.0.tde837gue 43,718,src/nimony/lib/std/system.nim
     (stmts "")) 
    (kv ~13,~2 :z.0.tde837gue 
-    (tup 30,~35
-     (stmts ~45,32,src/nimony/lib/std/system.nim
-      (false)) 33,~20
+    (tup 39,690,src/nimony/lib/std/system.nim
+     (stmts ~33,~320
+      (false)) 42,720,src/nimony/lib/std/system.nim
      (stmts 1
-      (conv ~34,13 Enum.0.tde837gue 1 +0)))))))
+      (conv ~43,~727,tests/nimony/sysbasics/tdefault.nim Enum.0.tde837gue 1 +0)))))) ,14
+ (proc 5 :foo.0.tde837gue . . . 8
+  (params 1
+   (param :x.0 . . ~5,~8,src/nimony/lib/std/system.nim
+    (i -1) .) 9
+   (param :y.0 . . ~13,30,src/nimony/lib/std/system.nim
+    (string) .)) 4,~8,src/nimony/lib/std/system.nim
+  (i -1) . . 2,1
+  (stmts 4
+   (result :result.0 . . ~2,~9,src/nimony/lib/std/system.nim
+    (i -1) .) 4
+   (var :x.1 . .
+    (string) 4 "abc") 7,1
+   (asgn ~7 result.0 2 +4) ~2,~1
+   (ret result.0))) 11,19
+ (type ~9 :MyObject.0.tde837gue . . . 2
+  (object . ~9,1
+   (fld :x.1.tde837gue . . ,~14,src/nimony/lib/std/system.nim
+    (i -1) .) ~6,1
+   (fld :y.1.tde837gue . . ~3,~14,src/nimony/lib/std/system.nim
+    (i -1) .))) 4,22
+ (var :global.0.tde837gue . . 8 MyObject.0.tde837gue .) 9,24
+ (asgn ~3
+  (dot ~6 global.0.tde837gue x.1.tde837gue +0) 2 +45) ,25
+ (discard 11
+  (call ~3 foo.0.tde837gue 7
+   (dot ~6 global.0.tde837gue x.1.tde837gue +0) 11 "123")) ,26
+ (discard 20
+  (call ~3 foo.0.tde837gue ~6
+   (dot ~6 global.0.tde837gue x.1.tde837gue +0) 1 "123")) 7,27
+ (asgn ~7 global.0.tde837gue 10
+  (obj ~5,~5 MyObject.0.tde837gue 2
+   (kv ~2 x.1.tde837gue 2 +123) 
+   (kv ~10,~7 :y.1.tde837gue 35,679,src/nimony/lib/std/system.nim
+    (stmts +0)))) 7,28
+ (asgn ~7 global.0.tde837gue 10
+  (obj ~5,~6 MyObject.0.tde837gue 2
+   (kv ~2 x.1.tde837gue 2 +123) 10
+   (kv ~10 y.1.tde837gue 2 +456))))

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -17,13 +17,13 @@
    (efld :b.0.tde837gue . . Enum.0.tde837gue 
     (tup +1 "b")) 11
    (efld :c.0.tde837gue . . Enum.0.tde837gue 
-    (tup +2 "c")))) 5,23
+    (tup +2 "c")))) 5,4
  (proc :dollar`.Enum.0.tde837gue x . . 
   (params 
    (param :e . . Enum.0.tde837gue .))
   (string) . . 
   (stmts 7
-   (result :result.0 . . ~8,21,src/nimony/lib/std/system.nim
+   (result :result.0 . .
     (string) .) 7
    (case e 5
     (of 
@@ -38,8 +38,8 @@
      (set c.0.tde837gue) 
      (stmts 
       (ret "c"))))
-   (ret result.0))) ,24
- (discard 48,~9
+   (ret result.0))) ,5
+ (discard 57,727,src/nimony/lib/std/system.nim
   (stmts 1
    (conv ~43,~727,tests/nimony/sysbasics/tdefault.nim Enum.0.tde837gue 1 +0))) 9,7
  (type ~4 :Obj.0.tde837gue . . . 2
@@ -73,12 +73,12 @@
     (string) .)) 4,~8,src/nimony/lib/std/system.nim
   (i -1) . . 2,1
   (stmts 4
-   (result :result.0 . . ~2,~9,src/nimony/lib/std/system.nim
+   (result :result.1 . . ~2,~9,src/nimony/lib/std/system.nim
     (i -1) .) 4
    (var :x.1 . .
     (string) 4 "abc") 7,1
-   (asgn ~7 result.0 2 +4) ~2,~1
-   (ret result.0))) 11,19
+   (asgn ~7 result.1 2 +4) ~2,~1
+   (ret result.1))) 11,19
  (type ~9 :MyObject.0.tde837gue . . . 2
   (object . ~9,1
    (fld :x.1.tde837gue . . ,~14,src/nimony/lib/std/system.nim

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -1,26 +1,3 @@
-template default*(x: typedesc[bool]): bool = false
-template default*(x: typedesc[char]): char = '\0'
-template default*(x: typedesc[int]): int = 0
-template default*(x: typedesc[uint]): uint = 0'u
-template default*(x: typedesc[int8]): int8 = 0'i8
-template default*(x: typedesc[uint8]): uint8 = 0'u8
-template default*(x: typedesc[int16]): int16 = 0'i16
-template default*(x: typedesc[uint16]): uint16 = 0'u16
-template default*(x: typedesc[int32]): int32 = 0'i32
-template default*(x: typedesc[uint32]): uint32 = 0'u32
-template default*(x: typedesc[int64]): int64 = 0'i64
-template default*(x: typedesc[uint64]): uint64 = 0'u64
-template default*(x: typedesc[float32]): float32 = 0.0'f32
-template default*(x: typedesc[float64]): float64 = 0.0'f64
-template default*(x: typedesc[string]): string = ""
-template default*[T: enum](x: typedesc[T]): T = T(0)
-
-template default*[T: ptr](x: typedesc[T]): T = T(nil)
-template default*[T: ref](x: typedesc[T]): T = T(nil)
-
-proc default*[T: object](x: typedesc[T]): T {.magic: DefaultObj.}
-proc default*[T: tuple](x: typedesc[T]): T {.magic: DefaultTup.}
-
 discard default(string)
 discard default(int)
 
@@ -34,3 +11,19 @@ type Obj = object
   z: tuple[a: bool, b: Enum]
 
 discard default(Obj)
+
+proc foo(x: int; y: string): int =
+  var x = "abc"
+  result = 4
+
+type
+  MyObject = object
+    x, y: int
+
+var global: MyObject
+
+global.x = 45
+discard foo(global.x, "123")
+discard global.x.foo("123")
+global = MyObject(x: 123)
+global = MyObject(x: 123, y: 456)

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -27,3 +27,7 @@ discard foo(global.x, "123")
 discard global.x.foo("123")
 global = MyObject(x: 123)
 global = MyObject(x: 123, y: 456)
+template resem() =
+  global = MyObject(x: 123)
+  global = MyObject(x: 123, y: 456)
+resem()

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -17,9 +17,20 @@ template default*[T: enum](x: typedesc[T]): T = T(0)
 
 template default*[T: ptr](x: typedesc[T]): T = T(nil)
 template default*[T: ref](x: typedesc[T]): T = T(nil)
+
+proc default*[T: object](x: typedesc[T]): T {.magic: DefaultObj.}
+proc default*[T: tuple](x: typedesc[T]): T {.magic: DefaultTup.}
+
 discard default(string)
 discard default(int)
 
 discard default(ptr int)
 type Enum = enum a, b, c
 discard default(Enum)
+
+type Obj = object
+  x: int
+  y: string
+  z: tuple[a: bool, b: Enum]
+
+discard default(Obj)


### PR DESCRIPTION
closes #276

Object constructors and the default object magic both build an object constructor containing every field in the object constructor: first starting with the fields of the most shallow base type of the object type (if it exists), then of its base type and so on, and finally adding the fields from the original object type. This order is the same one used in the VM in the old compiler, could be changed.

Object constructors build a table of the given field assignments first, then when the output object constructor is being built, the table is looked up for each field to see if it has been set and the assignment is used if it has. I'm not sure what the optimal way to do this is. Currently it looks up the object fields when initially going through the object constructor and maps the assignment to the field symbol ID. We could also map to the field name strings as well which would save iterations over the fields, this would require that we get the basename from each field and look that up when building the output object constructor (and don't bother when the field table is empty). But maybe it has pitfalls, it's not 1-to-1 with the field access syntax so I didn't start with it. I'm guessing we should optimize for most of the object fields being set in the constructor since this is going to be the case for typed AST and is reasonable enough for user code as well. ~~I would guess the second option is better for this but~~ maybe there's some method I'm not seeing.

Edit: Mapping to the symbol IDs is probably better for typed AST if we add the symbol IDs directly for symbol tokens. Now, it checks if the symbol token is a field symbol, and uses it directly for the mapping if it is (otherwise converts it to an identifier and looks it up). If we want to protect against field symbols belonging to other objects (after macro manipulation for example) then maybe we can build the set of field symbol IDs by iterating over the object type first.

Typevar symbols are also declared globally now for generic procs in system to work, it could be restricted to typevars in exported routines/types but maybe this would be too complex or incorrect.