### PR TITLE
add back base types to enums

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -318,6 +318,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
     of EnumT, HoleyEnumT:
       e.dest.add tagToken("enum", c.info)
       inc c
+      traverseType e, c, flags # base type
 
       var fields = createTokenBuf()
       var commonType = createTokenBuf()

--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -180,7 +180,7 @@ proc traverseField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
   inc c # skips value
   wantParRi e, c
 
-proc traverseEnumField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}): TokenBuf =
+proc traverseEnumField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
   e.dest.add c # efld
   inc c
 
@@ -193,11 +193,8 @@ proc traverseEnumField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}
 
   skip c # pragmas: must be empty
 
-  result = createTokenBuf()
 
-  swap(e.dest, result)
-  traverseType e, c, flags
-  swap(result, e.dest)
+  skip c # type: must be the enum itself
 
   inc c # skips TupleConstr
   traverseExpr e, c
@@ -320,16 +317,8 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
       inc c
       traverseType e, c, flags # base type
 
-      var fields = createTokenBuf()
-      var commonType = createTokenBuf()
-
-      swap(e.dest, fields)
       while c.substructureKind == EfldS:
-        commonType = traverseEnumField(e, c, flags)
-      swap(fields, e.dest)
-
-      e.dest.add commonType
-      e.dest.add fields
+        traverseEnumField(e, c, flags)
 
       wantParRi e, c
     of VoidT, StringT, VarargsT, NilT, ConceptT,

--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -343,7 +343,7 @@ proc genEnumDecl(c: var GeneratedCode; t: TypeGraph; n: NodePos; name: string) =
   c.add Semicolon
   c.add NewLine
 
-  for ch in sonsFromX(t, n, 2):
+  for ch in sonsFromX(t, n):
     if t[ch].kind == EfldC:
       let (a, b) = sons2(t, ch)
       if t[a].kind == SymDef:

--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -343,7 +343,7 @@ proc genEnumDecl(c: var GeneratedCode; t: TypeGraph; n: NodePos; name: string) =
   c.add Semicolon
   c.add NewLine
 
-  for ch in sonsFromX(t, n):
+  for ch in sonsFromX(t, n, 2):
     if t[ch].kind == EfldC:
       let (a, b) = sons2(t, ch)
       if t[a].kind == SymDef:

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -397,6 +397,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
     c.b.addTree("enum")
     if n.len > 0:
       assert n[0].kind == nkEmpty
+      c.b.addEmpty # base type
     for i in 1..<n.len:
       let it = n[i]
 

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -129,6 +129,7 @@ proc asObjectDecl*(c: Cursor): ObjectDecl =
 type
   EnumDecl* = object
     kind*: TypeKind
+    baseType*: Cursor
     firstField*: Cursor
 
 proc asEnumDecl*(c: Cursor): EnumDecl =
@@ -137,6 +138,8 @@ proc asEnumDecl*(c: Cursor): EnumDecl =
   result = EnumDecl(kind: kind)
   if kind in {EnumT, HoleyEnumT}:
     inc c
+    result.baseType = c
+    skip c
     result.firstField = c
 
 type

--- a/src/nimony/enumtostr.nim
+++ b/src/nimony/enumtostr.nim
@@ -10,6 +10,7 @@ proc genEnumToStrProcCase(dest: var TokenBuf; enumDecl: var Cursor; symId: SymId
   dest.add tagToken("case", enumDecl.info)
   dest.add symToken(symId, enumDecl.info)
   inc enumDecl # skips enum
+  skip enumDecl # skips base type
   while enumDecl.kind != ParRi:
     let enumDeclInfo = enumDecl.info
     dest.add tagToken("of", enumDeclInfo)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1744,6 +1744,7 @@ proc semEnumField(c: var SemContext; n: var Cursor; state: var EnumTypeState)
 proc semEnumType(c: var SemContext; n: var Cursor; enumType: SymId; beforeExportMarker: int) =
   let start = c.dest.len
   takeToken c, n
+  wantDot c, n
   let magicToken = c.dest[beforeExportMarker]
   var state = EnumTypeState(enumType: enumType, thisValue: createXint(0'i64), hasHole: false,
     isBoolType: magicToken.kind == ParLe and pool.tags[magicToken.tagId] == $BoolT)

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -13,7 +13,7 @@
     (object . .))
 
  (type ~6 :Color.0.tesg7afhq1 . . . 2
-  (enum . ,1
+  (enum (u +8) ,1
    (efld ~6 :Red.0.tesg7afhq1 . .
     (i -1) (tup +0 "r1")) 10,1
    (efld ~7 :Blue.0.tesg7afhq1 . .

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -13,7 +13,7 @@
     (object . .))
 
  (type ~6 :Color.0.tesg7afhq1 . . . 2
-  (enum ,1
+  (enum . ,1
    (efld ~6 :Red.0.tesg7afhq1 . .
     (i -1) (tup +0 "r1")) 10,1
    (efld ~7 :Blue.0.tesg7afhq1 . .
@@ -26,7 +26,7 @@
   (bool) . ~16
   (pragmas 2
    (magic 7 Bool)) 2
-  (enum ~18,1
+  (enum . ~18,1
    (efld ~8 :false.0.tesg7afhq1 
     (false) . 
     (bool) (tup +0 "false")) ~8,1

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -15,11 +15,11 @@
  (type ~6 :Color.0.tesg7afhq1 . . . 2
   (enum (u +8) ,1
    (efld ~6 :Red.0.tesg7afhq1 . .
-    (i -1) (tup +0 "r1")) 10,1
+    Color.0.tesg7afhq1 (tup +0 "r1")) 10,1
    (efld ~7 :Blue.0.tesg7afhq1 . .
-    (i -1) (tup +1 "r2")) 21,1
+    Color.0.tesg7afhq1 (tup +1 "r2")) 21,1
    (efld ~8 :Green.0.tesg7afhq1 . .
-    (i -1) (tup +2 "r3"))))
+    Color.0.tesg7afhq1 (tup +2 "r3"))))
 
 
 (type ~21 :bool.0.tesg7afhq1

--- a/tests/nimony/basics/tbool.nif
+++ b/tests/nimony/basics/tbool.nif
@@ -4,7 +4,7 @@
   (bool) . ~16
   (pragmas 2
    (magic 7 Bool)) 2
-  (enum ~18,1
+  (enum . ~18,1
    (efld ~8 :false.0.tbojn1uzv 
     (false) . 
     (bool) 

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -11,7 +11,7 @@
      (i -1)) 1
     (nil)))) 10,4
  (type ~5 :Enum.0.tde837gue . . . 2
-  (enum 5
+  (enum . 5
    (efld :a.0.tde837gue . . Enum.0.tde837gue 
     (tup +0 "a")) 8
    (efld :b.0.tde837gue . . Enum.0.tde837gue 

--- a/tests/nimony/sysbasics/tdollar.nif
+++ b/tests/nimony/sysbasics/tdollar.nif
@@ -1,7 +1,7 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tdollar.nim(stmts 9,1
  (type ~7 :Color1.0.tdoqc0e0v . . . 2
-  (enum ~7,1
+  (enum . ~7,1
    (efld :Red1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v 
     (tup +0 "Red1")) ~1,1
    (efld :Blue1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v 


### PR DESCRIPTION
refs #162 and #284

The issue before was that nifler didn't push an empty token for them

Guessing sem needs to set the base type, could do this now or in a followup PR