### PR TITLE
implement ref objects by generating inner object decl

### DIFF
--- a/tests/nimony/objects/trefobject.nif
+++ b/tests/nimony/objects/trefobject.nif
@@ -1,0 +1,44 @@
+(.nif24)
+,1,tests/nimony/objects/trefobject.nim(stmts 9
+ (type ~4 :Foo.0.trej8andz . . . 2
+  (ref 4 Foo.Obj.0.trej8andz)) 9
+ (type 2 :Foo.Obj.0.trej8andz . . . 6
+  (object . ~13,1
+   (fld :x.0.trej8andz . . 2,5,lib/std/system.nim
+    (i -1) .) ~13,2
+   (fld :parent.0.trej8andz . . 9,~2
+    (ref 4 Foo.Obj.0.trej8andz) .))) 4,4
+ (var :foo.0.trej8andz . . 7,~4
+  (ref 4 Foo.Obj.0.trej8andz) .) 13,6
+ (type ~8 :Node.0.trej8andz . ~4
+  (typevars 1
+   (typevar :T.0.trej8andz . . . .)) . 2
+  (ref 4
+   (at Node.Obj.0.trej8andz T.0.trej8andz))) 13,6
+ (type 2 :Node.Obj.0.trej8andz . ~4
+  (typevars 1
+   (typevar :T.1.trej8andz . . . .)) . 6
+  (object . ~17,1
+   (fld :val.0.trej8andz . . 5 T.1.trej8andz .) ~17,2
+   (fld :left.0.trej8andz . . 13,~2
+    (ref 4
+     (at Node.Obj.0.trej8andz 1,2 T.1.trej8andz)) .) ~11,2
+   (fld :right.0.trej8andz . . 7,~2
+    (ref 4
+     (at Node.Obj.0.trej8andz 1,2 T.1.trej8andz)) .))) 4,10
+ (var :node.0.trej8andz . . 11,~4
+  (ref 4 Node.Obj.1.trej8andz) .) 14,10
+ (type :Node.3.trej8andz .
+  (at Node.0.trej8andz ~10,~4,lib/std/system.nim
+   (i -1)) ~1,~4 . 1,~4
+  (ref 4 Node.Obj.1.trej8andz)) 19,6
+ (type :Node.Obj.1.trej8andz .
+  (at Node.Obj.0.trej8andz ~15,,lib/std/system.nim
+   (i -1)) ~6 .
+  (object . ~17,1
+   (fld :val.1.trej8andz . . 2,~1,lib/std/system.nim
+    (i -1) .) ~17,2
+   (fld :left.1.trej8andz . . 13,~2
+    (ref 4 Node.Obj.1.trej8andz) .) ~11,2
+   (fld :right.1.trej8andz . . 7,~2
+    (ref 4 Node.Obj.1.trej8andz) .))))

--- a/tests/nimony/objects/trefobject.nim
+++ b/tests/nimony/objects/trefobject.nim
@@ -1,0 +1,11 @@
+type Foo = ref object
+  x: int
+  parent: Foo
+
+var foo: Foo
+
+type Node[T] = ref object
+  val: T
+  left, right: Node[T]
+
+var node: Node[int]


### PR DESCRIPTION
refs #304

This is the simplest implementation for the time being, another implementation would take longer so I did this first.

When a `ref object` type is declared, a new symbol is created for the inner object type and a type declaration is built for it, copying the typevars, pragmas and object AST from the `ref object` type. Then the body of the `ref object` type declaration is replaced with either `ref ObjSym` if the type is not generic and `ref ObjSym[T1, T2, ...]` if it is. Finally the type declaration built for the inner object is processed (a forward type pass is also run on it before finishing the `ref object` type).

This works with the existing code for `ref ObjType` skipping and gives a proper type to expressions like `foo[]` where `foo` has `ref object` type. 