### PR TITLE
gear3: transform right parts of gvar into asgn if not literals

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -896,7 +896,20 @@ proc traverseLocal(e: var EContext; c: var Cursor; tag: string; mode: TraverseMo
     traverseType e, c
 
   if mode != TraverseSig:
-    traverseExpr e, c
+    if tag == "gvar":
+      case c.kind
+      of StringLit, CharLit, IntLit, UIntLit, FloatLit:
+        traverseExpr e, c
+      else:
+        e.dest.addDotToken()
+        e.dest.addParRi()
+
+        # asgn
+        e.dest.add tagToken($AsgnS, vinfo)
+        e.dest.add symToken(s, sinfo)
+        traverseExpr e, c
+    else:
+      traverseExpr e, c
   else:
     e.dest.addDotToken()
     skip c

--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -898,7 +898,7 @@ proc traverseLocal(e: var EContext; c: var Cursor; tag: string; mode: TraverseMo
   if mode != TraverseSig:
     if tag == "gvar":
       case c.kind
-      of StringLit, CharLit, IntLit, UIntLit, FloatLit:
+      of StringLit, CharLit, IntLit, UIntLit, FloatLit, DotToken:
         traverseExpr e, c
       else:
         e.dest.addDotToken()

--- a/tests/nimony/sysbasics/tglobalvar.nif
+++ b/tests/nimony/sysbasics/tglobalvar.nif
@@ -1,0 +1,27 @@
+(.nif24)
+,1,tests/nimony/sysbasics/tglobalvar.nim(stmts 4
+ (var :x.0.tglvud773 . .
+  (i -1) 4 +1) 4,1
+ (var :y.0.tglvud773 . .
+  (i -1) 4 +2) 2,2
+ (asgn ~2 x.0.tglvud773 2 y.0.tglvud773) 4,3
+ (var :z.0.tglvud773 . .
+  (i -1) 4 x.0.tglvud773) 6,5
+ (const :a.0.tglvud773 . .
+  (i -1) 4 +1) 4,6
+ (var :m.0.tglvud773 . .
+  (i -1) 4 a.0.tglvud773) 4,8
+ (let :s.0.tglvud773 . .
+  (i -1) 4 x.0.tglvud773) 4,9
+ (let :n.0.tglvud773 . .
+  (i -1) 4 +3) ,11
+ (proc 5 :foo.0.tglvud773 . . . 9
+  (params) . . . 2,1
+  (stmts 4
+   (var :m.0 . .
+    (i -1) 4 a.0.tglvud773) 4,1
+   (let :g.0 . .
+    (i -1) 4 x.0.tglvud773) 6,2
+   (const :s.0 . .
+    (i -1) 4 a.0.tglvud773))) 3,16
+ (call ~3 foo.0.tglvud773))

--- a/tests/nimony/sysbasics/tglobalvar.nim
+++ b/tests/nimony/sysbasics/tglobalvar.nim
@@ -1,0 +1,17 @@
+var x = 1
+var y = 2
+x = y
+var z = x
+
+const a = 1
+var m = a
+
+let s = x
+let n = 3
+
+proc foo =
+  var m = a
+  let g = x
+  const s = a
+
+foo()


### PR DESCRIPTION
Transforms `gvar` with expressions into a `(gvar; asgn)` pair. Literals are allowed to be assigned in the global sphere.