### PR TITLE
implement inc/dec as desugared magic

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -104,6 +104,20 @@ template `[]=`*[T](x: ptr T, val: T) =
 template `[]=`*[T](x: ref T, val: T) =
   (x[]) = val
 
+proc inc*[T, V#[: Ordinal]#](x: T, y: V) {.magic: "Inc", noSideEffect.}
+  ## Increments the ordinal `x` by `y`.
+
+proc dec*[T, V#[: Ordinal]#](x: T, y: V) {.magic: "Dec", noSideEffect.}
+  ## Decrements the ordinal `x` by `y`.
+
+template inc*[T#[: Ordinal]#](x: T) =
+  # workaround for no default params
+  inc[T, T](x, T(1))
+
+template dec*[T#[: Ordinal]#](x: T) =
+  # workaround for no default params
+  dec[T, T](x, T(1))
+
 # integer calculations:
 proc `+`*(x: int8): int8 {.magic: "UnaryPlusI", noSideEffect.}
 proc `+`*(x: int16): int16 {.magic: "UnaryPlusI", noSideEffect.}

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -104,17 +104,17 @@ template `[]=`*[T](x: ptr T, val: T) =
 template `[]=`*[T](x: ref T, val: T) =
   (x[]) = val
 
-proc inc*[T, V#[: Ordinal]#](x: T, y: V) {.magic: "Inc", noSideEffect.}
+proc inc*[T, V: Ordinal](x: T, y: V) {.magic: "Inc", noSideEffect.}
   ## Increments the ordinal `x` by `y`.
 
-proc dec*[T, V#[: Ordinal]#](x: T, y: V) {.magic: "Dec", noSideEffect.}
+proc dec*[T, V: Ordinal](x: T, y: V) {.magic: "Dec", noSideEffect.}
   ## Decrements the ordinal `x` by `y`.
 
-template inc*[T#[: Ordinal]#](x: T) =
+template inc*[T: Ordinal](x: T) =
   # workaround for no default params
   inc x, 1
 
-template dec*[T#[: Ordinal]#](x: T) =
+template dec*[T: Ordinal](x: T) =
   # workaround for no default params
   dec x, 1
 

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -112,11 +112,11 @@ proc dec*[T, V#[: Ordinal]#](x: T, y: V) {.magic: "Dec", noSideEffect.}
 
 template inc*[T#[: Ordinal]#](x: T) =
   # workaround for no default params
-  inc[T, T](x, T(1))
+  inc x, 1
 
 template dec*[T#[: Ordinal]#](x: T) =
   # workaround for no default params
-  dec[T, T](x, T(1))
+  dec x, 1
 
 # integer calculations:
 proc `+`*(x: int8): int8 {.magic: "UnaryPlusI", noSideEffect.}

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1164,7 +1164,7 @@ proc traverseStmt(e: var EContext; c: var Cursor; mode = TraverseAll) =
     of BlockS: traverseBlock e, c
     of IfS: traverseIf e, c
     of CaseS: traverseCase e, c
-    of YieldS, ForS, InclSetS, ExclSetS:
+    of YieldS, ForS, IncS, DecS, InclSetS, ExclSetS:
       error e, "BUG: not eliminated: ", c
     of TryS, RaiseS:
       error e, "BUG: not implemented: ", c

--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -367,7 +367,7 @@ proc trStmt(c: var Context; dest: var TokenBuf; n: var Cursor) =
 
   of WhileS:
     trWhile c, dest, n
-  of AsgnS, CallS, InclSetS, ExclSetS:
+  of AsgnS, CallS, IncS, DecS, InclSetS, ExclSetS:
     # IMPORTANT: Stores into `tar` helper!
     var tar = Target(m: IsAppend)
     tar.t.copyInto n:

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -174,6 +174,8 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mDefaultObj: res DefaultObjX
   of mDefaultTup: res DefaultTupX
   of mOpenArray: res OpenArrayT
+  of mInc: res IncS, TypedMagic
+  of mDec: res DecS, TypedMagic
   of mPlusSet: res PlusSetX, TypedMagic
   of mMinusSet: res MinusSetX, TypedMagic
   of mMulSet: res MulSetX, TypedMagic

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -50,6 +50,8 @@ type
     ExportS = "export"
     CommentS = "comment"
     PragmasLineS = "pragmas"
+    IncS = "inc"
+    DecS = "dec"
     InclSetS = "incl"
     ExclSetS = "excl"
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4885,6 +4885,20 @@ proc semPragmasLine(c: var SemContext; it: var Item) =
 
   skipParRi it.n
 
+proc semIncDec(c: var SemContext; it: var Item) =
+  let info = it.n.info
+  let beforeExpr = c.dest.len
+  takeToken c, it.n
+  let typeStart = c.dest.len
+  semLocalTypeImpl c, it.n, InLocalDecl
+  let typ = typeToCursor(c, typeStart)
+  var op = Item(n: it.n, typ: typ)
+  semExpr c, op
+  semExpr c, op
+  it.n = op.n
+  wantParRi c, it.n
+  producesVoid c, info, it.typ
+
 proc semInclExcl(c: var SemContext; it: var Item) =
   let info = it.n.info
   let beforeExpr = c.dest.len
@@ -5086,6 +5100,9 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
       of PragmasLineS:
         toplevelGuard c:
           semPragmasLine c, it
+      of IncS, DecS:
+        toplevelGuard c:
+          semIncDec c, it
       of InclSetS, ExclSetS:
         toplevelGuard c:
           semInclExcl c, it

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -246,7 +246,7 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
     assert f.kind == ParRi
     inc f
   of OrdinalT:
-    result = isOrdinalType(a)
+    result = isOrdinalType(a) or a.typeKind == OrdinalT
     skip f
   else:
     result = false

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -61,11 +61,9 @@
      (i -1) ~2 i.2 3 b.0) 2,1
     (stmts
      (yld 6 i.2) 11,227,lib/std/system.nim
-     (stmts 9
+     (stmts
       (inc 23,17,tests/nimony/sysbasics/tforloops1.nim
-       (i -1) 8,21,tests/nimony/sysbasics/tforloops1.nim i.2 5
-       (conv 23,17,tests/nimony/sysbasics/tforloops1.nim
-        (i -1) 1 +1))))))) 4,22
+       (i -1) 8,21,tests/nimony/sysbasics/tforloops1.nim i.2 7 +1)))))) 4,22
  (for 12
   (call ~7 countup.0.tfo6yv57p 1 +1 4 +5)
   (unpackflat
@@ -105,11 +103,9 @@
      (i -1) ~2 i.3 3 n.1) 2,1
     (stmts
      (yld 6 i.3) 11,227,lib/std/system.nim
-     (stmts 9
+     (stmts
       (inc
-       (i -1) 8,36,tests/nimony/sysbasics/tforloops1.nim i.3 5
-       (conv
-        (i -1) 1 +1))))))) ,37
+       (i -1) 8,36,tests/nimony/sysbasics/tforloops1.nim i.3 7 +1)))))) ,37
  (iterator 9 :powers2.0.tfo6yv57p . . . 16
   (params 1
    (param :n.2 . . 3

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -17,7 +17,7 @@
       (mul
        (i -1) ~1 i.0 1 i.0)) ,2
      (yld 9
-      (mul 20,279,lib/std/system.nim
+      (mul 20,307,lib/std/system.nim
        (i +64) ~2
        (mul
         (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
@@ -60,10 +60,12 @@
     (le 13,~2
      (i -1) ~2 i.2 3 b.0) 2,1
     (stmts
-     (yld 6 i.2) 2,1
-     (asgn ~2 i.2 4
-      (add 13,~4
-       (i -1) ~2 i.2 2 +1)))))) 4,22
+     (yld 6 i.2) 11,227,lib/std/system.nim
+     (stmts 9
+      (inc 23,17,tests/nimony/sysbasics/tforloops1.nim
+       (i -1) 8,21,tests/nimony/sysbasics/tforloops1.nim i.2 5
+       (conv 23,17,tests/nimony/sysbasics/tforloops1.nim
+        (i -1) 1 +1))))))) 4,22
  (for 12
   (call ~7 countup.0.tfo6yv57p 1 +1 4 +5)
   (unpackflat
@@ -76,7 +78,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,786,lib/std/system.nim
+    (elif 11,814,lib/std/system.nim
      (expr 2,1
       (lt
        (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1
@@ -102,10 +104,12 @@
     (le
      (i -1) ~2 i.3 3 n.1) 2,1
     (stmts
-     (yld 6 i.3) 2,1
-     (asgn ~2 i.3 4
-      (add
-       (i -1) ~2 i.3 2 +1)))))) ,37
+     (yld 6 i.3) 11,227,lib/std/system.nim
+     (stmts 9
+      (inc
+       (i -1) 8,36,tests/nimony/sysbasics/tforloops1.nim i.3 5
+       (conv
+        (i -1) 1 +1))))))) ,37
  (iterator 9 :powers2.0.tfo6yv57p . . . 16
   (params 1
    (param :n.2 . . 3
@@ -123,7 +127,7 @@
       (mul ~1,~9
        (i -1) ~1 i.4 1 i.4)) ,2
      (yld 9
-      (mul 20,279,lib/std/system.nim
+      (mul 20,307,lib/std/system.nim
        (i +64) ~2
        (mul ~1,~10
         (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,43

--- a/tests/nimony/sysbasics/tforloops1.nim
+++ b/tests/nimony/sysbasics/tforloops1.nim
@@ -18,7 +18,7 @@ iterator countup(a, b: int): int =
   var i = a
   while i <= b:
     yield i     # establish as the for loop variable
-    i = i + 1
+    inc i
 
 for x in countup(1, 5):
   let m = x
@@ -33,7 +33,7 @@ iterator countup2(n: int): int =
   var i = 0
   while i <= n:
     yield i
-    i = i + 1
+    inc i
 
 iterator powers2(n: int): int =
   for i in countup2(n):


### PR DESCRIPTION
Tried to implement as template, doesn't work because the use of `+`/`-` needs a concept and concepts still seem to have some issues, even `x = x` does not work (will still look at these issues). Alternatively it could be an untyped template. In any case this is more faithful, could be revisited later.

A problem with this approach is that mutability checking has to be special cased for these magics as well as `incl`/`excl`, which is not done yet