### PR TITLE
semcheck substituted return type of generic calls

### DIFF
--- a/tests/nimony/basics/tfib2.nif
+++ b/tests/nimony/basics/tfib2.nif
@@ -133,7 +133,7 @@
     (else 2,1
      (stmts 7
       (asgn ~7 result.1 11
-       (add
+       (add ~20,~25
         (i -1) ~6
         (call ~3 fib.1.tfie0imm3 2
          (sub

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -161,15 +161,15 @@
      (kv ~2 x.2.tde837gue 2 x.1))) 9,1
    (asgn ~3
     (dot ~6 result.2 x.2.tde837gue +0) 2 x.1) ~2,~1
-   (ret result.2))) ,45
- (discard 19
-  (call ~11 genericProc.1.tde837gue 1 +456)) 19,45
- (proc :genericProc.1.tde837gue . ~19,~4 . 
+   (ret result.2))) 8,44
+ (asgn ~8 generic.0.tde837gue 13
+  (call ~11 genericProc.1.tde837gue 1 +456)) 21,44
+ (proc :genericProc.1.tde837gue . ~21,~3 . 
   (at genericProc.0.tde837gue
-   (i -1)) ,~4
+   (i -1)) ~2,~3
   (params 1
    (param :x.4 . .
-    (i -1) .)) ~1,~4 GenericObj.1.tde837gue ~19,~4 . ~19,~4 . ~17,~3
+    (i -1) .)) ~3,~3 GenericObj.1.tde837gue ~21,~3 . ~21,~3 . ~19,~2
   (stmts 7
    (result :result.3 . . 9,~1 GenericObj.1.tde837gue .) 7
    (asgn ~7 result.3 15

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -42,5 +42,4 @@ generic = GenericObj[int](x: 123)
 proc genericProc[T](x: T): GenericObj[T] =
   result = GenericObj[T](x: x)
   result.x = x
-# type is left as InvokeT for now because requestRoutineInstance doesn't semcheck the return type:
-discard genericProc(456)
+generic = genericProc(456)


### PR DESCRIPTION
`requestRoutineInstance` only substitutes the return type and doesn't semcheck it, only giving the cursor of the return type from the delayed instantiated proc declaration. So we semcheck the given return type in `resolveOverloads`, though we could also do this inside `requestRoutineInstance` and put the semchecked type in the delayed proc too.