### PR TITLE
allow arbitrary type expressions

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2545,16 +2545,16 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
         c.dest.addParRi()
       elif xkind == TypeofX:
         semTypeofForType c, n
-      elif xkind in CallKinds:
-        var it = Item(n: n, typ: c.types.autoType)
-        semExpr c, it, {InTypeContext}
-        n = it.n
       elif context == AllowValues:
         let start = c.dest.len
         var it = Item(n: n, typ: c.types.autoType)
         semExpr c, it
         n = it.n
         exprToType c, it.typ, start, context, info
+      elif xkind in CallKinds:
+        var it = Item(n: n, typ: c.types.autoType)
+        semExpr c, it, {InTypeContext}
+        n = it.n
       elif false and isRangeExpr(n):
         # a..b, interpret as range type but only without AllowValues
         # to prevent conflict with HSlice

--- a/tests/nimony/nosystem/t2.nif
+++ b/tests/nimony/nosystem/t2.nif
@@ -23,8 +23,7 @@
   (typedesc 1 T.1.t2er4ggt1) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,9
- (type ~8 :string.0.t2er4ggt1 x . . 8
-  (call ~6 typeof 1 "")) ,12
+ (type ~8 :string.0.t2er4ggt1 x . . string.0.sys9azlf) ,12
  (proc 5 :\2B.0.t2er4ggt1
   (add -3) . . 9
   (params 1

--- a/tests/nimony/nosystem/tdistinct.nif
+++ b/tests/nimony/nosystem/tdistinct.nif
@@ -31,8 +31,7 @@
   (typedesc 1 T.1.tdiuhv8dm) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,11
- (type ~8 :string.0.tdiuhv8dm x . . 8
-  (call ~6 typeof 1 "")) ,13
+ (type ~8 :string.0.tdiuhv8dm x . . string.0.sys9azlf) ,13
  (proc 5 :\2B.0.tdiuhv8dm
   (add -3) . . 9
   (params 1

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -44,8 +44,7 @@
   (typedesc 1 T.3.tge7jvqqk1) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,14
- (type ~8 :string.0.tge7jvqqk1 x . . 8
-  (call ~6 typeof 1 "")) 4,16
+ (type ~8 :string.0.tge7jvqqk1 x . . string.0.sys9azlf) 4,16
  (var :myset.0.tge7jvqqk1 . . 10
   (sett 1
    (u +8)) .) 4,17

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -34,8 +34,7 @@
   (typedesc 1 T.2.tte5tld8n) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,12
- (type ~8 :string.0.tte5tld8n x . . 8
-  (call ~6 typeof 1 "")) 15,15
+ (type ~8 :string.0.tte5tld8n x . . string.0.sys9azlf) 15,15
  (type ~13 :MyGeneric.0.tte5tld8n . ~4
   (typevars 1
    (typevar :T.3.tte5tld8n . . . .)) . 2

--- a/tests/nimony/nosystem/tvarargs.nif
+++ b/tests/nimony/nosystem/tvarargs.nif
@@ -27,8 +27,7 @@
   (typedesc 1 T.1.tvah6culb) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,9
- (type ~8 :string.0.tvah6culb x . . 8
-  (call ~6 typeof 1 "")) ,11
+ (type ~8 :string.0.tvah6culb x . . string.0.sys9azlf) ,11
  (proc 5 :\2B.0.tvah6culb
   (add -3) . . 9
   (params 1


### PR DESCRIPTION
Was part of a local branch trying to implement statics that stalled, thought it was in master already.

An arbitrary expression in a type context is semchecked as a regular expression. Any expression that has `typedesc` type is considered a proper type and skipped. Otherwise it is considered a value and gives an error if only types are expected in the context.

Since types are usually processed in the signature phase, we need to temporarily change the phase to the bodies phase for the expression to be fully evaluated in the case of calls etc. This is the first time we change to the bodies phase in the codebase so I don't know if it will fully work when a routine is encountered that has not had its body typechecked. Probably won't be an issue until static evaluation.

The typeof/call special casing was just removed for simplicity, it could be brought back.