### PR TITLE
remove unused cyclic import of sigmatch in semdata

### DIFF
--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -9,7 +9,7 @@
 import std / [tables, sets, os, syncio, formatfloat, assertions]
 include nifprelude
 import nimony_model, symtabs, builtintypes, decls, symparser,
-  programs, sigmatch, magics, reporters, nifconfig, nifindexes
+  programs, magics, reporters, nifconfig, nifindexes
 
 import ".." / gear2 / modnames
 


### PR DESCRIPTION
Sigmatch imports semdata and semdata imports sigmatch but semdata doesn't use sigmatch, causes problems when compiling semdata or importing it by itself without sigmatch but not when compiling sigmatch or importing it by itself