### PR TITLE
fixes some issues

### DIFF
--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -374,9 +374,7 @@ proc genVarDecl(c: var GeneratedCode; t: Tree; n: NodePos; vk: VarKind; toExtern
         moveToInitSection:
           c.add name
           c.add AsgnOpr
-          inc c.inSimpleInit
           genx c, t, d.value
-          dec c.inSimpleInit
           c.add Semicolon
       else:
         c.add AsgnOpr

--- a/src/nimony/xints.nim
+++ b/src/nimony/xints.nim
@@ -116,7 +116,9 @@ proc `$`*(a: xint): string =
   else: $a.val
 
 proc createXint*(x: int64): xint =
-  if x < 0:
+  if x == low(int64):
+    xint(neg: true, val: cast[uint64](x))
+  elif x < 0:
     xint(neg: true, val: uint64(-x))
   else:
     xint(neg: false, val: uint64(x))

--- a/src/nimony/xints.nim
+++ b/src/nimony/xints.nim
@@ -117,7 +117,7 @@ proc `$`*(a: xint): string =
 
 proc createXint*(x: int64): xint =
   if x == low(int64):
-    xint(neg: true, val: cast[uint64](x))
+    xint(neg: true, val: uint64(high(int64)) + 1'u64)
   elif x < 0:
     xint(neg: true, val: uint64(-x))
   else:


### PR DESCRIPTION
- `inSimpleInit` means a global var initialization. Since the value parts are moved to `InitSection`, `inSimpleInit` should zero.

- `low(int64)` cannot be negated