### PR TITLE
implement standalone explicit routine instantiations

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3949,7 +3949,6 @@ proc tryExplicitRoutineInst(c: var SemContext; syms: Cursor; it: var Item): bool
       matchTypevars m, candidate, args
       if not m.err:
         # match
-        finishTypevarMatch m, candidate
         c.dest.add symToken(sym, syms.info)
         inc matches
         lastMatch = m

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -734,14 +734,6 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.error "routine is not generic"
       return
 
-proc finishTypevarMatch*(m: var Match; fn: FnCandidate) =
-  for v in typeVars(fn.sym):
-    let inf = m.inferred.getOrDefault(v)
-    if inf == default(Cursor):
-      m.error "could not infer type for " & pool.syms[v]
-      break
-    m.typeArgs.addSubtree inf
-
 proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
                explicitTypeVars: Cursor) =
   assert fn.kind != NoSym or fn.sym == SymId(0)
@@ -771,7 +763,12 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
 
   # check all type vars have a value:
   if not m.err and fn.kind in RoutineKinds:
-    finishTypevarMatch m, fn
+    for v in typeVars(fn.sym):
+      let inf = m.inferred.getOrDefault(v)
+      if inf == default(Cursor):
+        m.error "could not infer type for " & pool.syms[v]
+        break
+      m.typeArgs.addSubtree inf
 
 proc matchesBool*(m: var Match; t: Cursor) =
   var a = skipModifier(t)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -706,16 +706,17 @@ proc collectDefaultValues(f: var Cursor): seq[Item] =
     result.add Item(n: param.val, typ: param.typ)
     skip f
 
-proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
-               explicitTypeVars: Cursor) =
-  assert fn.kind != NoSym or fn.sym == SymId(0)
+proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
   m.tvars = initHashSet[SymId]()
-  m.fn = fn
   if fn.kind in RoutineKinds:
     var e = explicitTypeVars
     for v in typeVars(fn.sym):
       m.tvars.incl v
-      if e.kind != DotToken and e.kind != ParRi:
+      if e.kind == DotToken: discard
+      elif e.kind == ParRi:
+        m.error "missing explicit generic parameter for " & pool.syms[v]
+        break
+      else:
         if matchesConstraint(m, v, e):
           m.inferred[v] = e
         else:
@@ -725,11 +726,27 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
           assert typevar.kind == TypevarY
           m.error concat(typeToString(e), " does not match constraint ", typeToString(typevar.typ))
         skip e
+    if e.kind != DotToken and e.kind != ParRi:
+      m.error "extra generic parameter"
   elif explicitTypeVars.kind != DotToken:
     # aka there are explicit type vars
     if m.tvars.len == 0:
       m.error "routine is not generic"
       return
+
+proc finishTypevarMatch*(m: var Match; fn: FnCandidate) =
+  for v in typeVars(fn.sym):
+    let inf = m.inferred.getOrDefault(v)
+    if inf == default(Cursor):
+      m.error "could not infer type for " & pool.syms[v]
+      break
+    m.typeArgs.addSubtree inf
+
+proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
+               explicitTypeVars: Cursor) =
+  assert fn.kind != NoSym or fn.sym == SymId(0)
+  m.fn = fn
+  matchTypevars m, fn, explicitTypeVars
 
   var f = fn.typ
   assert f == "params"
@@ -754,12 +771,7 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
 
   # check all type vars have a value:
   if not m.err and fn.kind in RoutineKinds:
-    for v in typeVars(fn.sym):
-      let inf = m.inferred.getOrDefault(v)
-      if inf == default(Cursor):
-        m.error "could not infer type for " & pool.syms[v]
-        break
-      m.typeArgs.addSubtree inf
+    finishTypevarMatch m, fn
 
 proc matchesBool*(m: var Match; t: Cursor) =
   var a = skipModifier(t)

--- a/tests/nimony/generics/texplicitprocinst.nim
+++ b/tests/nimony/generics/texplicitprocinst.nim
@@ -1,0 +1,7 @@
+proc foo[T](x: T) = discard
+proc foo[T, U](x: T, y: U) = discard
+
+discard foo[int]
+discard foo[int, string]
+foo[int](123)
+foo[int, string](123, "abc")


### PR DESCRIPTION
closes #269 for now

The difference with original Nim is that for matching symchoices or templates etc, the compiler doesn't try to instantiate them, instead leaving the expression as `(at (symchoice ...) ...)`, only instantiating unambiguous concrete generic procs. This complicates any potential proc type disambiguation logic for overloaded explicit routine instantiations but this seems to not be a priority for now (though I remember something in system using it). Not hard to bring back the old behavior either way.