### PR TITLE
nimony: add basic `${path}` to `{.header.}` for relative c include

### DIFF
--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -291,7 +291,7 @@ proc generateFinalMakefile(c: DepContext): string =
 
     for cfile in buildList:
       s.add "\n" & mescape("nifcache" / cfile.obj) & ": " & mescape(cfile.name) &
-            "\n\t$(CC) -c $(CFLAGS) -I$(ROOT_PATH) $(CPPFLAGS) " &
+            "\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) " &
             mescape(cfile.customArgs) & " $< -o $@"
 
     # The .o files depend on all of their .c files:

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -251,6 +251,11 @@ type
   CFile = tuple
     name, obj, customArgs: string
 
+proc rootPath(c: DepContext): string =
+  # XXX: makefile is executed parent to nifcachePath
+  result = absoluteParentDir(c.rootNode.files[0].nimFile)
+  result = relativePath(result, parentDir c.config.nifcachePath)
+
 proc toBuildList(c: DepContext): seq[CFile] =
   result = @[]
   for v in c.nodes:
@@ -273,7 +278,7 @@ proc generateFinalMakefile(c: DepContext): string =
       exeFile(c.rootNode.files[0])
 
   # Absolute path of root node module
-  s.add "\nROOT_PATH = " & absoluteParentDir(c.rootNode.files[0].nimFile)
+  s.add "\nROOT_PATH = " & rootPath(c)
   s.add "\nall: " & mescape dest
 
   # The .exe file depends on all .o files:

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -271,6 +271,9 @@ proc generateFinalMakefile(c: DepContext): string =
       ""
     of DoCompile, DoRun:
       exeFile(c.rootNode.files[0])
+
+  # Absolute path of root node module
+  s.add "\nROOT_PATH = " & absoluteParentDir(c.rootNode.files[0].nimFile)
   s.add "\nall: " & mescape dest
 
   # The .exe file depends on all .o files:
@@ -288,11 +291,11 @@ proc generateFinalMakefile(c: DepContext): string =
 
     for cfile in buildList:
       s.add "\n" & mescape("nifcache" / cfile.obj) & ": " & mescape(cfile.name) &
-            "\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) " &
+            "\n\t$(CC) -c $(CFLAGS) -I$(ROOT_PATH) $(CPPFLAGS) " &
             mescape(cfile.customArgs) & " $< -o $@"
 
     # The .o files depend on all of their .c files:
-    s.add "\n%.o: %.c\n\t$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@"
+    s.add "\n%.o: %.c\n\t$(CC) -c $(CFLAGS) -I$(ROOT_PATH) $(CPPFLAGS) $< -o $@"
 
     # entry point is special:
     let nifc = findTool("nifc")

--- a/src/nimony/nifconfig.nim
+++ b/src/nimony/nifconfig.nim
@@ -14,6 +14,7 @@ type
   NifConfig* = object
     defines*: HashSet[string]
     paths*, nimblePaths*: seq[string]
+    nifcachePath*: string
     bits*: int
     compat*: bool
 

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -67,6 +67,8 @@ proc handleCmdLine() =
   var doRun = false
   var moduleFlags: set[ModuleFlag] = {}
   var config = NifConfig()
+  # XXX: harcoded relative nifcache path for now
+  config.nifcachePath = toAbsolutePath("nifcache")
   config.defines.incl "nimony"
   config.bits = sizeof(int)*8
   var commandLineArgs = ""

--- a/src/nimony/nimsem.nim
+++ b/src/nimony/nimsem.nim
@@ -56,6 +56,8 @@ proc handleCmdLine() =
   var useEnv = true
   var moduleFlags: set[ModuleFlag] = {}
   var config = NifConfig()
+  # XXX: harcoded relative nifcache path for now
+  config.nifcachePath = toAbsolutePath("nifcache")
   config.defines.incl "nimony"
   config.bits = sizeof(int)*8
   var commandLineArgs = ""

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1967,11 +1967,13 @@ proc semPragma(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kin
       return
     # Header pragma extra
     if pk == Header:
-      let strID = c.dest[c.dest.len - 1].litId
-      let name = addr pool.strings[strID]
+      let idx = c.dest.len - 1
+      let token = c.dest[idx]
       # Replace ${path} to absolute path
       let fileId = getFileId(pool.man, info)
-      name[] = replaceSubs(name[], "${path}", pool.files[fileId])
+      var name = pool.strings[token.litId]
+      name = replaceSubs(name, "${path}", pool.files[fileId])
+      c.dest[idx] = strToken(pool.strings.getOrIncl(name), token.info)
     # Finalize expression
     c.dest.addParRi()
   of Align, Bits:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1968,12 +1968,11 @@ proc semPragma(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kin
     # Header pragma extra
     if pk == Header:
       let idx = c.dest.len - 1
-      let token = c.dest[idx]
+      let tok = c.dest[idx]
       # Replace ${path} to absolute path
       let fileId = getFileId(pool.man, info)
-      var name = pool.strings[token.litId]
-      name = replaceSubs(name, "${path}", pool.files[fileId])
-      c.dest[idx] = strToken(pool.strings.getOrIncl(name), token.info)
+      let name = replaceSubs(pool.strings[tok.litId], "${path}", pool.files[fileId])
+      c.dest[idx] = strToken(pool.strings.getOrIncl(name), tok.info)
     # Finalize expression
     c.dest.addParRi()
   of Align, Bits:

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -6,6 +6,7 @@
 
 ## Path handling and `exec` like features as `sem.nim` needs it.
 
+from strutils import replace, contains
 import std / [tables, sets, os, syncio, formatfloat, assertions]
 include nifprelude
 import ".." / lib / nifchecksums
@@ -46,6 +47,16 @@ proc toAbsolutePath*(f: string, dir: string): string =
     result = f
   else:
     result = dir / f
+
+proc replaceSubs*(f: string, pattern, dir: string): string =
+  if not f.contains(pattern):
+    return f
+  # Unpack to an absolute path
+  var abs = absolutePath(dir)
+  if os.fileExists(abs):
+    abs = parentDir(abs)
+  # Replace found patterns by the absolute path
+  result = f.replace(pattern, abs).normalizedPath()
 
 proc findTool*(name: string): string =
   assert not name.isAbsolute

--- a/tests/nimony/sysbasics/bar.h
+++ b/tests/nimony/sysbasics/bar.h
@@ -1,0 +1,1 @@
+typedef struct {} Bar;

--- a/tests/nimony/sysbasics/bar1.h
+++ b/tests/nimony/sysbasics/bar1.h
@@ -1,0 +1,1 @@
+typedef struct {} Bar1;

--- a/tests/nimony/sysbasics/theader.nim
+++ b/tests/nimony/sysbasics/theader.nim
@@ -1,0 +1,2 @@
+type Bar {.importc: "Bar", header: "bar.h".} = object
+type Bar1 {.importc: "Bar1", header: "${path}/bar1.h".} = object


### PR DESCRIPTION
- add `replaceSubs` helper to `semos.nim` to replace a pattern by an absolute path
- add basic `${path}` and `${nifcache}`support to `{.header.}` + some tests
- add a `-I` of root module path relative to nifcache in final makefile for nim 2.x backwards compatibility (see https://github.com/nim-lang/Nim/pull/10012)

fixes https://github.com/nim-lang/nimony/issues/431