### PR TITLE
fixes line information is absolute when a filename is present

### DIFF
--- a/src/lib/nifbuilder.nim
+++ b/src/lib/nifbuilder.nim
@@ -232,9 +232,9 @@ proc addLineInfo*(b: var Builder; col, line: int32; file = "") =
     b.buf.addLine line
   of LineInfoFile:
     addSep b
-    b.buf.addLineIgnoreZero col
+    b.buf.addLine col
     b.buf.add ','
-    b.buf.addLineIgnoreZero line
+    b.buf.addLine line
     b.buf.add ','
     for c in file:
       if c.needsEscape:

--- a/src/lib/nifstreams.nim
+++ b/src/lib/nifstreams.nim
@@ -261,9 +261,10 @@ proc toString*(tree: openArray[PackedToken]; produceLineInfo = true): string =
       var fileAsStr = ""
       if stack.len > 0:
         let (pfile, pline, pcol) = unpack(pool.man, stack[^1])
-        line = line - pline
-        col = col - pcol
         if file != pfile: fileAsStr = pool.files[file]
+        if fileAsStr.len == 0:
+          line = line - pline
+          col = col - pcol
       else:
         fileAsStr = pool.files[file]
       b.addLineInfo(col, line, fileAsStr)

--- a/tests/nimony/nosystem/t2.nif
+++ b/tests/nimony/nosystem/t2.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/t2.nim(stmts 2,1
+0,2,tests/nimony/nosystem/t2.nim(stmts 2,1
  (type :int.0.t2er4ggt1
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tbinarytree.nif
+++ b/tests/nimony/nosystem/tbinarytree.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/tbinarytree.nim(stmts 5
+0,1,tests/nimony/nosystem/tbinarytree.nim(stmts 5
  (type :int.0.tbimvo1d9
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tbool.nif
+++ b/tests/nimony/nosystem/tbool.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/tbool.nim(stmts 26
+0,1,tests/nimony/nosystem/tbool.nim(stmts 26
  (type ~21 :bool.0.tbokvwxm9
   (bool) . ~16
   (pragmas 2

--- a/tests/nimony/nosystem/tcstring.nif
+++ b/tests/nimony/nosystem/tcstring.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/tcstring.nim(stmts 2,1
+0,2,tests/nimony/nosystem/tcstring.nim(stmts 2,1
  (type :int.0.tcsj45p9m
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tdefinedarg.nif
+++ b/tests/nimony/nosystem/tdefinedarg.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/tdefinedarg.nim(stmts 5
+0,1,tests/nimony/nosystem/tdefinedarg.nim(stmts 5
  (type :untyped.0.tdej0g1hh1
   (untyped) . 9
   (pragmas 2

--- a/tests/nimony/nosystem/tdistinct.nif
+++ b/tests/nimony/nosystem/tdistinct.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/tdistinct.nim(stmts 2,1
+0,2,tests/nimony/nosystem/tdistinct.nim(stmts 2,1
  (type :int.0.tdiuhv8dm
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tenumsizes.nif
+++ b/tests/nimony/nosystem/tenumsizes.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,3,tests/nimony/nosystem/tenumsizes.nim(stmts 7
+0,3,tests/nimony/nosystem/tenumsizes.nim(stmts 7
  (type ~2 :A.0.tene657oj . . . 2
   (enum
    (u +8) ~7,1

--- a/tests/nimony/nosystem/tfib2.nif
+++ b/tests/nimony/nosystem/tfib2.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/tfib2.nim(stmts 2,1
+0,2,tests/nimony/nosystem/tfib2.nim(stmts 2,1
  (type :int.0.tfitjdpcx
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tforloop.nif
+++ b/tests/nimony/nosystem/tforloop.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/tforloop.nim(stmts 2,1
+0,2,tests/nimony/nosystem/tforloop.nim(stmts 2,1
  (type :int.0.tfov349y21
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/tgeneric_obj.nim(stmts 2,1
+0,2,tests/nimony/nosystem/tgeneric_obj.nim(stmts 2,1
  (type :int.0.tge7jvqqk1
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/tgenericbinarytree.nim(stmts 5
+0,1,tests/nimony/nosystem/tgenericbinarytree.nim(stmts 5
  (type :int.0.tge70unlm
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/timportfromexcept.nif
+++ b/tests/nimony/nosystem/timportfromexcept.nif
@@ -1,7 +1,7 @@
 (.nif24)
-,1,tests/nimony/nosystem/timportfromexcept.nim(stmts 4,4
+0,1,tests/nimony/nosystem/timportfromexcept.nim(stmts 4,4
  (let :allImported.0.timhjtr28 . .
-  (array 11,~2,tests/nimony/nosystem/deps/modexcept.nim
+  (array 15,3,tests/nimony/nosystem/deps/modexcept.nim
    (i -1)
    (rangetype
     (i -1) +0 +2)) 14

--- a/tests/nimony/nosystem/trefobject.nif
+++ b/tests/nimony/nosystem/trefobject.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/trefobject.nim(stmts 5
+0,1,tests/nimony/nosystem/trefobject.nim(stmts 5
  (type :int.0.trerqi4zu
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tresemtype.nif
+++ b/tests/nimony/nosystem/tresemtype.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,3,tests/nimony/nosystem/tresemtype.nim(stmts
+0,3,tests/nimony/nosystem/tresemtype.nim(stmts
  (proc 5 :foo.0.treckpe1i1 . . 8
   (typevars 1
    (typevar :T.0.treckpe1i1 . . . .)) 11

--- a/tests/nimony/nosystem/tsetter.nif
+++ b/tests/nimony/nosystem/tsetter.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/tsetter.nim(stmts 5
+0,1,tests/nimony/nosystem/tsetter.nim(stmts 5
  (type :int.0.tseyic8ua1
   (i -1) . 4
   (pragmas 2

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/ttemplate.nim(stmts 2,1
+0,2,tests/nimony/nosystem/ttemplate.nim(stmts 2,1
  (type :int.0.tte5tld8n
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tvarargs.nif
+++ b/tests/nimony/nosystem/tvarargs.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/nosystem/tvarargs.nim(stmts 2,1
+0,2,tests/nimony/nosystem/tvarargs.nim(stmts 2,1
  (type :int.0.tvah6culb
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/twhen.nif
+++ b/tests/nimony/nosystem/twhen.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/nosystem/twhen.nim(stmts 2,3
+0,1,tests/nimony/nosystem/twhen.nim(stmts 2,3
  (stmts
   (discard 8 "good")) 2,10
  (stmts

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/sysbasics/tbasics.nim(stmts 8,1
+0,1,tests/nimony/sysbasics/tbasics.nim(stmts 8,1
  (type ~6 :Array.0.tbawx6nu81 . . . 7
   (array 4
    (i -1)

--- a/tests/nimony/sysbasics/tderefs2.nif
+++ b/tests/nimony/sysbasics/tderefs2.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/sysbasics/tderefs2.nim(stmts
+0,1,tests/nimony/sysbasics/tderefs2.nim(stmts
  (proc 5 :g.0.tdexr7cz81 . . . 6
   (params 1
    (param :x.0 . . 3

--- a/tests/nimony/sysbasics/tdollar.nif
+++ b/tests/nimony/sysbasics/tdollar.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/sysbasics/tdollar.nim(stmts 9,1
+0,1,tests/nimony/sysbasics/tdollar.nim(stmts 9,1
  (type ~7 :Color1.0.tdoqc0e0v . . . 2
   (enum
    (u +8) ~7,1

--- a/tests/nimony/sysbasics/tforloops.nif
+++ b/tests/nimony/sysbasics/tforloops.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/sysbasics/tforloops.nim(stmts 4
+0,1,tests/nimony/sysbasics/tforloops.nim(stmts 4
  (var :globalX.0.tfo6zftzj1 . .
   (i -1) 10 +12) ,2
  (iterator 9 :foo.0.tfo6zftzj1 . . . 12

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -1,0 +1,175 @@
+(.nif24)
+0,1,tests/nimony/sysbasics/tforloops1.nim(stmts
+ (iterator 9 :powers.0.tfo6yv57p . . . 15
+  (params 1
+   (param :n.0 . . 3
+    (i -1) .)) 10
+  (i -1) . . 2,1
+  (stmts 4
+   (var :i.0 . .
+    (i -1) 4 +0) ,1
+   (while 8
+    (le
+     (i -1) ~2 i.0 3 n.0) 2,1
+    (stmts
+     (yld 6 i.0) ,1
+     (yld 7
+      (mul
+       (i -1) ~1 i.0 1 i.0)) ,2
+     (yld 9
+      (mul 20,257,lib/std/system.nim
+       (i +64) ~2
+       (mul
+        (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
+     (asgn ~2 i.0 4
+      (add
+       (i -1) ~2 i.0 2 +1)))))) ,8
+ (proc 5 :printf.0.tfo6yv57p . . . 11
+  (params 1
+   (param :format.0 . . 8
+    (cstring) .) 39
+   (param :vanon.0 . .
+    (varargs) .)) . 29
+  (pragmas 2
+   (importc 9 "printf") 21
+   (varargs) 30
+   (header 8 "<stdio.h>") 51
+   (nodecl)) . .) 4,11
+ (for 11
+  (call ~6 powers.0.tfo6yv57p 1 +5)
+  (unpackflat
+   (let :i.1 . . 6,~11
+    (i -1) .)) ~2,1
+  (stmts 4
+   (let :m.0 . . 4,~12
+    (i -1) 4 i.1) 6,2
+   (call ~6 printf.0.tfo6yv57p 1
+    (hconv 11,~6
+     (cstring) "Hello, world\3A %ld\0A") 24 m.0))) ,16
+ (iterator 9 :countup.0.tfo6yv57p . . . 16
+  (params 1
+   (param :a.0 . . 6
+    (i -1) .) 4
+   (param :b.0 . . 3
+    (i -1) .)) 13
+  (i -1) . . 2,1
+  (stmts 4
+   (var :i.2 . . 17,~1
+    (i -1) 4 a.0) ,1
+   (while 8
+    (le 13,~2
+     (i -1) ~2 i.2 3 b.0) 2,1
+    (stmts
+     (yld 6 i.2) 2,1
+     (asgn ~2 i.2 4
+      (add 13,~4
+       (i -1) ~2 i.2 2 +1)))))) 4,22
+ (for 12
+  (call ~7 countup.0.tfo6yv57p 1 +1 4 +5)
+  (unpackflat
+   (let :x.0 . . 9,~6
+    (i -1) .)) ~2,1
+  (stmts 4
+   (let :m.1 . . 7,~7
+    (i -1) 4 x.0) 6,1
+   (call ~6 printf.0.tfo6yv57p 1
+    (hconv 11,~16
+     (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
+   (if 3
+    (elif 11,680,lib/std/system.nim
+     (expr 2,1
+      (lt
+       (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1
+     (stmts
+      (break .))) 5,2
+    (elif 2
+     (lt 4,~11
+      (i -1) ~2 x.0 2 +3) ~3,1
+     (stmts
+      (continue .)))) 6,6
+   (call ~6 printf.0.tfo6yv57p 1
+    (hconv 11,~21
+     (cstring) "countup end\3A %ld\0A") 23 m.1))) ,31
+ (iterator 9 :countup2.0.tfo6yv57p . . . 17
+  (params 1
+   (param :n.1 . . 3
+    (i -1) .)) 10
+  (i -1) . . 2,1
+  (stmts 4
+   (var :i.3 . .
+    (i -1) 4 +0) ,1
+   (while 8
+    (le
+     (i -1) ~2 i.3 3 n.1) 2,1
+    (stmts
+     (yld 6 i.3) 2,1
+     (asgn ~2 i.3 4
+      (add
+       (i -1) ~2 i.3 2 +1)))))) ,37
+ (iterator 9 :powers2.0.tfo6yv57p . . . 16
+  (params 1
+   (param :n.2 . . 3
+    (i -1) .)) 10
+  (i -1) . . 2,1
+  (stmts 4
+   (for 13
+    (call ~8 countup2.0.tfo6yv57p 1 n.2)
+    (unpackflat
+     (let :i.4 . . 4,~7
+      (i -1) .)) ~2,1
+    (stmts
+     (yld 6 i.4) ,1
+     (yld 7
+      (mul ~1,~9
+       (i -1) ~1 i.4 1 i.4)) ,2
+     (yld 9
+      (mul 20,257,lib/std/system.nim
+       (i +64) ~2
+       (mul ~1,~10
+        (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,43
+ (for 12
+  (call ~7 powers2.0.tfo6yv57p 1 +6)
+  (unpackflat
+   (let :i.5 . . 6,~6
+    (i -1) .)) ~2,1
+  (stmts 6
+   (call ~6 printf.0.tfo6yv57p 1
+    (hconv 11,~36
+     (cstring) "Hello, world\3A %ld\0A") 24 i.5))) ,46
+ (iterator 9 :countup3.0.tfo6yv57p . . . 17
+  (params 1
+   (param :a.1 . . 3
+    (i -1) .)) 10
+  (i -1) . . 2,1
+  (stmts
+   (yld 6 +3))) ,49
+ (iterator 9 :powers3.0.tfo6yv57p . . . 16
+  (params 1
+   (param :b.1 . . 3
+    (i -1) .)) 10
+  (i -1) . . 2,1
+  (stmts 4
+   (for 13
+    (call ~8 countup3.0.tfo6yv57p 1 b.1)
+    (unpackflat
+     (let :j.0 . . 4,~4
+      (i -1) .)) ~2,1
+    (stmts
+     (yld 6 j.0))))) 4,53
+ (for 12
+  (call ~7 powers3.0.tfo6yv57p 1 +5)
+  (unpackflat
+   (let :m.2 . . 6,~4
+    (i -1) .)) ~2,1
+  (stmts 4
+   (for 13
+    (call ~8 countup3.0.tfo6yv57p 1 +4)
+    (unpackflat
+     (let :n.3 . . 4,~8
+      (i -1) .)) ~2,1
+    (stmts 6
+     (call ~6 printf.0.tfo6yv57p 1
+      (hconv 9,~47
+       (cstring) "Hello, world\3A %ld\0A") 25
+      (add ~25,~6
+       (i -1) ~1 m.2 1 n.3)))))))

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/sysbasics/thooks.nim(stmts 15,1
+0,1,tests/nimony/sysbasics/thooks.nim(stmts 15,1
  (type ~13 :MyObjectBase.0.tho8gh7q4 . . . 2
   (object . ~13,1
    (fld :x.0.tho8gh7q4 . . 6

--- a/tests/nimony/sysbasics/tresultnoinit.nif
+++ b/tests/nimony/sysbasics/tresultnoinit.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,1,tests/nimony/sysbasics/tresultnoinit.nim(stmts
+0,1,tests/nimony/sysbasics/tresultnoinit.nim(stmts
  (proc 5 :foo.0.tremd49gb1 . . . 8
   (params) 4
   (i -1) 16


### PR DESCRIPTION
It becomes absolute
```
20,257,lib/std/system.nim
```
https://github.com/nim-lang/nimony/pull/395/commits/14313a84b7df31e146748d141cec5e6fc146e78e