### PR TITLE
Emit .global directive

### DIFF
--- a/src/nifc/amd64/asm_grammar.nif
+++ b/src/nifc/amd64/asm_grammar.nif
@@ -4,7 +4,7 @@
 
 (COM "This grammar reflects the fact that we produce GAS code in intel syntax.")
 
-(RULE :Directive (global SYMBOL (DO "nl")))
+(RULE :Directive (global ".global " SYMBOL (DO "nl")))
 
 (RULE :Code (text ".section .text" (DO "nl")  SYMBOLDEF ":" (DO "nl") (ONE_OR_MANY Instruction)) (DO "nl"))
 (RULE :ExternDecl (extern SYMBOLDEF (DO "nl")))

--- a/src/nifc/amd64/asm_grammar.nim
+++ b/src/nifc/amd64/asm_grammar.nim
@@ -9,7 +9,7 @@ proc genDirective(c: var Context): bool =
     var before1 = save(c)
   var kw2 = false
   if isTag(c, GlobalT):
-    emitTag(c, "global")
+    emit(c, ".global ")
     if not lookupSym(c):
       error(c, "SYMBOL expected")
       return false


### PR DESCRIPTION
Emit ".global" directive instead of "global".
All GAS directives has '.' prefix.