### PR TITLE
give local line info to magics

### DIFF
--- a/src/lib/nifstreams.nim
+++ b/src/lib/nifstreams.nim
@@ -44,6 +44,10 @@ proc addToken[L](tree: var seq[PackedToken]; kind: TokenKind; id: L; info: Packe
 proc copyKeepLineInfo*(dest: var PackedToken; src: PackedToken) {.inline.} =
   dest.x = src.x
 
+proc withLineInfo*(n: PackedToken; info: PackedLineInfo): PackedToken {.inline.} =
+  result = n
+  result.info = info
+
 type
   StrId* = distinct uint32
   SymId* = distinct uint32

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1762,10 +1762,11 @@ proc maybeInlineMagic(c: var SemContext; res: LoadResult) =
       inc n # skip the SymbolDef
       if n.kind == ParLe:
         # ^ export marker position has a `(`? If so, it is a magic!
-        c.dest[c.dest.len-1] = n.load
+        let info = c.dest[c.dest.len-1].info
+        c.dest[c.dest.len-1] = withLineInfo(n.load, info)
         inc n
         while true:
-          c.dest.add n
+          c.dest.add withLineInfo(n.load, info)
           if n.kind == ParRi: break
           inc n
 
@@ -2932,10 +2933,11 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
     it.typ = c.types.autoType
   elif s.kind in {TypeY, TypevarY}:
     let typeStart = c.dest.len
-    c.dest.buildTree TypedescT, it.n.info:
+    let info = c.dest[c.dest.len-1].info
+    c.dest.buildTree TypedescT, info:
       let symStart = c.dest.len
-      c.dest.add symToken(s.name, it.n.info)
-      semTypeSym c, s, it.n.info, symStart, InLocalDecl
+      c.dest.add symToken(s.name, info)
+      semTypeSym c, s, info, symStart, InLocalDecl
     it.typ = typeToCursor(c, typeStart)
     c.dest.shrink typeStart
     commonType c, it, start, expected

--- a/tests/nimony/basics/t2.nif
+++ b/tests/nimony/basics/t2.nif
@@ -15,22 +15,22 @@
  (proc 5 :\2B.0.t277k7ei1
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~6
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~6
-    (i -1) .)) 2,~6
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,9
  (proc 5 :foo.0.t277k7ei1 . . . 8
   (params 1
-   (param :x.1 . . ~7,~8
+   (param :x.1 . . 3
     (i -1) .) 9
-   (param :y.1 . . ~15,~5
-    (string) .)) 2,~8
+   (param :y.1 . . 3
+    (string) .)) 21
   (i -1) . . 2,1
   (stmts 4
-   (result :result.0 . . ~4,~9
+   (result :result.0 . . 10,~3
     (i -1) .) 4
    (var :x.3 . .
     (string) 4 "abc") 7,1
@@ -40,7 +40,7 @@
  (proc 5 :overloaded.0.t277k7ei1 . . . 15
   (params) . . . 2,1
   (stmts 4
-   (let :someInt.0 . . ~4,~14
+   (let :someInt.0 . . 7,~8
     (i -1) 13
     (add
      (i -1) 1 +23 5 +90)) ,1
@@ -50,11 +50,11 @@
       (i -1) ~2 +34 1 +56) 8 "xyz")))) ,18
  (proc 5 :exprReturn.0.t277k7ei1 . . . 15
   (params 1
-   (param :x.2 . . ~14,~17
-    (i -1) .)) 2,~17
+   (param :x.2 . . 3
+    (i -1) .)) 10
   (i -1) . . 31
   (stmts
-   (result :result.1 . . ~29,~17
+   (result :result.1 . . ~15,~11
     (i -1) .)
    (asgn result.1
     (expr x.2)) ~31

--- a/tests/nimony/basics/tbinarytree.nif
+++ b/tests/nimony/basics/tbinarytree.nif
@@ -6,7 +6,7 @@
    (magic 7 Int)) .) 10,3
  (type ~8 :NodeObj.0.tbivahh0m . . . 2
   (object . ~8,1
-   (fld :data.0.tbivahh0m . . 1,~4
+   (fld :data.0.tbivahh0m . . 6
     (i -1) .) ~8,2
    (fld :left.0.tbivahh0m . . 5,1
     (ref 4 NodeObj.0.tbivahh0m) .) ~2,2

--- a/tests/nimony/basics/tbool.nif
+++ b/tests/nimony/basics/tbool.nif
@@ -16,7 +16,7 @@
     (tup +1 "true")))) 5
  (proc :dollar`.bool.0.tbojn1uzv x . .
   (params
-   (param :e.0 . . 21
+   (param :e.0 . .
     (bool) .))
   (string) . .
   (stmts 23
@@ -24,16 +24,16 @@
     (string) .) 23
    (case e.0 ~18,1
     (of
-     (set
+     (set ~8
       (false))
      (stmts
       (ret "false"))) ~8,1
     (of
-     (set
+     (set ~7
       (true))
      (stmts
       (ret "true"))))
    (ret result.0))) 4,3
- (let :x.0.tbojn1uzv . . 22,~3
-  (bool) 16,~2
+ (let :x.0.tbojn1uzv . . 1,~3
+  (bool) 10
   (true)))

--- a/tests/nimony/basics/tcstring.nif
+++ b/tests/nimony/basics/tcstring.nif
@@ -19,46 +19,46 @@
  (proc 5 :\2B.0.tcs1re56a
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~7
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~7
-    (i -1) .)) 2,~7
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,9
  (proc 5 :\2D.0.tcs1re56a
   (sub -3) . . 9
   (params 1
-   (param :x.1 . . ~8,~8
+   (param :x.1 . . 6
     (i -1) .) 4
-   (param :y.1 . . ~11,~8
-    (i -1) .)) 2,~8
+   (param :y.1 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,11
  (proc 5 :<=.0.tcs1re56a
   (le -3) . . 10
   (params 1
-   (param :x.2 . . ~9,~10
+   (param :x.2 . . 6
     (i -1) .) 4
-   (param :y.2 . . ~12,~10
-    (i -1) .)) 2,~9
+   (param :y.2 . . 3
+    (i -1) .)) 13
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) 4,13
- (var :x.0.tcs1re56a . . ~2,~12
+ (var :x.0.tcs1re56a . . 12,~5
   (i -1) 4
-  (cast ~6,~12
+  (cast 5
    (i -1) 10 +55)) 4,15
- (var :y.0.tcs1re56a . . ~2,~10
+ (var :y.0.tcs1re56a . . 3
   (pointer) 13
   (nil)) 2,18
- (const :myconst.0.tcs1re56a . . ,~14
+ (const :myconst.0.tcs1re56a . . 10
   (cstring) 17
-  (conv ~17,~14
+  (conv ~7
    (cstring)
    (suf "abc" "R"))) 4,20
- (var :zz.0.tcs1re56a . . ~2,~16
+ (var :zz.0.tcs1re56a . . 4
   (cstring)
-  (hconv 2,6,tests/nimony/basics/tcstring.nim
+  (hconv 8,22,tests/nimony/basics/tcstring.nim
    (cstring) 18,22,tests/nimony/basics/tcstring.nim "xzy")))

--- a/tests/nimony/basics/tdefinedarg.nif
+++ b/tests/nimony/basics/tdefinedarg.nif
@@ -7,7 +7,7 @@
  (proc 5 :defined.0.tdetxkbxo
   (defined) . . 12
   (params 1
-   (param :x.0 . . ~8,~2
+   (param :x.0 . . 3
     (untyped) .)) . 25
   (pragmas 2
    (magic 7 Defined)) . .) 4,4

--- a/tests/nimony/basics/tdistinct.nif
+++ b/tests/nimony/basics/tdistinct.nif
@@ -23,35 +23,35 @@
  (proc 5 :\2B.0.tdikoa9tc1
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~7
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~7
-    (i -1) .)) 2,~7
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,9
  (proc 5 :\2D.0.tdikoa9tc1
   (sub -3) . . 9
   (params 1
-   (param :x.1 . . ~8,~8
+   (param :x.1 . . 6
     (i -1) .) 4
-   (param :y.1 . . ~11,~8
-    (i -1) .)) 2,~8
+   (param :y.1 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,11
  (proc 5 :<=.0.tdikoa9tc1
   (le -3) . . 10
   (params 1
-   (param :x.2 . . ~9,~10
+   (param :x.2 . . 6
     (i -1) .) 4
-   (param :y.2 . . ~12,~10
-    (i -1) .)) 2,~9
+   (param :y.2 . . 3
+    (i -1) .)) 13
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) 9,15
  (type ~7 :VarId.0.tdikoa9tc1 x . . 2
-  (distinct ~9,~14
+  (distinct 9
    (i -1))) ,17
  (proc 5 :\2B.1.tdikoa9tc1 x . . 9
   (params 1
@@ -62,16 +62,16 @@
   (stmts
    (ret
     (dconv 6 VarId.0.tdikoa9tc1
-     (add ~7,~16
+     (add 7,~9
       (i -1)
-      (dconv ~7,~16
+      (dconv 11,~2
        (i -1) x.3)
-      (dconv ~7,~16
+      (dconv 11,~2
        (i -1) y.3)))))) 4,24
  (var :x.0.tdikoa9tc1 . . 3 VarId.0.tdikoa9tc1 .) 2,26
  (asgn ~2 x.0.tdikoa9tc1 4
   (infix \2B.1.tdikoa9tc1 ~2 x.0.tdikoa9tc1 2 x.0.tdikoa9tc1)) 4,28
- (let :y.0.tdikoa9tc1 . . ~2,~22
+ (let :y.0.tdikoa9tc1 . . 4
   (i +8) 8
-  (conv ~10,~22
+  (conv ~4
    (i +8) 1 x.0.tdikoa9tc1)))

--- a/tests/nimony/basics/tfib2.nif
+++ b/tests/nimony/basics/tfib2.nif
@@ -15,60 +15,60 @@
  (proc 5 :\2B.0.tfie0imm3
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~4
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~4
-    (i -1) .)) 2,~4
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,6
  (proc 5 :\2D.0.tfie0imm3
   (sub -3) . . 9
   (params 1
-   (param :x.1 . . ~8,~5
+   (param :x.1 . . 6
     (i -1) .) 4
-   (param :y.1 . . ~11,~5
-    (i -1) .)) 2,~5
+   (param :y.1 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,8
  (proc 5 :<=.0.tfie0imm3
   (le -3) . . 10
   (params 1
-   (param :x.2 . . ~9,~7
+   (param :x.2 . . 6
     (i -1) .) 4
-   (param :y.2 . . ~12,~7
-    (i -1) .)) 2,~6
+   (param :y.2 . . 3
+    (i -1) .)) 13
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) ,10
  (proc 5 :\2B.1.tfie0imm3
   (add -3) . . 9
   (params 1
-   (param :x.3 . . ~8,~7
+   (param :x.3 . . 6
     (f +64) .) 4
-   (param :y.3 . . ~11,~7
-    (f +64) .)) 2,~7
+   (param :y.3 . . 3
+    (f +64) .)) 15
   (f +64) 30
   (pragmas 2
    (magic 7 "AddF64")) . .) ,11
  (proc 5 :\2D.1.tfie0imm3
   (sub -3) . . 9
   (params 1
-   (param :x.4 . . ~8,~8
+   (param :x.4 . . 6
     (f +64) .) 4
-   (param :y.4 . . ~11,~8
-    (f +64) .)) 2,~8
+   (param :y.4 . . 3
+    (f +64) .)) 15
   (f +64) 30
   (pragmas 2
    (magic 7 "SubF64")) . .) ,13
  (proc 5 :<=.1.tfie0imm3
   (le -3) . . 10
   (params 1
-   (param :x.5 . . ~9,~10
+   (param :x.5 . . 6
     (f +64) .) 4
-   (param :y.5 . . ~12,~10
-    (f +64) .)) 2,~11
+   (param :y.5 . . 3
+    (f +64) .)) 15
   (bool) 30
   (pragmas 2
    (magic 7 "LeF64")) . .) 10,17
@@ -79,7 +79,7 @@
     (proc 5 :<=.0 . . . 9
      (params 1
       (param :a.0 . . 6 Self.0.tfie0imm3 .) 4
-      (param :b.0 . . 3 Self.0.tfie0imm3 .)) ~2,~16
+      (param :b.0 . . 3 Self.0.tfie0imm3 .)) 14
      (bool) . . .) ,1
     (proc 5 :\2B.0 . . . 8
      (params 1
@@ -133,7 +133,7 @@
     (else 2,1
      (stmts 7
       (asgn ~7 result.1 11
-       (add ~20,~25
+       (add ~6,~21
         (i -1) ~6
         (call ~3 fib.1.tfie0imm3 2
          (sub

--- a/tests/nimony/basics/tforloop.nif
+++ b/tests/nimony/basics/tforloop.nif
@@ -11,55 +11,55 @@
  (proc 5 :\2B.0.tfoaf4sx41
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~3
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~3
-    (i -1) .)) 2,~3
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,5
  (proc 5 :\2D.0.tfoaf4sx41
   (sub -3) . . 9
   (params 1
-   (param :x.1 . . ~8,~4
+   (param :x.1 . . 6
     (i -1) .) 4
-   (param :y.1 . . ~11,~4
-    (i -1) .)) 2,~4
+   (param :y.1 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,7
  (proc 5 :<=.0.tfoaf4sx41
   (le -3) . . 10
   (params 1
-   (param :x.2 . . ~9,~6
+   (param :x.2 . . 6
     (i -1) .) 4
-   (param :y.2 . . ~12,~6
-    (i -1) .)) 2,~5
+   (param :y.2 . . 3
+    (i -1) .)) 13
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) ,9
  (iterator 9 :countup.0.tfoaf4sx41 . . . 16
   (params 1
-   (param :a.0 . . ~15,~8
+   (param :a.0 . . 6
     (i -1) .) 4
-   (param :b.0 . . ~18,~8
-    (i -1) .)) 2,~8
+   (param :b.0 . . 3
+    (i -1) .)) 13
   (i -1) . . 2,1
   (stmts 4
-   (var :x.3 . . ~4,~9
+   (var :x.3 . . 17,~1
     (i -1) 4 a.0) ,1
    (while 8
-    (le ~8,~10
+    (le 13,~2
      (i -1) ~2 x.3 3 b.0) 2,1
     (stmts
      (yld 6 x.3) 2,1
      (asgn ~2 x.3 4
-      (add ~8,~12
+      (add 13,~4
        (i -1) ~2 x.3 2 +1)))))) 4,15
  (for 20
   (call ~7 countup.0.tfoaf4sx41 1 +0 4 +44)
   (unpackflat
-   (let :mycounter.0 . . ~2,~14
+   (let :mycounter.0 . . 9,~6
     (i -1) .)) ~2,1
   (stmts
    (discard 8 mycounter.0))))

--- a/tests/nimony/basics/tgeneric_obj.nif
+++ b/tests/nimony/basics/tgeneric_obj.nif
@@ -30,10 +30,10 @@
   (pragmas 2
    (magic 7 Array)) .) 4,10
  (var :myset.0.tgekp9q4q1 . . 10
-  (sett ~12,~5
+  (sett 1
    (u +8)) .) 4,11
  (var :myarr.0.tgekp9q4q1 . . 12
-  (array ~14,~10
+  (array 4
    (i -1)
    (rangetype
     (i -1) +0 +2)) .) 4,12
@@ -63,10 +63,10 @@
  (proc 5 :\2B.0.tgekp9q4q1
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~26
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~26
-    (i -1) .)) 2,~26
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,29
@@ -76,13 +76,13 @@
    (break .))) ,32
  (proc 5 :foo.0.tgekp9q4q1 . . . 8
   (params 1
-   (param :x.1 . . ~7,~31
+   (param :x.1 . . 3
     (i -1) .) 9
-   (param :y.1 . . ~15,~28
-    (string) .)) 2,~31
+   (param :y.1 . . 3
+    (string) .)) 21
   (i -1) . . 2,1
   (stmts 4
-   (result :result.0 . . ~4,~32
+   (result :result.0 . . 10,~6
     (i -1) .) 4
    (var :x.4 . .
     (string) 4 "abc") 7,1
@@ -92,7 +92,7 @@
  (proc 5 :overloaded.0.tgekp9q4q1 . . . 15
   (params) . . . 2,1
   (stmts 4
-   (let :someInt.0 . . ~4,~37
+   (let :someInt.0 . . 7,~11
     (i -1) 13
     (add
      (i -1) 1 +23 5 +90)) ,1
@@ -125,20 +125,20 @@
    (discard .) ~45
    (ret result.1))) 4,50
  (var :myarr2.0.tgekp9q4q1 . . 12,~39
-  (array ~14,~10
+  (array 4
    (i -1)
    (rangetype
     (i -1) +0 +2)) 27 myarr.0.tgekp9q4q1) 7,51
  (asgn ~7 myarr2.0.tgekp9q4q1 2
   (arr 1 +4 4 +5 7 +6)) 4,53
  (var :m3.0.tgekp9q4q1 . . 9
-  (array ~11,~52
+  (array 4
    (i -1)
    (rangetype
     (i -1) +0 +3)) 20
   (arr 1 +1 4 +2 7 +3 10 +45)) 4,54
  (var :x3.0.tgekp9q4q1 . . 9
-  (array ~11,~53
+  (array 7
    (i -1)
    (rangetype
     (i -1) 1 +4 4 +7)) 23 m3.0.tgekp9q4q1) 3,55
@@ -185,11 +185,11 @@
  (proc :foo.2.tgekp9q4q1 . ~3,~1 .
   (at foo.1.tgekp9q4q1 13,~47
    (rangetype
-    (i -1) +0 +2) ~1,~57
+    (i -1) +0 +2) 17,~47
    (i -1)) 11,~1
   (params 1
    (param :x.7 . . 8
-    (array ~21,~56
+    (array ~3,~46
      (i -1) ~7,~46
      (rangetype
       (i -1) +0 +2)) .)) ~3,~1 . ~3,~1 . ~3,~1 . 30,~1
@@ -198,37 +198,37 @@
  (proc :identity.1.tgekp9q4q1 . ~17,~2 .
   (at identity.0.tgekp9q4q1 ~1,~51
    (rangetype
-    (i -1) +0 +2) ~15,~61
+    (i -1) +0 +2) 3,~51
    (i -1)) 2,~2
   (params 1
    (param :x.8 . . 8
-    (array ~26,~59
+    (array ~8,~49
      (i -1) ~12,~49
      (rangetype
       (i -1) +0 +2)) .)) 6,~2
-  (array ~21,~59
+  (array ~3,~49
    (i -1) ~7,~49
    (rangetype
     (i -1) +0 +2)) ~17,~2 . ~17,~2 . ~15,~1
   (stmts 7
    (result :result.4 . . 19,~1
-    (array ~26,~59
+    (array ~8,~49
      (i -1) ~12,~49
      (rangetype
       (i -1) +0 +2)) .) 7
    (asgn ~7 result.4 2 x.8) ~2,~1
    (ret result.4))) 19,21
  (type :MyGeneric.1.tgekp9q4q1 .
-  (at MyGeneric.0.tgekp9q4q1 ~17,~20
+  (at MyGeneric.0.tgekp9q4q1 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.1.tgekp9q4q1 . . ~2,~17
+   (fld :x.1.tgekp9q4q1 . . 16,3
     (i -1) .))) 18,22
  (type :MyGeneric.2.tgekp9q4q1 .
-  (at MyGeneric.0.tgekp9q4q1 ~16,~19
+  (at MyGeneric.0.tgekp9q4q1 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.2.tgekp9q4q1 . . ~2,~15
+   (fld :x.2.tgekp9q4q1 . . 15,4
     (f +64) .))) 20,47
  (type :HSlice.1.tgekp9q4q1 .
   (at HSlice.0.tgekp9q4q1

--- a/tests/nimony/basics/tgenericbinarytree.nif
+++ b/tests/nimony/basics/tgenericbinarytree.nif
@@ -113,14 +113,14 @@
     (ddot ~6 result.1 data.1.tge0lah6v +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
  (type :Node.4.tge0lah6v .
-  (at Node.0.tge0lah6v ~7,~8
+  (at Node.0.tge0lah6v 1
    (i -1)) ~2,~5 . ,~5
   (ref 11 NodeObj.1.tge0lah6v)) 23,3
  (type :NodeObj.1.tge0lah6v .
-  (at NodeObj.0.tge0lah6v ~18,~3
+  (at NodeObj.0.tge0lah6v ~10,5
    (i -1)) ~10,1 . ~8,1
   (object . ~11,1
-   (fld :data.1.tge0lah6v . . 1,~5
+   (fld :data.1.tge0lah6v . . 9,3
     (i -1) .) ~11,2
    (fld :left.1.tge0lah6v . . 8,~3
     (ref 11 NodeObj.1.tge0lah6v) .) ~5,2

--- a/tests/nimony/basics/trefobject.nif
+++ b/tests/nimony/basics/trefobject.nif
@@ -6,7 +6,7 @@
    (magic 7 Int)) .) 9,2
  (type ~4 :Foo.0.treb3udid . . . 6
   (refobj . ~13,1
-   (fld :x.0.treb3udid . . 3,~3
+   (fld :x.0.treb3udid . . 3
     (i -1) .) ~13,2
    (fld :parent.0.treb3udid . . 8 Foo.0.treb3udid .))) 4,6
  (var :foo.0.treb3udid . . 5 Foo.0.treb3udid .) 13,8
@@ -21,10 +21,10 @@
     (at ~4 Node.0.treb3udid 1 T.0.treb3udid) .))) 4,12
  (var :node.0.treb3udid . . 10 Node.1.treb3udid .) 14,12
  (type :Node.1.treb3udid .
-  (at Node.0.treb3udid ~9,~12
+  (at Node.0.treb3udid 1
    (i -1)) ~1,~4 . 5,~4
   (refobj . ~17,1
-   (fld :val.1.treb3udid . . 3,~9
+   (fld :val.1.treb3udid . . 13,3
     (i -1) .) ~17,2
    (fld :left.1.treb3udid . . 17 Node.1.treb3udid .) ~11,2
    (fld :right.1.treb3udid . . 11 Node.1.treb3udid .))))

--- a/tests/nimony/basics/tsetter.nif
+++ b/tests/nimony/basics/tsetter.nif
@@ -9,16 +9,16 @@
  (proc 5 :bar=.0.tseyo1t971 . . . 11
   (params 1
    (param :x.0 . . 3 Foo.0.tseyo1t971 .) 9
-   (param :y.0 . . ~15,~4
+   (param :y.0 . . 3
     (i -1) .)) . . . 30
   (stmts
    (discard .))) ,5
  (proc 5 :\5B\5D=.0.tseyo1t971 . . . 10
   (params 1
    (param :x.1 . . 3 Foo.0.tseyo1t971 .) 9
-   (param :y.1 . . ~14,~5
+   (param :y.1 . . 3
     (i -1) .) 17
-   (param :z.0 . . ~22,~5
+   (param :z.0 . . 3
     (i -1) .)) . . . 37
   (stmts
    (discard .))) 4,7

--- a/tests/nimony/basics/ttemplate.nif
+++ b/tests/nimony/basics/ttemplate.nif
@@ -33,48 +33,48 @@
  (proc 5 :\2B.0.tte6j7czy
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~18
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~18
-    (i -1) .)) 2,~18
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,21
  (template 9 :plus.0.tte6j7czy . . . 13
   (params 1
-   (param :x.1 . . ~12,~20
+   (param :x.1 . . 6
     (i -1) .) 4
-   (param :y.1 . . ~15,~20
-    (i -1) .)) 2,~20
+   (param :y.1 . . 3
+    (i -1) .)) 13
   (i -1) . . 32
   (stmts 2
-   (add ~32,~20
+   (add ~14
     (i -1) ~2 x.1 2 y.1))) ,23
  (proc 5 :foo.0.tte6j7czy . . . 8
   (params 1
-   (param :x.2 . . ~7,~22
+   (param :x.2 . . 3
     (i -1) .) 9
-   (param :y.2 . . ~15,~19
-    (string) .)) 2,~22
+   (param :y.2 . . 3
+    (string) .)) 21
   (i -1) . . 2,1
   (stmts 4
-   (result :result.0 . . ~4,~23
+   (result :result.0 . . 10,~5
     (i -1) .) 4
    (var :x.4 . .
     (string) 4 "abc") 7,1
    (asgn ~7 result.0 23,~4
     (expr 2
-     (add ~32,~20
+     (add ~14
       (i -1) ~18,4 +4 ~2
       (expr 2
-       (add ~32,~20
+       (add ~14
         (i -1) ~10,4 +2 ~7,4 +89))))) 2,2
    (asgn ~2 x.4 2 "34") ~2,~1
    (ret result.0))) ,28
  (proc 5 :overloaded.0.tte6j7czy . . . 15
   (params) . . . 2,1
   (stmts 4
-   (let :someInt.0 . . ~4,~28
+   (let :someInt.0 . . 7,~10
     (i -1) 13
     (add
      (i -1) 1 +23 5 +90)) ,1
@@ -90,25 +90,25 @@
   (typevars 1
    (typevar :T.2.tte6j7czy . . . .)) 16
   (params 1
-   (param :x.3 . . ~15,~33
+   (param :x.3 . . 3
     (i -1) .)) 10 T.2.tte6j7czy . . 30
   (stmts 1
-   (conv 1 T.2.tte6j7czy 1 x.3))) 4,36
+   (conv ~1 T.2.tte6j7czy 1 x.3))) 4,36
  (let :val.0.tte6j7czy . .
   (i -1) 6 +123) ,37
  (discard 30,~3
   (expr 1
-   (conv ~26,~2
+   (conv ~18,3
     (u -1) ~12,3 val.0.tte6j7czy))) 19,13
  (type :MyGeneric.1.tte6j7czy .
-  (at MyGeneric.0.tte6j7czy ~17,~12
+  (at MyGeneric.0.tte6j7czy 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.1.tte6j7czy . . ~2,~9
+   (fld :x.1.tte6j7czy . . 16,3
     (i -1) .))) 18,14
  (type :MyGeneric.2.tte6j7czy .
-  (at MyGeneric.0.tte6j7czy ~16,~11
+  (at MyGeneric.0.tte6j7czy 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.2.tte6j7czy . . ~2,~7
+   (fld :x.2.tte6j7czy . . 15,4
     (f +64) .))))

--- a/tests/nimony/basics/tvarargs.nif
+++ b/tests/nimony/basics/tvarargs.nif
@@ -19,30 +19,30 @@
  (proc 5 :\2B.0.tvaktfkwp
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~5
+   (param :x.0 . . 6
     (i -1) .) 4
-   (param :y.0 . . ~11,~5
-    (i -1) .)) 2,~5
+   (param :y.0 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,7
  (proc 5 :\2D.0.tvaktfkwp
   (sub -3) . . 9
   (params 1
-   (param :x.1 . . ~8,~6
+   (param :x.1 . . 6
     (i -1) .) 4
-   (param :y.1 . . ~11,~6
-    (i -1) .)) 2,~6
+   (param :y.1 . . 3
+    (i -1) .)) 13
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,9
  (proc 5 :<=.0.tvaktfkwp
   (le -3) . . 10
   (params 1
-   (param :x.2 . . ~9,~8
+   (param :x.2 . . 6
     (i -1) .) 4
-   (param :y.2 . . ~12,~8
-    (i -1) .)) 2,~7
+   (param :y.2 . . 3
+    (i -1) .)) 13
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) 8,12
@@ -53,7 +53,7 @@
   (params 1
    (param :f.0 . . 3
     (mut 4 File.0.tvaktfkwp) .) 14
-   (param :c.0 . . ~22,~13
+   (param :c.0 . . 3
     (c +8) .)) . . . 35
   (stmts
    (discard .))) ,17
@@ -61,7 +61,7 @@
   (params 1
    (param :f.1 . . 3
     (mut 4 File.0.tvaktfkwp) .) 14
-   (param :s.0 . . ~22,~13
+   (param :s.0 . . 3
     (string) .)) . . . 37
   (stmts
    (discard .))) ,19
@@ -73,7 +73,7 @@
    (magic 7 Expr)) .) ,24
  (iterator 9 :unpack.0.tvaktfkwp
   (unpack) . . 15
-  (params) 2,~2
+  (params) 4
   (untyped) 27
   (pragmas 2
    (magic 7 Unpack)) . .) ,26
@@ -87,7 +87,7 @@
    (for 11
     (unpack)
     (unpackflat
-     (let :x.3 . . ~4,~5
+     (let :x.3 . . ~2,~3
       (untyped) .)) ~2,1
     (expr
      (cmd

--- a/tests/nimony/basics/twhen.nif
+++ b/tests/nimony/basics/twhen.nif
@@ -11,8 +11,8 @@
  (proc 5 :not.0.twh0750pd
   (not) . . 11
   (params 1
-   (param :x.0 . . 14,~26,tests/nimony/basics/deps/mwhen.nim
-    (bool) .)) 26,~26,tests/nimony/basics/deps/mwhen.nim
+   (param :x.0 . . 3
+    (bool) .)) 11
   (bool) 27
   (pragmas 2
    (magic 7 Not)) . .) 2,33

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -1,7 +1,7 @@
 (.nif24)
 ,1,tests/nimony/sysbasics/tbasics.nim(stmts 8,1
  (type ~6 :Array.0.tbawx6nu81 . . . 7
-  (array ~11,5,lib/std/system.nim
+  (array 4
    (i -1)
    (rangetype
     (i -1) +0 +4))) 4,3
@@ -12,12 +12,12 @@
     (i -1) +0 +2)) 4
   (arr 1 +1 4 +2 7 +3)) 4,4
  (var :s2.0.tbawx6nu81 . . 11,~3
-  (array ~11,5,lib/std/system.nim
+  (array 4
    (i -1)
    (rangetype
     (i -1) +0 +4)) .) 4,5
  (var :s3.0.tbawx6nu81 . . 11,~4
-  (array ~11,5,lib/std/system.nim
+  (array 4
    (i -1)
    (rangetype
     (i -1) +0 +4)) 12
@@ -40,7 +40,7 @@
  (call ~3 foo.0.tbawx6nu81) ,13
  (proc 5 :foo2.0.tbawx6nu81 . . . 9
   (params 1
-   (param :m.0 . . ~6,~7,lib/std/system.nim
+   (param :m.0 . . 3
     (i -1) .)) . . . 2,1
   (stmts 4
    (var :x.2 . .
@@ -56,7 +56,7 @@
     (tup 1 x.2 4 +1 7 +2)) 4,2
    (let :m1.0 . . 6
     (tuple
-     (fld :Field0.1.tbawx6nu81 . . ~8,~10,lib/std/system.nim
+     (fld :Field0.1.tbawx6nu81 . . 1,~3
       (i -1) .) 3
      (fld :Field1.1.tbawx6nu81 . .
       (i -1) .)) 5
@@ -77,7 +77,7 @@
         (i -1) .)) .) 6
      (fld :Field2.1.tbawx6nu81 . . ~6,~2
       (tuple
-       (fld :Field0.1.tbawx6nu81 . . ~8,~10,lib/std/system.nim
+       (fld :Field0.1.tbawx6nu81 . . 1,~3
         (i -1) .) 3
        (fld :Field1.1.tbawx6nu81 . .
         (i -1) .)) .)) 5
@@ -85,18 +85,18 @@
  (call ~4 foo2.0.tbawx6nu81 1 +12) ,22
  (proc 5 :foo3.0.tbawx6nu81 . . . 9
   (params 1
-   (param :x.0 . . ~6,26,lib/std/system.nim
+   (param :x.0 . . 3
     (pointer) .)) . . . 2,1
   (stmts 4
-   (let :m.2 . . ~2,25,lib/std/system.nim
+   (let :m.2 . . 7,~1
     (pointer) 4 x.0) 4,1
    (let :s2.0 . . 10
-    (ptr ~12,~18,lib/std/system.nim
+    (ptr 4
      (i -1)) 5
     (cast 5
-     (ptr ~12,~18,lib/std/system.nim
+     (ptr 4
       (i -1)) 14 x.0)) 4,2
-   (let :s3.0 . . ~2,~19,lib/std/system.nim
+   (let :s3.0 . . 14,~1
     (i -1) 5
     (deref s2.0)))) ,27
  (block . 2,1
@@ -104,14 +104,14 @@
    (var :s.1 . .
     (i -1) 4 +2) 4,1
    (let :m.3 . . 10,~5
-    (ptr ~12,~18,lib/std/system.nim
+    (ptr 4
      (i -1)) 9
     (addr s.1)) 4,2
    (call ~4 foo3.0.tbawx6nu81 1
-    (hconv ~3,18,lib/std/system.nim
+    (hconv 6,~8
      (pointer) m.3)) 4,3
-   (let :m2.0 . . ~2,17,lib/std/system.nim
+   (let :m2.0 . . 7,~9
     (pointer) 5
-    (cast ~7,17,lib/std/system.nim
+    (cast 5
      (pointer) 14 m.3)) 4,4
    (call ~4 foo3.0.tbawx6nu81 1 m2.0))))

--- a/tests/nimony/sysbasics/tforloops.nif
+++ b/tests/nimony/sysbasics/tforloops.nif
@@ -4,12 +4,12 @@
   (i -1) 10 +12) ,2
  (iterator 9 :foo.0.tfo6zftzj1 . . . 12
   (params 1
-   (param :x.0 . . ~9,4,lib/std/system.nim
+   (param :x.0 . . 3
     (i -1) .)) 10
   (tuple 1
-   (fld :Field0.0.tfo6zftzj1 . . ~7,4,lib/std/system.nim
+   (fld :Field0.0.tfo6zftzj1 . .
     (i -1) .) 6
-   (fld :Field1.0.tfo6zftzj1 . . ~12,4,lib/std/system.nim
+   (fld :Field1.0.tfo6zftzj1 . .
     (i -1) .)) . . 2,2
   (stmts 4
    (let :ff.0 . .
@@ -33,8 +33,8 @@
     (tup 1 +22 5 +4)))) ,10
  (iterator 9 :foo1.0.tfo6zftzj1 . . . 13
   (params 1
-   (param :x.1 . . ~10,~4,lib/std/system.nim
-    (i -1) .)) 4,~4,lib/std/system.nim
+   (param :x.1 . . 3
+    (i -1) .)) 10
   (i -1) . . 2,1
   (stmts
    (yld 6 +1) ,1
@@ -42,36 +42,36 @@
  (for 9
   (call ~4 foo1.0.tfo6zftzj1 1 +2)
   (unpackflat
-   (let :m.0 . . ,~8,lib/std/system.nim
+   (let :m.0 . . 6,~4
     (i -1) .)) ~2,1
   (stmts 4
-   (let :n.0 . . ~2,~9,lib/std/system.nim
+   (let :n.0 . . 4,~5
     (i -1) 4 m.0))) 4,18
  (for 11
   (call ~3 foo.0.tfo6zftzj1 1 +2)
   (unpackflat
-   (let :i.0 . . ,~12,lib/std/system.nim
+   (let :i.0 . . 7,~16
     (i -1) .)
-   (let 3 :j.0 . . ,~12,lib/std/system.nim
+   (let 3 :j.0 . . 12,~16
     (i -1) .)) ~2,1
   (stmts 4
-   (let :s.0 . . ~2,~13,lib/std/system.nim
+   (let :s.0 . . 5,~17
     (i -1) 4 i.0) 4,1
-   (let :m.1 . . ~2,~14,lib/std/system.nim
+   (let :m.1 . . 10,~18
     (i -1) 4 j.0) 4,2
-   (let :n.1 . . ~2,~15,lib/std/system.nim
+   (let :n.1 . . 5,~19
     (i -1) 4 s.0))) 4,23
  (for 11
   (call ~3 foo.0.tfo6zftzj1 1 +2)
   (unpackflat
-   (let :i.1 . . ,~17,lib/std/system.nim
+   (let :i.1 . . 7,~21
     (i -1) .)
-   (let 3 :j.1 . . ,~17,lib/std/system.nim
+   (let 3 :j.1 . . 12,~21
     (i -1) .)) ~2,1
   (stmts 4
-   (let :s.1 . . ~2,~18,lib/std/system.nim
+   (let :s.1 . . 5,~22
     (i -1) 4 i.1) 4,1
-   (let :m.2 . . ~2,~19,lib/std/system.nim
+   (let :m.2 . . 10,~23
     (i -1) 4 j.1))) ,27
  (proc 5 :bar.0.tfo6zftzj1 . . . 8
   (params) . . . 2,1
@@ -79,25 +79,25 @@
    (for 11
     (call ~3 foo.0.tfo6zftzj1 1 +2)
     (unpackflat
-     (let :i.2 . . ~2,~22,lib/std/system.nim
+     (let :i.2 . . 5,~26
       (i -1) .)
-     (let 3 :j.2 . . ~2,~22,lib/std/system.nim
+     (let 3 :j.2 . . 10,~26
       (i -1) .)) ~2,1
     (stmts 4
-     (let :s.2 . . ~4,~23,lib/std/system.nim
+     (let :s.2 . . 3,~27
       (i -1) 4 i.2) 4,1
-     (let :m.3 . . ~4,~24,lib/std/system.nim
+     (let :m.3 . . 8,~28
       (i -1) 4 j.2))) 4,4
    (for 13
     (call ~3 foo.0.tfo6zftzj1 1 +2)
     (unpacktup
-     (let 1 :i.3 . . ~2,~26,lib/std/system.nim
+     (let 1 :i.3 . . 5,~30
       (i -1) .)
-     (let 4 :j.3 . . ~2,~26,lib/std/system.nim
+     (let 4 :j.3 . . 10,~30
       (i -1) .)) ~2,1
     (stmts 4
-     (let :s.3 . . ~4,~27,lib/std/system.nim
+     (let :s.3 . . 3,~31
       (i -1) 4 i.3) 4,1
-     (let :m.4 . . ~4,~28,lib/std/system.nim
+     (let :m.4 . . 8,~32
       (i -1) 4 j.3))))) 3,36
  (call ~3 bar.0.tfo6zftzj1))

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -2,24 +2,24 @@
 ,1,tests/nimony/sysbasics/thooks.nim(stmts 15,1
  (type ~13 :MyObjectBase.0.tho8gh7q4 . . . 2
   (object . ~13,1
-   (fld :x.0.tho8gh7q4 . . ,4,lib/std/system.nim
+   (fld :x.0.tho8gh7q4 . . 6
     (i -1) .) ~10,1
-   (fld :y.0.tho8gh7q4 . . ~3,4,lib/std/system.nim
+   (fld :y.0.tho8gh7q4 . . 3
     (i -1) .))) 17,4
  (type ~15 :MyObject.0.tho8gh7q4 . ~7
   (typevars 1
    (typevar :T.0.tho8gh7q4 . . . .) 4
    (typevar :Y.0.tho8gh7q4 . . . .)) . 2
   (object . ~15,1
-   (fld :x.1.tho8gh7q4 . . ,1,lib/std/system.nim
+   (fld :x.1.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.tho8gh7q4 . . ~3,1,lib/std/system.nim
+   (fld :y.1.tho8gh7q4 . . 3
     (i -1) .))) ,7
  (proc 5 :=trace.0.tho8gh7q4 . . . 13
   (params 1
    (param :x.0 . . 3
     (mut 4 MyObjectBase.0.tho8gh7q4) .) 22
-   (param :p.0 . . ~31,41,lib/std/system.nim
+   (param :p.0 . . 3
     (pointer) .)) . . . 2,1
   (stmts
    (discard .))) ,10
@@ -118,55 +118,55 @@
  (var :obj.0.tho8gh7q4 . . 13 MyObject.1.tho8gh7q4 .) 12,53
  (call 1 =checkHook.1.tho8gh7q4 1 obj.0.tho8gh7q4) 12,40
  (proc :=destroy.2.tho8gh7q4 . ~12,~8 .
-  (at =destroy.1.tho8gh7q4 ~8,~34,lib/std/system.nim
-   (i -1) ~8,~8,lib/std/system.nim
+  (at =destroy.1.tho8gh7q4 8,~4
+   (i -1) 13,~4
    (f +64)) 9,~8
   (params 1
    (param :x.14 . . 11 MyObject.1.tho8gh7q4 .)) ~12,~8 . ~12,~8 . ~12,~8 . ~10,~7
   (stmts 4
-   (let :x.15 . . ~2,~27,lib/std/system.nim
+   (let :x.15 . . 4,~31
     (i -1) 4 +12))) 12,53
  (proc :=checkHook.1.tho8gh7q4 . ~12,~4 .
-  (at =checkHook.0.tho8gh7q4 ~8,~47,lib/std/system.nim
-   (i -1) ~8,~21,lib/std/system.nim
+  (at =checkHook.0.tho8gh7q4 8,~17
+   (i -1) 13,~17
    (f +64)) 11,~4
   (params 1
    (param :x.16 . . 12 MyObject.1.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
   (stmts
    (discard .))) 19,36
  (type :MyObject.1.tho8gh7q4 .
-  (at MyObject.0.tho8gh7q4 ~15,~30,lib/std/system.nim
-   (i -1) ~15,~4,lib/std/system.nim
+  (at MyObject.0.tho8gh7q4 1
+   (i -1) 6
    (f +64)) ~2,~32 . ,~32
   (object . ~15,1
-   (fld :x.2.tho8gh7q4 . . ,1,lib/std/system.nim
+   (fld :x.2.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.2.tho8gh7q4 . . ~3,1,lib/std/system.nim
+   (fld :y.2.tho8gh7q4 . . 3
     (i -1) .))) 20,38
  (type :MyObject.2.tho8gh7q4 .
-  (at MyObject.0.tho8gh7q4 ~16,~6,lib/std/system.nim
-   (f +64) ~16,~32,lib/std/system.nim
+  (at MyObject.0.tho8gh7q4 1
+   (f +64) 8
    (i -1)) ~3,~34 . ~1,~34
   (object . ~15,1
-   (fld :x.3.tho8gh7q4 . . ,1,lib/std/system.nim
+   (fld :x.3.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.3.tho8gh7q4 . . ~3,1,lib/std/system.nim
+   (fld :y.3.tho8gh7q4 . . 3
     (i -1) .))) ,22
  (proc :=wasMoved.2.tho8gh7q4 . .
-  (at =wasMoved.1.tho8gh7q4 4,~16,lib/std/system.nim
-   (i -1) 4,10,lib/std/system.nim
+  (at =wasMoved.1.tho8gh7q4 20,14
+   (i -1) 25,14
    (f +64)) 22
   (params 1
    (param :x.24 . . 3
     (mut 12 MyObject.1.tho8gh7q4) .)) . . . 2,1
   (stmts 4
-   (let :x.25 . . ~2,~17,lib/std/system.nim
+   (let :x.25 . . 4,~21
     (i -1) 4 +12) 4,1
-   (let :y.9 . . ~2,~18,lib/std/system.nim
+   (let :y.9 . . 4,~22
     (i -1) 4 +4))) ,26
  (proc :=copy.2.tho8gh7q4 . .
-  (at =copy.1.tho8gh7q4 4,~20,lib/std/system.nim
-   (i -1) 4,6,lib/std/system.nim
+  (at =copy.1.tho8gh7q4 20,10
+   (i -1) 25,10
    (f +64)) 18
   (params 1
    (param :x.26 . . 3
@@ -175,8 +175,8 @@
   (stmts
    (discard .))) ,29
  (proc :=sink.2.tho8gh7q4 . .
-  (at =sink.1.tho8gh7q4 4,~23,lib/std/system.nim
-   (i -1) 4,3,lib/std/system.nim
+  (at =sink.1.tho8gh7q4 20,7
+   (i -1) 25,7
    (f +64)) 18
   (params 1
    (param :x.27 . . 3
@@ -185,20 +185,20 @@
   (stmts
    (discard .))) ,22
  (proc :=wasMoved.3.tho8gh7q4 . .
-  (at =wasMoved.1.tho8gh7q4 4,10,lib/std/system.nim
-   (f +64) 4,~16,lib/std/system.nim
+  (at =wasMoved.1.tho8gh7q4 21,16
+   (f +64) 28,16
    (i -1)) 22
   (params 1
    (param :x.28 . . 3
     (mut 12 MyObject.2.tho8gh7q4) .)) . . . 2,1
   (stmts 4
-   (let :x.29 . . ~2,~17,lib/std/system.nim
+   (let :x.29 . . 4,~21
     (i -1) 4 +12) 4,1
-   (let :y.12 . . ~2,~18,lib/std/system.nim
+   (let :y.12 . . 4,~22
     (i -1) 4 +4))) ,26
  (proc :=copy.3.tho8gh7q4 . .
-  (at =copy.1.tho8gh7q4 4,6,lib/std/system.nim
-   (f +64) 4,~20,lib/std/system.nim
+  (at =copy.1.tho8gh7q4 21,12
+   (f +64) 28,12
    (i -1)) 18
   (params 1
    (param :x.30 . . 3
@@ -207,8 +207,8 @@
   (stmts
    (discard .))) ,29
  (proc :=sink.3.tho8gh7q4 . .
-  (at =sink.1.tho8gh7q4 4,3,lib/std/system.nim
-   (f +64) 4,~23,lib/std/system.nim
+  (at =sink.1.tho8gh7q4 21,9
+   (f +64) 28,9
    (i -1)) 18
   (params 1
    (param :x.31 . . 3
@@ -217,11 +217,11 @@
   (stmts
    (discard .))) ,32
  (proc :=destroy.3.tho8gh7q4 . .
-  (at =destroy.1.tho8gh7q4 4,,lib/std/system.nim
-   (f +64) 4,~26,lib/std/system.nim
+  (at =destroy.1.tho8gh7q4 21,6
+   (f +64) 28,6
    (i -1)) 21
   (params 1
    (param :x.32 . . 11 MyObject.2.tho8gh7q4 .)) . . . 2,1
   (stmts 4
-   (let :x.33 . . ~2,~27,lib/std/system.nim
+   (let :x.33 . . 4,~31
     (i -1) 4 +12))))


### PR DESCRIPTION
Previously it would directly copy the magic tag from the declaration of the magic symbol including the declaration line info, when it should be the line info of the use.