### PR TITLE
NIFC: Implement #423 only for the simplest case

### DIFF
--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -13,7 +13,7 @@ import std / [assertions, syncio, tables, sets, intsets, formatfloat, strutils, 
 from std / os import changeFileExt, splitFile, extractFilename
 
 import .. / lib / [bitabs, packedtrees, lineinfos]
-import mangler, nifc_model, cprelude, noptions
+import mangler, nifc_model, cprelude, noptions, typenav
 
 type
   Token = distinct uint32

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -82,6 +82,8 @@ proc genLvalue(c: var GeneratedCode; t: Tree; n: NodePos) =
     let (a, i) = sons2(t, n)
     genx c, t, a
     let tyArr = getType(c.m, t, a)
+    if tyArr.isError:
+      error c.m, "cannot get the type of ", t, a
     let litId = t[tyArr.rawPos].litId
     if not c.m.lits.strings[litId].isImportC:
       c.add Dot

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -84,8 +84,7 @@ proc genLvalue(c: var GeneratedCode; t: Tree; n: NodePos) =
     let tyArr = getType(c.m, t, a)
     if tyArr.isError:
       error c.m, "cannot get the type of ", t, a
-    let litId = t[tyArr.rawPos].litId
-    if not c.m.lits.strings[litId].isImportC:
+    if not c.m.isImportC(tyArr):
       c.add Dot
       c.add "a"
     c.add BracketLe

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -81,8 +81,11 @@ proc genLvalue(c: var GeneratedCode; t: Tree; n: NodePos) =
   of AtC:
     let (a, i) = sons2(t, n)
     genx c, t, a
-    c.add Dot
-    c.add "a"
+    let tyArr = getType(c.m, t, a)
+    let litId = t[tyArr.rawPos].litId
+    if not c.m.lits.strings[litId].isImportC:
+      c.add Dot
+      c.add "a"
     c.add BracketLe
     genx c, t, i
     c.add BracketRi

--- a/src/nifc/mangler.nim
+++ b/src/nifc/mangler.nim
@@ -19,8 +19,11 @@ proc escape(result: var string; c: char) {.inline.} =
   result.add HexChars[n and 0xF]
   result.add 'Q'
 
+proc isImportC*(s: string): bool =
+  s.len > 2 and s[s.len-2] == '.' and s[s.len-1] == 'c'
+
 proc mangle*(s: string): string =
-  if s.len > 2 and s[s.len-2] == '.' and s[s.len-1] == 'c':
+  if s.isImportC:
     result = substr(s, 0, s.len-3)
   else:
     var i = 0

--- a/src/nifc/typenav.nim
+++ b/src/nifc/typenav.nim
@@ -75,6 +75,14 @@ proc makePtrType(m: var Module; typ: TypeDesc): TypeDesc =
   result = atomType(m.lits, PtrC)
   result.down = TypeDescRef(p: typ.p, a: typ.a, down: typ.down)
 
+proc isImportC*(m: Module; typ: TypeDesc): bool =
+  assert m.code.kind(typ) == Sym
+  let litId = if typ.p != NodePos(0):
+                m.code[typ.rawPos].litId
+              else:
+                typ.a.litId
+  m.lits.strings[litId].isImportC
+
 proc getType*(m: var Module; t: Tree; n: NodePos): TypeDesc =
   case t[n].kind
   of Empty, Ident, SymDef, Err:

--- a/src/nifc/typenav.nim
+++ b/src/nifc/typenav.nim
@@ -9,7 +9,7 @@
 import std / [strutils, tables, assertions]
 import bitabs, packedtrees
 
-import nifc_model
+import nifc_model, mangler
 
 type
   TypeDesc* {.acyclic.} = object
@@ -84,7 +84,11 @@ proc getType*(m: var Module; t: Tree; n: NodePos): TypeDesc =
     if d.pos != NodePos(0):
       result = getType(m, t, d.pos)
     else:
-      result = errorType()
+      # importC types are not defined
+      if m.lits.strings[t[n].litId].isImportC:
+        result = TypeDesc(p: n)
+      else:
+        result = errorType()
   of ProcC:
     result = TypeDesc(p: n)
   of GvarC, TvarC, ConstC, VarC:

--- a/tests/nifc/cimport_array.c.nif
+++ b/tests/nifc/cimport_array.c.nif
@@ -4,4 +4,18 @@
  (gvar :cary.mangled . CArray.c .)
  (discard
   (at
-   cary.mangled +0)))
+   cary.mangled +0))
+ (gvar :caryInStruct.mangled . CStruct.c .)
+ (discard
+  (at
+   (dot caryInStruct.mangled field.c +0) +0))
+ (gvar :caryInStruct2.mangled . CStruct2.c .)
+ (discard
+  (at
+   (dot
+    (dot caryInStruct2.mangled cs.c +0) field.c +0) +0))
+ (discard
+  (at
+   (dot
+    (at
+     (dot caryInStruct2.mangled cs2.c +0) +1) field.c +0) +2)))

--- a/tests/nifc/cimport_array.c.nif
+++ b/tests/nifc/cimport_array.c.nif
@@ -5,11 +5,11 @@
  (discard
   (at
    cary.mangled +0))
- (gvar :caryInStruct.mangled . CStruct.c .)
+ (gvar :caryInStruct.mangled . struct\20CStruct.c .)
  (discard
   (at
    (dot caryInStruct.mangled field.c +0) +0))
- (gvar :caryInStruct2.mangled . CStruct2.c .)
+ (gvar :caryInStruct2.mangled . struct\20CStruct2.c .)
  (discard
   (at
    (dot

--- a/tests/nifc/cimport_array.c.nif
+++ b/tests/nifc/cimport_array.c.nif
@@ -1,0 +1,7 @@
+(.nif24)
+(stmts
+ (incl "testcarry.h")
+ (gvar :cary.mangled . CArray.c .)
+ (discard
+  (at
+   cary.mangled +0)))

--- a/tests/nifc/testcarry.h
+++ b/tests/nifc/testcarry.h
@@ -5,3 +5,8 @@ typedef int CArray[10];
 struct CStruct {
   int field[10];
 };
+
+struct CStruct2 {
+  struct CStruct cs;
+  struct CStruct cs2[2];
+};

--- a/tests/nifc/testcarry.h
+++ b/tests/nifc/testcarry.h
@@ -1,0 +1,7 @@
+// C header file for testing.
+
+typedef int CArray[10];
+
+struct CStruct {
+  int field[10];
+};


### PR DESCRIPTION
Currently, it works only for plain C arrays.
Doesn't work for arrays in C struct field.