### PR TITLE
implement deref as overload of `[]` (and `[]=`)

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -84,6 +84,10 @@ template `[]=`*(x: cstring, i: int; elem: char) =
 
 proc `[]`*[T](x: ptr T): var T {.magic: "Deref", noSideEffect.}
 proc `[]`*[T](x: ref T): var T {.magic: "Deref", noSideEffect.}
+template `[]=`*[T](x: ptr T, val: T) =
+  (x[]) = val
+template `[]=`*[T](x: ref T, val: T) =
+  (x[]) = val
 
 # integer calculations:
 proc `+`*(x: int8): int8 {.magic: "UnaryPlusI", noSideEffect.}

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -82,6 +82,9 @@ template `[]=`*[I, T](x: array[I, T], i: I; elem: T) =
 template `[]=`*(x: cstring, i: int; elem: char) =
   (x[i]) = elem
 
+proc `[]`*[T](x: ptr T): var T {.magic: "Deref", noSideEffect.}
+proc `[]`*[T](x: ref T): var T {.magic: "Deref", noSideEffect.}
+
 # integer calculations:
 proc `+`*(x: int8): int8 {.magic: "UnaryPlusI", noSideEffect.}
 proc `+`*(x: int16): int16 {.magic: "UnaryPlusI", noSideEffect.}

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -89,6 +89,7 @@ type
     mUnpack
     mDefaultObj, mDefaultTup
     mArrAt, mPat
+    mDeref
 
 declareMatcher parseMagic, TMagic, 1, 1
 
@@ -125,6 +126,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mSizeOf: res SizeofX
   of mType, mTypeOf: res TypeofX
   of mAddr: res AddrX
+  of mDeref: res DerefX
   of mEqI, mEqB, mEqCh, mEqF64, mEqRef: res EqX, TypedMagic
   of mLeI, mLeB, mLeCh, mLeF64, mLePtr: res LeX, TypedMagic
   of mLtI, mLtB, mLtCh, mLtF64, mLtPtr: res LtX, TypedMagic

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -1,12 +1,12 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tdefault.nim(stmts 
- (discard 58,692,lib/std/system.nim
+ (discard 58,706,lib/std/system.nim
   (expr "")) ,1
- (discard 52,667,lib/std/system.nim
+ (discard 52,681,lib/std/system.nim
   (expr +0)) ,3
- (discard 56,695,lib/std/system.nim
+ (discard 56,709,lib/std/system.nim
   (expr 1
-   (conv ~41,~695,tests/nimony/sysbasics/tdefault.nim
+   (conv ~41,~709,tests/nimony/sysbasics/tdefault.nim
     (ptr ~12,3,lib/std/system.nim
      (i -1)) 1
     (nil)))) 10,4
@@ -40,7 +40,7 @@
      (stmts 
       (ret "c"))))
    (ret result.0))) ,5
- (discard 57,689,lib/std/system.nim
+ (discard 57,703,lib/std/system.nim
   (expr 3 a.0.tde837gue)) 9,7
  (type ~4 :Obj.0.tde837gue . . . 2
   (object . ~9,1
@@ -55,14 +55,14 @@
      (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,12
  (discard 15
   (obj 1 Obj.0.tde837gue 
-   (kv x.0.tde837gue 37,656,lib/std/system.nim
+   (kv x.0.tde837gue 37,670,lib/std/system.nim
     (expr +0)) 
-   (kv y.0.tde837gue 43,680,lib/std/system.nim
+   (kv y.0.tde837gue 43,694,lib/std/system.nim
     (expr "")) 
    (kv z.0.tde837gue 
-    (tup 39,652,lib/std/system.nim
-     (expr ~33,~301
-      (false)) 42,682,lib/std/system.nim
+    (tup 39,666,lib/std/system.nim
+     (expr ~33,~308
+      (false)) 42,696,lib/std/system.nim
      (expr 3 a.0.tde837gue))))) ,14
  (proc 5 :foo.0.tde837gue . . . 8
   (params 1
@@ -76,14 +76,14 @@
     (i -1) .) 4
    (var :data.0 . . 10,~3 Obj.0.tde837gue 10
     (obj ,~3 Obj.0.tde837gue 
-     (kv x.0.tde837gue 36,653,lib/std/system.nim
+     (kv x.0.tde837gue 36,667,lib/std/system.nim
       (expr +0)) 
-     (kv y.0.tde837gue 42,677,lib/std/system.nim
+     (kv y.0.tde837gue 42,691,lib/std/system.nim
       (expr "")) 
      (kv z.0.tde837gue 
-      (tup 38,649,lib/std/system.nim
-       (expr ~33,~301
-        (false)) 41,679,lib/std/system.nim
+      (tup 38,663,lib/std/system.nim
+       (expr ~33,~308
+        (false)) 41,693,lib/std/system.nim
        (expr 3 a.0.tde837gue))))) 4,1
    (var :x.1 . .
     (string) 4 "abc") 7,2
@@ -107,7 +107,7 @@
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~5 MyObject.0.tde837gue 2
    (kv ~2 x.1.tde837gue 2 +123) 
-   (kv y.1.tde837gue 35,640,lib/std/system.nim
+   (kv y.1.tde837gue 35,654,lib/std/system.nim
     (expr +0)))) 7,29
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~6 MyObject.0.tde837gue 2
@@ -119,7 +119,7 @@
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~8 MyObject.0.tde837gue 2
      (kv ~2 x.1.tde837gue 2 +123) 
-     (kv y.1.tde837gue 33,637,lib/std/system.nim
+     (kv y.1.tde837gue 33,651,lib/std/system.nim
       (expr +0)))) 7,1
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~9 MyObject.0.tde837gue 2
@@ -129,7 +129,7 @@
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~8 MyObject.0.tde837gue 2
     (kv ~2 x.1.tde837gue 2 +123) 
-    (kv y.1.tde837gue 33,637,lib/std/system.nim
+    (kv y.1.tde837gue 33,651,lib/std/system.nim
      (expr +0)))) 7,1
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~9 MyObject.0.tde837gue 2

--- a/tests/nimony/sysbasics/tderef.nim
+++ b/tests/nimony/sysbasics/tderef.nim
@@ -1,0 +1,5 @@
+proc main =
+  var x: ptr int
+  if false:
+    discard x[]
+  

--- a/tests/nimony/sysbasics/tderef.nim
+++ b/tests/nimony/sysbasics/tderef.nim
@@ -2,4 +2,4 @@ proc main =
   var x: ptr int
   if false:
     discard x[]
-  
+    x[] = 123


### PR DESCRIPTION
refs #304

Something to note is that the return type of the overload is `var T` but this could generate a hidden deref when matching to `T` or no hidden addr when matching to `var T` which would be wrong, so instead `semDeref` generates a type of `T`. Something may be wrong here