### PR TITLE
fixes for symbol defs in generics and templates

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -379,8 +379,8 @@ proc declareResult(c: var SemContext; info: PackedLineInfo): SymId =
 
 # -------------------- generics ---------------------------------
 
-proc newSymId(c: var SemContext; s: SymId; overrideGlobal = false): SymId =
-  var isGlobal = overrideGlobal and c.currentScope.kind == ToplevelScope
+proc newSymId(c: var SemContext; s: SymId): SymId =
+  var isGlobal = false
   var name = extractBasename(pool.syms[s], isGlobal)
   if isGlobal:
     c.makeGlobalSym(name)
@@ -417,7 +417,7 @@ proc subs(c: var SemContext; dest: var TokenBuf; sc: var SubsContext; body: Curs
           dest.add n # keep Symbol as it was
     of SymbolDef:
       let s = n.symId
-      let newDef = newSymId(c, s, overrideGlobal = true)
+      let newDef = newSymId(c, s)
       sc.newVars[s] = newDef
       dest.add symdefToken(newDef, n.info)
     of ParLe:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -379,8 +379,8 @@ proc declareResult(c: var SemContext; info: PackedLineInfo): SymId =
 
 # -------------------- generics ---------------------------------
 
-proc newSymId(c: var SemContext; s: SymId): SymId =
-  var isGlobal = false
+proc newSymId(c: var SemContext; s: SymId; overrideGlobal = false): SymId =
+  var isGlobal = overrideGlobal and c.currentScope.kind == ToplevelScope
   var name = extractBasename(pool.syms[s], isGlobal)
   if isGlobal:
     c.makeGlobalSym(name)
@@ -392,6 +392,10 @@ type
   SubsContext = object
     newVars: Table[SymId, SymId]
     params: ptr Table[SymId, Cursor]
+
+proc addFreshSyms(c: var SemContext, sc: var SubsContext) =
+  for _, newVar in sc.newVars:
+    c.freshSyms.incl newVar
 
 proc subs(c: var SemContext; dest: var TokenBuf; sc: var SubsContext; body: Cursor) =
   var nested = 0
@@ -413,7 +417,7 @@ proc subs(c: var SemContext; dest: var TokenBuf; sc: var SubsContext; body: Curs
           dest.add n # keep Symbol as it was
     of SymbolDef:
       let s = n.symId
-      let newDef = newSymId(c, s)
+      let newDef = newSymId(c, s, overrideGlobal = true)
       sc.newVars[s] = newDef
       dest.add symdefToken(newDef, n.info)
     of ParLe:
@@ -458,6 +462,7 @@ proc subsGenericType(c: var SemContext; dest: var TokenBuf; req: InstRequest) =
     dest.copyTree decl.pragmas
     var sc = SubsContext(params: addr req.inferred)
     subs(c, dest, sc, decl.body)
+    addFreshSyms(c, sc)
 
 proc subsGenericProc(c: var SemContext; dest: var TokenBuf; req: InstRequest) =
   let info = req.requestFrom[^1]
@@ -478,6 +483,7 @@ proc subsGenericProc(c: var SemContext; dest: var TokenBuf; req: InstRequest) =
     subs(c, dest, sc, decl.effects)
     subs(c, dest, sc, decl.pragmas)
     subs(c, dest, sc, decl.body)
+    addFreshSyms(c, sc)
 
 template withFromInfo(req: InstRequest; body: untyped) =
   let oldLen = c.instantiatedFrom.len
@@ -896,6 +902,7 @@ proc requestRoutineInstance(c: var SemContext; origin: SymId;
       subs(c, signature, sc, decl.retType)
       subs(c, signature, sc, decl.pragmas)
       subs(c, signature, sc, decl.effects)
+      addFreshSyms(c, sc)
       signature.addDotToken() # no body
 
     result = ProcInstance(targetSym: targetSym, procType: cursorAt(signature, 0),
@@ -1969,6 +1976,7 @@ proc subsGenericTypeFromArgs(c: var SemContext; dest: var TokenBuf; info: Packed
     if err == 0:
       var sc = SubsContext(params: addr inferred)
       subs(c, dest, sc, decl.body)
+      addFreshSyms(c, sc)
     elif err == 1:
       dest.buildLocalErr info, "too few generic arguments provided"
     else:
@@ -3358,7 +3366,9 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
 
   var isEnumTypeDecl = false
 
-  if c.phase == SemcheckSignatures or (delayed.status == OkNew and c.phase != SemcheckTopLevelSyms):
+  if c.phase == SemcheckSignatures or
+      (delayed.status in {OkNew, OkExistingFresh} and
+        c.phase != SemcheckTopLevelSyms):
     var isGeneric: bool
     let prevGeneric = c.routine.inGeneric
     if n.kind == DotToken:

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -95,3 +95,4 @@ type
     meta*: MetaInfo
     genericHooks*: Table[SymId, seq[SymId]]
     hookIndexMap*: Table[string, seq[(SymId, SymId)]]
+    freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking

--- a/src/nimony/templates.nim
+++ b/src/nimony/templates.nim
@@ -41,7 +41,7 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
             dest.add body # keep Symbol as it was
     of SymbolDef:
       let s = body.symId
-      let newDef = newSymId(c, s, overrideGlobal = true)
+      let newDef = newSymId(c, s)
       e.newVars[s] = newDef
       dest.add symdefToken(newDef, body.info)
     of StringLit, CharLit, IntLit, UIntLit, FloatLit:

--- a/src/nimony/templates.nim
+++ b/src/nimony/templates.nim
@@ -41,7 +41,7 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
             dest.add body # keep Symbol as it was
     of SymbolDef:
       let s = body.symId
-      let newDef = newSymId(c, s)
+      let newDef = newSymId(c, s, overrideGlobal = true)
       e.newVars[s] = newDef
       dest.add symdefToken(newDef, body.info)
     of StringLit, CharLit, IntLit, UIntLit, FloatLit:
@@ -140,3 +140,6 @@ proc expandTemplate*(c: var SemContext; dest: var TokenBuf;
       skip f
 
   expandTemplateImpl c, dest, e, templ.body
+
+  for _, newVar in e.newVars:
+    c.freshSyms.incl newVar

--- a/tests/nimony/basics/tresemtype.nif
+++ b/tests/nimony/basics/tresemtype.nif
@@ -1,0 +1,72 @@
+(.nif24)
+,3,tests/nimony/basics/tresemtype.nim(stmts
+ (proc 5 :foo.0.treh8w5hd . . 8
+  (typevars 1
+   (typevar :T.0.treh8w5hd . . . .)) 11
+  (params 1
+   (param :x.0 . . 3 T.0.treh8w5hd .)) . . . 2,1
+  (stmts 9
+   (type ~4 :Foo.0 . . . 2
+    (object . ~9,1
+     (fld :val.0.treh8w5hd . . 5 T.0.treh8w5hd .))) 4,2
+   (var :obj.0 . . 6 Foo.0 9
+    (obj ~3 Foo.0 4
+     (kv ~4 val.0.treh8w5hd 2 x.0))))) 3,5
+ (call ~3 foo.1.treh8w5hd 1 +123) 3,6
+ (call ~3 foo.2.treh8w5hd 1 "abc") ,8
+ (template 9 :fooTempl.0.treh8w5hd . . 17
+  (typevars 1
+   (typevar :T.1.treh8w5hd . . . .)) 20
+  (params 1
+   (param :x.1 . . 3 T.1.treh8w5hd .)) . . . 2,1
+  (stmts 9
+   (type ~4 :Foo.1 . . . 2
+    (object . ~9,1
+     (fld :val.1.treh8w5hd . . 5 T.1.treh8w5hd .))) 4,2
+   (var :obj.1 . . 6 Foo.1 9
+    (obj ~3 Foo.1 4
+     (kv ~4 val.1.treh8w5hd 2 x.1))))) 2,9
+ (stmts 9
+  (type ~4 :Foo.0.treh8w5hd . . . 2
+   (object . ~9,1
+    (fld :val.2.treh8w5hd . .
+     (i -1) .))) 4,2
+  (var :obj.0.treh8w5hd . . 6 Foo.0.treh8w5hd 9
+   (obj ~3 Foo.0.treh8w5hd 4
+    (kv ~4 val.2.treh8w5hd ~10,2 +123)))) 2,9
+ (stmts 9
+  (type ~4 :Foo.1.treh8w5hd . . . 2
+   (object . ~9,1
+    (fld :val.3.treh8w5hd . .
+     (string) .))) 4,2
+  (var :obj.1.treh8w5hd . . 6 Foo.1.treh8w5hd 9
+   (obj ~3 Foo.1.treh8w5hd 4
+    (kv ~4 val.3.treh8w5hd ~10,3 "abc")))) 3,5
+ (proc :foo.1.treh8w5hd . ~3,~5 .
+  (at foo.0.treh8w5hd
+   (i -1)) 8,~5
+  (params 1
+   (param :x.2.treh8w5hd . .
+    (i -1) .)) ~3,~5 . ~3,~5 . ~3,~5 . ~1,~4
+  (stmts 9
+   (type ~4 :Foo.2.treh8w5hd . . . 2
+    (object . ~9,1
+     (fld :val.4.treh8w5hd . .
+      (i -1) .))) 4,2
+   (var :obj.2.treh8w5hd . . 6 Foo.2.treh8w5hd 9
+    (obj ~3 Foo.2.treh8w5hd 4
+     (kv ~4 val.4.treh8w5hd 2 x.2.treh8w5hd))))) 3,6
+ (proc :foo.2.treh8w5hd . ~3,~6 .
+  (at foo.0.treh8w5hd
+   (string)) 8,~6
+  (params 1
+   (param :x.3.treh8w5hd . .
+    (string) .)) ~3,~6 . ~3,~6 . ~3,~6 . ~1,~5
+  (stmts 9
+   (type ~4 :Foo.3.treh8w5hd . . . 2
+    (object . ~9,1
+     (fld :val.5.treh8w5hd . .
+      (string) .))) 4,2
+   (var :obj.3.treh8w5hd . . 6 Foo.3.treh8w5hd 9
+    (obj ~3 Foo.3.treh8w5hd 4
+     (kv ~4 val.5.treh8w5hd 2 x.3.treh8w5hd))))))

--- a/tests/nimony/basics/tresemtype.nif
+++ b/tests/nimony/basics/tresemtype.nif
@@ -27,46 +27,46 @@
     (obj ~3 Foo.1 4
      (kv ~4 val.1.treh8w5hd 2 x.1))))) 2,9
  (stmts 9
-  (type ~4 :Foo.0.treh8w5hd . . . 2
+  (type ~4 :Foo.2 . . . 2
    (object . ~9,1
     (fld :val.2.treh8w5hd . .
      (i -1) .))) 4,2
-  (var :obj.0.treh8w5hd . . 6 Foo.0.treh8w5hd 9
-   (obj ~3 Foo.0.treh8w5hd 4
+  (var :obj.2 . . 6 Foo.2 9
+   (obj ~3 Foo.2 4
     (kv ~4 val.2.treh8w5hd ~10,2 +123)))) 2,9
  (stmts 9
-  (type ~4 :Foo.1.treh8w5hd . . . 2
+  (type ~4 :Foo.3 . . . 2
    (object . ~9,1
     (fld :val.3.treh8w5hd . .
      (string) .))) 4,2
-  (var :obj.1.treh8w5hd . . 6 Foo.1.treh8w5hd 9
-   (obj ~3 Foo.1.treh8w5hd 4
+  (var :obj.3 . . 6 Foo.3 9
+   (obj ~3 Foo.3 4
     (kv ~4 val.3.treh8w5hd ~10,3 "abc")))) 3,5
  (proc :foo.1.treh8w5hd . ~3,~5 .
   (at foo.0.treh8w5hd
    (i -1)) 8,~5
   (params 1
-   (param :x.2.treh8w5hd . .
+   (param :x.4 . .
     (i -1) .)) ~3,~5 . ~3,~5 . ~3,~5 . ~1,~4
   (stmts 9
-   (type ~4 :Foo.2.treh8w5hd . . . 2
+   (type ~4 :Foo.4 . . . 2
     (object . ~9,1
      (fld :val.4.treh8w5hd . .
       (i -1) .))) 4,2
-   (var :obj.2.treh8w5hd . . 6 Foo.2.treh8w5hd 9
-    (obj ~3 Foo.2.treh8w5hd 4
-     (kv ~4 val.4.treh8w5hd 2 x.2.treh8w5hd))))) 3,6
+   (var :obj.4 . . 6 Foo.4 9
+    (obj ~3 Foo.4 4
+     (kv ~4 val.4.treh8w5hd 2 x.4))))) 3,6
  (proc :foo.2.treh8w5hd . ~3,~6 .
   (at foo.0.treh8w5hd
    (string)) 8,~6
   (params 1
-   (param :x.3.treh8w5hd . .
+   (param :x.5 . .
     (string) .)) ~3,~6 . ~3,~6 . ~3,~6 . ~1,~5
   (stmts 9
-   (type ~4 :Foo.3.treh8w5hd . . . 2
+   (type ~4 :Foo.5 . . . 2
     (object . ~9,1
      (fld :val.5.treh8w5hd . .
       (string) .))) 4,2
-   (var :obj.3.treh8w5hd . . 6 Foo.3.treh8w5hd 9
-    (obj ~3 Foo.3.treh8w5hd 4
-     (kv ~4 val.5.treh8w5hd 2 x.3.treh8w5hd))))))
+   (var :obj.5 . . 6 Foo.5 9
+    (obj ~3 Foo.5 4
+     (kv ~4 val.5.treh8w5hd 2 x.5))))))

--- a/tests/nimony/basics/tresemtype.nim
+++ b/tests/nimony/basics/tresemtype.nim
@@ -1,0 +1,17 @@
+# does not fully compile yet because types in procs are not lifted
+
+proc foo[T](x: T) =
+  type Foo = object
+    val: T
+  var obj = Foo(val: x)
+
+foo(123)
+foo("abc")
+
+template fooTempl[T](x: T) =
+  type Foo = object
+    val: T
+  var obj = Foo(val: x)
+
+fooTempl(123)
+fooTempl("abc")


### PR DESCRIPTION
Probably no high priority bugs here, just wanted to lay this out before I forgot about it. If the fixes aren't good enough then this can be closed for now.

Type definitions only semcheck the type bodies if the symbol is freshly declared (an identifier). However in generics and templates, definitions define symbols even if their bodies are not fully checked yet. To deal with this, every symboldef introduced by a template/generic instantiation is marked as "fresh" in the sem context so that type definitions can typecheck their bodies. The way this is done I'm not sure about, it's a set of sym IDs that removes a sym when it's been processed via `handleSymDef`, I don't know if this would leave any symbols remaining. It's not scope sensitive either.

The test does not pass hexer (which is not tested) due to the `tryLoadSym` call in `traverseType` breaking for local type symbols, and doesn't pass nifc due to types not being lifted yet, so for now it's a semcheck test.