### PR TITLE
gear3: consider mangled syms with different owners

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -1108,9 +1108,14 @@ proc writeOutput(e: var EContext) =
     of Ident:
       b.addIdent(pool.strings[c.litId])
     of Symbol:
-      let owner = ownerStack[^1][0]
-      let key = (c.symId, owner)
-      let val = e.toMangle.getOrDefault(key)
+      var val = ""
+      var ownerPos = ownerStack.len - 1
+      while ownerPos >= 0:
+        let owner = ownerStack[ownerPos][0]
+        let key = (c.symId, owner)
+        val = e.toMangle.getOrDefault(key)
+        if val.len > 0: break
+        dec ownerPos
       if val.len > 0:
         b.addSymbol(val)
       else:


### PR DESCRIPTION
i.e.

```nim
proc foo() {.importc: "foo".}
proc bar() =
  foo()
```

Previously `foo` wasn't mangled.

This is probably a slow way of doing this since it's on every symbol use, maybe each owner can have its own mangle table instead that copies every mangled symbol from the previous owner. Or maybe the key can be changed or there is some other different solution, in which case this PR can be closed.