### PR TITLE
implement field visibility

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1349,7 +1349,15 @@ proc semCall(c: var SemContext; it: var Item; source: TransformedCallSource = Re
   else:
     resolveOverloads c, it, cs
 
-proc findObjField(t: Cursor; name: StrId; level = 0): ObjField =
+proc genericRootSym(td: TypeDecl): SymId =
+  result = td.name.symId
+  if td.typevars.typeKind == InvokeT:
+    var root = td.typevars
+    inc root
+    assert root.kind == Symbol
+    result = root.symId
+
+proc findObjFieldAux(t: Cursor; name: StrId; level = 0): ObjField =
   assert t == "object"
   var n = t
   inc n # skip `(object` token
@@ -1360,9 +1368,10 @@ proc findObjField(t: Cursor; name: StrId; level = 0): ObjField =
     if n.kind == SymbolDef and sameIdent(n.symId, name):
       let symId = n.symId
       inc n # skip name
+      let exported = n.kind != DotToken
       skip n # export marker
       skip n # pragmas
-      return ObjField(sym: symId, level: level, typ: n)
+      return ObjField(sym: symId, level: level, typ: n, exported: exported, rootOwner: SymId(0))
     skip n # skip name
     skip n # export marker
     skip n # pragmas
@@ -1377,9 +1386,42 @@ proc findObjField(t: Cursor; name: StrId; level = 0): ObjField =
     if baseType.typeKind == InvokeT:
       inc baseType # get to root symbol
     if baseType.kind == Symbol:
-      result = findObjField(objtypeImpl(baseType.symId), name, level+1)
+      let decl = getTypeSection(baseType.symId)
+      var objType = decl.body
+      # emulate objtypeImpl
+      if objType.typeKind in {RefT, PtrT}:
+        inc objType
+      result = findObjFieldAux(objType, name, level+1)
+      if result.level == level+1:
+        result.rootOwner = genericRootSym(decl)
     else:
       # maybe error
+      result = ObjField(level: -1)
+
+proc findObjFieldConsiderVis(c: var SemContext; decl: TypeDecl; name: StrId; info: PackedLineInfo): ObjField =
+  var impl = decl.body
+  # emulate objtypeImpl
+  if impl.typeKind in {RefT, PtrT}:
+    inc impl
+  result = findObjFieldAux(impl, name)
+  if result.level == 0:
+    result.rootOwner = genericRootSym(decl)
+  if result.level >= 0:
+    # check visibility
+    var visible = false
+    if result.exported:
+      visible = true
+    else:
+      let owner = result.rootOwner
+      if owner == SymId(0):
+        visible = true
+      else:
+        let ownerModule = extractModule(pool.syms[owner])
+        # safe to get this from line info?
+        let currentModule = moduleSuffix(getFile(info), c.g.config.paths)
+        visible = ownerModule == "" or currentModule == "" or ownerModule == currentModule
+    if not visible:
+      # treat as undeclared
       result = ObjField(level: -1)
 
 proc findModuleSymbol(n: Cursor): SymId =
@@ -1432,9 +1474,13 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
     if root.typeKind == InvokeT:
       inc root
     if root.kind == Symbol:
-      let objType = objtypeImpl(root.symId)
+      let decl = getTypeSection(root.symId)
+      var objType = decl.body
+      # emulate objtypeImpl
+      if objType.typeKind in {RefT, PtrT}:
+        inc objType
       if objType.typeKind == ObjectT:
-        let field = findObjField(objType, fieldName)
+        let field = findObjFieldConsiderVis(c, decl, fieldName, info)
         if field.level >= 0:
           c.dest.add symToken(field.sym, info)
           c.dest.add intToken(pool.integers.getOrIncl(field.level), info)
@@ -1767,7 +1813,10 @@ proc semObjectType(c: var SemContext; n: var Cursor) =
     takeToken c, n
   else:
     # object fields:
+    let oldScopeKind = c.currentScope.kind
     withNewScope c:
+      # copy toplevel scope status for exported fields
+      c.currentScope.kind = oldScopeKind
       while n.substructureKind == FldS:
         semLocal(c, n, FldY)
   wantParRi c, n
@@ -3273,8 +3322,11 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
       takeToken c, n
       isGeneric = false
     else:
+      let oldScopeKind = c.currentScope.kind
       openScope c
       semGenericParams c, n
+      # copy toplevel scope status for exported fields
+      c.currentScope.kind = oldScopeKind
       isGeneric = true
 
     semTypePragmas c, n, beforeExportMarker
@@ -3606,13 +3658,18 @@ proc semObjConstr(c: var SemContext, it: var Item) =
   inc it.n
   it.typ = semLocalType(c, it.n)
   c.dest.shrink exprStart
+  var decl = default(TypeDecl)
   var objType = it.typ
   if objType.typeKind in {RefT, PtrT}:
     inc objType
   if objType.typeKind == InvokeT:
     inc objType
   if objType.kind == Symbol:
-    objType = objtypeImpl(objType.symId)
+    decl = getTypeSection(objType.symId)
+    objType = decl.body
+    # emulate objtypeImpl
+    if objType.typeKind in {RefT, PtrT}:
+      inc objType
     if objType.typeKind != ObjectT:
       c.buildErr info, "expected object type for object constructor"
       return
@@ -3641,9 +3698,9 @@ proc semObjConstr(c: var SemContext, it: var Item) =
             # level is not known but not used either, set it to 0:
             field = ObjField(sym: sym, typ: asLocal(res.decl).typ, level: 0)
           else:
-            field = findObjField(objType, fieldName)
+            field = findObjFieldConsiderVis(c, decl, fieldName, info)
         else:
-          field = findObjField(objType, fieldName)
+          field = findObjFieldConsiderVis(c, decl, fieldName, info)
         if field.level >= 0:
           if field.sym in setFieldPositions:
             c.buildErr fieldInfo, "field already set: " & pool.strings[fieldName]

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -52,6 +52,8 @@ type
     sym*: SymId
     level*: int # inheritance level
     typ*: TypeCursor
+    exported*: bool
+    rootOwner*: SymId # generic root of owner type
 
   SemPhase* = enum
     SemcheckTopLevelSyms,

--- a/tests/nimony/modules/deps/mfieldvis.nim
+++ b/tests/nimony/modules/deps/mfieldvis.nim
@@ -1,0 +1,13 @@
+type Foo* = object
+  public*: int
+  private: int
+
+type Generic*[T] = object
+  public*: T
+  private: T
+
+proc getPrivate*(x: Foo): int = x.private
+proc getPrivate*[T](x: Generic[T]): T = x.private
+
+template getPrivateTempl*(x: Foo): int = x.private
+template getPrivateTempl*[T](x: Generic[T]): T = T(x.private)

--- a/tests/nimony/modules/tfieldvis.nim
+++ b/tests/nimony/modules/tfieldvis.nim
@@ -1,0 +1,14 @@
+import deps/mfieldvis
+
+var foo = Foo(public: 123)
+discard getPrivate(foo)
+discard getPrivateTempl(foo)
+
+var generic = Generic[int](public: 123)
+discard getPrivate(foo)
+discard getPrivateTempl(foo)
+
+template resem() =
+  foo = Foo(public: 123)
+  generic = Generic[int](public: 123)
+resem()

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,0 +1,4 @@
+tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: private
+tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared identifier
+tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: private
+tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared identifier

--- a/tests/nimony/modules/tfieldviserr.nim
+++ b/tests/nimony/modules/tfieldviserr.nim
@@ -1,0 +1,7 @@
+import deps/mfieldvis
+
+var foo = Foo(private: 123)
+discard foo.private
+
+var generic = Generic[int](private: 123)
+discard generic.private


### PR DESCRIPTION
Code is a bit ugly for now

Currently checks for the line info of the field access to compare modules. An alternative might be to track the current instantiated routine symbol in a stack which would include templates

Tests need some workarounds for/tweaks in hastur, otherwise they work for the most part. Imported modules don't seem to compile to C yet so will try to see how to test just sem compilation of `tfieldvis`. `tfieldviserr` also has mismatching output with the `make` call

The type conversion in:

```nim
template getPrivateTempl*[T](x: Generic[T]): T =
  T(x.private)
```

is a workaround, the type of `x.private` is the `T` in the original definition of `Generic`. This only errors for templates because other routines use `commonType` since #320, which matches anything to typevar expected types. Maybe `x.private` can substitute the type of `private` according to the `InvokeT` params of the type of `x`, this would have to be done for inherited types too.