### PR TITLE
Fix compile errors from nifc when asm enabled

### DIFF
--- a/src/nifc/amd64/machine.nim
+++ b/src/nifc/amd64/machine.nim
@@ -242,7 +242,7 @@ proc paramOnStack(loc: Location): bool {.inline.} =
 
 proc allocParamWin64*(a: var RegAllocator; param: AsmSlot): Location =
   # Fix compile error: Cannot prove that 'result' is initialized.
-  #result = default(Location)
+  result = default(Location)
 
   if param.kind == AFloat:
     # see https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170


### PR DESCRIPTION
I'm sorry, but I forgot to uncomment the line in the previous PR https://github.com/nim-lang/nimony/pull/365 that also fix the compile error.
