### PR TITLE
implement inc/dec as inline procs

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -259,6 +259,28 @@ proc `-`*(x, y: float): float {.magic: "SubF64", noSideEffect.}
 proc `*`*(x, y: float): float {.magic: "MulF64", noSideEffect.}
 proc `/`*(x, y: float): float {.magic: "DivF64", noSideEffect.}
 
+type
+  Incable = concept
+    proc `+`(x, y: Self): Self
+  Decable = concept
+    proc `-`(x, y: Self): Self
+
+template inc*[T: Incable, V: Ordinal](x: var T, y: V) =
+  ## Increments the ordinal `x` by `y`.
+  x = x + T(y)
+
+template dec*[T: Decable, V: Ordinal](x: var T, y: V) =
+  ## Decrements the ordinal `x` by `y`.
+  x = x - T(y)
+
+template inc*[T: Incable](x: var T) =
+  # workaround for no default params
+  x = x + T(1)
+
+template dec*[T: Decable](x: var T) =
+  # workaround for no default params
+  x = x - T(1)
+
 # comparison operators:
 proc `==`*[Enum: enum](x, y: Enum): bool {.magic: "EqEnum", noSideEffect.}
   ## Checks whether values within the *same enum* have the same underlying value.

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -265,19 +265,19 @@ type
   Decable = concept
     proc `-`(x, y: Self): Self
 
-template inc*[T: Incable, V: Ordinal](x: var T, y: V) =
+proc inc*[T: Incable, V: Ordinal](x: var T, y: V) {.inline.} =
   ## Increments the ordinal `x` by `y`.
   x = x + T(y)
 
-template dec*[T: Decable, V: Ordinal](x: var T, y: V) =
+proc dec*[T: Decable, V: Ordinal](x: var T, y: V) {.inline.} =
   ## Decrements the ordinal `x` by `y`.
   x = x - T(y)
 
-template inc*[T: Incable](x: var T) =
+proc inc*[T: Incable](x: var T) {.inline.} =
   # workaround for no default params
   x = x + T(1)
 
-template dec*[T: Decable](x: var T) =
+proc dec*[T: Decable](x: var T) {.inline.} =
   # workaround for no default params
   x = x - T(1)
 

--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -313,7 +313,7 @@ proc genInclExcl(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let a: Cursor
   let b: Cursor
   if useTemp:
-    dest.add parLeToken(ExprX, info)
+    dest.add parLeToken(StmtsS, info)
     # lift both so (n, (n = 123; n)) works
     a = liftTempAddr(c, dest, aOrig, typ, info)
     b = liftTemp(c, dest, bOrig, typ, info)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -829,7 +829,7 @@ proc addFn(c: var SemContext; fn: FnCandidate; fnOrig: Cursor; args: openArray[I
           inc n
           if n.kind == IntLit:
             if pool.integers[n.intId] == TypedMagic:
-              c.dest.addSubtree args[0].typ
+              c.dest.addSubtree skipModifier(args[0].typ)
             else:
               c.dest.add n
             inc n

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -509,8 +509,8 @@ proc subsGenericProc(c: var SemContext; dest: var TokenBuf; req: InstRequest) =
     var sc = SubsContext(params: addr req.inferred)
     subs(c, dest, sc, decl.params)
     subs(c, dest, sc, decl.retType)
-    subs(c, dest, sc, decl.effects)
     subs(c, dest, sc, decl.pragmas)
+    subs(c, dest, sc, decl.effects)
     subs(c, dest, sc, decl.body)
     addFreshSyms(c, sc)
 

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -60,31 +60,30 @@
     (le 13,~2
      (i -1) ~2 i.2 3 b.0) 2,1
     (stmts
-     (yld 6 i.2) 2,1
-     (asgn ~2 i.2 4
-      (add 13,~4
-       (i -1) ~2 i.2 2 +1)))))) 4,22
+     (yld 6 i.2) ,1
+     (cmd inc.0.tfo6yv57p 4
+      (haddr i.2)))))) 4,22
  (for 12
   (call ~7 countup.0.tfo6yv57p 1 +1 4 +5)
   (unpackflat
-   (let :x.0 . . 9,~6
+   (let :x.1 . . 9,~6
     (i -1) .)) ~2,1
   (stmts 4
    (let :m.1 . . 7,~7
-    (i -1) 4 x.0) 6,1
+    (i -1) 4 x.1) 6,1
    (call ~6 printf.0.tfo6yv57p 1
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,786,lib/std/system.nim
+    (elif 11,830,lib/std/system.nim
      (expr 2,1
       (lt
-       (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.0)) ~1,1
+       (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.1)) ~1,1
      (stmts
       (break .))) 5,2
     (elif 2
      (lt 4,~11
-      (i -1) ~2 x.0 2 +3) ~3,1
+      (i -1) ~2 x.1 2 +3) ~3,1
      (stmts
       (continue .)))) 6,6
    (call ~6 printf.0.tfo6yv57p 1
@@ -102,10 +101,9 @@
     (le
      (i -1) ~2 i.3 3 n.1) 2,1
     (stmts
-     (yld 6 i.3) 2,1
-     (asgn ~2 i.3 4
-      (add
-       (i -1) ~2 i.3 2 +1)))))) ,37
+     (yld 6 i.3) ,1
+     (cmd inc.0.tfo6yv57p 4
+      (haddr i.3)))))) ,37
  (iterator 9 :powers2.0.tfo6yv57p . . . 16
   (params 1
    (param :n.2 . . 3
@@ -172,4 +170,21 @@
       (hconv 9,~47
        (cstring) "Hello, world\3A %ld\0A") 25
       (add ~25,~6
-       (i -1) ~1 m.2 1 n.3)))))))
+       (i -1) ~1 m.2 1 n.3)))))) 4,20
+ (proc :inc.0.tfo6yv57p . 5,551,lib/std/system.nim .
+  (at inc.1.sys9azlf 19,~4
+   (i -1)) 26,551,lib/std/system.nim
+  (params 1
+   (param :x.2 . . 3
+    (mut 23,17,tests/nimony/sysbasics/tforloops1.nim
+     (i -1)) .)) 5,551,lib/std/system.nim . 37,551,lib/std/system.nim
+  (pragmas 2
+   (inline)) 5,551,lib/std/system.nim . 7,553,lib/std/system.nim
+  (stmts 2
+   (asgn ~2
+    (hderef x.2) 4
+    (add 23,17,tests/nimony/sysbasics/tforloops1.nim
+     (i -1) ~2
+     (hderef x.2) 3
+     (conv 23,17,tests/nimony/sysbasics/tforloops1.nim
+      (i -1) 1 +1))))))

--- a/tests/nimony/sysbasics/tforloops1.nim
+++ b/tests/nimony/sysbasics/tforloops1.nim
@@ -18,7 +18,7 @@ iterator countup(a, b: int): int =
   var i = a
   while i <= b:
     yield i     # establish as the for loop variable
-    i = i + 1
+    inc i
 
 for x in countup(1, 5):
   let m = x
@@ -33,7 +33,7 @@ iterator countup2(n: int): int =
   var i = 0
   while i <= n:
     yield i
-    i = i + 1
+    inc i
 
 iterator powers2(n: int): int =
   for i in countup2(n):


### PR DESCRIPTION
Old system also implements `*=` as [inline proc](https://github.com/nim-lang/Nim/blob/0861dabfa70f40f00c5c95d58c344ad5e0fd19ec/lib/system/arithmetics.nim#L307)