### PR TITLE
patches for stringimpl

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -413,4 +413,4 @@ proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}
 
 include "system/setops"
 
-include "system/stringimpl"
+#include "system/stringimpl"

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -84,11 +84,14 @@ proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
 proc `[]`*[T: tuple](x: T, i: int): untyped {.magic: "TupAt".}
 proc `[]`*[I, T](x: array[I, T], i: I): var T {.magic: "ArrAt".}
 proc `[]`*(x: cstring, i: int): var char {.magic: "Pat".}
+proc `[]`*[T](x: ptr UncheckedArray[T], i: int): var T {.magic: "Pat".}
 template `[]=`*[T: tuple](x: T, i: int, elem: typed) =
   (x[i]) = elem
 template `[]=`*[I, T](x: array[I, T], i: I; elem: T) =
   (x[i]) = elem
 template `[]=`*(x: cstring, i: int; elem: char) =
+  (x[i]) = elem
+template `[]=`*[T](x: ptr UncheckedArray[T], i: int; elem: T) =
   (x[i]) = elem
 
 proc `[]`*[T](x: ptr T): var T {.magic: "Deref", noSideEffect.}
@@ -334,6 +337,34 @@ proc `<`*(x, y: float): bool {.magic: "LtF64", noSideEffect.}
 proc `==`*(x, y: float32): bool {.magic: "EqF64", noSideEffect.}
 proc `==`*(x, y: float): bool {.magic: "EqF64", noSideEffect.}
 
+proc min*(x, y: int8): int8 {.noSideEffect, inline.} =
+  if x <= y: x else: y
+proc min*(x, y: int16): int16 {.noSideEffect, inline.} =
+  if x <= y: x else: y
+proc min*(x, y: int32): int32 {.noSideEffect, inline.} =
+  if x <= y: x else: y
+proc min*(x, y: int64): int64 {.noSideEffect, inline.} =
+  ## The minimum value of two integers.
+  if x <= y: x else: y
+proc min*(x, y: float32): float32 {.noSideEffect, inline.} =
+  if x <= y or y != y: x else: y
+proc min*(x, y: float): float {.noSideEffect, inline.} =
+  if x <= y or y != y: x else: y
+
+proc max*(x, y: int8): int8 {.noSideEffect, inline.} =
+  if y <= x: x else: y
+proc max*(x, y: int16): int16 {.noSideEffect, inline.} =
+  if y <= x: x else: y
+proc max*(x, y: int32): int32 {.noSideEffect, inline.} =
+  if y <= x: x else: y
+proc max*(x, y: int64): int64 {.noSideEffect, inline.} =
+  ## The maximum value of two integers.
+  if y <= x: x else: y
+proc max*(x, y: float32): float32 {.noSideEffect, inline.} =
+  if y <= x or y != y: x else: y
+proc max*(x, y: float): float {.noSideEffect, inline.} =
+  if y <= x or y != y: x else: y
+
 template `!=`*(x, y: untyped): untyped =
   ## Unequals operator. This is a shorthand for `not (x == y)`.
   not (x == y)
@@ -382,4 +413,4 @@ proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}
 
 include "system/setops"
 
-#include "system/stringimpl"
+include "system/stringimpl"

--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -134,7 +134,6 @@ proc makeAllocated(s: var string; newLen: int) =
 
 proc add*(s: var string; part: string) =
   let len = s.len
-  discard part.len
   let newLen = len + part.len
   if not isAllocated(s):
     makeAllocated s, newLen

--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -29,7 +29,7 @@ proc `=destroy`*(s: string) {.exportc: "nimStrDestroy", inline.} =
   if isAllocated(s): dealloc(s.a)
 
 template safeCopyMem(dest: var string; src: string; len, allocated: int) =
-  if dest.a != StrData(nil):
+  if dest.a != nil:
     copyMem dest.a, src.a, len
     dest.i = len shl LenShift
   else:
@@ -62,7 +62,7 @@ proc `=dup`*(s: string): string {.exportc: "nimStrDup", inline, nodestroy.} =
   if isAllocated(s):
     let len = s.len
     result = string(a: cast[StrData](alloc(len)), i: s.i)
-    if result.a != StrData(nil):
+    if result.a != nil:
       copyMem result.a, s.a, len
     else:
       oomHandler len
@@ -86,7 +86,7 @@ proc ensureTerminatingZero*(s: var string) =
     else:
       let newCap = len+1
       let a = cast[StrData](realloc(s.a, newCap))
-      if a != StrData(nil):
+      if a != nil:
         a[len] = '\0'
         s.a = a
       else:
@@ -97,7 +97,7 @@ proc ensureTerminatingZero*(s: var string) =
   else:
     let newCap = len+1
     let a = cast[StrData](alloc(newCap))
-    if a != StrData(nil):
+    if a != nil:
       copyMem a, s.a, len
       a[len] = '\0'
       s.a = a
@@ -116,7 +116,7 @@ proc growImpl(s: var string; newLen: int) =
   if newLen > cap:
     let newCap = max(newLen, cap + (cap shr 1))
     s.a = cast[StrData](realloc(s.a, newCap))
-    if s.a != StrData(nil):
+    if s.a != nil:
       s.i = newLen shl LenShift
     else:
       oomHandler newCap
@@ -126,7 +126,7 @@ proc makeAllocated(s: var string; newLen: int) =
   let len = s.len
   let newCap = max(newLen, len + (len shr 1))
   s.a = cast[StrData](alloc(newCap))
-  if s.a != StrData(nil):
+  if s.a != nil:
     s.i = newLen shl LenShift
   else:
     oomHandler newCap
@@ -139,7 +139,7 @@ proc add*(s: var string; part: string) =
     makeAllocated s, newLen
   else:
     growImpl s, newLen
-  if s.a != StrData(nil):
+  if s.a != nil:
     copyMem addr(s.a[len]), part.a, part.len
 
 proc add*(s: var string; c: char) =
@@ -148,7 +148,7 @@ proc add*(s: var string; c: char) =
     makeAllocated s, newLen
   else:
     growImpl s, newLen
-  if s.a != StrData(nil):
+  if s.a != nil:
     s.a[newLen-1] = c
 
 proc setLen*(s: var string; newLen: int) =
@@ -182,7 +182,7 @@ proc substr*(s: string; first, last: int): string =
     let newLen = l - f
     if isAllocated(s):
       result = string(a: cast[StrData](alloc(newLen)), i: newLen shl LenShift or (s.i and IsStaticMask))
-      if result.a != StrData(nil):
+      if result.a != nil:
         copyMem result.a, addr s.a[f], newLen
       else:
         oomHandler newLen
@@ -221,7 +221,7 @@ proc prepareMutation*(s: var string) =
   if not isAllocated(s):
     let len = s.len
     let a = cast[StrData](alloc(len))
-    if a != StrData(nil):
+    if a != nil:
       copyMem a, s.a, len
       s.i = len shl LenShift
     else:

--- a/src/hexer/constparams.nim
+++ b/src/hexer/constparams.nim
@@ -83,7 +83,7 @@ proc trConstRef(c: var Context; dest: var TokenBuf; n: var Cursor) =
 proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
   dest.add n
   inc n # skip `(call)`
-  var fnType = getType(c.typeCache, n)
+  var fnType = skipProcTypeToParams(getType(c.typeCache, n))
   takeTree dest, n # skip `fn`
   assert fnType == "params"
   inc fnType

--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -412,7 +412,7 @@ proc trCall(c: var Context; n: var Cursor; e: Expects) =
 
   c.dest.add n
   inc n # skip `(call)`
-  var fnType = getType(c.typeCache, n)
+  var fnType = skipProcTypeToParams(getType(c.typeCache, n))
   takeTree c.dest, n # skip `fn`
   assert fnType == "params"
   inc fnType

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -240,6 +240,68 @@ proc traverseArrayBody(e: var EContext; c: var Cursor) =
     traverseExpr e, c
   wantParRi e, c
 
+type
+  CollectedPragmas = object
+    externName: string
+    flags: set[PragmaKind]
+    align, bits: IntId
+    header: StrId
+    callConv: CallConv
+
+proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas
+
+type
+  GenPragmas = object
+    opened: bool
+
+proc openGenPragmas(): GenPragmas = GenPragmas(opened: false)
+
+proc maybeOpen(e: var EContext; g: var GenPragmas; info: PackedLineInfo) {.inline.} =
+  if not g.opened:
+    g.opened = true
+    e.dest.add tagToken("pragmas", info)
+
+proc addKey(e: var EContext; g: var GenPragmas; key: string; info: PackedLineInfo) =
+  maybeOpen e, g, info
+  e.dest.add tagToken(key, info)
+  e.dest.addParRi()
+
+proc addKeyVal(e: var EContext; g: var GenPragmas; key: string; val: PackedToken; info: PackedLineInfo) =
+  maybeOpen e, g, info
+  e.dest.add tagToken(key, info)
+  e.dest.add val
+  e.dest.addParRi()
+
+proc closeGenPragmas(e: var EContext; g: GenPragmas) =
+  if g.opened:
+    e.dest.addParRi()
+  else:
+    e.dest.addDotToken()
+
+proc traverseParams(e: var EContext; c: var Cursor)
+
+proc traverseProcTypeBody(e: var EContext; c: var Cursor) =
+  e.dest.add tagToken("proctype", c.info)
+  # This is really stupid...
+  e.dest.addDotToken() # name
+  inc c # proc
+  # name, export marker, pattern, type vars:
+  for i in 0..<4: skip c
+  traverseParams e, c
+
+  let pinfo = c.info
+  let prag = parsePragmas(e, c)
+  var genPragmas = openGenPragmas()
+  if prag.callConv != NoCallConv:
+    let name = if prag.callConv == NimcallC: "fastcall" else: $prag.callConv
+    e.addKey genPragmas, name, pinfo
+  closeGenPragmas e, genPragmas
+
+  # ignore, effects and body:
+  skip c
+  skip c
+  wantParRi e, c
+
 proc traverseAsNamedType(e: var EContext; c: var Cursor) =
   let info = c.info
   var body = c
@@ -265,6 +327,8 @@ proc traverseAsNamedType(e: var EContext; c: var Cursor) =
       traverseArrayBody e, body
     of OpenArrayT:
       traverseOpenArrayBody e, body
+    of ProcT:
+      traverseProcTypeBody e, body
     else:
       error e, "expected tuple or array, but got: ", body
     e.dest.addParRi() # "type"
@@ -273,25 +337,6 @@ proc traverseAsNamedType(e: var EContext; c: var Cursor) =
     e.pending.add buf
   # regardless of what we had to do, we still need to add the typename:
   e.dest.add symToken(val, info)
-
-proc traverseParams(e: var EContext; c: var Cursor)
-
-proc traverseProcType(e: var EContext; c: var Cursor) =
-  e.dest.add tagToken("proc", c.info)
-  # This is really stupid...
-  e.dest.addDotToken() # name
-  e.dest.addDotToken() # export marker
-  e.dest.addDotToken() # pattern
-  e.dest.addDotToken() # type vars
-  inc c # proc
-  for i in 0..<4: skip c
-  traverseParams e, c
-  # copy pragmas:
-  e.dest.takeTree c
-  # ignore, effects and body:
-  skip c
-  skip c
-  wantParRi e, c
 
 proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
   case c.kind
@@ -331,9 +376,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
       inc c
       e.loop c:
         traverseType e, c, {IsPointerOf}
-    of ProcT:
-      traverseProcType e, c
-    of ArrayT, OpenArrayT:
+    of ArrayT, OpenArrayT, ProcT:
       traverseAsNamedType e, c
     of RangeT:
       # skip to base type
@@ -442,14 +485,6 @@ proc traverseParams(e: var EContext; c: var Cursor) =
   # the result type
   traverseType e, c
 
-type
-  CollectedPragmas = object
-    externName: string
-    flags: set[PragmaKind]
-    align, bits: IntId
-    header: StrId
-    callConv: CallConv
-
 proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
   result = default(CollectedPragmas)
   if c.kind == DotToken:
@@ -513,6 +548,7 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
           inc c
         of Requires, Ensures, StringP:
           skip c
+          continue
         of BuildP, EmitP:
           raiseAssert "unreachable"
         skipParRi e, c
@@ -520,34 +556,6 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
         error e, "unknown pragma: ", c
   else:
     error e, "(pragmas) or '.' expected, but got: ", c
-
-type
-  GenPragmas = object
-    opened: bool
-
-proc openGenPragmas(): GenPragmas = GenPragmas(opened: false)
-
-proc maybeOpen(e: var EContext; g: var GenPragmas; info: PackedLineInfo) {.inline.} =
-  if not g.opened:
-    g.opened = true
-    e.dest.add tagToken("pragmas", info)
-
-proc addKey(e: var EContext; g: var GenPragmas; key: string; info: PackedLineInfo) =
-  maybeOpen e, g, info
-  e.dest.add tagToken(key, info)
-  e.dest.addParRi()
-
-proc addKeyVal(e: var EContext; g: var GenPragmas; key: string; val: PackedToken; info: PackedLineInfo) =
-  maybeOpen e, g, info
-  e.dest.add tagToken(key, info)
-  e.dest.add val
-  e.dest.addParRi()
-
-proc closeGenPragmas(e: var EContext; g: GenPragmas) =
-  if g.opened:
-    e.dest.addParRi()
-  else:
-    e.dest.addDotToken()
 
 proc traverseProc(e: var EContext; c: var Cursor; mode: TraverseMode) =
   e.openMangleScope()
@@ -604,6 +612,9 @@ proc traverseProc(e: var EContext; c: var Cursor; mode: TraverseMode) =
   let oldOwner = setOwner(e, s)
 
   var genPragmas = openGenPragmas()
+  if prag.callConv != NoCallConv:
+    let name = if prag.callConv == NimcallC: "fastcall" else: $prag.callConv
+    e.addKey genPragmas, name, pinfo
   if prag.externName.len > 0:
     e.registerMangleInParent(s, prag.externName & ".c")
     e.addKeyVal genPragmas, "was", symToken(s, pinfo), pinfo

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -877,13 +877,25 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         inc c
         inc nested
       of SufX:
-        e.dest.add c
-        inc c
-        traverseExpr e, c
-        assert c.kind == StringLit
-        e.dest.add c
-        inc c
-        inc nested
+        var suf = c
+        inc suf
+        let arg = suf
+        skip suf
+        assert suf.kind == StringLit
+        if arg.kind == StringLit and pool.strings[suf.litId] == "R":
+          # cstring conversion
+          inc c
+          e.dest.add c # add string lit directly
+          inc c # arg
+          inc c # suf
+          skipParRi e, c
+        else:
+          e.dest.add c
+          inc c
+          traverseExpr e, c
+          e.dest.add c
+          inc c
+          wantParRi e, c
       else:
         e.dest.add c
         inc c

--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -123,7 +123,7 @@ proc trOr(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
     tar.t.addSymUse tmp, info
     skipParRi n
   else:
-    copyInto dest, n:
+    copyInto tar.t, n:
       trExpr c, dest, n, tar
       trExpr c, dest, n, tar
 
@@ -150,7 +150,7 @@ proc trAnd(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
     tar.t.addSymUse tmp, info
     skipParRi n
   else:
-    copyInto dest, n:
+    copyInto tar.t, n:
       trExpr c, dest, n, tar
       trExpr c, dest, n, tar
 
@@ -309,7 +309,7 @@ proc trLocal(c: var Context; dest: var TokenBuf; n: var Cursor) =
     c.typeCache.registerLocal(name, n)
     takeTree tmp, n # type
     var v = Target(m: IsEmpty)
-    trExpr c, tmp, n, v
+    trExpr c, dest, n, v
     tmp.add v
   dest.add tmp
 

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -19,6 +19,15 @@ proc isNominal*(t: TypeKind): bool {.inline.} =
   ## type kinds that should stay as symbols, see sigmatch.matchSymbol
   t in {ObjectT, RefObjectT, PtrObjectT, EnumT, HoleyEnumT, DistinctT, ConceptT}
 
+proc skipProcTypeToParams*(t: Cursor): Cursor =
+  result = t
+  if result.typeKind == ProcT:
+    inc result # skip ParLe
+    skip result # skip name
+    skip result # skip export marker
+    skip result # skip pattern
+    skip result # skip generics
+
 const
   LocalTypePos* = 3
   LocalValuePos* = 4

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -128,7 +128,7 @@ proc validBorrowsFrom(c: var Context; n: Cursor): bool =
       let fn = n
       skip n # skip the `fn`
       if n.kind != ParRi:
-        var fnType = getType(c.typeCache, fn)
+        var fnType = skipProcTypeToParams(getType(c.typeCache, fn))
         assert fnType == "params"
         inc fnType
         let firstParam = asLocal(fnType)
@@ -244,7 +244,7 @@ proc checkForDangerousLocations(c: var Context; n: var Cursor) =
   elif n.exprKind in CallKinds:
     inc n # skip `(call)`
     let orig = n
-    var fnType = getType(c.typeCache, n)
+    var fnType = skipProcTypeToParams(getType(c.typeCache, n))
     skip n # skip `fn`
     assert fnType == "params"
     inc fnType
@@ -298,7 +298,7 @@ proc trProcDecl(c: var Context; n: var Cursor) =
   c.typeCache.closeScope()
 
 proc trCallArgs(c: var Context; n: var Cursor; fnType: Cursor) =
-  var fnType = fnType
+  var fnType = skipProcTypeToParams(fnType)
   assert fnType == "params"
   inc fnType
   while n.kind != ParRi:
@@ -337,7 +337,7 @@ proc trCall(c: var Context; n: var Cursor; e: Expects; dangerous: var bool) =
 
   swap c.dest, callBuf
   takeToken c, n
-  let fnType = getType(c.typeCache, n)
+  let fnType = skipProcTypeToParams(getType(c.typeCache, n))
   assert fnType == "params"
   takeToken c, n
   var retType = fnType

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -17,7 +17,7 @@
       (mul
        (i -1) ~1 i.0 1 i.0)) ,2
      (yld 9
-      (mul 20,267,lib/std/system.nim
+      (mul 20,273,lib/std/system.nim
        (i +64) ~2
        (mul
         (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
@@ -76,7 +76,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,690,lib/std/system.nim
+    (elif 11,752,lib/std/system.nim
      (expr 2,1
       (lt
        (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1
@@ -123,7 +123,7 @@
       (mul ~1,~9
        (i -1) ~1 i.4 1 i.4)) ,2
      (yld 9
-      (mul 20,267,lib/std/system.nim
+      (mul 20,273,lib/std/system.nim
        (i +64) ~2
        (mul ~1,~10
         (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,43


### PR DESCRIPTION
1. `[]` for `ptr UncheckedArray`, just maps to `Pat`, not sure about `UncheckedArray` in general
2. `min`/`max` implementation, needs 2 bugfixes:
3. `not`/`or`/`and` produce `bool` type for their `Item`
4. xelim fixes: trivial `or`/`and` copy to the target and not the dest, locals build their target on the dest and not in their own declaration

Procvar fixes:

5. Generate proc types as named types in nifcgen
6. Allow proc types where `params` types are expected across the codebase and skip to the params (`skipProcTypeToParams`)

Other codegen fixes:

7. Generate call convention pragma for procs and proc types
8. Generate `suf` cstring literals
9. `importc`/`exportc` etc without arguments emit their symbol name as an argument since codegen expects an argument (`CrucialPragma` changes)

Sem changes, possibly more impactful:

10. Calls generate a full symchoice for their callee symbols instead of just the innermost symbol so a shadowed proc can still be called (`FindOverloads`, `semIdent`/`semQuoted` changes) 
11. `rootOf` when used to check addressability in `addr` allows pointer indirection

Can split if necessary