### PR TITLE
map set type to uint8 array

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -69,6 +69,7 @@ type
   range*[T]{.magic: "Range".}         ## Generic type to construct range types.
   array*[I, T]{.magic: "Array".}      ## Generic type to construct
                                       ## fixed-length arrays.
+  set*[T]{.magic: "Set".}             ## Generic type to construct bit sets.
 
 proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect.}
 proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
@@ -367,3 +368,6 @@ proc `$`*[T: enum](x: T): string {.magic: "EnumToStr", noSideEffect.}
   ## Converts an enum value to a string.
 
 proc addr*[T](x: T): ptr T {.magic: "Addr", noSideEffect.}
+
+proc sizeof*[T](x: T): int {.magic: "SizeOf", noSideEffect.}
+proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}

--- a/lib/std/system/setimpl.nim
+++ b/lib/std/system/setimpl.nim
@@ -1,4 +1,6 @@
 func `[]`[T](a: set[T]; i: int): var uint8 {.magic: "ArrAt".}
+template `[]=`[T](a: set[T]; i: int; val: uint8) =
+  (a[i]) = val
 
 func `+`*[T](a, b: set[T]): set[T] {.inline, noinit.} =
   for i in 0 ..< sizeof(a): result[i] = a[i] or b[i]
@@ -16,7 +18,7 @@ func `==`*[T](a, b: set[T]): bool {.inline.} =
 
 func `<=`*[T](a, b: set[T]): bool {.inline.} =
   for i in 0 ..< sizeof(a):
-    if (a[i] and not b[i]) != 0: return false
+    if (a[i] and not b[i]) != 0'u8: return false
   return true
 
 func `<`*[T](a, b: set[T]): bool = (a <= b) and not (a == b)

--- a/lib/std/system/setimpl.nim
+++ b/lib/std/system/setimpl.nim
@@ -1,0 +1,25 @@
+func `[]`[T](a: set[T]; i: int): var uint8 {.magic: "ArrAt".}
+
+func `+`*[T](a, b: set[T]): set[T] {.inline, noinit.} =
+  for i in 0 ..< sizeof(a): result[i] = a[i] or b[i]
+
+func `*`*[T](a, b: set[T]): set[T] {.inline, noinit.} =
+  for i in 0 ..< sizeof(a): result[i] = a[i] and b[i]
+
+func `-`*[T](a, b: set[T]): set[T] {.inline, noinit.} =
+  for i in 0 ..< sizeof(a): result[i] = a[i] and not b[i]
+
+func `==`*[T](a, b: set[T]): bool {.inline.} =
+  for i in 0 ..< sizeof(a):
+    if a[i] != b[i]: return false
+  return true
+
+func `<=`*[T](a, b: set[T]): bool {.inline.} =
+  for i in 0 ..< sizeof(a):
+    if (a[i] and not b[i]) != 0: return false
+  return true
+
+func `<`*[T](a, b: set[T]): bool = (a <= b) and not (a == b)
+
+func contains*[T](a: set[T], b: T): bool =
+  a * {b} != {}

--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -461,7 +461,7 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
           result.externName = pool.strings[c.litId]
           inc c
         of Nodecl, Selectany, Threadvar, Globalvar, Discardable, NoReturn,
-           Varargs, Borrow, NoSideEffect, NoDestroy, ByCopy, ByRef, Inline:
+           Varargs, Borrow, NoSideEffect, NoDestroy, ByCopy, ByRef, Inline, NoInit:
           result.flags.incl pk
           inc c
         of Header:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -218,6 +218,7 @@ type
     ByCopy = "bycopy"
     ByRef = "byref"
     Inline = "inline"
+    NoInit = "noinit"
 
   SubstructureKind* = enum
     NoSub

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4079,6 +4079,8 @@ proc semTypedAt(c: var SemContext; it: var Item) =
     inc it.typ
   of StringT, CstringT:
     it.typ = c.types.charType
+  of SetT:
+    it.typ = c.types.uint8Type
   else:
     c.buildErr lhsInfo, "invalid lhs type for typed index: " & typeToString(typ)
   wantParRi c, it.n

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1692,7 +1692,7 @@ proc semPragma(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kin
     semConstIntExpr(c, n)
     c.dest.addParRi()
   of Nodecl, Selectany, Threadvar, Globalvar, Discardable, Noreturn, Borrow,
-     NoSideEffect, NoDestroy, ByCopy, ByRef, Inline:
+     NoSideEffect, NoDestroy, ByCopy, ByRef, Inline, NoInit:
     crucial.flags.incl pk
     c.dest.add parLeToken(pool.tags.getOrIncl($pk), n.info)
     c.dest.addParRi()
@@ -2341,8 +2341,10 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
       semLocalTypeImpl c, n, context
       wantParRi c, n
       let elemType = cursorAt(c.dest, elemTypeStart)
-      # XXX allow unresolved types
-      if not isOrdinalType(elemType, allowEnumWithHoles = true):
+      if containsGenericParams(elemType):
+        # allow
+        c.dest.endRead()
+      elif not isOrdinalType(elemType, allowEnumWithHoles = true):
         c.dest.endRead()
         c.buildErr info, "set element type must be ordinal"
       else:
@@ -3526,8 +3528,9 @@ proc semSetConstr(c: var SemContext, it: var Item) =
       skip elem.n # resem elements?
     else:
       semExpr c, elem
-  # XXX allow unresolved types
-  if not isOrdinalType(elem.typ, allowEnumWithHoles = true):
+  if containsGenericParams(elem.typ):
+    discard
+  elif not isOrdinalType(elem.typ, allowEnumWithHoles = true):
     c.buildErr elemInfo, "set element type must be ordinal"
   #elif elem.typ.typeKind == IntT and c.dest[elemStart].kind == IntLit:
   #  set to range of 0..<DefaultSetElements

--- a/tests/nimony/sysbasics/tdefault.nif
+++ b/tests/nimony/sysbasics/tdefault.nif
@@ -1,12 +1,12 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tdefault.nim(stmts
- (discard 58,712,lib/std/system.nim
+ (discard 58,714,lib/std/system.nim
   (expr "")) ,1
- (discard 52,687,lib/std/system.nim
+ (discard 52,689,lib/std/system.nim
   (expr +0)) ,3
- (discard 56,715,lib/std/system.nim
+ (discard 56,717,lib/std/system.nim
   (expr 1
-   (conv ~41,~715,tests/nimony/sysbasics/tdefault.nim
+   (conv ~41,~717,tests/nimony/sysbasics/tdefault.nim
     (ptr ~12,3,lib/std/system.nim
      (i -1)) 1
     (nil)))) 10,4
@@ -40,7 +40,7 @@
      (stmts
       (ret "c"))))
    (ret result.0))) ,5
- (discard 57,709,lib/std/system.nim
+ (discard 57,711,lib/std/system.nim
   (expr 3 a.0.tde837gue)) 9,7
  (type ~4 :Obj.0.tde837gue . . . 2
   (object . ~9,1
@@ -55,14 +55,14 @@
      (fld :b.1.tde837gue . . 3 Enum.0.tde837gue .)) .))) ,12
  (discard 15
   (obj 1 Obj.0.tde837gue
-   (kv x.0.tde837gue 37,676,lib/std/system.nim
+   (kv x.0.tde837gue 37,678,lib/std/system.nim
     (expr +0))
-   (kv y.0.tde837gue 43,700,lib/std/system.nim
+   (kv y.0.tde837gue 43,702,lib/std/system.nim
     (expr ""))
    (kv z.0.tde837gue
-    (tup 39,672,lib/std/system.nim
-     (expr ~33,~311
-      (false)) 42,702,lib/std/system.nim
+    (tup 39,674,lib/std/system.nim
+     (expr ~33,~312
+      (false)) 42,704,lib/std/system.nim
      (expr 3 a.0.tde837gue))))) ,14
  (proc 5 :foo.0.tde837gue . . . 8
   (params 1
@@ -76,14 +76,14 @@
     (i -1) .) 4
    (var :data.0 . . 10,~3 Obj.0.tde837gue 10
     (obj ,~3 Obj.0.tde837gue
-     (kv x.0.tde837gue 36,673,lib/std/system.nim
+     (kv x.0.tde837gue 36,675,lib/std/system.nim
       (expr +0))
-     (kv y.0.tde837gue 42,697,lib/std/system.nim
+     (kv y.0.tde837gue 42,699,lib/std/system.nim
       (expr ""))
      (kv z.0.tde837gue
-      (tup 38,669,lib/std/system.nim
-       (expr ~33,~311
-        (false)) 41,699,lib/std/system.nim
+      (tup 38,671,lib/std/system.nim
+       (expr ~33,~312
+        (false)) 41,701,lib/std/system.nim
        (expr 3 a.0.tde837gue))))) 4,1
    (var :x.2 . .
     (string) 4 "abc") 7,2
@@ -107,7 +107,7 @@
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~5 MyObject.0.tde837gue 2
    (kv ~2 x.1.tde837gue 2 +123)
-   (kv y.1.tde837gue 35,660,lib/std/system.nim
+   (kv y.1.tde837gue 35,662,lib/std/system.nim
     (expr +0)))) 7,29
  (asgn ~7 global.0.tde837gue 10
   (obj ~5,~6 MyObject.0.tde837gue 2
@@ -119,7 +119,7 @@
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~8 MyObject.0.tde837gue 2
      (kv ~2 x.1.tde837gue 2 +123)
-     (kv y.1.tde837gue 33,657,lib/std/system.nim
+     (kv y.1.tde837gue 33,659,lib/std/system.nim
       (expr +0)))) 7,1
    (asgn ~7 global.0.tde837gue 10
     (obj ~7,~9 MyObject.0.tde837gue 2
@@ -129,7 +129,7 @@
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~8 MyObject.0.tde837gue 2
     (kv ~2 x.1.tde837gue 2 +123)
-    (kv y.1.tde837gue 33,657,lib/std/system.nim
+    (kv y.1.tde837gue 33,659,lib/std/system.nim
      (expr +0)))) 7,1
   (asgn ~7 global.0.tde837gue 10
    (obj ~7,~9 MyObject.0.tde837gue 2


### PR DESCRIPTION
refs #351

Instead of mapping the set type to the respective integer types when it has size 1, 2, 4 or 8, it is always mapped to an array of bytes. Otherwise its implementation would need complex generic code, we could implement this later.

This is not enough to implement sets as set constructors are not lowered. I'm not sure when this would be done, maybe a de-abstraction pass before everything else in gear3? It could maybe be implemented as a compilerproc that takes an array of values (when values are not constant), but this could be too slow. Not using a compilerproc could also optimize over range values.