### PR TITLE
generate set ops in desugar pass

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -270,6 +270,8 @@ proc `==`*(x, y: char): bool {.magic: "EqCh", noSideEffect.}
   ## Checks for equality between two `char` variables.
 proc `==`*(x, y: bool): bool {.magic: "EqB", noSideEffect.}
   ## Checks for equality between two `bool` variables.
+proc `==`*[T](x, y: set[T]): bool {.magic: "EqSet", noSideEffect.}
+  ## Checks for equality between two variables of type `set`.
 
 proc `==`*[T](x, y: ref T): bool {.magic: "EqRef", noSideEffect.}
   ## Checks that two `ref` variables refer to the same item.
@@ -285,6 +287,12 @@ proc `<=`*(x, y: char): bool {.magic: "LeCh", noSideEffect.}
   ## Compares two chars and returns true if `x` is lexicographically
   ## before `y` (uppercase letters come before lowercase letters).
 
+proc `<=`*[T](x, y: set[T]): bool {.magic: "LeSet", noSideEffect.}
+  ## Returns true if `x` is a subset of `y`.
+  ##
+  ## A subset `x` has all of its members in `y` and `y` doesn't necessarily
+  ## have more members than `x`. That is, `x` can be equal to `y`.
+
 proc `<=`*(x, y: bool): bool {.magic: "LeB", noSideEffect.}
 proc `<=`*[T](x, y: ref T): bool {.magic: "LePtr", noSideEffect.}
 proc `<=`*(x, y: pointer): bool {.magic: "LePtr", noSideEffect.}
@@ -297,6 +305,12 @@ proc `<`*(x, y: string): bool {.magic: "LtStr", noSideEffect.}
 proc `<`*(x, y: char): bool {.magic: "LtCh", noSideEffect.}
   ## Compares two chars and returns true if `x` is lexicographically
   ## before `y` (uppercase letters come before lowercase letters).
+
+proc `<`*[T](x, y: set[T]): bool {.magic: "LtSet", noSideEffect.}
+  ## Returns true if `x` is a strict or proper subset of `y`.
+  ##
+  ## A strict or proper subset `x` has all of its members in `y` but `y` has
+  ## more elements than `y`.
 
 proc `==`*(x, y: int8): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: int16): bool {.magic: "EqI", noSideEffect.}

--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -1,4 +1,4 @@
-## Removes abstractions like set ops and ref object constructors.
+# removes abstractions like set ops and ref object constructors
 
 import std / [assertions]
 include nifprelude
@@ -110,14 +110,10 @@ proc trSetType(c: var Context; dest: var TokenBuf; n: var Cursor) =
   else:
     case size
     of 1, 2, 4, 8:
-      dest.add tagToken("u", info)
-      dest.addIntLit(size * 8, info)
-      dest.addParRi()
+      dest.addUintType(size * 8, info)
     else:
       dest.add tagToken("array", info)
-      dest.add tagToken("u", info)
-      dest.addIntLit(8, info)
-      dest.addParRi()
+      dest.addUintType(8, info)
       dest.addIntLit(size, info)
       dest.addParRi()
   skip n

--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -340,6 +340,7 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
     of PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardSetX:
       genSetOp(c, dest, n)
     of NewOconstrX:
+      # XXX `new`
       raiseAssert("unimplemented")
     of TypeofX:
       takeTree dest, n

--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -1,0 +1,357 @@
+## Removes abstractions like set ops and ref object constructors.
+
+import std / [assertions]
+include nifprelude
+import ".." / nimony / [nimony_model, decls, programs, typenav, sizeof, expreval, xints]
+import basics
+
+type
+  Context = object
+    counter: int
+    typeCache: TypeCache
+    thisModuleSuffix: string
+
+proc declareTemp(c: var Context; dest: var TokenBuf; n: Cursor): SymId =
+  let info = n.info
+  let typ = getType(c.typeCache, n)
+  let s = "`desugar." & $c.counter & "." & c.thisModuleSuffix
+  inc c.counter
+  result = pool.syms.getOrIncl(s)
+  copyIntoKind dest, VarS, info:
+    dest.addSymDef result, info
+    dest.addDotToken() # export, pragmas
+    dest.addDotToken()
+    copyTree dest, typ # type
+    dest.addDotToken() # value
+
+proc skipParRi(n: var Cursor) =
+  if n.kind == ParRi:
+    inc n
+  else:
+    error "expected ')', but got: ", n
+
+proc tr(c: var Context; dest: var TokenBuf; n: var Cursor)
+
+proc trSons(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  copyInto dest, n:
+    while n.kind != ParRi:
+      tr(c, dest, n)
+
+proc trLocal(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  copyInto dest, n:
+    let name = n.symId
+    takeTree dest, n # name
+    takeTree dest, n # export marker
+    takeTree dest, n # pragmas
+    c.typeCache.registerLocal(name, n)
+    takeTree dest, n # type
+    tr(c, dest, n)
+
+proc trProc(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  c.typeCache.openScope()
+  copyInto dest, n:
+    let sym = n.symId
+    for i in 0..<BodyPos:
+      if i == ParamsPos:
+        c.typeCache.registerParams(sym, n)
+      takeTree dest, n
+    tr(c, dest, n)
+  c.typeCache.closeScope()
+
+proc addUintType(buf: var TokenBuf; bits: int; info: PackedLineInfo) =
+  buf.add tagToken("u", info)
+  buf.addIntLit(bits, info)
+  buf.addParRi()
+
+proc trSetType(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  let info = n.info
+  inc n
+  let sizeOrig = bitsetSizeInBytes(n)
+  var err = false
+  let size = asSigned(sizeOrig, err)
+  if err:
+    error "invalid set element type: ", n
+  else:
+    case size
+    of 1, 2, 4, 8:
+      dest.add tagToken("u", info)
+      dest.addIntLit(size * 8, info)
+      dest.addParRi()
+    else:
+      dest.add tagToken("array", info)
+      dest.add tagToken("u", info)
+      dest.addIntLit(8, info)
+      dest.addParRi()
+      dest.addIntLit(size, info)
+      dest.addParRi()
+  skip n
+  skipParRi n
+
+proc genSetOp(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  let info = n.info
+  let kind = n.exprKind
+  inc n
+  let typ = n
+  if typ.typeKind != SetT:
+    error "expected set type for set op", n
+  var baseType = typ
+  inc baseType
+  var argsBuf = createTokenBuf(16)
+  swap dest, argsBuf
+  let typeStart = dest.len
+  trSetType(c, dest, n)
+  let aStart = dest.len
+  tr(c, dest, n)
+  let bStart = dest.len
+  tr(c, dest, n)
+  swap dest, argsBuf
+  skipParRi n
+  let cType = cursorAt(argsBuf, typeStart)
+  let a = cursorAt(argsBuf, aStart)
+  let b = cursorAt(argsBuf, bStart)
+  var err = false
+  let size = asSigned(bitsetSizeInBytes(baseType), err)
+  assert not err
+  # XXX AST of a and b are copied more than once, maybe ensure it is moved to a temp if necessary
+  case size
+  of 1, 2, 4, 8:
+    case kind
+    of CardSetX:
+      # XXX needs countBits compilerproc
+      raiseAssert("unimplemented")
+    of LtSetX:
+      copyIntoKind dest, AndX, info:
+        copyIntoKind dest, EqX, info:
+          dest.addSubtree cType
+          copyIntoKind dest, BitAndX, info:
+            dest.addSubtree cType
+            dest.addSubtree a
+            copyIntoKind dest, BitNotX, info:
+              dest.addSubtree cType
+              dest.addSubtree b
+          dest.addIntLit(0, info)
+        copyIntoKind dest, NeqX, info:
+          dest.addSubtree cType
+          dest.addSubtree a
+          dest.addSubtree b
+    of LeSetX:
+      copyIntoKind dest, EqX, info:
+        dest.addSubtree cType
+        copyIntoKind dest, BitAndX, info:
+          dest.addSubtree cType
+          dest.addSubtree a
+          copyIntoKind dest, BitNotX, info:
+            dest.addSubtree cType
+            dest.addSubtree b
+        dest.addIntLit(0, info)
+    of EqSetX:
+      copyIntoKind dest, EqX, info:
+        dest.addSubtree cType
+        dest.addSubtree a
+        dest.addSubtree b
+    of MulSetX:
+      copyIntoKind dest, BitAndX, info:
+        dest.addSubtree cType
+        dest.addSubtree a
+        dest.addSubtree b
+    of PlusSetX:
+      copyIntoKind dest, BitOrX, info:
+        dest.addSubtree cType
+        dest.addSubtree a
+        dest.addSubtree b
+    of XorSetX:
+      copyIntoKind dest, BitXorX, info:
+        dest.addSubtree cType
+        dest.addSubtree a
+        dest.addSubtree b
+    of InSetX:
+      let mask = size * 8 - 1
+      copyIntoKind dest, NeqX, info:
+        dest.addSubtree cType
+        copyIntoKind dest, BitAndX, info:
+          dest.addSubtree cType
+          dest.addSubtree a
+          copyIntoKind dest, ShlX, info:
+            dest.addSubtree cType
+            copyIntoKind dest, CastX, info:
+              dest.addSubtree cType
+              dest.addIntLit(1, info)
+            copyIntoKind dest, BitAndX, info:
+              dest.addUintType(-1, info)
+              copyIntoKind dest, CastX, info:
+                dest.addUintType(-1, info)
+                dest.addSubtree b
+              dest.addUintLit(uint64(mask), info)
+        dest.addUintLit(0, info)
+    else:
+      raiseAssert("unreachable")
+  else:
+    # XXX temp generation required here for `for` loops
+    raiseAssert("unimplemented")
+
+proc genSetConstr(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  let info = n.info
+  var typ = c.typeCache.getType(n)
+  var bytes = evalBitSet(n, typ)
+  case bytes.len
+  of 0:
+    # not constant
+    # XXX also needs temps
+    raiseAssert("unimplemented")
+  of 1, 2, 4, 8:
+    # hopefully this is correct?
+    bytes.setLen(8)
+    dest.addUintLit(cast[ptr uint64](addr bytes[0])[], info)
+    skip n
+  else:
+    dest.addParLe(AconstrX, info)
+    #trSetType(c, dest, typ)
+    for b in bytes:
+      dest.addUintLit(b, info)
+
+proc genInclExcl(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  let info = n.info
+  let kind = n.stmtKind
+  inc n
+  let typ = n
+  if typ.typeKind != SetT:
+    error "expected set type for incl/excl", n
+  var baseType = typ
+  inc baseType
+  var argsBuf = createTokenBuf(16)
+  swap dest, argsBuf
+  let typeStart = dest.len
+  trSetType(c, dest, n)
+  let aStart = dest.len
+  tr(c, dest, n)
+  let bStart = dest.len
+  tr(c, dest, n)
+  swap dest, argsBuf
+  skipParRi n
+  let cType = cursorAt(argsBuf, typeStart)
+  let a = cursorAt(argsBuf, aStart)
+  let b = cursorAt(argsBuf, bStart)
+  var err = false
+  let size = asSigned(bitsetSizeInBytes(baseType), err)
+  assert not err
+  # XXX AST of a and b are copied more than once, maybe ensure it is moved to a temp if necessary
+  case size
+  of 1, 2, 4, 8:
+    let mask = size * 8 - 1
+    copyIntoKind dest, AsgnS, info:
+      dest.addSubtree a
+      if kind == InclSetS:
+        dest.addParLe(BitOrX, info)
+        dest.addSubtree cType
+        dest.addSubtree a
+      else:
+        dest.addParLe(BitAndX, info)
+        dest.addSubtree cType
+        dest.addSubtree a
+        dest.addParLe(BitNotX, info)
+        dest.addSubtree cType
+      copyIntoKind dest, ShlX, info:
+        dest.addSubtree cType
+        copyIntoKind dest, CastX, info:
+          dest.addSubtree cType
+          dest.addIntLit(1, info)
+        copyIntoKind dest, BitAndX, info:
+          dest.addUintType(-1, info)
+          dest.addSubtree b
+          dest.addIntLit(mask, info)
+      if kind == InclSetS:
+        dest.addParRi() # bitor
+      else:
+        dest.addParRi() # bitand
+        dest.addParRi() # bitnot
+  else:
+    template addLhs() =
+      copyIntoKind dest, ArrAtX, info:
+        dest.addSubtree a
+        copyIntoKind dest, ShrX, info:
+          dest.addUintType(-1, info)
+          copyIntoKind dest, CastX, info:
+            dest.addUintType(-1, info)
+            dest.addParRi()
+            dest.addSubtree b
+          dest.addIntLit(3)
+    copyIntoKind dest, AsgnS, info:
+      addLhs()
+      copyIntoKind dest, if kind == InclSetS: BitOrX else: BitAndX, info:
+        addLhs()
+        if kind == ExclSetS:
+          dest.addParLe BitNotX, info
+          dest.addUintType(8, info)
+        copyIntoKind dest, ShlX, info:
+          dest.addUintType(8, info)
+          dest.addUintLit(1, info)
+          copyIntoKind dest, BitAndX, info:
+            dest.addUintType(-1, info)
+            dest.addSubtree b
+            dest.addUintLit(7, info)
+        if kind == ExclSetS:
+          dest.addParRi()
+
+proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  case n.kind
+  of DotToken, UnknownToken, EofToken, Ident, Symbol, SymbolDef, IntLit, UIntLit, FloatLit, CharLit, StringLit:
+    takeTree dest, n
+  of ParLe:
+    case n.exprKind
+    of NoExpr:
+      case n.stmtKind
+      of NoStmt:
+        case n.typeKind
+        of SetT:
+          #trSetType(c, dest, n)
+          # leave this to nifcgen
+          trSons(c, dest, n)
+        else:
+          trSons(c, dest, n)
+      of InclSetS, ExclSetS:
+        genInclExcl(c, dest, n)
+      of CaseS:
+        copyInto dest, n:
+          while n.kind != ParRi:
+            case n.substructureKind
+            of OfS:
+              copyInto dest, n:
+                takeTree dest, n # keep set constructor
+                tr(c, dest, n)
+            else:
+              tr(c, dest, n)
+      of ResultS, LetS, VarS, CursorS, ConstS:
+        trLocal c, dest, n
+      of ProcS, FuncS, MacroS, MethodS, ConverterS:
+        trProc c, dest, n
+      of IterS, TemplateS, TypeS, EmitS, BreakS, ContinueS,
+        ForS, CmdS, IncludeS, ImportS, FromImportS, ImportExceptS,
+        ExportS, CommentS, ClonerS, TracerS, DisarmerS, MoverS, DtorS,
+        PragmasLineS:
+        takeTree dest, n
+      of ScopeS:
+        c.typeCache.openScope()
+        trSons(c, dest, n)
+        c.typeCache.closeScope()
+      else:
+        trSons(c, dest, n)
+    of SetX:
+      genSetConstr(c, dest, n)
+    of PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardSetX:
+      genSetOp(c, dest, n)
+    of NewOconstrX:
+      raiseAssert("unimplemented")
+    of TypeofX:
+      takeTree dest, n
+    else:
+      trSons(c, dest, n)
+  of ParRi:
+    raiseAssert "unexpected ')' inside"
+
+proc desugar*(n: Cursor; moduleSuffix: string): TokenBuf =
+  var c = Context(counter: 0, typeCache: createTypeCache(), thisModuleSuffix: moduleSuffix)
+  c.typeCache.openScope()
+  result = createTokenBuf(300)
+  var n = n
+  tr c, result, n
+  c.typeCache.closeScope()

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -895,6 +895,26 @@ proc genSetOp(e: var EContext; c: var Cursor) =
     # XXX temp generation required here for `for` loops
     raiseAssert("unimplemented")
 
+proc genSetConstr(e: var EContext; c: var Cursor) =
+  let info = c.info
+  var typ = e.typeCache.getType(c)
+  var bytes = evalBitSet(c, typ)
+  case bytes.len
+  of 0:
+    # not constant
+    # XXX also needs temps
+    raiseAssert("unimplemented")
+  of 1, 2, 4, 8:
+    # hopefully this is correct?
+    bytes.setLen(8)
+    e.dest.addUintLit(cast[ptr uint64](addr bytes[0])[], info)
+    skip c
+  else:
+    e.dest.add tagToken("aconstr", info)
+    traverseType e, typ
+    for b in bytes:
+      e.dest.addUintLit(b, info)
+
 proc traverseExpr(e: var EContext; c: var Cursor) =
   var nested = 0
   while true:
@@ -944,6 +964,8 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         inc nested
       of TupleConstrX:
         traverseTupleConstr e, c
+      of SetX:
+        genSetConstr e, c
       of CmdX, CallStrLitX, InfixX, PrefixX, HcallX:
         e.dest.add tagToken("call", c.info)
         inc c

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -69,6 +69,11 @@ proc expectIntLit(e: var EContext; c: var Cursor) =
 proc add(e: var EContext; tag: string; info: PackedLineInfo) =
   e.dest.add tagToken(tag, info)
 
+proc addUintType(buf: var TokenBuf; bits: int; info: PackedLineInfo) =
+  buf.add tagToken("u", info)
+  buf.addIntLit(bits, info)
+  buf.addParRi()
+
 type
   TraverseMode = enum
     TraverseAll, TraverseSig, TraverseTopLevel
@@ -452,15 +457,21 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
       if err:
         error e, "invalid set element type: ", c
       else:
-        var arrBuf = createTokenBuf(16)
-        arrBuf.add tagToken("array", info)
-        arrBuf.add tagToken("u", info)
-        arrBuf.addIntLit(8, info)
-        arrBuf.addParRi()
-        arrBuf.addIntLit(size, info)
-        arrBuf.addParRi()
-        var arrCursor = cursorAt(arrBuf, 0)
-        traverseAsNamedType(e, arrCursor)
+        case size
+        of 1, 2, 4, 8:
+          e.dest.add tagToken("u", info)
+          e.dest.addIntLit(size * 8, info)
+          e.dest.addParRi()
+        else:
+          var arrBuf = createTokenBuf(16)
+          arrBuf.add tagToken("array", info)
+          arrBuf.add tagToken("u", info)
+          arrBuf.addIntLit(8, info)
+          arrBuf.addParRi()
+          arrBuf.addIntLit(size, info)
+          arrBuf.addParRi()
+          var arrCursor = cursorAt(arrBuf, 0)
+          traverseAsNamedType(e, arrCursor)
       skip c
       skipParRi e, c
     of VoidT, VarargsT, NilT, ConceptT,
@@ -787,6 +798,103 @@ proc traverseTupleConstr(e: var EContext; c: var Cursor) =
     e.dest.addParRi() # "kv"
   wantParRi e, c
 
+proc genSetOp(e: var EContext; c: var Cursor) =
+  let info = c.info
+  let kind = c.exprKind
+  inc c
+  let typ = c
+  if typ.typeKind != SetT:
+    error e, "expected set type for set op", c
+  var baseType = typ
+  inc baseType
+  var argsBuf = createTokenBuf(16)
+  swap e.dest, argsBuf
+  let typeStart = e.dest.len
+  traverseType e, c
+  let aStart = e.dest.len
+  traverseExpr e, c
+  let bStart = e.dest.len
+  traverseExpr e, c
+  swap e.dest, argsBuf
+  skipParRi e, c
+  let cType = cursorAt(argsBuf, typeStart)
+  let a = cursorAt(argsBuf, aStart)
+  let b = cursorAt(argsBuf, bStart)
+  var err = false
+  let size = asSigned(bitsetSizeInBytes(baseType), err)
+  assert not err
+  # XXX AST of a and b are copied more than once, maybe ensure it is moved to a temp if necessary
+  case size
+  of 1, 2, 4, 8:
+    case kind
+    of CardSetX:
+      # XXX needs countBits compilerproc
+      raiseAssert("unimplemented")
+    of LtSetX:
+      e.dest.buildTree $AndX, info:
+        e.dest.buildTree $EqX, info:
+          e.dest.buildTree $BitAndX, info:
+            e.dest.addSubtree cType
+            e.dest.addSubtree a
+            e.dest.buildTree $BitNotX, info:
+              e.dest.addSubtree cType
+              e.dest.addSubtree b
+          e.dest.addIntLit(0, info)
+        e.dest.buildTree $NeqX, info:
+          e.dest.addSubtree a
+          e.dest.addSubtree b
+    of LeSetX:
+      e.dest.buildTree $EqX, info:
+        e.dest.buildTree $BitAndX, info:
+          e.dest.addSubtree cType
+          e.dest.addSubtree a
+          e.dest.buildTree $BitNotX, info:
+            e.dest.addSubtree cType
+            e.dest.addSubtree b
+        e.dest.addIntLit(0, info)
+    of EqSetX:
+      e.dest.buildTree $EqX, info:
+        e.dest.addSubtree a
+        e.dest.addSubtree b
+    of MulSetX:
+      e.dest.buildTree $BitAndX, info:
+        e.dest.addSubtree cType
+        e.dest.addSubtree a
+        e.dest.addSubtree b
+    of PlusSetX:
+      e.dest.buildTree $BitOrX, info:
+        e.dest.addSubtree cType
+        e.dest.addSubtree a
+        e.dest.addSubtree b
+    of XorSetX:
+      e.dest.buildTree $BitXorX, info:
+        e.dest.addSubtree cType
+        e.dest.addSubtree a
+        e.dest.addSubtree b
+    of InSetX:
+      let mask = size * 8 - 1
+      e.dest.buildTree $NeqX, info:
+        e.dest.buildTree $BitAndX, info:
+          e.dest.addSubtree cType
+          e.dest.addSubtree a
+          e.dest.buildTree $ShlX, info:
+            e.dest.addSubtree cType
+            e.dest.buildTree $CastX, info:
+              e.dest.addSubtree cType
+              e.dest.addIntLit(1, info)
+            e.dest.buildTree $BitAndX, info:
+              e.dest.addUintType(-1, info)
+              e.dest.buildTree $CastX, info:
+                e.dest.addUintType(-1, info)
+                e.dest.addSubtree b
+              e.dest.addUintLit(uint64(mask), info)
+        e.dest.addUintLit(0, info)
+    else:
+      raiseAssert("unreachable")
+  else:
+    # XXX temp generation required here for `for` loops
+    raiseAssert("unimplemented")
+
 proc traverseExpr(e: var EContext; c: var Cursor) =
   var nested = 0
   while true:
@@ -858,7 +966,7 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         e.dest.add c # add right paren
         inc c # skip right paren
       of PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardSetX:
-        raiseAssert("unimplemented")
+        genSetOp e, c
       of DerefDotX:
         e.dest.add tagToken("dot", c.info)
         e.dest.add tagToken("deref", c.info)
@@ -1080,6 +1188,89 @@ proc traverseCase(e: var EContext; c: var Cursor) =
       error e, "expected (of) or (else) but got: ", c
   wantParRi e, c
 
+proc genInclExcl(e: var EContext; c: var Cursor) =
+  let info = c.info
+  let kind = c.stmtKind
+  inc c
+  let typ = c
+  if typ.typeKind != SetT:
+    error e, "expected set type for incl/excl", c
+  var baseType = typ
+  inc baseType
+  var argsBuf = createTokenBuf(16)
+  swap e.dest, argsBuf
+  let typeStart = e.dest.len
+  traverseType e, c
+  let aStart = e.dest.len
+  traverseExpr e, c
+  let bStart = e.dest.len
+  traverseExpr e, c
+  swap e.dest, argsBuf
+  skipParRi e, c
+  let cType = cursorAt(argsBuf, typeStart)
+  let a = cursorAt(argsBuf, aStart)
+  let b = cursorAt(argsBuf, bStart)
+  var err = false
+  let size = asSigned(bitsetSizeInBytes(baseType), err)
+  assert not err
+  # XXX AST of a and b are copied more than once, maybe ensure it is moved to a temp if necessary
+  case size
+  of 1, 2, 4, 8:
+    let mask = size * 8 - 1
+    e.dest.buildTree "asgn", info:
+      e.dest.addSubtree a
+      if kind == InclSetS:
+        e.dest.add tagToken($BitOrX, info)
+        e.dest.addSubtree cType
+        e.dest.addSubtree a
+      else:
+        e.dest.add tagToken($BitAndX, info)
+        e.dest.addSubtree cType
+        e.dest.addSubtree a
+        e.dest.add tagToken($BitNotX, info)
+        e.dest.addSubtree cType
+      e.dest.buildTree $ShlX, info:
+        e.dest.addSubtree cType
+        e.dest.buildTree $CastX, info:
+          e.dest.addSubtree cType
+          e.dest.addIntLit(1, info)
+        e.dest.buildTree $BitAndX, info:
+          e.dest.addUintType(-1, info)
+          e.dest.addSubtree b
+          e.dest.addIntLit(mask, info)
+      if kind == InclSetS:
+        e.dest.addParRi() # bitor
+      else:
+        e.dest.addParRi() # bitand
+        e.dest.addParRi() # bitnot
+  else:
+    template addLhs() =
+      e.dest.buildTree "at", info:
+        e.dest.addSubtree a
+        e.dest.buildTree $ShrX, info:
+          e.dest.addUintType(-1, info)
+          e.dest.buildTree $CastX, info:
+            e.dest.addUintType(-1, info)
+            e.dest.addParRi()
+            e.dest.addSubtree b
+          e.dest.addIntLit(3)
+    e.dest.buildTree "asgn", info:
+      addLhs()
+      e.dest.buildTree (if kind == InclSetS: $BitOrX else: $BitAndX), info:
+        addLhs()
+        if kind == ExclSetS:
+          e.dest.add tagToken($BitNotX, info)
+          e.dest.addUintType(8, info)
+        e.dest.buildTree $ShlX, info:
+          e.dest.addUintType(8, info)
+          e.dest.addUintLit(1, info)
+          e.dest.buildTree $BitAndX, info:
+            e.dest.addUintType(-1, info)
+            e.dest.addSubtree b
+            e.dest.addUintLit(7, info)
+        if kind == ExclSetS:
+          e.dest.addParRi()
+
 proc traverseStmt(e: var EContext; c: var Cursor; mode = TraverseAll) =
   case c.kind
   of DotToken:
@@ -1154,8 +1345,10 @@ proc traverseStmt(e: var EContext; c: var Cursor; mode = TraverseAll) =
     of CaseS: traverseCase e, c
     of YieldS, ForS:
       error e, "BUG: not eliminated: ", c
-    of TryS, RaiseS, InclSetS, ExclSetS:
+    of TryS, RaiseS:
       error e, "BUG: not implemented: ", c
+    of InclSetS, ExclSetS:
+      genInclExcl e, c
     of FuncS, ProcS, ConverterS, MethodS:
       traverseProc e, c, mode
     of MacroS, TemplateS, IncludeS, ImportS, FromImportS, ImportExceptS, ExportS, CommentS, IterS:

--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -221,6 +221,11 @@ template buildTree*(dest: var TokenBuf; tag: TagId; info: PackedLineInfo; body: 
   body
   dest.add parRiToken(info)
 
+template buildTree*(dest: var TokenBuf; tag: string; info: PackedLineInfo; body: untyped) =
+  dest.add parLeToken(pool.tags.getOrIncl(tag), info)
+  body
+  dest.add parRiToken(info)
+
 proc addParLe*(dest: var TokenBuf; tag: TagId; info = NoLineInfo) =
   dest.add parLeToken(tag, info)
 
@@ -235,6 +240,9 @@ proc addStrLit*(dest: var TokenBuf; s: string; info = NoLineInfo) =
 
 proc addIntLit*(dest: var TokenBuf; i: BiggestInt; info = NoLineInfo) =
   dest.add intToken(pool.integers.getOrIncl(i), info)
+
+proc addUintLit*(dest: var TokenBuf; i: BiggestUInt; info = NoLineInfo) =
+  dest.add uintToken(pool.uintegers.getOrIncl(i), info)
 
 proc span*(c: Cursor): int =
   result = 0

--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -221,11 +221,6 @@ template buildTree*(dest: var TokenBuf; tag: TagId; info: PackedLineInfo; body: 
   body
   dest.add parRiToken(info)
 
-template buildTree*(dest: var TokenBuf; tag: string; info: PackedLineInfo; body: untyped) =
-  dest.add parLeToken(pool.tags.getOrIncl(tag), info)
-  body
-  dest.add parRiToken(info)
-
 proc addParLe*(dest: var TokenBuf; tag: TagId; info = NoLineInfo) =
   dest.add parLeToken(tag, info)
 

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -214,7 +214,9 @@ proc enumBounds*(n: Cursor): Bounds =
   result = Bounds(lo: createNan(), hi: createNaN())
   while n.kind != ParRi:
     let enumField = takeLocal(n, SkipFinalParRi)
-    let x = evalOrdinal(nil, enumField.val)
+    var val = enumField.val
+    inc val # skip tuple tag
+    let x = evalOrdinal(nil, val)
     if isNaN(result.lo) or x < result.lo: result.lo = x
     if isNaN(result.hi) or x > result.hi: result.hi = x
 
@@ -311,6 +313,7 @@ proc evalBitSet*(n, typ: Cursor): seq[uint8] =
     return @[]
   result = newSeq[uint8](s)
   var n = n
+  inc n # skip set tag
   while n.kind != ParRi:
     if n.exprKind == RangeX:
       inc n

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -88,14 +88,7 @@ proc error0(m: var Match; k: MatchErrorKind) =
 proc getErrorMsg(m: Match): string =
   case m.error.kind
   of InvalidMatch:
-    var s = concat("expected: ", typeToString(m.error.expected), " but got: ", typeToString(m.error.got))
-    if false:
-      for a, b in m.inferred:
-        s.add("\n")
-        s.add(pool.syms[a])
-        s.add(": ")
-        s.add(typeToString(b))
-    s
+    concat("expected: ", typeToString(m.error.expected), " but got: ", typeToString(m.error.got))
   of InvalidRematch:
     concat("Could not match again: ", pool.syms[m.error.typeVar], " expected ",
       typeToString(m.error.expected), " but got ", typeToString(m.error.got))

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -88,7 +88,14 @@ proc error0(m: var Match; k: MatchErrorKind) =
 proc getErrorMsg(m: Match): string =
   case m.error.kind
   of InvalidMatch:
-    concat("expected: ", typeToString(m.error.expected), " but got: ", typeToString(m.error.got))
+    var s = concat("expected: ", typeToString(m.error.expected), " but got: ", typeToString(m.error.got))
+    if false:
+      for a, b in m.inferred:
+        s.add("\n")
+        s.add(pool.syms[a])
+        s.add(": ")
+        s.add(typeToString(b))
+    s
   of InvalidRematch:
     concat("Could not match again: ", pool.syms[m.error.typeVar], " expected ",
       typeToString(m.error.expected), " but got ", typeToString(m.error.got))

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -76,7 +76,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,752,lib/std/system.nim
+    (elif 11,780,lib/std/system.nim
      (expr 2,1
       (lt
        (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -76,7 +76,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,780,lib/std/system.nim
+    (elif 11,786,lib/std/system.nim
      (expr 2,1
       (lt
        (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1

--- a/tests/nimony/sysbasics/tsets.nim
+++ b/tests/nimony/sysbasics/tsets.nim
@@ -1,0 +1,12 @@
+type Foo = enum
+  A, B, C, D, E, F
+
+var s, s1: set[Foo]
+s = {A..D}
+s1 = {A..C}
+discard s1 < s
+let y = s1 * s
+let z: set[Foo] = y
+discard y == {A..C}
+discard z == {A..C}
+discard s1 <= s

--- a/tests/nimony/sysbasics/tsets.nim
+++ b/tests/nimony/sysbasics/tsets.nim
@@ -9,4 +9,5 @@ let y = s1 * s
 let z: set[Foo] = y
 discard y == {A..C}
 discard z == {A..C}
+discard s - s1 == {D}
 discard s1 <= s


### PR DESCRIPTION
refs #351, succeeds #415 as described in https://github.com/nim-lang/nimony/pull/415#issuecomment-2615788335

Set types are still only transformed in nifcgen, maybe could generate `dconv` too

* [x] move operands to temps if they have side effects
* [ ] implement set ops for array sets (can be done later, some might need compilerprocs)