### PR TITLE
semcheck substitution output of invoked generic types

### DIFF
--- a/tests/nimony/generics/tnestedobj.nim
+++ b/tests/nimony/generics/tnestedobj.nim
@@ -1,0 +1,6 @@
+type
+  Foo[T] = object
+  Bar[T] = object
+    foo: Foo[T]
+
+var bar: Bar[int]

--- a/tests/nimony/generics/trecursiveobj.nim
+++ b/tests/nimony/generics/trecursiveobj.nim
@@ -1,0 +1,5 @@
+type
+  Foo[T] = object
+    x: ref Foo[T]
+
+var foo: Foo[int]


### PR DESCRIPTION
This allows things like nested generics to compile due to converting InvokeT types to sym types.

The symbol is saved to the type instantiation cache before semchecking so that recursive types do not try to infinitely create a new instantiation. However the type symbol cannot be loaded until the semchecking is done, so if anything tries to introspect the type in its own definition it will fail when trying to load it. For now this is not an issue. Maybe a solution is to perform a `SemcheckTopLevelSyms` phase on the substituted type first, though the AST of the symbol would then be substituted but not semchecked type AST.

A followup would be to inline the produced types if they are structural instead of giving their symbols. Edit: Actually this is just a `semTypeSym` call, and requires getting the symbol AST which needs the `SemcheckTopLevelSyms` phase anyway. Can do these here or in a followup: #333