### PR TITLE
don't build error in tryBuiltinDot

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4055,7 +4055,7 @@ proc semObjConstr(c: var SemContext, it: var Item) =
             swap c.dest, fieldBuf
             it.n = val.n
         else:
-          c.buildErr fieldInfo, "undeclared field: " & pool.strings[fieldName]
+          c.buildErr fieldInfo, "undeclared field: '" & pool.strings[fieldName] & "' for type " & typeToString(it.typ)
           skip it.n
       fieldBuf.addParRi()
       skipParRi it.n

--- a/tests/nimony/errmsgs/tdot.msgs
+++ b/tests/nimony/errmsgs/tdot.msgs
@@ -1,0 +1,2 @@
+tests/nimony/errmsgs/tdot.nim(2, 12) Error: undeclared field: 'foo' for type (i -1)
+tests/nimony/errmsgs/tdot.nim(5, 12) Error: undeclared field: 'bar' for type (i -1)

--- a/tests/nimony/errmsgs/tdot.nim
+++ b/tests/nimony/errmsgs/tdot.nim
@@ -1,0 +1,5 @@
+var abc = 123
+discard abc.foo
+
+proc bar(x: string) = discard
+discard abc.bar

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,4 +1,4 @@
-tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: private
-tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared identifier
-tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: private
-tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared identifier
+tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
+tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
+tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.tfis16ujj


### PR DESCRIPTION
Every caller to `tryBuiltinDot` builds a call if it fails so any error generated by it is swallowed, and it's enough to produce an error message when the call fails.