### PR TITLE
Fix compile errors from nifc when asm enabled

### DIFF
--- a/src/nifc/amd64/emitter.nim
+++ b/src/nifc/amd64/emitter.nim
@@ -120,6 +120,8 @@ proc matchAndEmitTag(c: var Context; tag: TagId; asStr: string): bool =
     result = false
 
 proc matchAny(c: var Context): bool =
+  result = false
+
   while true:
     case c.current.kind
     of UnknownToken, DotToken, Ident, Symbol, SymbolDef, StringLit, CharLit, IntLit, UIntLit, FloatLit:
@@ -170,5 +172,5 @@ proc produceAsmCode*(buffer, outp: string) =
   c.current = beginRead(c.input)
   if not genModule(c):
     error(c, "(stmts) expected")
-  endRead(c.input, c.current)
+  endRead(c.input)
   writeFile outp, c.dest

--- a/src/nifc/amd64/genasm.nim
+++ b/src/nifc/amd64/genasm.nim
@@ -61,36 +61,40 @@ proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) {.nor
 # Atoms
 
 proc genIntLit(c: var GeneratedCode; litId: LitId; info: PackedLineInfo) =
-  let i = parseBiggestInt(c.m.lits.strings[litId])
-  let id = pool.integers.getOrIncl(i)
-  c.code.add toToken(IntLit, id, info)
+  c.code.addIntLit parseBiggestInt(c.m.lits.strings[litId]), info
 
 proc genIntLit(c: var GeneratedCode; i: BiggestInt; info: PackedLineInfo) =
-  let id = pool.integers.getOrIncl(i)
-  c.code.add toToken(IntLit, id, info)
+  c.code.addIntLit i, info
 
 proc genIntLit(c: var TokenBuf; i: BiggestInt; info: PackedLineInfo) =
-  let id = pool.integers.getOrIncl(i)
-  c.add toToken(IntLit, id, info)
+  c.addIntLit i, info
 
 proc genUIntLit(c: var GeneratedCode; litId: LitId; info: PackedLineInfo) =
   let i = parseBiggestUInt(c.m.lits.strings[litId])
   let id = pool.uintegers.getOrIncl(i)
-  c.code.add toToken(UIntLit, id, info)
+  c.code.add uintToken(id, info)
+
+proc genUIntLit(c: var GeneratedCode; i: BiggestUInt; info: PackedLineInfo) =
+  let id = pool.uintegers.getOrIncl(i)
+  c.code.add uintToken(id, info)
 
 proc genFloatLit(c: var GeneratedCode; litId: LitId; info: PackedLineInfo) =
   let i = parseFloat(c.m.lits.strings[litId])
   let id = pool.floats.getOrIncl(i)
-  c.code.add toToken(FloatLit, id, info)
+  c.code.add floatToken(id, info)
+
+proc genFloatLit(c: var GeneratedCode; i: float; info: PackedLineInfo) =
+  let id = pool.floats.getOrIncl(i)
+  c.code.add floatToken(id, info)
 
 proc genCharLit(c: var GeneratedCode; ch: char; info: PackedLineInfo) =
-  c.code.add toToken(CharLit, uint32(ch), info)
+  c.code.add charToken(ch, info)
 
 proc addIdent(c: var GeneratedCode; s: string; info: PackedLineInfo) =
-  c.code.add toToken(Ident, pool.strings.getOrIncl(s), info)
+  c.code.add identToken(pool.strings.getOrIncl(s), info)
 
 proc addEmpty(c: var GeneratedCode; info: PackedLineInfo) =
-  c.code.add toToken(DotToken, 0'u32, info)
+  c.code.add dotToken(info)
 
 proc addKeyw(c: var GeneratedCode; keyw: TagId; info = NoLineInfo) =
   c.code.buildTree keyw, info: discard
@@ -99,13 +103,13 @@ proc addKeywUnchecked(c: var GeneratedCode; keyw: string; info = NoLineInfo) =
   c.code.buildTree pool.tags.getOrIncl(keyw), info: discard
 
 proc addSymDef(c: var TokenBuf; s: string; info: PackedLineInfo) =
-  c.add toToken(SymbolDef, pool.syms.getOrIncl(s), info)
+  c.add symdefToken(pool.syms.getOrIncl(s), info)
 
 proc addStrLit(c: var TokenBuf; s: string; info: PackedLineInfo) =
-  c.add toToken(StringLit, pool.strings.getOrIncl(s), info)
+  c.addStrLit s, info
 
 proc addSym(c: var GeneratedCode; s: string; info: PackedLineInfo) =
-  c.code.add toToken(Symbol, pool.syms.getOrIncl(s), info)
+  c.code.add symToken(pool.syms.getOrIncl(s), info)
 
 proc getLabel(c: var GeneratedCode): Label =
   result = Label(c.labels)
@@ -140,7 +144,7 @@ include ".." / preasm / genpreasm_t
 
 proc genWas(c: var GeneratedCode; t: Tree; ch: NodePos) =
   c.code.buildTree(CommentT, t[ch].info):
-    c.code.add toToken(Ident, pool.strings.getOrIncl(toString(t, ch.firstSon, c.m)), t[ch].info)
+    c.addIdent toString(t, ch.firstSon, c.m), t[ch].info
 
 type
   ProcFlag = enum

--- a/src/nifc/amd64/genasm_e.nim
+++ b/src/nifc/amd64/genasm_e.nim
@@ -41,21 +41,21 @@ proc jumpToPutInstr(t: TagId): TagId =
   else: NopT
 
 proc emitDataRaw(c: var GeneratedCode; loc: Location) =
-  c.code.add toToken(Symbol, pool.syms.getOrIncl(c.m.lits.strings[loc.data]), NoLineInfo)
+  c.addSym c.m.lits.strings[loc.data], NoLineInfo
 
 proc emitImmediate*(c: var GeneratedCode; ival: int) =
-  c.code.add toToken(IntLit, pool.integers.getOrIncl(ival), NoLineInfo)
+  c.genIntLit ival, NoLineInfo
 
 proc emitLoc*(c: var GeneratedCode; loc: Location) =
   case loc.kind
   of Undef:
     assert false, "location should have been set"
   of ImmediateInt:
-    c.code.add toToken(IntLit, pool.integers.getOrIncl(loc.ival), NoLineInfo)
+    c.genIntLit loc.ival, NoLineInfo
   of ImmediateUInt:
-    c.code.add toToken(UIntLit, pool.uintegers.getOrIncl(loc.uval), NoLineInfo)
+    c.genUIntLit loc.uval, NoLineInfo
   of ImmediateFloat:
-    c.code.add toToken(FloatLit, pool.floats.getOrIncl(loc.fval), NoLineInfo)
+    c.genFloatLit loc.fval, NoLineInfo
   of InReg:
     c.addKeywUnchecked regName(loc.reg1)
   of InRegFp:
@@ -63,7 +63,7 @@ proc emitLoc*(c: var GeneratedCode; loc: Location) =
   of InFlag:
     assert false, "not implemented"
   of JumpMode:
-    c.code.add toToken(Ident, pool.strings.getOrIncl("L." & $loc.label), NoLineInfo)
+    c.addIdent "L." & $loc.label, NoLineInfo
   of InData:
     c.buildTree RelT:
       c.emitDataRaw loc
@@ -75,19 +75,19 @@ proc emitLoc*(c: var GeneratedCode; loc: Location) =
   of InRegOffset:
     c.buildTree Mem2T:
       c.addKeywUnchecked regName(loc.reg1)
-      c.code.add toToken(IntLit, pool.integers.getOrIncl(loc.typ.offset), NoLineInfo)
+      c.genIntLit loc.typ.offset, NoLineInfo
   of InRegRegScaledOffset:
     if loc.typ.offset == 0:
       c.buildTree Mem3T:
         c.addKeywUnchecked regName(loc.reg1)
         c.addKeywUnchecked regName(loc.reg2)
-        c.code.add toToken(IntLit, pool.integers.getOrIncl(loc.typ.size), NoLineInfo)
+        c.genIntLit loc.typ.size, NoLineInfo
     else:
       c.buildTree Mem4T:
         c.addKeywUnchecked regName(loc.reg1)
         c.addKeywUnchecked regName(loc.reg2)
-        c.code.add toToken(IntLit, pool.integers.getOrIncl(loc.typ.size), NoLineInfo)
-        c.code.add toToken(IntLit, pool.integers.getOrIncl(loc.typ.offset), NoLineInfo)
+        c.genIntLit loc.typ.size, NoLineInfo
+        c.genIntLit loc.typ.offset, NoLineInfo
 
 proc genx(c: var GeneratedCode; t: Tree; n: NodePos; dest: var Location)
 

--- a/src/nifc/amd64/genasm_s.nim
+++ b/src/nifc/amd64/genasm_s.nim
@@ -217,7 +217,7 @@ proc fixupStackOffset(c: var GeneratedCode; j, s: int) =
   of Mem2T, Mem4T:
     let newOffset = pool.integers[c.code[patchPos].intId] + s
     let sid = pool.integers.getOrIncl(newOffset)
-    c.code[patchPos] = toToken(IntLit, sid, NoLineInfo)
+    c.code[patchPos] = intToken(sid, NoLineInfo)
   of Mem3T:
     assert false, "should have been a Mem4T instruction"
   else:
@@ -230,12 +230,12 @@ proc fixupProlog(c: var GeneratedCode) =
   if s > 0:
     # patch the tokens
     # SkipT becomes SubT:
-    c.code[i] = toToken(ParLe, SubT, NoLineInfo)
+    c.code[i] = parLeToken(SubT, NoLineInfo)
     # i+1: (rsp
     # i+2: )
     # i+3: 0
     let sid = pool.integers.getOrIncl(s)
-    c.code[i+3] = toToken(IntLit, sid, NoLineInfo)
+    c.code[i+3] = intToken(sid, NoLineInfo)
     # i+4: )
     # Now also fixup every address that used `rsp` as it's off
     # by the offset

--- a/src/nifc/amd64/machine.nim
+++ b/src/nifc/amd64/machine.nim
@@ -241,6 +241,9 @@ proc paramOnStack(loc: Location): bool {.inline.} =
   loc.kind == InRegOffset and loc.reg1 == Rsp2
 
 proc allocParamWin64*(a: var RegAllocator; param: AsmSlot): Location =
+  # Fix compile error: Cannot prove that 'result' is initialized.
+  #result = default(Location)
+
   if param.kind == AFloat:
     # see https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170
     # Use XMM0L, XMM1L, XMM2L, and XMM3L.

--- a/src/nifc/amd64/register_allocator.nim
+++ b/src/nifc/amd64/register_allocator.nim
@@ -99,7 +99,8 @@ proc allocRegsForProc(c: var GeneratedCode; t: Tree; n: NodePos; weights: Table[
      ParC, AndC, OrC, NotC, NegC, OconstrC, AconstrC, KvC,
      AddC, SubC, MulC, DivC, ModC, ShrC, ShlC, BitandC, BitorC, BitxorC, BitnotC,
      EqC, NeqC, LeC, LtC, CastC, ConvC, RangeC, RangesC, IfC, ElifC, ElseC,
-     BreakC, CaseC, OfC, LabC, JmpC, RetC, ParamsC, CallC:
+     BreakC, CaseC, OfC, LabC, JmpC, RetC, ParamsC, CallC, OnErrC, DiscardC,
+     TryC, RaiseC:
     for ch in sons(t, n):
       allocRegsForProc(c, t, ch, weights)
   of DotC, GvarC, TvarC, ConstC, ProcC, FldC,
@@ -107,7 +108,8 @@ proc allocRegsForProc(c: var GeneratedCode; t: Tree; n: NodePos; weights: Table[
      IntC, UIntC, FloatC, CharC, BoolC, VoidC, PtrC, ArrayC, FlexarrayC,
      APtrC, TypeC, CdeclC, StdcallC, SafecallC, SyscallC, FastcallC, ThiscallC,
      NoconvC, MemberC, AttrC, InlineC, NoinlineC, VarargsC, WasC, SelectanyC,
-     PragmasC, AlignC, BitsC, VectorC, ImpC, NodeclC, InclC, SufC, RaisesC, ErrsC:
+     PragmasC, AlignC, BitsC, VectorC, ImpC, NodeclC, InclC, SufC, RaisesC, ErrsC,
+     StaticC, ErrC:
     discard "do not traverse these"
 
 proc allocateVars*(c: var GeneratedCode; t: Tree; n: NodePos) =

--- a/src/nifc/native/analyser.nim
+++ b/src/nifc/native/analyser.nim
@@ -70,7 +70,7 @@ proc analyseVarUsages(c: var Context; t: Tree; n: NodePos) =
     for ch in sons(t, n):
       analyseVarUsages(c, t, ch)
     c.closeScope()
-  of CallC:
+  of CallC, OnErrC:
     # XXX Special case `cold` procs like `raiseIndexError` in order
     # to produce better code for the common case.
     for ch in sons(t, n):
@@ -148,7 +148,7 @@ proc analyseVarUsages(c: var Context; t: Tree; n: NodePos) =
   of ParC, AndC, OrC, NotC, NegC, OconstrC, AconstrC, KvC,
      AddC, SubC, MulC, DivC, ModC, ShrC, ShlC, BitandC, BitorC, BitxorC, BitnotC,
      EqC, NeqC, LeC, LtC, CastC, ConvC, RangeC, RangesC, IfC, ElifC, ElseC,
-     BreakC, CaseC, OfC, LabC, JmpC, RetC, ParamsC:
+     BreakC, CaseC, OfC, LabC, JmpC, RetC, ParamsC, DiscardC, TryC:
     for ch in sons(t, n):
       analyseVarUsages(c, t, ch)
   of ProcC, FldC,
@@ -156,7 +156,8 @@ proc analyseVarUsages(c: var Context; t: Tree; n: NodePos) =
      IntC, UIntC, FloatC, CharC, BoolC, VoidC, PtrC, ArrayC, FlexarrayC,
      APtrC, TypeC, CdeclC, StdcallC, SafecallC, SyscallC, FastcallC, ThiscallC,
      NoconvC, MemberC, AttrC, InlineC, NoinlineC, VarargsC, WasC, SelectanyC,
-     PragmasC, AlignC, BitsC, VectorC, ImpC, NodeclC, InclC, SufC, RaiseC, ErrsC:
+     PragmasC, AlignC, BitsC, VectorC, ImpC, NodeclC, InclC, SufC, RaiseC, ErrsC,
+     RaisesC, ErrC, StaticC:
     discard "do not traverse these"
 
 proc analyseVarUsages*(t: Tree; n: NodePos): ProcBodyProps =


### PR DESCRIPTION
I tried to compile nifc with `nim c -d:enableAsm src/nifc/nifc.nim` to try nifc's native target. But I got compile errors.

In `proc matchAny(c: var Context): bool` in `src/nifc/amd64/emitter.nim`, it seems `result` should be set in `of ParLe:` branch.
But I don't know how `result` should be set, so I just initialized `result` with `false`.

In `proc allocParamWin64*(a: var RegAllocator; param: AsmSlot): Location =` proc in `src/nifc/amd64/machine.nim`,
it seems `result` is assigned in all branches and always initialized but compiler says "Error: Cannot prove that 'result' is initialized.".
