### PR TITLE
make basic concept test compile

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -695,6 +695,8 @@ proc traverseTypeDecl(e: var EContext; c: var Cursor) =
 
   if prag.externName.len > 0:
     e.registerMangle(s, prag.externName & ".c")
+  if c.typeKind in TypeclassKinds:
+    isGeneric = true
   if isGeneric:
     skip c
   else:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -353,6 +353,7 @@ const
   RoutineKinds* = {ProcY, FuncY, IterY, TemplateY, MacroY, ConverterY, MethodY}
   CallKinds* = {CallX, CallStrLitX, CmdX, PrefixX, InfixX, HcallX}
   ConvKinds* = {HconvX, ConvX, OconvX, DconvX, CastX}
+  TypeclassKinds* = {ConceptT, TypeKindT, OrdinalT, OrT, AndT, NotT}
 
 proc addParLe*(dest: var TokenBuf; kind: TypeKind|SymKind|ExprKind|StmtKind|SubstructureKind; info = NoLineInfo) =
   dest.add parLeToken(pool.tags.getOrIncl($kind), info)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -254,17 +254,15 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
 proc matchesConstraint(m: var Match; f: var Cursor; a: Cursor): bool =
   result = false
   if f.kind == DotToken:
-    result = true
     inc f
-  elif a.kind == Symbol:
+    return true
+  if a.kind == Symbol:
     let res = tryLoadSym(a.symId)
     assert res.status == LacksNothing
     if res.decl.symKind == TypevarY:
       var typevar = asTypevar(res.decl)
-      result = matchesConstraint(m, f, typevar.typ)
-    elif res.decl.symKind == TypeY:
-      result = matchesConstraintAux(m, f, a)
-  elif f.kind == Symbol:
+      return matchesConstraint(m, f, typevar.typ)
+  if f.kind == Symbol:
     let res = tryLoadSym(f.symId)
     assert res.status == LacksNothing
     var typeImpl = asTypeDecl(res.decl)

--- a/tests/nimony/concepts/tadd.nim
+++ b/tests/nimony/concepts/tadd.nim
@@ -1,0 +1,8 @@
+type Addable = concept
+  proc `+`(a, b: Self): Self
+
+template incr[T: Addable](x: var T) =
+  x = x + T(1)
+
+var a = 0
+incr(a)


### PR DESCRIPTION
1. Make nifcgen not generate concept types or other typeclasses, probably not general enough
2. A constraint type that is a symbol is supposed to be skipped when calling `matchesConstraintAux` (the `f.kind == Symbol` part). This was not done when the matched type is also a symbol type (the `a.kind == Symbol` branch would take over), now it is

tfib and tfib2 also compile with these, they could be moved out of the nosystem category instead