### PR TITLE
nimony: implement `build` + mimalloc support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ jobs:
         if: runner.os == 'Windows'
         run: winget install ezwinports.make --disable-interactivity --accept-source-agreements
 
+      - name: System Info (Windows)
+        if: runner.os == 'Windows'
+        run: "gcc -v"
+
       # - name: Restore Nim from cache
       #   if: >
       #     steps.nim-compiler-cache.outputs.cache-hit != 'true' &&

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/mimalloc"]
+	path = vendor/mimalloc
+	url = https://github.com/microsoft/mimalloc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/mimalloc"]
 	path = vendor/mimalloc
-	url = https://github.com/microsoft/mimalloc
+	url = https://github.com/nim-lang/mimalloc

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -1,0 +1,23 @@
+{.build("C", "${path}/../../../vendor/mimalloc/src/static.c", "-I${path}/../../../vendor/mimalloc/include").}
+
+type
+  csize_t* {.importc: "size_t", nodecl.} = uint
+
+proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc".}
+proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc".}
+proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc".}
+proc mi_free(p: pointer) {.importc: "mi_free".}
+
+proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size".}
+
+proc alloc*(size: int): pointer =
+  result = mi_malloc(size.csize_t)
+
+proc realloc*(p: pointer; size: int): pointer =
+  result = mi_realloc(p, size.csize_t)
+
+proc dealloc*(p: pointer) =
+  mi_free(p)
+
+proc allocatedSize*(p: pointer): int =
+  result = int mi_usable_size(p)

--- a/src/config.nims
+++ b/src/config.nims
@@ -1,3 +1,4 @@
 --define:nimPreviewSlimSystem
 --warningAsError:Uninit
 --warningAsError:ProveInit
+--experimental:strictdefs

--- a/src/hexer/expander.nim
+++ b/src/hexer/expander.nim
@@ -471,7 +471,13 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
             error e, "expected string literal or ident, but got: ", c
           result.flags.incl Nodecl
           inc c
-        of ImportC, ImportCpp, ExportC, Plugin:
+        of ImportC, ImportCpp:
+          inc c
+          expectStrLit e, c
+          result.externName = pool.strings[c.litId]
+          result.flags.incl pk
+          inc c
+        of ExportC, Plugin:
           inc c
           expectStrLit e, c
           result.externName = pool.strings[c.litId]
@@ -484,6 +490,7 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
           inc c
           expectStrLit e, c
           result.header = c.litId
+          result.flags.incl Nodecl
           inc c
         of Align:
           inc c
@@ -608,6 +615,10 @@ proc traverseProc(e: var EContext; c: var Cursor; mode: TraverseMode) =
   swap dst, e.dest
   if Nodecl in prag.flags or isGeneric:
     discard "do not add to e.dest"
+  elif prag.flags * {ImportC, ImportCpp} != {}:
+    e.dest.add tagToken("imp", c.info)
+    e.dest.add dst
+    e.dest.addParRi()
   else:
     e.dest.add dst
   if prag.header != StrId(0):

--- a/src/hexer/expander.nim
+++ b/src/hexer/expander.nim
@@ -1108,9 +1108,9 @@ proc traverseStmt(e: var EContext; c: var Cursor; mode = TraverseAll) =
       skip c
     of TypeS:
       traverseTypeDecl e, c
-    of ContinueS, WhenS:
+    of ContinueS, WhenS, ClonerS, TracerS, DisarmerS, MoverS, DtorS:
       error e, "unreachable: ", c
-    of ClonerS, TracerS, DisarmerS, MoverS, DtorS:
+    of PragmasLineS:
       skip c
   else:
     error e, "statement expected, but got: ", c

--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -365,7 +365,8 @@ proc trStmt(c: var Context; dest: var TokenBuf; n: var Cursor) =
     trBlock c, dest, n, tar
   of IterS, TemplateS, TypeS, EmitS, BreakS, ContinueS,
      ForS, CmdS, IncludeS, ImportS, FromImportS, ImportExceptS,
-     ExportS, CommentS, ClonerS, TracerS, DisarmerS, MoverS, DtorS:
+     ExportS, CommentS, ClonerS, TracerS, DisarmerS, MoverS, DtorS,
+     PragmasLineS:
     takeTree dest, n
   of ScopeS:
     c.typeCache.openScope()

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -15,7 +15,7 @@
 ]#
 
 import std/[os, tables, sets, syncio, assertions, strutils, times]
-import semos, nifconfig, nimony_model
+import semos, nifconfig, nimony_model, nifindexes
 import ".." / gear2 / modnames, semdata
 
 include nifprelude
@@ -247,6 +247,20 @@ const makefileHeader = """
 .SECONDARY:
   """ # don't delete intermediate files
 
+type
+  CFile = tuple
+    name, obj, customArgs: string
+
+proc toBuildList(c: DepContext): seq[CFile] =
+  result = @[]
+  for v in c.nodes:
+    let index = readIndex(mescape(indexFile(v.files[0])))
+    for i in index.toBuild:
+      let path = i[1]
+      let obj = splitFile(path).name & ".o"
+      let customArgs = i[2]
+      result.add (path, obj, customArgs)
+
 proc generateFinalMakefile(c: DepContext): string =
   var s = makefileHeader
   let dest =
@@ -261,10 +275,21 @@ proc generateFinalMakefile(c: DepContext): string =
 
   # The .exe file depends on all .o files:
   if c.cmd in {DoCompile, DoRun}:
+    let buildList = toBuildList(c)
+
     s.add "\n" & mescape(exeFile(c.rootNode.files[0])) & ":"
+
+    for cfile in buildList:
+      s.add " " & mescape("nifcache" / cfile.obj)
+
     for v in c.nodes:
       s.add " " & mescape(objFile(v.files[0]))
     s.add "\n\t$(CC) -o $@ $^"
+
+    for cfile in buildList:
+      s.add "\n" & mescape("nifcache" / cfile.obj) & ": " & mescape(cfile.name) &
+            "\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) " &
+            cfile.customArgs & " $< -o $@"
 
     # The .o files depend on all of their .c files:
     s.add "\n%.o: %.c\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@"
@@ -337,7 +362,6 @@ proc buildGraph*(config: sink NifConfig; project: string; compat, forceRebuild, 
   c.processedModules.incl p.modname
   parseDeps c, p, c.rootNode
   let makeFilename = generateFrontendMakefile(c, commandLineArgs)
-  let makeFinalFilename = generateFinalMakefile(c)
   #echo "run with: make -f ", makeFilename
   when defined(windows):
     putEnv("CC", "gcc")
@@ -346,6 +370,8 @@ proc buildGraph*(config: sink NifConfig; project: string; compat, forceRebuild, 
     (if forceRebuild: " -B" else: "") &
     " -f "
   exec makeCommand & quoteShell(makeFilename)
+
+  let makeFinalFilename = generateFinalMakefile(c)
   exec makeCommand & quoteShell(makeFinalFilename)
   if cmd == DoRun:
     exec exeFile(c.rootNode.files[0])

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -289,7 +289,7 @@ proc generateFinalMakefile(c: DepContext): string =
     for cfile in buildList:
       s.add "\n" & mescape("nifcache" / cfile.obj) & ": " & mescape(cfile.name) &
             "\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) " &
-            cfile.customArgs & " $< -o $@"
+            mescape(cfile.customArgs) & " $< -o $@"
 
     # The .o files depend on all of their .c files:
     s.add "\n%.o: %.c\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@"

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -149,6 +149,7 @@ proc handleCmdLine() =
   of FullProject:
     createDir("nifcache")
     createDir(binDir())
+    exec "git submodule update --init"
     requiresTool "nifler", "src/nifler/nifler.nim", forceRebuild
     requiresTool "nimsem", "src/nimony/nimsem.nim", forceRebuild
     requiresTool "hexer", "src/hexer/hexer.nim", forceRebuild

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -54,6 +54,7 @@ type
     DisarmerS = "disarmer"
     MoverS = "mover"
     DtorS = "dtor"
+    PragmasLineS = "pragmas"
 
   SymKind* = enum
     NoSym

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -8,7 +8,7 @@
 ## Most important task is to turn identifiers into symbols and to perform
 ## type checking.
 
-import std / [tables, sets, syncio, formatfloat, assertions, packedsets, strutils, os]
+import std / [tables, sets, syncio, formatfloat, assertions, packedsets, strutils]
 include nifprelude
 import nimony_model, symtabs, builtintypes, decls, symparser, asthelpers,
   programs, sigmatch, magics, reporters, nifconfig, nifindexes,
@@ -4529,16 +4529,13 @@ proc semPragmasLine(c: var SemContext; it: var Item) =
         buildErr c, it.n.info, "build expected 2 or 3 parameters"
 
       let fileId = getFileId(pool.man, info)
-      let fullPath = absolutePath(pool.files[fileId])
-      let dir = parentDir(fullPath)
+      let dir = absoluteParentDir(pool.files[fileId])
 
       let compileType = args[0]
-      var name = args[1].replace("${path}", dir)
+      let name = args[1].replace("${path}", dir).toAbsolutePath(dir)
       let customArgs = if args.len == 3: args[2].replace("${path}", dir) else: ""
-      if not name.isAbsolute:
-        name = dir / name
 
-      if not fileExists(name):
+      if not fileExists2(name):
         buildErr c, it.n.info, "cannot find: " & name
 
       c.toBuild.buildTree TupleConstrX, info:

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -97,3 +97,4 @@ type
     genericHooks*: Table[SymId, seq[SymId]]
     hookIndexMap*: Table[string, seq[(SymId, SymId)]]
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking
+    toBuild*: TokenBuf

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -35,6 +35,18 @@ proc binDir*(): string =
 proc toolDir*(f: string): string =
   result = binDir() / f
 
+proc absoluteParentDir*(f: string): string =
+  result = f.absolutePath().parentDir()
+
+proc fileExists2*(f: string): bool =
+  result = os.fileExists(f)
+
+proc toAbsolutePath*(f: string, dir: string): string =
+  if f.isAbsolute:
+    result = f
+  else:
+    result = dir / f
+
 proc findTool*(name: string): string =
   assert not name.isAbsolute
   let exe = name.addFileExt(ExeExt)

--- a/tests/nifc/hello.expected.idx.nif
+++ b/tests/nifc/hello.expected.idx.nif
@@ -6,5 +6,6 @@
  (kv MyObject.ptr.object +699)
  (kv MyObject.my.sequence +171)
  (kv MyObject.sequence.base +127))
+(build)
 
 )

--- a/tests/nimony/sysbasics/foo.c
+++ b/tests/nimony/sysbasics/foo.c
@@ -1,0 +1,3 @@
+int myFunc() {
+  return 12;
+}

--- a/tests/nimony/sysbasics/foo1.c
+++ b/tests/nimony/sysbasics/foo1.c
@@ -1,0 +1,3 @@
+int myFunc2() {
+  return 12;
+}

--- a/tests/nimony/sysbasics/tbuild.nim
+++ b/tests/nimony/sysbasics/tbuild.nim
@@ -1,0 +1,9 @@
+{.build("C", "foo.c").}
+{.build("C", "foo1.c", "-fno-strict-aliasing").}
+
+
+proc myFunc(): int {.importc: "myFunc".}
+proc myFunc2(): int {.importc: "myFunc2".}
+
+let s = myFunc()
+let s2 = myFunc2()

--- a/tests/nimony/sysbasics/tmimalloc.nim
+++ b/tests/nimony/sysbasics/tmimalloc.nim
@@ -1,0 +1,23 @@
+{.build("C", "${path}/../../../vendor/mimalloc/src/static.c", "-I${path}/../../../vendor/mimalloc/include").}
+
+type
+  csize_t* {.importc: "size_t", nodecl.} = uint
+
+proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc".}
+proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc".}
+proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc".}
+proc mi_free(p: pointer) {.importc: "mi_free".}
+
+proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size".}
+
+proc alloc*(size: int): pointer =
+  result = mi_malloc(size.csize_t)
+
+proc realloc*(p: pointer; size: int): pointer =
+  result = mi_realloc(p, size.csize_t)
+
+proc dealloc*(p: pointer) =
+  mi_free(p)
+
+proc allocatedSize*(p: pointer): int =
+  result = int mi_usable_size(p)


### PR DESCRIPTION
fixes https://github.com/nim-lang/nimony/issues/357

ref https://github.com/microsoft/mimalloc

- [x] Make hastur download mimalloc as part of the build process. Maybe depend on it via a git submodule.
- [x] Add `.build: "foo.c"` to Nimony so that we can also depend on C code like mimalloc.
- [x] Make use of `.build` in system.nim so we can use a decent memory allocator which offers `allocatedSize()` so that our new super efficient strings and seq can use it.