### PR TITLE
nimony: implements `instantiationInfo`

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -371,3 +371,39 @@ proc addr*[T](x: T): ptr T {.magic: "Addr", noSideEffect.}
 
 proc sizeof*[T](x: T): int {.magic: "SizeOf", noSideEffect.}
 proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}
+
+proc instantiationInfo*(index = -1, fullPaths = false): tuple[
+  filename: string, line: int, column: int] {.magic: "InstantiationInfo", noSideEffect.}
+  ## Provides access to the compiler's instantiation stack line information
+  ## of a template.
+  ##
+  ## While similar to the `caller info`:idx: of other languages, it is determined
+  ## at compile time.
+  ##
+  ## This proc is mostly useful for meta programming (eg. `assert` template)
+  ## to retrieve information about the current filename and line number.
+  ## Example:
+  ##
+  ##   ```nim
+  ##   import std/strutils
+  ##
+  ##   template testException(exception, code: untyped): typed =
+  ##     try:
+  ##       let pos = instantiationInfo()
+  ##       discard(code)
+  ##       echo "Test failure at $1:$2 with '$3'" % [pos.filename,
+  ##         $pos.line, astToStr(code)]
+  ##       assert false, "A test expecting failure succeeded?"
+  ##     except exception:
+  ##       discard
+  ##
+  ##   proc tester(pos: int): int =
+  ##     let
+  ##       a = @[1, 2, 3]
+  ##     result = a[pos]
+  ##
+  ##   when isMainModule:
+  ##     testException(IndexDefect, tester(30))
+  ##     testException(IndexDefect, tester(1))
+  ##     # --> Test failure at example.nim:20 with 'tester(1)'
+  ##   ```

--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -588,7 +588,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
        DefinedX, HighX, LowX, TypeofX, UnpackX, EnumToStrX, IsMainModuleX, QuotedX,
        DerefX, HderefX, AddrX, HaddrX:
       trSons c, n, WantNonOwner
-    of DefaultObjX, DefaultTupX:
+    of DefaultObjX, DefaultTupX, InstantiationInfoX:
       raiseAssert "nodekind should have been eliminated in sem.nim"
     of NoExpr:
       case n.stmtKind

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -174,6 +174,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mDefaultTup: res DefaultTupX
   of mOpenArray: res OpenArrayT
   of mEnsureMove: res EnsureMoveX
+  of mInstantiationInfo: res InstantiationInfoX
   else: ("", 0)
 
 when isMainModule:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -153,6 +153,7 @@ type
     ArrAtX = "arrat"
     TupAtX = "tupat" # tup[0] syntax
     EnsureMoveX = "emove" # note that `move` can be written in standard Nim
+    InstantiationInfoX = "instantiationinfo"
 
   TypeKind* = enum
     NoType

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -142,7 +142,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     result = c.builtins.boolType
   of NegX, NegInfX, NanX, InfX:
     result = c.builtins.floatType
-  of EnumToStrX, DefaultObjX, DefaultTupX:
+  of EnumToStrX, DefaultObjX, DefaultTupX, InstantiationInfoX:
     result = c.builtins.stringType
   of SizeofX:
     result = c.builtins.intType

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -114,4 +114,10 @@
     (pointer) 5
     (cast 5
      (pointer) 14 m.3)) 4,4
-   (call ~4 foo3.0.tbawx6nu81 1 m2.0))))
+   (call ~4 foo3.0.tbawx6nu81 1 m2.0))) 4,35
+ (let :sInfo.0.tbawx6nu81 . . 25
+  (tuple
+   (string)
+   (i -1)
+   (i -1)) 25
+  (tup "tests/nimony/sysbasics/tbasics.nim" +36 +29)))

--- a/tests/nimony/sysbasics/tbasics.nim
+++ b/tests/nimony/sysbasics/tbasics.nim
@@ -31,3 +31,6 @@ block:
   foo3(m)
   let m2 = cast[pointer](m)
   foo3(m2)
+
+
+let sInfo = instantiationInfo(-1, false)


### PR DESCRIPTION
It is required because `compile` needs to pass a parameter relative to the source path. Call info stacks are not implemented in this PR