### PR TITLE
make concept procs work for typedesc calls

### DIFF
--- a/lib/std/system/seqimpl.nim
+++ b/lib/std/system/seqimpl.nim
@@ -20,7 +20,10 @@ proc `=wasMoved`*[T](s: var seq[T]) {.inline.} =
   s.len = 0
   s.data = nil
 
-proc newSeq*[T](size: int): seq[T] {.nodestroy.} =
+type HasDefault* = concept
+  proc default(_: typedesc[Self]): Self
+
+proc newSeq*[T: HasDefault](size: int): seq[T] {.nodestroy.} =
   if size == 0:
     result = seq[T](len: size, data: nil)
   else:

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -220,7 +220,7 @@ proc containsGenericParams*(n: TypeCursor): bool =
     inc n
   return false
 
-proc nominalRoot*(t: TypeCursor): SymId =
+proc nominalRoot*(t: TypeCursor, allowTypevar = false): SymId =
   result = SymId(0)
   var t = t
   while true:
@@ -237,8 +237,9 @@ proc nominalRoot*(t: TypeCursor): SymId =
           return root.symId
         else:
           return t.symId
+      elif allowTypevar and res.decl.symKind == TypevarY:
+        return t.symId
       else:
-        # includes typevar case
         break
     of ParLe:
       case t.typeKind


### PR DESCRIPTION
Skips `var`/`sink`/`typedesc` etc modifiers for checking if an argument type is a typevar with a concept