### PR TITLE
structural converters in compat mode

### DIFF
--- a/src/lib/nifindexes.nim
+++ b/src/lib/nifindexes.nim
@@ -128,7 +128,10 @@ proc getSymbolSection(tag: TagId; values: seq[(SymId, SymId)]): TokenBuf =
   for value in values:
     let (key, sym) = value
     result.buildTree KvT, NoLineInfo:
-      result.add symToken(key, NoLineInfo)
+      if key == SymId(0):
+        result.add dotToken(NoLineInfo)
+      else:
+        result.add symToken(key, NoLineInfo)
       result.add symToken(sym, NoLineInfo)
 
   result.addParRi()
@@ -297,6 +300,8 @@ proc readSymbolSection(s: var Stream; tab: var Table[string, string]) =
           key = pool.syms[t.symId]
         elif t.kind == Ident:
           key = pool.strings[t.litId]
+        elif t.kind == DotToken:
+          key = "."
         else:
           raiseAssert "invalid (kv) construct: symbol expected"
         t = next(s) # skip Symbol

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -343,11 +343,11 @@ proc generateFrontendMakefile(c: DepContext; commandLineArgs: string): string =
   result = "nifcache" / c.rootNode.files[0].modname & ".makefile"
   writeFile result, s
 
-proc buildGraph*(config: sink NifConfig; project: string; compat, forceRebuild, silentMake: bool;
+proc buildGraph*(config: sink NifConfig; project: string; forceRebuild, silentMake: bool;
     commandLineArgs: string; moduleFlags: set[ModuleFlag]; cmd: Command) =
   let nifler = findTool("nifler")
 
-  if compat:
+  if config.compat:
     let cfgNif = "nifcache" / moduleSuffix(project, []) & ".cfg.nif"
     exec quoteShell(nifler) & " config " & quoteShell(project) & " " &
       quoteShell(cfgNif)

--- a/src/nimony/nifconfig.nim
+++ b/src/nimony/nifconfig.nim
@@ -15,6 +15,7 @@ type
     defines*: HashSet[string]
     paths*, nimblePaths*: seq[string]
     bits*: int
+    compat*: bool
 
 proc parseConfig(c: Cursor; result: var NifConfig) =
   var c = c
@@ -46,6 +47,11 @@ proc parseConfig(c: Cursor; result: var NifConfig) =
         inc c
         if c.kind == IntLit:
           result.bits = pool.integers[c.intId]
+          inc c
+      of "compat":
+        inc c
+        if c.kind == IntLit:
+          result.compat = bool(pool.integers[c.intId])
           inc c
       else:
         inc c

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -62,7 +62,6 @@ proc handleCmdLine() =
   var args: seq[string] = @[]
   var cmd = Command.None
   var forceRebuild = false
-  var compat = false
   var silentMake = false
   var useEnv = true
   var doRun = false
@@ -95,7 +94,7 @@ proc handleCmdLine() =
       of "run", "r":
         doRun = true
         forwardArg = false
-      of "compat": compat = true
+      of "compat": config.compat = true
       of "path", "p": config.paths.add val
       of "define", "d": config.defines.incl val
       of "noenv": useEnv = false
@@ -154,7 +153,7 @@ proc handleCmdLine() =
     requiresTool "nimsem", "src/nimony/nimsem.nim", forceRebuild
     requiresTool "hexer", "src/hexer/hexer.nim", forceRebuild
     requiresTool "nifc", "src/nifc/nifc.nim", forceRebuild
-    buildGraph config, args[0], compat, forceRebuild, silentMake,
+    buildGraph config, args[0], forceRebuild, silentMake,
       commandLineArgs, moduleFlags, (if doRun: DoRun else: DoCompile)
 
 when isMainModule:

--- a/src/nimony/nimsem.nim
+++ b/src/nimony/nimsem.nim
@@ -25,6 +25,7 @@ Command:
 Options:
   -d, --define:SYMBOL       define a symbol for conditional compilation
   -p, --path:PATH           add PATH to the search path
+  --compat                  turn on compatibility mode
   --noenv                   do not read configuration from `NIM_*`
                             environment variables
   --isSystem                passed module is a `system.nim` module
@@ -76,6 +77,7 @@ proc handleCmdLine() =
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
       of "forcebuild", "f": forceRebuild = true
+      of "compat": config.compat = true
       of "path", "p": config.paths.add val
       of "define", "d": config.defines.incl val
       of "noenv": useEnv = false

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -70,7 +70,7 @@ proc loadInterface*(suffix: string; iface: var Iface;
     let nameId = pool.strings.getOrIncl(name)
     # check that the converter is imported, slow but better to be slow here:
     if nameId in importTab and module in importTab[nameId]:
-      let key = pool.syms.getOrIncl(k)
+      let key = if k == ".": SymId(0) else: pool.syms.getOrIncl(k)
       let val = pool.syms.getOrIncl(v)
       converters.mgetOrPut(key, @[]).add(val)
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1215,8 +1215,10 @@ proc tryConverterMatch(c: var SemContext; convMatch: var Match; f: TypeCursor, a
   ## sets `convMatch` to the match to the converter
   result = false
   let root = nominalRoot(f)
-  if root == SymId(0): return
-  let converters = c.converters.getOrDefault(root)
+  if root == SymId(0) and not c.g.config.compat: return
+  var converters = c.converters.getOrDefault(root)
+  if root != SymId(0) and c.g.config.compat:
+    converters.add c.converters.getOrDefault(SymId(0))
   var convMatches: seq[Match] = @[]
   for conv in items converters:
     # f(a)
@@ -3019,7 +3021,7 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
     publishSignature c, symId, declStart
     if kind == ConverterY:
       let root = nominalRoot(c.routine.returnType)
-      if root == SymId(0):
+      if root == SymId(0) and not c.g.config.compat:
         buildErr c, info, "cannot attach converter to type " & typeToString(c.routine.returnType)
       else:
         if pass == checkSignatures: # to prevent duplicates, could also use a set

--- a/tests/nimony/compat/tstructuralconverter.nim
+++ b/tests/nimony/compat/tstructuralconverter.nim
@@ -1,0 +1,5 @@
+converter toString(x: int): string = "abc"
+converter toInt(x: string): int = 123
+
+let a: string = 456
+let b: int = a


### PR DESCRIPTION
Followup to #399

Attaches any converter with non-nominal result type to `.` corresponding to `SymId(0)` which is always looked up when matching converters