### PR TITLE
implement low/high as magic

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -217,7 +217,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
     inc c
   of ParLe:
     case c.typeKind
-    of NoType, OrT, AndT, NotT, TypedescT, UntypedT, TypedT, TypeKindT:
+    of NoType, OrT, AndT, NotT, TypedescT, UntypedT, TypedT, TypeKindT, OrdinalT:
       error e, "type expected but got: ", c
     of IntT, UIntT, FloatT, CharT, BoolT, AutoT, SymKindT:
       e.loop c:

--- a/src/nimony/lib/std/system.nim
+++ b/src/nimony/lib/std/system.nim
@@ -50,6 +50,7 @@ proc `xor`*(x, y: bool): bool {.magic: "Xor", noSideEffect.}
 
 type
   untyped* {.magic: Expr.}
+  typed* {.magic: Stmt.}
 
 iterator unpack*(): untyped {.magic: Unpack.}
 
@@ -306,6 +307,9 @@ template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
 
+proc low*[T](x: typedesc[T]): typed {.magic: Low.}
+proc high*[T](x: typedesc[T]): typed {.magic: High.}
+
 template default*(x: typedesc[bool]): bool = false
 template default*(x: typedesc[char]): char = '\0'
 template default*(x: typedesc[int]): int = 0
@@ -321,7 +325,7 @@ template default*(x: typedesc[uint64]): uint64 = 0'u64
 template default*(x: typedesc[float32]): float32 = 0.0'f32
 template default*(x: typedesc[float64]): float64 = 0.0'f64
 template default*(x: typedesc[string]): string = ""
-template default*[T: enum](x: typedesc[T]): T = T(0)
+template default*[T: enum](x: typedesc[T]): T = low(T)
 
 template default*[T: ptr](x: typedesc[T]): T = T(nil)
 template default*[T: ref](x: typedesc[T]): T = T(nil)

--- a/src/nimony/lib/std/system.nim
+++ b/src/nimony/lib/std/system.nim
@@ -59,6 +59,22 @@ proc unpackToCall(fn: untyped) {.magic: Unpack.}
 const
   isMainModule* {.magic: "IsMainModule".}: bool = false
 
+type
+  Ordinal*[T] {.magic: Ordinal.} ## Generic ordinal type. Includes integer,
+                                  ## bool, character, and enumeration types
+                                  ## as well as their subtypes. See also
+                                  ## `SomeOrdinal`.
+
+type
+  range*[T]{.magic: "Range".}         ## Generic type to construct range types.
+  array*[I, T]{.magic: "Array".}      ## Generic type to construct
+                                      ## fixed-length arrays.
+
+proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect.}
+proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
+proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffect.}
+proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
+
 # integer calculations:
 proc `+`*(x: int8): int8 {.magic: "UnaryPlusI", noSideEffect.}
 proc `+`*(x: int16): int16 {.magic: "UnaryPlusI", noSideEffect.}
@@ -306,9 +322,6 @@ template `>=`*(x, y: untyped): untyped =
 template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
-
-proc low*[T](x: typedesc[T]): typed {.magic: Low.}
-proc high*[T](x: typedesc[T]): typed {.magic: High.}
 
 template default*(x: typedesc[bool]): bool = false
 template default*(x: typedesc[char]): char = '\0'

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -139,6 +139,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mDistinct: res DistinctT
   of mVoid: res VoidT
   of mTuple: res TupleT
+  of mOrdinal: res OrdinalT
   of mIterableType: res IterT
   of mInt: res IntT, -1
   of mInt8: res IntT, 8

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -183,6 +183,7 @@ type
     TypedT = "typed"
     CstringT = "cstring"
     PointerT = "pointer"
+    OrdinalT = "ordinal"
 
   PragmaKind* = enum
     NoPragma

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3624,14 +3624,8 @@ proc buildLowValue(c: var SemContext; typ: Cursor; info: PackedLineInfo) =
       var field = asEnumDecl(decl.body).firstField
       let first = asLocal(field)
       c.dest.add first.name
-    of DistinctT:
-      c.dest.addParLe(DconvX, info)
-      var baseType = decl.body
-      inc baseType # skip distinct tag
-      buildLowValue c, baseType, info
-      c.dest.addParRi()
     else:
-      buildLowValue c, decl.body, info
+      c.buildErr info, "invalid type for low: " & typeToString(typ)
   of ParLe:
     case typ.typeKind
     of IntT:
@@ -3713,14 +3707,8 @@ proc buildHighValue(c: var SemContext; typ: Cursor; info: PackedLineInfo) =
         skip field
       let last = asLocal(lastField)
       c.dest.add last.name
-    of DistinctT:
-      c.dest.addParLe(DconvX, info)
-      var baseType = decl.body
-      inc baseType # skip distinct tag
-      buildHighValue c, baseType, info
-      c.dest.addParRi()
     else:
-      buildHighValue c, decl.body, info
+      c.buildErr info, "invalid type for high: " & typeToString(typ)
   of ParLe:
     case typ.typeKind
     of IntT:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -165,6 +165,8 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
     var aTag = a
     if a.kind == Symbol:
       aTag = typeImpl(a.symId)
+    if aTag.typeKind == TypeKindT:
+      inc aTag
     inc f
     assert f.kind == ParLe
     result = aTag.kind == ParLe and f.tagId == aTag.tagId
@@ -173,6 +175,9 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
     inc f
     assert f.kind == ParRi
     inc f
+  of OrdinalT:
+    result = isOrdinalType(a)
+    skip f
   else:
     result = false
 
@@ -496,7 +501,7 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
           # len(a) > len(f)
           m.error expected(fOrig, aOrig)
     of NoType, ObjectT, EnumT, HoleyEnumT, VoidT, OutT, LentT, SinkT, NilT, OrT, AndT, NotT,
-        ConceptT, DistinctT, StaticT, ProcT, IterT, AutoT, SymKindT, TypeKindT:
+        ConceptT, DistinctT, StaticT, ProcT, IterT, AutoT, SymKindT, TypeKindT, OrdinalT:
       m.error "BUG: unhandled type: " & pool.tags[f.tagId]
   else:
     m.error "BUG: " & expected(f, arg.typ)

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -1,12 +1,12 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tdefault.nim(stmts 
- (discard 58,644,src/nimony/lib/std/system.nim
+ (discard 58,652,src/nimony/lib/std/system.nim
   (stmts "")) ,1
- (discard 52,619,src/nimony/lib/std/system.nim
+ (discard 52,627,src/nimony/lib/std/system.nim
   (stmts +0)) ,3
- (discard 56,647,src/nimony/lib/std/system.nim
+ (discard 56,655,src/nimony/lib/std/system.nim
   (stmts 1
-   (conv ~41,~647,tests/nimony/sysbasics/tdefault.nim
+   (conv ~41,~655,tests/nimony/sysbasics/tdefault.nim
     (ptr ~12,3,src/nimony/lib/std/system.nim
      (i -1)) 1
     (nil)))) 10,4
@@ -39,9 +39,8 @@
      (stmts 
       (ret "c"))))
    (ret result.0))) ,5
- (discard 57,641,src/nimony/lib/std/system.nim
-  (stmts 1
-   (conv ~43,~641,tests/nimony/sysbasics/tdefault.nim Enum.0.tde837gue 1 +0))) 9,7
+ (discard 57,649,src/nimony/lib/std/system.nim
+  (stmts ~40,~650,tests/nimony/sysbasics/tdefault.nim :a.0.tde837gue)) 9,7
  (type ~4 :Obj.0.tde837gue . . . 2
   (object . ~9,1
    (fld :x.0.tde837gue . . 2,~2,src/nimony/lib/std/system.nim
@@ -55,16 +54,15 @@
      (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,12
  (discard 15
   (obj 1 Obj.0.tde837gue 
-   (kv ~13,~4 :x.0.tde837gue 37,608,src/nimony/lib/std/system.nim
+   (kv ~13,~4 :x.0.tde837gue 37,616,src/nimony/lib/std/system.nim
     (stmts +0)) 
-   (kv ~13,~3 :y.0.tde837gue 43,632,src/nimony/lib/std/system.nim
+   (kv ~13,~3 :y.0.tde837gue 43,640,src/nimony/lib/std/system.nim
     (stmts "")) 
    (kv ~13,~2 :z.0.tde837gue 
-    (tup 39,604,src/nimony/lib/std/system.nim
-     (stmts ~33,~277
-      (false)) 42,634,src/nimony/lib/std/system.nim
-     (stmts 1
-      (conv ~43,~641,tests/nimony/sysbasics/tdefault.nim Enum.0.tde837gue 1 +0)))))) ,14
+    (tup 39,612,src/nimony/lib/std/system.nim
+     (stmts ~33,~281
+      (false)) 42,642,src/nimony/lib/std/system.nim
+     (stmts ~40,~650,tests/nimony/sysbasics/tdefault.nim :a.0.tde837gue))))) ,14
  (proc 5 :foo.0.tde837gue . . . 8
   (params 1
    (param :x.0 . . ~5,~8,src/nimony/lib/std/system.nim
@@ -97,7 +95,7 @@
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~5 MyObject.0.tde837gue 2
    (kv ~2 x.1.tde837gue 2 +123) 
-   (kv ~10,~7 :y.1.tde837gue 35,593,src/nimony/lib/std/system.nim
+   (kv ~10,~7 :y.1.tde837gue 35,601,src/nimony/lib/std/system.nim
     (stmts +0)))) 7,28
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~6 MyObject.0.tde837gue 2
@@ -109,7 +107,7 @@
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~8 MyObject.0.tde837gue 2
      (kv ~2 x.1.tde837gue 2 +123) 
-     (kv ~12,~10 :y.1.tde837gue 33,590,src/nimony/lib/std/system.nim
+     (kv ~12,~10 :y.1.tde837gue 33,598,src/nimony/lib/std/system.nim
       (stmts +0)))) 7,1
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~9 MyObject.0.tde837gue 2
@@ -119,7 +117,7 @@
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~8 MyObject.0.tde837gue 2
     (kv ~2 x.1.tde837gue 2 +123) 
-    (kv y.1.tde837gue 33,590,src/nimony/lib/std/system.nim
+    (kv y.1.tde837gue 33,598,src/nimony/lib/std/system.nim
      (stmts +0)))) 7,1
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~9 MyObject.0.tde837gue 2

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -1,12 +1,12 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tdefault.nim(stmts 
- (discard 58,652,src/nimony/lib/std/system.nim
+ (discard 58,678,src/nimony/lib/std/system.nim
   (stmts "")) ,1
- (discard 52,627,src/nimony/lib/std/system.nim
+ (discard 52,653,src/nimony/lib/std/system.nim
   (stmts +0)) ,3
- (discard 56,655,src/nimony/lib/std/system.nim
+ (discard 56,681,src/nimony/lib/std/system.nim
   (stmts 1
-   (conv ~41,~655,tests/nimony/sysbasics/tdefault.nim
+   (conv ~41,~681,tests/nimony/sysbasics/tdefault.nim
     (ptr ~12,3,src/nimony/lib/std/system.nim
      (i -1)) 1
     (nil)))) 10,4
@@ -39,8 +39,8 @@
      (stmts 
       (ret "c"))))
    (ret result.0))) ,5
- (discard 57,649,src/nimony/lib/std/system.nim
-  (stmts ~40,~650,tests/nimony/sysbasics/tdefault.nim :a.0.tde837gue)) 9,7
+ (discard 57,675,src/nimony/lib/std/system.nim
+  (stmts ~40,~676,tests/nimony/sysbasics/tdefault.nim :a.0.tde837gue)) 9,7
  (type ~4 :Obj.0.tde837gue . . . 2
   (object . ~9,1
    (fld :x.0.tde837gue . . 2,~2,src/nimony/lib/std/system.nim
@@ -54,15 +54,15 @@
      (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,12
  (discard 15
   (obj 1 Obj.0.tde837gue 
-   (kv ~13,~4 :x.0.tde837gue 37,616,src/nimony/lib/std/system.nim
+   (kv ~13,~4 :x.0.tde837gue 37,642,src/nimony/lib/std/system.nim
     (stmts +0)) 
-   (kv ~13,~3 :y.0.tde837gue 43,640,src/nimony/lib/std/system.nim
+   (kv ~13,~3 :y.0.tde837gue 43,666,src/nimony/lib/std/system.nim
     (stmts "")) 
    (kv ~13,~2 :z.0.tde837gue 
-    (tup 39,612,src/nimony/lib/std/system.nim
-     (stmts ~33,~281
-      (false)) 42,642,src/nimony/lib/std/system.nim
-     (stmts ~40,~650,tests/nimony/sysbasics/tdefault.nim :a.0.tde837gue))))) ,14
+    (tup 39,638,src/nimony/lib/std/system.nim
+     (stmts ~33,~294
+      (false)) 42,668,src/nimony/lib/std/system.nim
+     (stmts ~40,~676,tests/nimony/sysbasics/tdefault.nim :a.0.tde837gue))))) ,14
  (proc 5 :foo.0.tde837gue . . . 8
   (params 1
    (param :x.0 . . ~5,~8,src/nimony/lib/std/system.nim
@@ -95,7 +95,7 @@
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~5 MyObject.0.tde837gue 2
    (kv ~2 x.1.tde837gue 2 +123) 
-   (kv ~10,~7 :y.1.tde837gue 35,601,src/nimony/lib/std/system.nim
+   (kv ~10,~7 :y.1.tde837gue 35,627,src/nimony/lib/std/system.nim
     (stmts +0)))) 7,28
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~6 MyObject.0.tde837gue 2
@@ -107,7 +107,7 @@
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~8 MyObject.0.tde837gue 2
      (kv ~2 x.1.tde837gue 2 +123) 
-     (kv ~12,~10 :y.1.tde837gue 33,598,src/nimony/lib/std/system.nim
+     (kv ~12,~10 :y.1.tde837gue 33,624,src/nimony/lib/std/system.nim
       (stmts +0)))) 7,1
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~9 MyObject.0.tde837gue 2
@@ -117,7 +117,7 @@
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~8 MyObject.0.tde837gue 2
     (kv ~2 x.1.tde837gue 2 +123) 
-    (kv y.1.tde837gue 33,598,src/nimony/lib/std/system.nim
+    (kv y.1.tde837gue 33,624,src/nimony/lib/std/system.nim
      (stmts +0)))) 7,1
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~9 MyObject.0.tde837gue 2


### PR DESCRIPTION
Currently entirely a magic unlike `default` for a couple reasons:

* The overload for either `int` and `uint` would be hard to represent at this point
* Enums and range types require the use of a magic
* The original overloads also use a magic

