### PR TITLE
add tag for dereferencing dot fields

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -567,7 +567,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
       trConvExpr c, n, e
     of OconstrX, NewOconstrX:
       trObjConstr c, n, e
-    of DotX, AtX, ArrAtX, PatX, TupAtX:
+    of DotX, DerefDotX, AtX, ArrAtX, PatX, TupAtX:
       trLocation c, n, e
     of ParX:
       trSons c, n, e

--- a/src/hexer/expander.nim
+++ b/src/hexer/expander.nim
@@ -823,6 +823,15 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         e.dest.addIntLit(0, c.info) # inheritance
         e.dest.add c # add right paren
         inc c # skip right paren
+      of DerefDotX:
+        e.dest.add tagToken("dot", c.info)
+        e.dest.add tagToken("deref", c.info)
+        inc c # skip tag
+        traverseExpr e, c
+        e.dest.addParRi()
+        traverseExpr e, c
+        traverseExpr e, c
+        wantParRi e, c
       of SufX:
         e.dest.add c
         inc c

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -62,7 +62,7 @@ proc rootOf(n: Cursor): SymId =
   while true:
     case n.exprKind
     of DotX, AtX, ArrAtX, ParX:
-      # `PatX` deliberately missing here as it is not protected from mutation
+      # `PatX`, `DerefDotX` deliberately missing here as they are not protected from mutation
       inc n
     of DconvX, OconvX:
       inc n
@@ -104,7 +104,7 @@ proc validBorrowsFrom(c: var Context; n: Cursor): bool =
     case n.exprKind
     of DotX, AtX, ArrAtX, ParX:
       inc n
-    of HderefX, HaddrX, DerefX, AddrX:
+    of HderefX, HaddrX, DerefX, AddrX, DerefDotX:
       inc n
       someIndirection = true
     of DconvX, OconvX, ConvX, CastX:
@@ -465,7 +465,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
     of CallKinds:
       var disallowDangerous = true
       trCall c, n, e, disallowDangerous
-    of DotX, AtX, ArrAtX, PatX:
+    of DotX, DerefDotX, AtX, ArrAtX, PatX:
       trLocation c, n, e
     of OconstrX, NewOconstrX:
       if e notin {WantT, WantTButSkipDeref}:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -82,6 +82,7 @@ type
     DerefX = "deref"
     HderefX = "hderef"
     DotX = "dot"
+    DerefDotX = "ddot"
     PatX = "pat"
     ParX = "par"
     AddrX = "addr"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1461,7 +1461,6 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
                    info: PackedLineInfo; flags: set[SemFlag]): DotExprState =
   let exprStart = c.dest.len
   let expected = it.typ
-  let dotTagPos = c.dest.len
   c.dest.addParLe(DotX, info)
   c.dest.addSubtree lhs.n
   result = FailedDot
@@ -1489,7 +1488,7 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
         let field = findObjFieldConsiderVis(c, decl, fieldName, info)
         if field.level >= 0:
           if doDeref or objType.typeKind in {RefObjectT, PtrObjectT}:
-            c.dest[dotTagPos] = parLeToken(DerefDotX, info)
+            c.dest[exprStart] = parLeToken(DerefDotX, info)
           c.dest.add symToken(field.sym, info)
           c.dest.add intToken(pool.integers.getOrIncl(field.level), info)
           it.typ = field.typ # will be fit later with commonType

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -98,7 +98,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     result = getTypeImpl(c, n.firstSon)
   of NilX:
     result = c.builtins.nilType
-  of DotX:
+  of DotX, DerefDotX:
     result = n
     skip result # obj
     result = getTypeImpl(c, result) # typeof(obj.field) == typeof field

--- a/tests/nimony/basics/tbinarytree.nif
+++ b/tests/nimony/basics/tbinarytree.nif
@@ -24,9 +24,11 @@
    (kv ~28 right.0.tbivahh0m 2
     (nil)))) 7,9
  (asgn ~6
-  (dot ~1 x.0.tbivahh0m data.0.tbivahh0m +0) 2 +456) 7,10
+  (dot ~1
+   (hderef x.0.tbivahh0m) data.0.tbivahh0m +0) 2 +456) 7,10
  (asgn ~6
-  (dot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) 6
+  (dot ~1
+   (hderef x.0.tbivahh0m) left.0.tbivahh0m +0) 6
   (newobj ~4,~4
    (ref 4 NodeObj.0.tbivahh0m) 5
    (kv ~5 data.0.tbivahh0m 2 +123) 16
@@ -35,11 +37,14 @@
    (kv ~28 right.0.tbivahh0m 2
     (nil)))) 8,11
  (asgn ~7
-  (dot ~1 x.0.tbivahh0m right.0.tbivahh0m +0) 2
+  (dot ~1
+   (hderef x.0.tbivahh0m) right.0.tbivahh0m +0) 2
   (nil)) 13,12
  (asgn ~7
   (dot ~5
-   (dot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) right.0.tbivahh0m +0) 2
+   (hderef
+    (dot ~1
+     (hderef x.0.tbivahh0m) left.0.tbivahh0m +0)) right.0.tbivahh0m +0) 2
   (nil)) 4,13
  (var :y.0.tbivahh0m . . 5,~7
   (ref 4 NodeObj.0.tbivahh0m) 8
@@ -52,7 +57,9 @@
     (nil)))) 12,14
  (asgn ~6
   (dot ~5
-   (dot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) left.0.tbivahh0m +0) 15
+   (hderef
+    (dot ~1
+     (hderef x.0.tbivahh0m) left.0.tbivahh0m +0)) left.0.tbivahh0m +0) 15
   (newobj ~18,~8
    (ref 4 NodeObj.0.tbivahh0m) 5
    (kv ~5 data.0.tbivahh0m 2 -123) 17

--- a/tests/nimony/basics/tbinarytree.nif
+++ b/tests/nimony/basics/tbinarytree.nif
@@ -24,11 +24,9 @@
    (kv ~28 right.0.tbivahh0m 2
     (nil)))) 7,9
  (asgn ~6
-  (dot ~1
-   (hderef x.0.tbivahh0m) data.0.tbivahh0m +0) 2 +456) 7,10
+  (ddot ~1 x.0.tbivahh0m data.0.tbivahh0m +0) 2 +456) 7,10
  (asgn ~6
-  (dot ~1
-   (hderef x.0.tbivahh0m) left.0.tbivahh0m +0) 6
+  (ddot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) 6
   (newobj ~4,~4
    (ref 4 NodeObj.0.tbivahh0m) 5
    (kv ~5 data.0.tbivahh0m 2 +123) 16
@@ -37,14 +35,11 @@
    (kv ~28 right.0.tbivahh0m 2
     (nil)))) 8,11
  (asgn ~7
-  (dot ~1
-   (hderef x.0.tbivahh0m) right.0.tbivahh0m +0) 2
+  (ddot ~1 x.0.tbivahh0m right.0.tbivahh0m +0) 2
   (nil)) 13,12
  (asgn ~7
-  (dot ~5
-   (hderef
-    (dot ~1
-     (hderef x.0.tbivahh0m) left.0.tbivahh0m +0)) right.0.tbivahh0m +0) 2
+  (ddot ~5
+   (ddot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) right.0.tbivahh0m +0) 2
   (nil)) 4,13
  (var :y.0.tbivahh0m . . 5,~7
   (ref 4 NodeObj.0.tbivahh0m) 8
@@ -56,10 +51,8 @@
    (kv ~28 right.0.tbivahh0m 2
     (nil)))) 12,14
  (asgn ~6
-  (dot ~5
-   (hderef
-    (dot ~1
-     (hderef x.0.tbivahh0m) left.0.tbivahh0m +0)) left.0.tbivahh0m +0) 15
+  (ddot ~5
+   (ddot ~1 x.0.tbivahh0m left.0.tbivahh0m +0) left.0.tbivahh0m +0) 15
   (newobj ~18,~8
    (ref 4 NodeObj.0.tbivahh0m) 5
    (kv ~5 data.0.tbivahh0m 2 -123) 17

--- a/tests/nimony/basics/tgenericbinarytree.nif
+++ b/tests/nimony/basics/tgenericbinarytree.nif
@@ -30,11 +30,9 @@
    (kv ~28 right.1.tge0lah6v 2
     (nil)))) 7,9
  (asgn ~6
-  (dot ~1
-   (hderef x.0.tge0lah6v) data.1.tge0lah6v +0) 2 +456) 7,10
+  (ddot ~1 x.0.tge0lah6v data.1.tge0lah6v +0) 2 +456) 7,10
  (asgn ~6
-  (dot ~1
-   (hderef x.0.tge0lah6v) left.1.tge0lah6v +0) 11
+  (ddot ~1 x.0.tge0lah6v left.1.tge0lah6v +0) 11
   (newobj ~6,~7
    (ref 11 NodeObj.1.tge0lah6v) 5
    (kv ~5 data.1.tge0lah6v 2 +123) 16
@@ -43,14 +41,11 @@
    (kv ~28 right.1.tge0lah6v 2
     (nil)))) 8,11
  (asgn ~7
-  (dot ~1
-   (hderef x.0.tge0lah6v) right.1.tge0lah6v +0) 2
+  (ddot ~1 x.0.tge0lah6v right.1.tge0lah6v +0) 2
   (nil)) 13,12
  (asgn ~7
-  (dot ~5
-   (hderef
-    (dot ~1
-     (hderef x.0.tge0lah6v) left.1.tge0lah6v +0)) right.1.tge0lah6v +0) 2
+  (ddot ~5
+   (ddot ~1 x.0.tge0lah6v left.1.tge0lah6v +0) right.1.tge0lah6v +0) 2
   (nil)) 4,13
  (var :y.0.tge0lah6v . . 8,~10
   (ref 11 NodeObj.1.tge0lah6v) 13
@@ -62,10 +57,8 @@
    (kv ~28 right.1.tge0lah6v 2
     (nil)))) 12,14
  (asgn ~6
-  (dot ~5
-   (hderef
-    (dot ~1
-     (hderef x.0.tge0lah6v) left.1.tge0lah6v +0)) left.1.tge0lah6v +0) 11
+  (ddot ~5
+   (ddot ~1 x.0.tge0lah6v left.1.tge0lah6v +0) left.1.tge0lah6v +0) 11
   (newobj ~11,~11
    (ref 11 NodeObj.1.tge0lah6v) 5
    (kv ~5 data.1.tge0lah6v 2 -123) 17
@@ -92,8 +85,7 @@
      (kv ~29 right 2
       (nil)))) 12,1
    (asgn ~6
-    (dot ~6
-     (hderef result.0) data.0.tge0lah6v +0) 2 data.0) ~2,~1
+    (ddot ~6 result.0 data.0.tge0lah6v +0) 2 data.0) ~2,~1
    (ret result.0))) 4,19
  (let :a.0.tge0lah6v . . 8,~16
   (ref 11 NodeObj.1.tge0lah6v) 7
@@ -118,9 +110,7 @@
      (kv ~29 right.1.tge0lah6v 2
       (nil)))) 12,1
    (asgn ~6
-    (dot ~6
-     (hderef
-      (hderef result.1)) data.1.tge0lah6v +0) 2 data.2) ~2,~1
+    (ddot ~6 result.1 data.1.tge0lah6v +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
  (type :Node.4.tge0lah6v .
   (at Node.0.tge0lah6v ~7,~8

--- a/tests/nimony/basics/tgenericbinarytree.nif
+++ b/tests/nimony/basics/tgenericbinarytree.nif
@@ -30,9 +30,11 @@
    (kv ~28 right.1.tge0lah6v 2
     (nil)))) 7,9
  (asgn ~6
-  (dot ~1 x.0.tge0lah6v data.1.tge0lah6v +0) 2 +456) 7,10
+  (dot ~1
+   (hderef x.0.tge0lah6v) data.1.tge0lah6v +0) 2 +456) 7,10
  (asgn ~6
-  (dot ~1 x.0.tge0lah6v left.1.tge0lah6v +0) 11
+  (dot ~1
+   (hderef x.0.tge0lah6v) left.1.tge0lah6v +0) 11
   (newobj ~6,~7
    (ref 11 NodeObj.1.tge0lah6v) 5
    (kv ~5 data.1.tge0lah6v 2 +123) 16
@@ -41,11 +43,14 @@
    (kv ~28 right.1.tge0lah6v 2
     (nil)))) 8,11
  (asgn ~7
-  (dot ~1 x.0.tge0lah6v right.1.tge0lah6v +0) 2
+  (dot ~1
+   (hderef x.0.tge0lah6v) right.1.tge0lah6v +0) 2
   (nil)) 13,12
  (asgn ~7
   (dot ~5
-   (dot ~1 x.0.tge0lah6v left.1.tge0lah6v +0) right.1.tge0lah6v +0) 2
+   (hderef
+    (dot ~1
+     (hderef x.0.tge0lah6v) left.1.tge0lah6v +0)) right.1.tge0lah6v +0) 2
   (nil)) 4,13
  (var :y.0.tge0lah6v . . 8,~10
   (ref 11 NodeObj.1.tge0lah6v) 13
@@ -58,7 +63,9 @@
     (nil)))) 12,14
  (asgn ~6
   (dot ~5
-   (dot ~1 x.0.tge0lah6v left.1.tge0lah6v +0) left.1.tge0lah6v +0) 11
+   (hderef
+    (dot ~1
+     (hderef x.0.tge0lah6v) left.1.tge0lah6v +0)) left.1.tge0lah6v +0) 11
   (newobj ~11,~11
    (ref 11 NodeObj.1.tge0lah6v) 5
    (kv ~5 data.1.tge0lah6v 2 -123) 17
@@ -85,7 +92,8 @@
      (kv ~29 right 2
       (nil)))) 12,1
    (asgn ~6
-    (dot ~6 result.0 data.0.tge0lah6v +0) 2 data.0) ~2,~1
+    (dot ~6
+     (hderef result.0) data.0.tge0lah6v +0) 2 data.0) ~2,~1
    (ret result.0))) 4,19
  (let :a.0.tge0lah6v . . 8,~16
   (ref 11 NodeObj.1.tge0lah6v) 7
@@ -110,7 +118,9 @@
      (kv ~29 right.1.tge0lah6v 2
       (nil)))) 12,1
    (asgn ~6
-    (dot ~6 result.1 data.1.tge0lah6v +0) 2 data.2) ~2,~1
+    (dot ~6
+     (hderef
+      (hderef result.1)) data.1.tge0lah6v +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
  (type :Node.4.tge0lah6v .
   (at Node.0.tge0lah6v ~7,~8


### PR DESCRIPTION
Started by inserting derefs but this might be less annoying for ref/ptr objects. Not sure if I adapted hexer behavior correctly.