### PR TITLE
implement array len, misc bugfixes

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -463,6 +463,15 @@ proc move*[T](x: var T): T {.nodestroy, inline, noSideEffect.} =
   result = x
   `=wasMoved`(x)
 
+template len*[I, T](x: typedesc[array[I, T]]): int =
+  ## Returns the length of an array type.
+  ## This is roughly the same as `high(T)-low(T)+1`.
+  high(array[I, T]).int - low(array[I, T]).int + 1
+template len*[I, T](x: array[I, T]): int =
+  ## Returns the length of an array.
+  ## This is roughly the same as `high(T)-low(T)+1`.
+  len(array[I, T])
+
 include "system/setops"
 
 #include "system/stringimpl"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4426,7 +4426,6 @@ proc tryBuiltinSubscript(c: var SemContext; it: var Item; lhs: Item): bool =
   if (lhs.n.kind == Symbol and lhs.kind == TypeY and
         isGeneric(getTypeSection(lhs.n.symId))) or
       (lhs.n.typeKind in InvocableTypeMagics and isSinglePar(lhs.n)):
-    let start = c.dest.len
     # lhs is a generic type symbol, this is a generic invocation
     # treat it as a type expression to call semInvoke
     var typeExpr = createTokenBuf(16)

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -64,8 +64,9 @@
     (i -1) .)) 13
   (i -1) . . 32
   (stmts 2
-   (add ~14
-    (i -1) ~2 x.2 2 y.1))) ,29
+   (expr
+    (add ~14
+     (i -1) ~2 x.2 2 y.1)))) ,29
  (proc 5 :foo.0.tte5tld8n . . . 8
   (params 1
    (param :x.3 . . 3
@@ -78,11 +79,13 @@
    (var :x.5 . . string.0.sys9azlf 4 "abc") 7,1
    (asgn ~7 result.0 23,~4
     (expr 2
-     (add ~14
-      (i -1) ~18,4 +4 ~2
-      (expr 2
-       (add ~14
-        (i -1) ~10,4 +2 ~7,4 +89))))) 2,2
+     (expr
+      (add ~14
+       (i -1) ~18,4 +4 ~2
+       (expr 2
+        (expr
+         (add ~14
+          (i -1) ~10,4 +2 ~7,4 +89))))))) 2,2
    (asgn ~2 x.5 2 "34") ~2,~1
    (ret result.0))) ,34
  (proc 5 :overloaded.0.tte5tld8n . . . 15
@@ -107,13 +110,15 @@
    (param :x.4 . . 3
     (i -1) .)) 10 T.4.tte5tld8n . . 30
   (stmts 1
-   (conv ~1 T.4.tte5tld8n 1 x.4))) 4,42
+   (expr
+    (conv ~1 T.4.tte5tld8n 1 x.4)))) 4,42
  (let :val.0.tte5tld8n . .
   (i -1) 6 +123) ,43
  (discard 30,~3
   (expr 1
-   (conv ~18,3
-    (u -1) ~12,3 val.0.tte5tld8n))) 19,19
+   (expr
+    (conv ~18,3
+     (u -1) ~12,3 val.0.tte5tld8n)))) 19,19
  (type :MyGeneric.1.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (i -1)) ~4,~4 . ~2,~4

--- a/tests/nimony/sysbasics/tconstarrlen.nif
+++ b/tests/nimony/sysbasics/tconstarrlen.nif
@@ -16,4 +16,26 @@
   (array 6
    (i -1)
    (rangetype
-    (i -1) +0 +99)) .))
+    (i -1) +0 +99)) .) ,7
+ (if 3
+  (elif 6
+   (eq 24,603,lib/std/system.nim
+    (i +64) 11,940,lib/std/system.nim
+    (expr
+     (expr ,~4
+      (expr
+       (expr 45,2
+        (add ~32,~335
+         (i +64) ~23
+         (sub 6,~48
+          (i -1) ~5
+          (conv 11,~48
+           (i -1) ~13
+           (conv
+            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +99)) 18
+          (conv ~12,~48
+           (i -1) ~13
+           (conv
+            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))))) 3 Len.0.tcoacwdbr) ~1,1
+   (stmts
+    (discard .)))))

--- a/tests/nimony/sysbasics/tconstarrlen.nim
+++ b/tests/nimony/sysbasics/tconstarrlen.nim
@@ -5,3 +5,5 @@ type
   FooArray = array[Len, int]
 
 var b: FooArray
+if b.len == Len:
+  discard


### PR DESCRIPTION
Implemented as template as opposed to `mLengthArray` magic, this means treating it as a constant value would need `+`/`-` and type conversions to be implemented in expreval.

Required bugfixes:

1. Template bodies use `commonType` on return type (result type of `+`/`-` is `(i +64)` not `(i -1)`)
2. Dot fields of typevars are always treated as nonexistant for UFCS to work
3. Type invocations from normal subscript expressions work properly, including invocations of magic types
4. `low`/`high` give proper return type