### PR TITLE
inline structural/alias invocations even with generic arguments, broken

### DIFF
--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -14,6 +14,10 @@ proc isRoutine*(t: SymKind): bool {.inline.} =
 proc isLocal*(t: SymKind): bool {.inline.} =
   t in {LetY, VarY, ResultY, ConstY, ParamY, TypevarY, CursorY, FldY, EfldY}
 
+proc isNominal*(t: TypeKind): bool {.inline.} =
+  ## type kinds that should stay as symbols, see sigmatch.matchSymbol
+  t in {ObjectT, EnumT, HoleyEnumT, DistinctT, ConceptT}
+
 const
   LocalTypePos* = 3
   LocalValuePos* = 4

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1725,9 +1725,9 @@ proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; start: int; con
           typeclassBuf.addParRi()
           typeclassBuf.addParRi()
           replace(c.dest, cursorAt(typeclassBuf, 0), start)
-    else:
+    elif res.status == LacksNothing:
       let typ = asTypeDecl(res.decl)
-      if isGeneric(typ) or typ.body.typeKind in {ObjectT, EnumT, HoleyEnumT, DistinctT, ConceptT}:
+      if isGeneric(typ) or isNominal(typ.body.typeKind):
         # types that should stay as symbols, see sigmatch.matchSymbol
         discard
       else:
@@ -1985,7 +1985,11 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     semLocalTypeImpl c, n, AllowValues
   swap c.usedTypevars, genericArgs
   wantParRi c, n
-  if (genericArgs == 0 or magicKind != NoType) and ok:
+  if ok and (genericArgs == 0 or magicKind != NoType or
+      # structural types are inlined even with generic arguments
+      # XXX cannot instantiate properly if forward declared because typevars are not created in SemcheckTopLevelSyms
+      # maybe they could be declared along with an untyped prepass for the body
+      not isNominal(decl.body.typeKind)):
     # we have to be eager in generic type instantiations so that type-checking
     # can do its job properly:
     let key = typeToCanon(c.dest, typeStart)

--- a/tests/nimony/basics/tgenericbinarytree.nim
+++ b/tests/nimony/basics/tgenericbinarytree.nim
@@ -1,0 +1,21 @@
+type int* {.magic: Int.}
+
+type
+  Node[T] = ref NodeObj[T] # does not work if defined after NodeObj
+  NodeObj[T] = object
+    data: T
+    left, right: Node[T]
+
+var x = Node[int](data: 123, left: nil, right: nil)
+x.data = 456
+x.left = Node[int](data: 123, left: nil, right: nil)
+x.right = nil
+x.left.right = nil
+var y = Node[int](data: 987, left: nil, right: nil)
+x.left.left = Node[int](data: -123, left: y, right: y)
+
+proc foo[T](data: T): Node[T] =
+  result = Node[T](data: data, left: nil, right: nil)
+  result.data = data
+let a = foo(123)
+x = a


### PR DESCRIPTION
In:

```nim
type
  NodeObj[T] = object
    x: Node[T]
  Node[T] = ref NodeObj[T]
```

first `SemcheckTopLevelSyms` will save the untyped AST of the types to their symbols, however they will not define typevars or look them up in the body. This means when `NodeObj` is being semchecked, attempting to inline `Node[T]` by instantiating it will not work because there will be no typevars to replace.

This is a general problem for forwarded generic types:

```nim
type
  Foo[T] = object
    x: Bar[int]
  Bar[T] = object
```

A solution might be to define the typevars in the `SemcheckTopLevelSyms` pass and use an untyped prepass on the body so that they can be instantiated. But this is not done yet as an untyped prepass is not implemented.