### PR TITLE
fix linearMatch for typevars

### DIFF
--- a/tests/nimony/generics/tdoubleptr.nim
+++ b/tests/nimony/generics/tdoubleptr.nim
@@ -1,0 +1,5 @@
+proc generic[T](a, b: ptr T) =
+  discard a == b
+
+proc generic2[T](a, b: ptr T) =
+  generic(a, b)


### PR DESCRIPTION
1. Use the original `f` and `a` passed to `linearMatch` for error messages
2. `m.inferred[fs]` was passed to `linearMatch` as an argument but `linearMatch` mutates its arguments, use an intermediary variable
3. Progress typevar symbol tokens after matching them via `linearMatch`
4. Break the loop in `linearMatch` after matching any token if the nesting level is 0, needed when matching single tokens by themselves e.g. symbols