### PR TITLE
recursively skip invocations for generic ref object types

### DIFF
--- a/tests/nimony/basics/tgenericbinarytree.nim
+++ b/tests/nimony/basics/tgenericbinarytree.nim
@@ -1,0 +1,21 @@
+type int* {.magic: Int.}
+
+type
+  NodeObj[T] = object
+    data: T
+    left, right: ref NodeObj[T]
+  Node[T] = ref NodeObj[T]
+
+var x = Node[int](data: 123, left: nil, right: nil)
+x.data = 456
+x.left = Node[int](data: 123, left: nil, right: nil)
+x.right = nil
+x.left.right = nil
+var y = Node[int](data: 987, left: nil, right: nil)
+x.left.left = Node[int](data: -123, left: y, right: y)
+
+proc foo[T](data: T): Node[T] =
+  result = Node[T](data: data, left: nil, right: nil)
+  result.data = data
+let a = foo(123)
+x = a


### PR DESCRIPTION
The alternative to #335 for just object primitives, but this is a more deep rooted problem for `ref` etc in general, for example `nil` does not match `Node[T]`. Unless it's a priority, we can wait until #335 can work.