### PR TITLE
fix expression proc bodies, use commonType

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -662,7 +662,11 @@ proc semProcBody(c: var SemContext; itB: var Item) =
   elif classifyType(c, it.typ) == VoidT:
     discard "ok"
   else:
-    typecheck(c, info, it.typ, c.routine.returnType)
+    # uses closing paren of (stmts:
+    c.dest.insert [parLeToken(pool.tags.getOrIncl($ExprX), info)], beforeBodyPos
+    commonType c, it, beforeBodyPos, c.routine.returnType
+    # now add closing paren
+    c.dest.addParRi()
     # transform `expr` to `result = expr`:
     if c.routine.resId != SymId(0):
       var prefix = [

--- a/tests/nimony/generics/tdouble.nim
+++ b/tests/nimony/generics/tdouble.nim
@@ -1,0 +1,5 @@
+proc foo[T](x: T): T = x
+proc bar[T](x: T): T =
+  foo(x)
+
+let x = bar(123)


### PR DESCRIPTION
`beforeBodyPos` in `semProcBody` is in this position: `(stmts | ...)`. When an assignment to `result` is being generated, `beforeBodyPos` is used to insert the `(asgn result`, so we get `(stmts (asgn result ...))`. This is wrong when there is more than 1 statement in the body. To fix this, we first insert `(expr` to transform it to `(stmts (expr ...))` then the assignment insertion gives `(stmts (asgn result (expr ...)))`.

We also call `commonType` on the `(expr ...)` part before the final closing paren to `(expr)` is added (i.e. when the body is in the form `(stmts (expr ...)`) since `commonType` does `c.dest.shrink`. The added test was why this was done but it would have needed `commonType` to use `replace` instead without the above fix.