### PR TITLE
allow object constructors and dot fields for structural ref objects

### DIFF
--- a/tests/nimony/basics/tbinarytree.nif
+++ b/tests/nimony/basics/tbinarytree.nif
@@ -1,0 +1,60 @@
+(.nif24)
+,1,tests/nimony/basics/tbinarytree.nim(stmts 5
+ (type :int.0.tbivahh0m 
+  (i -1) . 5
+  (pragmas 2
+   (magic 7 Int)) .) 10,3
+ (type ~8 :NodeObj.0.tbivahh0m . . . 2
+  (object . ~8,1
+   (fld :data.0.tbivahh0m . . 1,~4
+    (i -1) .) ~8,2
+   (fld :left.0.tbivahh0m . . 5,1
+    (ref 4 NodeObj.0.tbivahh0m) .) ~2,2
+   (fld :right.0.tbivahh0m . . ~1,1
+    (ref 4 NodeObj.0.tbivahh0m) .))) 7,6
+ (type ~5 :Node.0.tbivahh0m . . . 2
+  (ref 4 NodeObj.0.tbivahh0m)) 4,8
+ (var :x.0.tbivahh0m . . 5,~2
+  (ref 4 NodeObj.0.tbivahh0m) 8
+  (obj ~3,~2
+   (ref 4 NodeObj.0.tbivahh0m) 5
+   (kv ~5 data.0.tbivahh0m 2 +123) 16
+   (kv ~16 left.0.tbivahh0m 2
+    (nil)) 28
+   (kv ~28 right.0.tbivahh0m 2
+    (nil)))) 7,9
+ (asgn ~6
+  (dot ~1 x.0.tbivahh0m data.0.tbivahh0m +0) 2 +456) 7,10
+ (asgn ~6
+  (dot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) 6
+  (obj ~4,~4
+   (ref 4 NodeObj.0.tbivahh0m) 5
+   (kv ~5 data.0.tbivahh0m 2 +123) 16
+   (kv ~16 left.0.tbivahh0m 2
+    (nil)) 28
+   (kv ~28 right.0.tbivahh0m 2
+    (nil)))) 8,11
+ (asgn ~7
+  (dot ~1 x.0.tbivahh0m right.0.tbivahh0m +0) 2
+  (nil)) 13,12
+ (asgn ~7
+  (dot ~5
+   (dot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) right.0.tbivahh0m +0) 2
+  (nil)) 4,13
+ (var :y.0.tbivahh0m . . 5,~7
+  (ref 4 NodeObj.0.tbivahh0m) 8
+  (obj ~3,~7
+   (ref 4 NodeObj.0.tbivahh0m) 5
+   (kv ~5 data.0.tbivahh0m 2 +987) 16
+   (kv ~16 left.0.tbivahh0m 2
+    (nil)) 28
+   (kv ~28 right.0.tbivahh0m 2
+    (nil)))) 12,14
+ (asgn ~6
+  (dot ~5
+   (dot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) left.0.tbivahh0m +0) 15
+  (obj ~18,~8
+   (ref 4 NodeObj.0.tbivahh0m) 5
+   (kv ~5 data.0.tbivahh0m 2 -123) 17
+   (kv ~17 left.0.tbivahh0m 2 y.0.tbivahh0m) 27
+   (kv ~27 right.0.tbivahh0m 2 y.0.tbivahh0m))))

--- a/tests/nimony/basics/tbinarytree.nim
+++ b/tests/nimony/basics/tbinarytree.nim
@@ -1,0 +1,15 @@
+type int* {.magic: Int.}
+
+type
+  NodeObj = object
+    data: int
+    left, right: Node
+  Node = ref NodeObj
+
+var x = Node(data: 123, left: nil, right: nil)
+x.data = 456
+x.left = Node(data: 123, left: nil, right: nil)
+x.right = nil
+x.left.right = nil
+var y = Node(data: 987, left: nil, right: nil)
+x.left.left = (ref NodeObj)(data: -123, left: y, right: y)


### PR DESCRIPTION
For types of the form `type Foo = object; ref Foo` rather than `type Foo = ref object` which doesn't work yet

They are treated the same as regular object types in these expressions in sem