### PR TITLE
patches for seqimpl round 1

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -76,6 +76,9 @@ type
                                       ## fixed-length arrays.
   set*[T]{.magic: "Set".}             ## Generic type to construct bit sets.
 
+type sink*[T]{.magic: "Sink".}
+type lent*[T]{.magic: "Lent".}
+
 proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect.}
 proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
 proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffect.}

--- a/lib/std/system/seqimpl.nim
+++ b/lib/std/system/seqimpl.nim
@@ -121,9 +121,9 @@ proc `[]`*[T](s: seq[T]; i: int): var T {.requires: (i < s.len and i >= 0), inli
 proc `[]=`*[T](s: var seq[T]; i: int; elem: sink T) {.requires: (i < s.len and i >= 0), inline.} =
   (s.data[i]) = elem
 
-proc `[]`*[T](s: seq[T]; i: uint): var T {.requires: (i < s.len), inline.} = s.data[int i]
+proc `[]`*[T](s: seq[T]; i: uint): var T {.requires: (i < s.len.uint), inline.} = s.data[int i]
 
-proc `[]=`*[T](s: var seq[T]; i: uint; elem: sink T) {.requires: (i < s.len), inline.} =
+proc `[]=`*[T](s: var seq[T]; i: uint; elem: sink T) {.requires: (i < s.len.uint), inline.} =
   (s.data[int i]) = elem
 
 proc `@`*[I, T](a: array[I, T]): seq[T] {.nodestroy.} =

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -90,6 +90,7 @@ type
     mDefaultObj, mDefaultTup
     mArrAt, mPat, mTupAt
     mDeref
+    mSink, mLent # were mBuiltinType
 
 declareMatcher parseMagic, TMagic, 1, 1
 
@@ -185,6 +186,8 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mExcl: res ExclSetS, TypedMagic
   of mEnsureMove: res EnsureMoveX
   of mUncheckedArray: res UncheckedArrayT
+  of mSink: res SinkT
+  of mLent: res LentT
   else: ("", 0)
 
 when isMainModule:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1401,7 +1401,10 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
         returnType = semReturnType(c, subsReturnType)
         swap c.dest, instReturnType
       else:
-        returnType = instantiateType(c, matched.returnType, matched.inferred)
+        if matched.returnType.kind == DotToken:
+          returnType = matched.returnType
+        else:
+          returnType = instantiateType(c, matched.returnType, matched.inferred)
       typeofCallIs c, it, cs.beforeCall, returnType
     else:
       typeofCallIs c, it, cs.beforeCall, m[idx].returnType

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -585,7 +585,7 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
       var a = skipModifier(arg.typ)
       if a.kind == Symbol:
         var t = getTypeSection(a.symId)
-        if t.typevars.typeKind == InvokeT:
+        if t.kind == TypeY and t.typevars.typeKind == InvokeT:
           linearMatch m, f, t.typevars
         else:
           m.error InvalidMatch, f, a

--- a/tests/nimony/nosystem/tfib2.nif
+++ b/tests/nimony/nosystem/tfib2.nif
@@ -104,7 +104,8 @@
     (else 2,1
      (stmts 7
       (asgn ~7 result.0 11
-       (infix \2B ~6
+       (add ~6,~21
+        (i -1) ~6
         (call ~3 fib.0.tfitjdpcx 2
          (infix \2D ~1 a.1 1 +1)) 5
         (call ~3 fib.0.tfitjdpcx 2

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -17,7 +17,7 @@
       (mul
        (i -1) ~1 i.0 1 i.0)) ,2
      (yld 9
-      (mul 20,273,lib/std/system.nim
+      (mul 20,279,lib/std/system.nim
        (i +64) ~2
        (mul
         (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
@@ -76,7 +76,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,752,lib/std/system.nim
+    (elif 11,758,lib/std/system.nim
      (expr 2,1
       (lt
        (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1
@@ -123,7 +123,7 @@
       (mul ~1,~9
        (i -1) ~1 i.4 1 i.4)) ,2
      (yld 9
-      (mul 20,273,lib/std/system.nim
+      (mul 20,279,lib/std/system.nim
        (i +64) ~2
        (mul ~1,~10
         (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,43


### PR DESCRIPTION
refs #422

* implements `sink`/`lent`
* similar to #417, instantiate return type of calls in generics but do not instantiate proc, so stuff like `newSeqUninit[T](0)` works
* fix typevars matching invoke types