### PR TITLE
object constructors and dot fields for generic objects

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1412,6 +1412,8 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
     var root = t
     if root.typeKind in {RefT, PtrT}:
       inc root
+    if root.typeKind == InvokeT:
+      inc root
     if root.kind == Symbol:
       let objType = objtypeImpl(root.symId)
       if objType.typeKind == ObjectT:
@@ -3373,6 +3375,8 @@ proc buildDefaultObjConstr(c: var SemContext; typ: Cursor; setFields: Table[SymI
   var objImpl = typ
   if objImpl.typeKind in {RefT, PtrT}:
     inc objImpl
+  if objImpl.typeKind == InvokeT:
+    inc objImpl
   if objImpl.kind == Symbol:
     objImpl = objtypeImpl(objImpl.symId)
   var obj = asObjectDecl(objImpl)
@@ -3412,6 +3416,8 @@ proc semObjConstr(c: var SemContext, it: var Item) =
   c.dest.shrink exprStart
   var objType = it.typ
   if objType.typeKind in {RefT, PtrT}:
+    inc objType
+  if objType.typeKind == InvokeT:
     inc objType
   if objType.kind == Symbol:
     objType = objtypeImpl(objType.symId)

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -85,7 +85,7 @@
        (expr ~33,~308
         (false)) 41,693,lib/std/system.nim
        (expr 3 a.0.tde837gue))))) 4,1
-   (var :x.1 . .
+   (var :x.2 . .
     (string) 4 "abc") 7,2
    (asgn ~7 result.1 2 +4) ~2,~1
    (ret result.1))) 11,20
@@ -134,4 +134,54 @@
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~9 MyObject.0.tde837gue 2
     (kv ~2 x.1.tde837gue 2 +123) 10
-    (kv ~10 y.1.tde837gue 2 +456)))))
+    (kv ~10 y.1.tde837gue 2 +456)))) 19,35
+ (type ~14 :GenericObj.0.tde837gue . ~4
+  (typevars 1
+   (typevar :T.0.tde837gue . . . .)) . 2
+  (object . ~19,1
+   (fld :x.2.tde837gue . . 3 T.0.tde837gue .))) 4,38
+ (var :generic.0.tde837gue . . 19 GenericObj.1.tde837gue .) 10,39
+ (asgn ~3
+  (dot ~7 generic.0.tde837gue x.3.tde837gue +0) 2 +45) 8,40
+ (asgn ~8 generic.0.tde837gue 17
+  (obj ~2,~2 GenericObj.1.tde837gue 2
+   (kv ~2 x.3.tde837gue 2 +123))) ,41
+ (proc 5 :genericProc.0.tde837gue . . 16
+  (typevars 1
+   (typevar :T.1.tde837gue . . . .)) 19
+  (params 1
+   (param :x.1 . . 3 T.1.tde837gue .)) 18
+  (at ~10 GenericObj.0.tde837gue 1 T.1.tde837gue) . . 2,1
+  (stmts 7
+   (result :result.2 . . 9,~1
+    (at ~10 GenericObj.0.tde837gue 1 T.1.tde837gue) .) 7
+   (asgn ~7 result.2 15
+    (obj ~6,~1
+     (at ~10 GenericObj.0.tde837gue 1 T.1.tde837gue) 2
+     (kv ~2 x.2.tde837gue 2 x.1))) 9,1
+   (asgn ~3
+    (dot ~6 result.2 x.2.tde837gue +0) 2 x.1) ~2,~1
+   (ret result.2))) ,45
+ (discard 19
+  (call ~11 genericProc.1.tde837gue 1 +456)) 19,45
+ (proc :genericProc.1.tde837gue . ~19,~4 . 
+  (at genericProc.0.tde837gue
+   (i -1)) ,~4
+  (params 1
+   (param :x.4 . .
+    (i -1) .)) ~1,~4 GenericObj.1.tde837gue ~19,~4 . ~19,~4 . ~17,~3
+  (stmts 7
+   (result :result.3 . . 9,~1 GenericObj.1.tde837gue .) 7
+   (asgn ~7 result.3 15
+    (obj ~1,~4 GenericObj.1.tde837gue 
+     (kv x.3.tde837gue 28,640,lib/std/system.nim
+      (expr +0)))) 9,1
+   (asgn ~3
+    (dot ~6 result.3 x.3.tde837gue +0) 2 x.4) ~2,~1
+   (ret result.3))) 23,38
+ (type :GenericObj.1.tde837gue . 
+  (at GenericObj.0.tde837gue ~19,~32,lib/std/system.nim
+   (i -1)) ~4,~3 . ~2,~3
+  (object . ~19,1
+   (fld :x.3.tde837gue . . 2,~30,lib/std/system.nim
+    (i -1) .))))

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -32,3 +32,15 @@ template resem() =
   global = MyObject(x: 123)
   global = MyObject(x: 123, y: 456)
 resem()
+
+type GenericObj[T] = object
+  x: T
+
+var generic: GenericObj[int]
+generic.x = 45
+generic = GenericObj[int](x: 123)
+proc genericProc[T](x: T): GenericObj[T] =
+  result = GenericObj[T](x: x)
+  result.x = x
+# type is left as InvokeT for now because requestRoutineInstance doesn't semcheck the return type:
+discard genericProc(456)


### PR DESCRIPTION
Also made gear3 stop traversing generic bodies at all for now, the alternative is to do something like [this](https://github.com/nim-lang/nimony/pull/326/commits/03b1dc130a1004b6c8983baa702b84f7853d152e#diff-d86ef2b503c1ba11be6f2f477871862aea3ab8e5432038ed6923b9873fd6ce76) which is not comprehensive enough. Don't know if we'll need to traverse them eventually, can add a comment about it if so.