### PR TITLE
keep generic type symbols as symbols in semTypeSym

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1708,7 +1708,7 @@ proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; start: int; con
           replace(c.dest, cursorAt(typeclassBuf, 0), start)
     else:
       let typ = asTypeDecl(res.decl)
-      if typ.body.typeKind in {ObjectT, EnumT, HoleyEnumT, DistinctT, ConceptT}:
+      if isGeneric(typ) or typ.body.typeKind in {ObjectT, EnumT, HoleyEnumT, DistinctT, ConceptT}:
         # types that should stay as symbols, see sigmatch.matchSymbol
         discard
       else:


### PR DESCRIPTION
i.e. in `Foo[int]`, `Foo` should not be inlined

A followup might be to add inlining logic to `semInvoke` for non-nominal values, maybe even with unresolved parameters, i.e. with `type Foo[T] = ref Bar[T]`, `Foo[U]` in a generic context could inline to `ref Bar[U]`