### PR TITLE
transform unoverloadable magic calls without typechecking args

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1499,7 +1499,7 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
     while true:
       case syms.kind
       of Symbol:
-        let res = tryLoadSym(syms.sym)
+        let res = tryLoadSym(syms.symId)
         if res.status == LacksNothing:
           var n = res.decl
           inc n # skip the symbol kind
@@ -1519,8 +1519,9 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
     endRead(c.dest)
     if magic != NoExpr:
       swap c.dest, cs.dest
+      let nifTag = [parLeToken(magic, cs.callNode.info)]
       # keep args after if they were produced by dotcall:
-      cs.dest.replace [parLeToken(magic, cs.callNode.info)], 0
+      cs.dest.replace fromBuffer(nifTag), 0
       while it.n.kind != ParRi:
         # add all args in call:
         takeTree cs.dest, it.n

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1563,7 +1563,7 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
     semExpr(c, cs.fn, {KeepMagics, AllowUndeclared, FindOverloads})
     cs.fnName = getFnIdent(c)
     it.n = cs.fn.n
-  if c.g.config.compat and fnName in c.unoverloadableMagics:
+  if c.g.config.compat and cs.fnName in c.unoverloadableMagics:
     # transform call early before semchecking arguments
     let syms = beginRead(c.dest)
     let magic = findMagicInSyms(syms)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1400,6 +1400,47 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
     buildCallSource errored, cs
     buildErr c, cs.callNode.info, errorMsg, cursorAt(errored, 0)
 
+proc findMagicInSyms(syms: Cursor): ExprKind =
+  var syms = syms
+  result = NoExpr
+  var nested = 0
+  while true:
+    case syms.kind
+    of Symbol:
+      let res = tryLoadSym(syms.symId)
+      if res.status == LacksNothing:
+        var n = res.decl
+        inc n # skip the symbol kind
+        if n.kind == SymbolDef:
+          inc n # skip the SymbolDef
+          if n.kind == ParLe:
+            result = n.exprKind
+            if result != NoExpr: break
+    of ParLe:
+      if syms.exprKind notin {OchoiceX, CchoiceX}: break
+      inc nested
+    of ParRi:
+      dec nested
+    else: break
+    if nested == 0: break
+    inc syms
+
+proc unoverloadableMagicCall(c: var SemContext; it: var Item; cs: var CallState; magic: ExprKind) =
+  let nifTag = parLeToken(magic, cs.callNode.info)
+  if cs.args.len != 0:
+    # keep args after if they were produced by dotcall:
+    cs.dest.replace fromBuffer([nifTag]), 0
+  else:
+    cs.dest.shrink 0
+    cs.dest.add nifTag
+  while it.n.kind != ParRi:
+    # add all args in call:
+    takeTree cs.dest, it.n
+  wantParRi cs.dest, it.n
+  var magicCall = Item(n: beginRead(cs.dest), typ: it.typ)
+  semExpr c, magicCall, cs.flags
+  it.typ = magicCall.typ
+
 proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: TransformedCallSource = RegularCall) =
   var cs = CallState(
     beforeCall: c.dest.len,
@@ -1491,48 +1532,14 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
     semExpr(c, cs.fn, {KeepMagics, AllowUndeclared})
     fnName = getFnIdent(c)
     it.n = cs.fn.n
-  if fnName in c.unoverloadableMagics:
+  if c.g.config.compat and fnName in c.unoverloadableMagics:
     # transform call early before semchecking arguments
-    var syms = beginRead(c.dest)
-    var magic = NoExpr
-    var nested = 0
-    while true:
-      case syms.kind
-      of Symbol:
-        let res = tryLoadSym(syms.symId)
-        if res.status == LacksNothing:
-          var n = res.decl
-          inc n # skip the symbol kind
-          if n.kind == SymbolDef:
-            inc n # skip the SymbolDef
-            if n.kind == ParLe:
-              magic = n.exprKind
-              if magic != NoExpr: break
-      of ParLe:
-        if syms.exprKind notin {OchoiceX, CchoiceX}: break
-        inc nested
-      of ParRi:
-        dec nested
-      else: break
-      if nested == 0: break
-      inc syms
+    let syms = beginRead(c.dest)
+    let magic = findMagicInSyms(syms)
     endRead(c.dest)
     if magic != NoExpr:
       swap c.dest, cs.dest
-      let nifTag = parLeToken(magic, cs.callNode.info)
-      if cs.args.len != 0:
-        # keep args after if they were produced by dotcall:
-        cs.dest.replace fromBuffer([nifTag]), 0
-      else:
-        cs.dest.shrink 0
-        cs.dest.add nifTag
-      while it.n.kind != ParRi:
-        # add all args in call:
-        takeTree cs.dest, it.n
-      wantParRi cs.dest, it.n
-      var magicCall = Item(n: beginRead(cs.dest), typ: it.typ)
-      semExpr c, magicCall, flags
-      it.typ = magicCall.typ
+      unoverloadableMagicCall(c, it, cs, magic)
       return
   cs.fnKind = cs.fn.kind
   var skipSemCheck = false

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1519,9 +1519,13 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
     endRead(c.dest)
     if magic != NoExpr:
       swap c.dest, cs.dest
-      let nifTag = [parLeToken(magic, cs.callNode.info)]
-      # keep args after if they were produced by dotcall:
-      cs.dest.replace fromBuffer(nifTag), 0
+      let nifTag = parLeToken(magic, cs.callNode.info)
+      if cs.args.len != 0:
+        # keep args after if they were produced by dotcall:
+        cs.dest.replace fromBuffer([nifTag]), 0
+      else:
+        cs.dest.shrink 0
+        cs.dest.add nifTag
       while it.n.kind != ParRi:
         # add all args in call:
         takeTree cs.dest, it.n

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -100,3 +100,4 @@ type
     converterIndexMap*: seq[(SymId, SymId)]
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking
     toBuild*: TokenBuf
+    unoverloadableMagics*: HashSet[StrId]


### PR DESCRIPTION
This is so we can have more control over the typechecking of `typeof`, `compiles` etc for their special cases in the future (edit: `compiles` doesn't seem to affect semchecking except maybe `compiles do: import ...`?). The analog in the old compiler is the [early evaluation of some magics](https://github.com/nim-lang/Nim/blob/95b1dda1db86881f0119bd319380790fbd594ac5/compiler/semexprs.nim#L2577) before overloading. Maybe we could still walk back error tokens for these magics as `declared`/`defined` already do though.

This is pre-emptive so we could also close it if we don't need it for now.