### PR TITLE
implement converters in sigmatch

### DIFF
--- a/src/hexer/expander.nim
+++ b/src/hexer/expander.nim
@@ -814,7 +814,7 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         inc nested
       of TupleConstrX:
         traverseTupleConstr e, c
-      of CmdX, CallStrLitX, InfixX, PrefixX:
+      of CmdX, CallStrLitX, InfixX, PrefixX, HcallX:
         e.dest.add tagToken("call", c.info)
         inc c
         inc nested

--- a/src/lib/nifindexes.nim
+++ b/src/lib/nifindexes.nim
@@ -99,8 +99,40 @@ proc processForChecksum(dest: var Sha1State; content: var TokenBuf) =
     else:
       inc n
 
-proc createIndex*(infile: string; buildChecksum: bool;
-    hookIndexMap: Table[string, seq[(SymId, SymId)]]) =
+type IndexSections* = object
+  hooks*: Table[string, seq[(SymId, SymId)]]
+  converters*: seq[(SymId, SymId)]
+
+proc getSection(tag: TagId; values: seq[(SymId, SymId)]; symToOffsetMap: Table[SymId, int]): TokenBuf =
+  let KvT = registerTag "kv"
+
+  result = default(TokenBuf)
+  result.addParLe tag
+
+  for value in values:
+    let (key, sym) = value
+    let offset = symToOffsetMap[sym]
+    result.buildTree KvT, NoLineInfo:
+      result.add symToken(key, NoLineInfo)
+      result.add intToken(pool.integers.getOrIncl(offset), NoLineInfo)
+
+  result.addParRi()
+
+proc getSymbolSection(tag: TagId; values: seq[(SymId, SymId)]): TokenBuf =
+  let KvT = registerTag "kv"
+
+  result = default(TokenBuf)
+  result.addParLe tag
+
+  for value in values:
+    let (key, sym) = value
+    result.buildTree KvT, NoLineInfo:
+      result.add symToken(key, NoLineInfo)
+      result.add symToken(sym, NoLineInfo)
+
+  result.addParRi()
+
+proc createIndex*(infile: string; buildChecksum: bool; sections: IndexSections) =
   let PublicT = registerTag "public"
   let PrivateT = registerTag "private"
   let KvT = registerTag "kv"
@@ -160,21 +192,18 @@ proc createIndex*(infile: string; buildChecksum: bool;
   content.add toString(private)
   content.add "\n"
 
-  for (key, values) in hookIndexMap.pairs:
-    var hookSectionBuf = default(TokenBuf)
+  for (key, values) in sections.hooks.pairs:
     let tag = registerTag(key)
-    hookSectionBuf.addParLe tag
-
-    for value in values:
-      let (obj, sym) = value
-      let offset = symToOffsetMap[sym]
-      hookSectionBuf.buildTree KvT, NoLineInfo:
-        hookSectionBuf.add symToken(obj, NoLineInfo)
-        hookSectionBuf.add intToken(pool.integers.getOrIncl(offset), NoLineInfo)
-
-    hookSectionBuf.addParRi()
+    let hookSectionBuf = getSection(tag, values, symToOffsetMap)
 
     content.add toString(hookSectionBuf)
+    content.add "\n"
+  
+  if sections.converters.len != 0:
+    let ConverterT = registerTag "converter"
+    let converterSectionBuf = getSymbolSection(ConverterT, sections.converters)
+
+    content.add toString(converterSectionBuf)
     content.add "\n"
 
   if buildChecksum:
@@ -189,7 +218,7 @@ proc createIndex*(infile: string; buildChecksum: bool;
     writeFile(indexName, content)
 
 proc createIndex*(infile: string; buildChecksum: bool) =
-  createIndex(infile, buildChecksum, initTable[string, seq[(SymId, SymId)]]())
+  createIndex(infile, buildChecksum, IndexSections(hooks: initTable[string, seq[(SymId, SymId)]]()))
 
 type
   NifIndexEntry* = object
@@ -198,6 +227,7 @@ type
   NifIndex* = object
     public*, private*: Table[string, NifIndexEntry]
     hooks*: Table[string, Table[string, NifIndexEntry]]
+    converters*: Table[string, string] # map of dest types to converter symbols
 
 proc readSection(s: var Stream; tab: var Table[string, NifIndexEntry]; useAbsoluteOffset = false) =
   let KvT = registerTag "kv"
@@ -242,6 +272,49 @@ proc readSection(s: var Stream; tab: var Table[string, NifIndexEntry]; useAbsolu
       assert false, "expected (kv) construct"
       #t = next(s)
 
+proc readSymbolSection(s: var Stream; tab: var Table[string, string]) =
+  let KvT = registerTag "kv"
+  var t = next(s)
+  var nested = 1
+  while t.kind != EofToken:
+    let info = t.info
+    if t.kind == ParLe:
+      inc nested
+      if t.tagId == KvT:
+        t = next(s)
+        var key: string
+        if t.kind == Symbol:
+          key = pool.syms[t.symId]
+        elif t.kind == Ident:
+          key = pool.strings[t.litId]
+        else:
+          raiseAssert "invalid (kv) construct: symbol expected"
+        t = next(s) # skip Symbol
+        var value: string
+        if t.kind == Symbol:
+          value = pool.syms[t.symId]
+        elif t.kind == Ident:
+          value = pool.strings[t.litId]
+        else:
+          raiseAssert "invalid (kv) construct: symbol expected"
+        t = next(s) # skip value symbol
+        tab[key] = value
+        if t.kind == ParRi:
+          t = next(s)
+          dec nested
+        else:
+          assert false, "invalid (kv) construct: ')' expected"
+      else:
+        assert false, "expected (kv) construct"
+    elif t.kind == ParRi:
+      dec nested
+      if nested == 0:
+        break
+      t = next(s)
+    else:
+      assert false, "expected (kv) construct"
+      #t = next(s)
+
 proc readIndex*(indexName: string): NifIndex =
   var s = nifstreams.open(indexName)
   let res = processDirectives(s.r)
@@ -258,6 +331,8 @@ proc readIndex*(indexName: string): NifIndex =
   let DtorT = registerTag "dtor"
 
   let hookSet = toHashSet([ClonerT, TracerT, DisarmerT, MoverT, DtorT])
+
+  let ConverterT = registerTag "converter"
 
   result = default(NifIndex)
   var t = next(s)
@@ -277,6 +352,9 @@ proc readIndex*(indexName: string): NifIndex =
       let tagName = pool.tags[t.tag]
       result.hooks[tagName] = initTable[string, NifIndexEntry]()
       readSection(s, result.hooks[tagName])
+      t = next(s)
+    if t.tag == ConverterT:
+      readSymbolSection(s, result.converters)
       t = next(s)
 
   else:

--- a/src/lib/nifindexes.nim
+++ b/src/lib/nifindexes.nim
@@ -210,7 +210,7 @@ proc createIndex*(infile: string; buildChecksum: bool; sections: IndexSections) 
   let buildT = registerTag "build"
   var buildBuf = createTokenBuf()
   buildBuf.addParLe buildT
-  buildBuf.add toBuild
+  buildBuf.add sections.toBuild
   buildBuf.addParRi
   content.add toString(buildBuf)
   content.add "\n"

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -132,6 +132,7 @@ type
     CallStrLitX = "callstrlit"
     InfixX = "infix"
     PrefixX = "prefix"
+    HcallX = "hcall" # hidden converter call
     CmdX = "cmd"
     InfX = "inf"
     NegInfX = "neginf"
@@ -334,7 +335,7 @@ template `==`*(n: Cursor; s: string): bool = n.kind == ParLe and pool.tags[n.tag
 
 const
   RoutineKinds* = {ProcY, FuncY, IterY, TemplateY, MacroY, ConverterY, MethodY}
-  CallKinds* = {CallX, CallStrLitX, CmdX, PrefixX, InfixX}
+  CallKinds* = {CallX, CallStrLitX, CmdX, PrefixX, InfixX, HcallX}
   ConvKinds* = {HconvX, ConvX, OconvX, DconvX, CastX}
 
 proc addParLe*(dest: var TokenBuf; kind: TypeKind|SymKind|ExprKind|StmtKind|SubstructureKind; info = NoLineInfo) =

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -49,6 +49,7 @@ proc load*(suffix: string): NifModule =
 
 proc loadInterface*(suffix: string; iface: var Iface;
                     module: SymId; importTab: var OrderedTable[StrId, seq[SymId]];
+                    converters: var Table[SymId, SymId];
                     marker: var PackedSet[StrId]; negateMarker: bool) =
   let m = load(suffix)
   for k, _ in m.index.public:
@@ -63,6 +64,10 @@ proc loadInterface*(suffix: string; iface: var Iface;
     if not symMarked:
       # mark that this module contains the identifier `strId`:
       importTab.mgetOrPut(strId, @[]).add(module)
+  for k, v in m.index.converters:
+    let key = pool.syms.getOrIncl(k)
+    let val = pool.syms.getOrIncl(v)
+    converters[key] = val
 
 proc error*(msg: string; c: Cursor) {.noreturn.} =
   when defined(debug):

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -49,7 +49,7 @@ proc load*(suffix: string): NifModule =
 
 proc loadInterface*(suffix: string; iface: var Iface;
                     module: SymId; importTab: var OrderedTable[StrId, seq[SymId]];
-                    converters: var Table[SymId, SymId];
+                    converters: var Table[SymId, seq[SymId]];
                     marker: var PackedSet[StrId]; negateMarker: bool) =
   let m = load(suffix)
   for k, _ in m.index.public:
@@ -65,9 +65,14 @@ proc loadInterface*(suffix: string; iface: var Iface;
       # mark that this module contains the identifier `strId`:
       importTab.mgetOrPut(strId, @[]).add(module)
   for k, v in m.index.converters:
-    let key = pool.syms.getOrIncl(k)
-    let val = pool.syms.getOrIncl(v)
-    converters[key] = val
+    var name = v
+    extractBasename(name)
+    let nameId = pool.strings.getOrIncl(name)
+    # check that the converter is imported, slow but better to be slow here than anywhere else:
+    if nameId in importTab and module in importTab[nameId]:
+      let key = pool.syms.getOrIncl(k)
+      let val = pool.syms.getOrIncl(v)
+      converters.mgetOrPut(key, @[]).add(val)
 
 proc error*(msg: string; c: Cursor) {.noreturn.} =
   when defined(debug):

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -68,7 +68,7 @@ proc loadInterface*(suffix: string; iface: var Iface;
     var name = v
     extractBasename(name)
     let nameId = pool.strings.getOrIncl(name)
-    # check that the converter is imported, slow but better to be slow here than anywhere else:
+    # check that the converter is imported, slow but better to be slow here:
     if nameId in importTab and module in importTab[nameId]:
       let key = pool.syms.getOrIncl(k)
       let val = pool.syms.getOrIncl(v)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2854,16 +2854,15 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
       skip it.n
 
     publishSignature c, symId, declStart
-    var converterRoot = SymId(0)
     if kind == ConverterY:
-      converterRoot = nominalRoot(c.routine.returnType)
-      if converterRoot == SymId(0):
+      let root = nominalRoot(c.routine.returnType)
+      if root == SymId(0):
         buildErr c, info, "cannot attach converter to type " & typeToString(c.routine.returnType)
       else:
-        c.converters.mgetOrPut(converterRoot, @[]).add(symId)
+        c.converters.mgetOrPut(root, @[]).add(symId)
         if pass == checkBody and c.dest[beforeExportMarker].kind != DotToken:
           # don't register instances
-          c.converterIndexMap.add((converterRoot, symId))
+          c.converterIndexMap.add((root, symId))
     if it.n.kind != DotToken:
       case pass
       of checkGenericInst:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2860,7 +2860,7 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
       if converterRoot == SymId(0):
         buildErr c, info, "cannot attach converter to type " & typeToString(c.routine.returnType)
       else:
-        c.converters.mgetOrPut(converterRoot, @[]).add(converterRoot)
+        c.converters.mgetOrPut(converterRoot, @[]).add(symId)
         if pass == checkBody and c.dest[beforeExportMarker].kind != DotToken:
           # don't register instances
           c.converterIndexMap.add((converterRoot, symId))

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2860,7 +2860,7 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
       if converterRoot == SymId(0):
         buildErr c, info, "cannot attach converter to type " & typeToString(c.routine.returnType)
       else:
-        c.converters[converterRoot] = symId
+        c.converters.mgetOrPut(converterRoot, @[]).add(converterRoot)
         if pass == checkBody and c.dest[beforeExportMarker].kind != DotToken:
           # don't register instances
           c.converterIndexMap.add((converterRoot, symId))

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4116,6 +4116,7 @@ proc tryExplicitRoutineInst(c: var SemContext; syms: Cursor; it: var Item): bool
       let routine = getProcDecl(sym)
       let candidate = FnCandidate(kind: routine.kind, sym: sym, typ: routine.params)
       var m = createMatch(addr c)
+      m.fn = candidate
       matchTypevars m, candidate, args
       if not m.err:
         # match

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -96,6 +96,6 @@ type
     meta*: MetaInfo
     genericHooks*: Table[SymId, seq[SymId]]
     hookIndexMap*: Table[string, seq[(SymId, SymId)]]
-    converters*: Table[SymId, SymId]
+    converters*: Table[SymId, seq[SymId]]
     converterIndexMap*: seq[(SymId, SymId)]
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -98,5 +98,6 @@ type
     hookIndexMap*: Table[string, seq[(SymId, SymId)]]
     converters*: Table[SymId, seq[SymId]]
     converterIndexMap*: seq[(SymId, SymId)]
+    instantiateType*: proc (c: var SemContext; typ: Cursor; bindings: Table[SymId, Cursor]): Cursor
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking
     toBuild*: TokenBuf

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -96,4 +96,6 @@ type
     meta*: MetaInfo
     genericHooks*: Table[SymId, seq[SymId]]
     hookIndexMap*: Table[string, seq[(SymId, SymId)]]
+    converters*: Table[SymId, SymId]
+    converterIndexMap*: seq[(SymId, SymId)]
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -644,7 +644,7 @@ proc tryConverter(m: var Match; conv: SymId; f: Cursor; arg: Item) =
   src = asLocal(src).typ
   let srcStart = m.args.len
   let srcCost = m.intCosts
-  singleArgImpl(m, src, arg) # XXX this infers the converter typevars for the entire candidate, probably a source of bugs in nim, maybe #19517?
+  singleArgImpl(m, src, arg) # XXX this infers the converter typevars for the entire candidate, probably a source of bugs in nim, maybe #4554, #19517
   if m.err: return
   if srcCost != m.intCosts:
     # cannot be conversion match

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -639,7 +639,11 @@ proc singleArg(m: var Match; f: var Cursor; arg: Item) =
   singleArgImpl(m, f, arg)
   if m.err:
     # try converter
-    discard
+    let root = nominalRoot(fOrig)
+    if root != SymId(0):
+      let converters = m.context.converters.getOrDefault(root)
+      if converters.len != 0:
+        discard
   if not m.err:
     m.useArg arg # since it was a match, copy it
     while m.opened > 0:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -650,7 +650,7 @@ proc tryConverter(m: var Match; conv: SymId; f: Cursor; arg: Item) =
     # cannot be conversion match
     m.err = true
     return
-  var dest = fn.retType
+  var dest = fn.retType # XXX nim also instantiates this
   var callBuf = createTokenBuf(16) # dummy call node to use for matching dest type
   let callTokens = [
     parLeToken(CallX, arg.n.info), # HiddenCallConv

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -39,10 +39,11 @@ type
     context: ptr SemContext
     error: MatchError
     firstVarargPosition*: int
-    disallowConverter*: bool
+    matchConverters*: bool
     genericConverter*: bool
 
-proc createMatch*(context: ptr SemContext): Match = Match(context: context, firstVarargPosition: -1)
+proc createMatch*(context: ptr SemContext; matchConverters = false): Match =
+  Match(context: context, matchConverters: matchConverters, firstVarargPosition: -1)
 
 proc concat(a: varargs[string]): string =
   result = a[0]
@@ -681,7 +682,7 @@ proc tryConverter(m: var Match; conv: SymId; f: Cursor; arg: Item) =
 proc singleArg(m: var Match; f: var Cursor; arg: Item) =
   let fOrig = f
   singleArgImpl(m, f, arg)
-  if m.err and not m.disallowConverter:
+  if m.err and m.matchConverters:
     # try converter
     let root = nominalRoot(fOrig)
     if root != SymId(0):

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -635,7 +635,11 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
     m.error "BUG: " & expected(f, arg.typ)
 
 proc singleArg(m: var Match; f: var Cursor; arg: Item) =
+  let fOrig = f
   singleArgImpl(m, f, arg)
+  if m.err:
+    # try converter
+    discard
   if not m.err:
     m.useArg arg # since it was a match, copy it
     while m.opened > 0:

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -128,7 +128,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
       skip n
       if n.kind == ParRi:
         result = getTypeImpl(c, prev)
-  of CallX, CallStrLitX, InfixX, PrefixX, CmdX:
+  of CallX, CallStrLitX, InfixX, PrefixX, CmdX, HcallX:
     result = getTypeImpl(c, n.firstSon)
     if isRoutine(symKind(result)):
       let routine = asRoutine(result)

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -202,6 +202,24 @@ proc lengthOrd*(c: var SemContext; typ: TypeCursor): xint =
   if last.isNaN: return last
   result = last - first + createXint(1.uint64)
 
+proc containsGenericParams*(n: TypeCursor): bool =
+  var n = n
+  var nested = 0
+  while true:
+    case n.kind
+    of Symbol:
+      let res = tryLoadSym(n.symId)
+      if res.status == LacksNothing and res.decl == $TypevarY:
+        return true
+    of ParLe:
+      inc nested
+    of ParRi:
+      dec nested
+    else: discard
+    if nested == 0: break
+    inc n
+  return false
+
 proc nominalRoot*(t: TypeCursor): SymId =
   result = SymId(0)
   var t = t

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -1,3 +1,4 @@
+import std/assertions
 include nifprelude
 import nimony_model, decls, xints, semdata, programs, nifconfig
 
@@ -200,3 +201,27 @@ proc lengthOrd*(c: var SemContext; typ: TypeCursor): xint =
   let last = lastOrd(c, typ)
   if last.isNaN: return last
   result = last - first + createXint(1.uint64)
+
+proc nominalRoot*(t: TypeCursor): SymId =
+  result = SymId(0)
+  var t = t
+  while true:
+    case t.kind
+    of Symbol:
+      let res = tryLoadSym(t.symId)
+      assert res.status == LacksNothing
+      if res.decl.symKind == TypeY:
+        return t.symId
+      else:
+        # includes typevar case
+        break
+    of ParLe:
+      case t.typeKind
+      of MutT, OutT, LentT, SinkT, StaticT, TypedescT:
+        inc t
+      of InvokeT:
+        inc t
+      else:
+        break
+    else:
+      break

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -229,7 +229,14 @@ proc nominalRoot*(t: TypeCursor): SymId =
       let res = tryLoadSym(t.symId)
       assert res.status == LacksNothing
       if res.decl.symKind == TypeY:
-        return t.symId
+        let decl = asTypeDecl(res.decl)
+        if decl.typevars.typeKind == InvokeT:
+          var root = decl.typevars
+          inc root
+          assert root.kind == Symbol
+          return root.symId
+        else:
+          return t.symId
       else:
         # includes typevar case
         break

--- a/tests/nimony/sysbasics/tconverter.nim
+++ b/tests/nimony/sysbasics/tconverter.nim
@@ -6,3 +6,4 @@ converter toFoo(x: int): Foo = Foo(val: x)
 proc bar(x: Foo) = discard
 
 bar(123)
+let foo: Foo = 123

--- a/tests/nimony/sysbasics/tconverter.nim
+++ b/tests/nimony/sysbasics/tconverter.nim
@@ -1,0 +1,8 @@
+type Foo = object
+  val: int
+
+converter toFoo(x: int): Foo = Foo(val: x)
+
+proc bar(x: Foo) = discard
+
+bar(123)

--- a/tests/nimony/sysbasics/tgenericconverter.nim
+++ b/tests/nimony/sysbasics/tgenericconverter.nim
@@ -6,3 +6,4 @@ converter toFoo[T](x: T): Foo[T] = Foo[T](val: x)
 proc bar[T](x: Foo[T], y: T) = discard
 
 bar(123, 456)
+let foo: Foo[int] = 123

--- a/tests/nimony/sysbasics/tgenericconverter.nim
+++ b/tests/nimony/sysbasics/tgenericconverter.nim
@@ -1,0 +1,8 @@
+type Foo[T] = object
+  val: T
+
+converter toFoo[T](x: T): Foo[T] = Foo[T](val: x)
+
+proc bar[T](x: Foo[T], y: T) = discard
+
+bar(123, 456)


### PR DESCRIPTION
refs #381

Implemented with a converter section in the index like `(converter (kv <type> <converter>))`, was just my first guess for what to do, maybe there is a better way. The converter symbol is stored rather than the offset which I'm hoping is fine, I tried offsets first and couldn't figure out what to do with them.

Attaches to nominal return types for now skipping ref/ptr like type bound ops, both because the algorithm already exists and just storing symbol IDs in the index is simpler. Unlike type bound ops, attachment is required to use converters, so this means only converters to nominal types work. An idea for structural types would be to store the root magic but still skip magics like ref/ptr, so `array[I, T]` and `ref array[3, int]` both attach to `array` but `T` or `ref T` cannot be attached to anything. For converters that can't be attached to anything we could also attach them to `.` and always consider these.

Only generics are left but looks like a can of worms