### PR TITLE
implements `{.compile.}`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "mimalloc"]
+[submodule "vendor/mimalloc"]
 	path = vendor/mimalloc
 	url = https://github.com/microsoft/mimalloc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mimalloc"]
+	path = vendor/mimalloc
+	url = https://github.com/microsoft/mimalloc

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -1,4 +1,4 @@
-{.compile("vendor/mimalloc/src/static.c", "-Ivendor/mimalloc/include").}
+{.compile("../../../vendor/mimalloc/src/static.c", "-Ivendor/mimalloc/include").}
 
 type
   csize_t* {.importc: "size_t", nodecl.} = uint

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -1,0 +1,26 @@
+{.compile("vendor/mimalloc/src/static.c", "-Ivendor/mimalloc/include").}
+
+type
+  csize_t* {.importc: "size_t", nodecl.} = uint
+
+proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc".}
+proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc".}
+proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc".}
+proc mi_free(p: pointer) {.importc: "mi_free".}
+
+
+proc reallocImpl(p: pointer, newSize: int): pointer =
+  
+
+proc realloc0Impl(p: pointer, oldSize, newSize: Natural): pointer =
+  result = realloc(p, newSize.csize_t)
+
+
+proc alloc*(size: int): pointer =
+  result = mi_malloc(size.csize_t)
+
+proc realloc*(p: pointer; size: int): pointer =
+  result = mi_realloc(p, size.csize_t)
+
+proc dealloc*(p: pointer) =
+  mi_free(p)

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -8,6 +8,7 @@ proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc".}
 proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc".}
 proc mi_free(p: pointer) {.importc: "mi_free".}
 
+proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size".}
 
 proc alloc*(size: int): pointer =
   result = mi_malloc(size.csize_t)
@@ -17,3 +18,6 @@ proc realloc*(p: pointer; size: int): pointer =
 
 proc dealloc*(p: pointer) =
   mi_free(p)
+
+proc allocatedSize*(p: pointer): int =
+  result = int mi_usable_size(p)

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -9,13 +9,6 @@ proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc".}
 proc mi_free(p: pointer) {.importc: "mi_free".}
 
 
-proc reallocImpl(p: pointer, newSize: int): pointer =
-  
-
-proc realloc0Impl(p: pointer, oldSize, newSize: Natural): pointer =
-  result = realloc(p, newSize.csize_t)
-
-
 proc alloc*(size: int): pointer =
   result = mi_malloc(size.csize_t)
 

--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -357,7 +357,8 @@ proc trStmt(c: var Context; dest: var TokenBuf; n: var Cursor) =
     trBlock c, dest, n, tar
   of IterS, TemplateS, TypeS, EmitS, BreakS, ContinueS,
      ForS, CmdS, IncludeS, ImportS, FromImportS, ImportExceptS,
-     ExportS, CommentS, ClonerS, TracerS, DisarmerS, MoverS, DtorS:
+     ExportS, CommentS, ClonerS, TracerS, DisarmerS, MoverS, DtorS,
+     PragmasLineS:
     takeTree dest, n
   of StmtsS:
     copyInto(dest, n):

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -300,7 +300,9 @@ proc generateMakefile(c: DepContext; commandLineArgs: string): string =
     s.add "\n\t$(CC) -o $@ $^"
 
     for cfile in c.toCompile:
-      s.add "\n" & mescape("nifcache" / cfile.obj) & ": " & mescape(cfile.name) & "\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@"
+      s.add "\n" & mescape("nifcache" / cfile.obj) & ": " & mescape(cfile.name) &
+            "\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) " &
+            cfile.customArgs & " $< -o $@"
 
     # The .o files depend on all of their .c files:
     s.add "\n%.o: %.c\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@"

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -184,7 +184,7 @@ proc processCompile(c: var DepContext; it: var Cursor; current: Node) =
     inc it # skips TupleConstrX
     # (file, obj, customArgs)
     let name = pool.strings[it.litId]
-    compileObj.name = absolutePath(name)
+    compileObj.name = name
     inc it
     if compileObj.obj.len == 0:
       compileObj.obj = name

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -149,6 +149,7 @@ proc handleCmdLine() =
   of FullProject:
     createDir("nifcache")
     createDir(binDir())
+    exec "git submodule update --init"
     requiresTool "nifler", "src/nifler/nifler.nim", forceRebuild
     requiresTool "nimsem", "src/nimony/nimsem.nim", forceRebuild
     requiresTool "hexer", "src/hexer/hexer.nim", forceRebuild

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -51,6 +51,7 @@ type
     DisarmerS = "disarmer"
     MoverS = "mover"
     DtorS = "dtor"
+    PragmasLineS = "pragmas"
 
   SymKind* = enum
     NoSym

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4572,6 +4572,8 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
         skip it.n
       of ClonerS, TracerS, DisarmerS, MoverS, DtorS:
         takeTree c, it.n
+      of PragmasLineS:
+        takeTree c, it.n
     of FalseX, TrueX:
       literalB c, it, c.types.boolType
     of InfX, NegInfX, NanX:

--- a/tests/nimony/sysbasics/foo.c
+++ b/tests/nimony/sysbasics/foo.c
@@ -1,0 +1,3 @@
+int myFunc() {
+  return 12;
+}

--- a/tests/nimony/sysbasics/foo1.c
+++ b/tests/nimony/sysbasics/foo1.c
@@ -1,0 +1,3 @@
+int myFunc2() {
+  return 12;
+}

--- a/tests/nimony/sysbasics/tcompile.nim
+++ b/tests/nimony/sysbasics/tcompile.nim
@@ -1,5 +1,4 @@
-{.compile: "tests/nimony/sysbasics/foo.c".}
-# TODO: stores filename in the deps so that relative paths work
+{.compile: "foo.c".}
 
 proc myFunc(): int {.importc: "myFunc".}
 

--- a/tests/nimony/sysbasics/tcompile.nim
+++ b/tests/nimony/sysbasics/tcompile.nim
@@ -1,5 +1,8 @@
 {.compile: "foo.c".}
+{.compile("foo.c", "-fno-strict-aliasing")
 
 proc myFunc(): int {.importc: "myFunc".}
+proc myFunc2(): int {.importc: "myFunc2".}
 
 let s = myFunc()
+let s2 = myFunc2()

--- a/tests/nimony/sysbasics/tcompile.nim
+++ b/tests/nimony/sysbasics/tcompile.nim
@@ -1,0 +1,6 @@
+{.compile: "tests/nimony/sysbasics/foo.c".}
+# TODO: stores filename in the deps so that relative paths work
+
+proc myFunc(): int {.importc: "myFunc".}
+
+let s = myFunc()


### PR DESCRIPTION
fixes https://github.com/nim-lang/nimony/issues/357

ref https://github.com/microsoft/mimalloc

- [x] Make hastur download mimalloc as part of the build process. Maybe depend on it via a git submodule.
- [x] Add `.compile: "foo.c"` to Nimony so that we can also depend on C code like mimalloc.
- [x] Make use of `.compile` in system.nim so we can use a decent memory allocator which offers `allocatedSize()` so that our new super efficient strings and seq can use it.