### PR TITLE
gear3: mangle array types based on length

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -59,6 +59,24 @@ proc mangleImpl(b: var Mangler; c: var Cursor) =
         mangleImpl b, c # type is interesting
         skip c # value
         inc c # ParRi
+      elif tag == "array":
+        b.addTree tag
+        inc c
+        mangleImpl b, c # type is interesting
+        if c.kind == ParLe and c.typeKind == RangeT:
+          inc c # RangeT
+          skip c # type is irrelevant, we care about the length
+          assert c.kind == IntLit
+          let first = pool.integers[c.intId]
+          inc c
+          assert c.kind == IntLit
+          let last = pool.integers[c.intId]
+          inc c
+          inc c # ParRi
+          b.addIntLit(last - first + 1)
+        else:
+          mangleImpl b, c
+        inc nested
       else:
         b.addTree(tag)
         inc nested

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -148,6 +148,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     buf.addSubtree elemType
     var n = n
     var arrayLen = 0
+    inc n # skips AconstrX
     while n.kind != ParRi:
       skip n
       inc arrayLen

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -21,4 +21,20 @@
    (i -1)
    (rangetype
     (i -1) +0 +4)) 12
-  (arr 1 +1 4 +2 7 +3 10 +4 13 +5)))
+  (arr 1 +1 4 +2 7 +3 10 +4 13 +5)) ,7
+ (proc 5 :foo.0.tbawx6nu81 . . . 9
+  (params) . . . 2,1
+  (stmts 4
+   (var :x.0 . . ~2,~5
+    (array
+     (i -1)
+     (rangetype
+      (i -1) +0 +2)) 19
+    (arr 1 +5 4 +6 7 +7)) 4,1
+   (var :m.0 . .
+    (array
+     (i -1)
+     (rangetype
+      (i -1) +0 +3)) 4
+    (arr 1 +5 4 +6 7 +7 10 +8)))) 3,11
+ (call ~3 foo.0.tbawx6nu81))

--- a/tests/nimony/sysbasics/tbasics.nim
+++ b/tests/nimony/sysbasics/tbasics.nim
@@ -4,3 +4,9 @@ type
 var s = [1, 2, 3]
 var s2: Array
 var s3: Array = [1, 2, 3, 4, 5]
+
+proc foo =
+  var x: array[3, int] = [5, 6, 7]
+  var m = [5, 6, 7, 8]
+
+foo()


### PR DESCRIPTION
So that in backend, `array[0..3, int]` is the same as the `array[1..4, int]` and the type of `[1, 2, 3, 4]`