### PR TITLE
experiment: allow nimony compile projects outside compiler folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 nimcache/
 nimblecache/
 htmldocs/

--- a/src/gear2/bridge.nim
+++ b/src/gear2/bridge.nim
@@ -64,9 +64,9 @@ proc closeAll*(r: var RContext) =
 proc openNifModule*(r: var RContext; modname: string) =
   if r.modules.hasKey(modname): return
   if r.thisModule.len == 0: r.thisModule = modname
-  let filename = "nifcache/" & modname & ".nif"
+  let filename = modname & ".nif"
   r.modules[modname] = RModule(
-    index: readIndex("nifcache/" & modname & ".idx.nif"),
+    index: readIndex(modname & ".idx.nif"),
     s: nifstreams.open(filename)
   )
 

--- a/src/gear2/gear2.nim
+++ b/src/gear2/gear2.nim
@@ -15,8 +15,7 @@ proc moduleSuffix(conf: ConfigRef; fileIdx: FileIndex): string =
   moduleSuffix(toFullPath(conf, fileIdx))
 
 proc toNifFile(conf: ConfigRef; fileIdx: FileIndex): string =
-  let dest = moduleSuffix(toFullPath(conf, fileIdx))
-  result = "nifcache" / dest
+  result = moduleSuffix(toFullPath(conf, fileIdx))
 
 proc importPipelineModule2(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   # this is called by the semantic checking phase
@@ -181,12 +180,11 @@ proc commandCheck(graph: ModuleGraph) =
   elif conf.backend == backendJs:
     setTarget(conf.target, osJS, cpuJS)
   setPipeLinePass(graph, SemPass)
-  createDir "nifcache"
   let module = compilePipelineProject2(graph)
   when defined(debug):
     echo renderTree(module.ast)
   #let dest = moduleSuffix(toFullPath(conf, module.fileIdx))
-  #toNif(conf, module.ast, "nifcache" / dest.addFileExt".nif")
+  #toNif(conf, module.ast, dest.addFileExt".nif")
 
 proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
   var p = parseopt.initOptParser(cmd)

--- a/src/nifc/nifc.nim
+++ b/src/nifc/nifc.nim
@@ -79,7 +79,6 @@ proc handleCmdLine() =
     s.config.cCompiler = ccCLang
   else:
     s.config.cCompiler = ccGcc
-  s.config.nifcacheDir = "nifcache"
 
   for kind, key, val in getopt():
     case kind
@@ -153,7 +152,8 @@ proc handleCmdLine() =
       else: writeHelp()
     of cmdEnd: assert false, "cannot happen"
 
-  createDir(s.config.nifcacheDir)
+  if len(s.config.nifcacheDir) > 0:
+    createDir(s.config.nifcacheDir)
   if actionTable.len != 0:
     for action in actionTable.keys:
       case action

--- a/src/nimony/nimsem.nim
+++ b/src/nimony/nimsem.nim
@@ -56,8 +56,7 @@ proc handleCmdLine() =
   var useEnv = true
   var moduleFlags: set[ModuleFlag] = {}
   var config = NifConfig()
-  # XXX: harcoded relative nifcache path for now
-  config.nifcachePath = toAbsolutePath("nifcache")
+  config.nifcachePath = getCurrentDir()
   config.defines.incl "nimony"
   config.bits = sizeof(int)*8
   var commandLineArgs = ""
@@ -105,11 +104,15 @@ proc handleCmdLine() =
     of cmdEnd: assert false, "cannot happen"
   if args.len != 3:
     quit "want exactly 3 command line arguments"
+
   if useEnv:
     let nimPath = getEnv("NIMPATH")
     for entry in split(nimPath, PathSep):
       if entry.strip != "":
         config.paths.add entry
+  # fundamental compiler path
+  config.paths.add compilerDir()
+
   case cmd
   of None:
     quit "command missing"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -5040,18 +5040,14 @@ proc semPragmaLine(c: var SemContext; it: var Item; info: PackedLineInfo) =
     if args.len != 2 and args.len != 3:
       buildErr c, it.n.info, "build expected 2 or 3 parameters"
 
-    # XXX: makefile is executed parent to nifcachePath
-    let nifcacheDir = absoluteParentDir(c.g.config.nifcachePath)
-    let currentDir = absoluteParentDir(info.getFile)
-
-    # Extract build pragma arguments
     let compileType = args[0]
+    let currentDir = absoluteParentDir(info.getFile)
     var name = replaceSubs(args[1], currentDir, c.g.config).toAbsolutePath(currentDir)
     let customArgs = if args.len == 3: replaceSubs(args[2], currentDir, c.g.config) else: ""
 
     if not fileExists2(name):
       buildErr c, it.n.info, "cannot find: " & name
-    name = name.toRelativePath(nifcacheDir)
+    name = name.toRelativePath(c.g.config.nifcachePath)
 
     c.toBuild.buildTree TupleConstrX, info:
       c.toBuild.addStrLit compileType, info

--- a/tests/nimony/errmsgs/tbadconverter.msgs
+++ b/tests/nimony/errmsgs/tbadconverter.msgs
@@ -1,3 +1,3 @@
-tests/nimony/errmsgs/tbadconverter.nim(1, 1) Error: cannot attach converter to type (err Foo "undeclared identifier")
-tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier
-tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier
+../tests/nimony/errmsgs/tbadconverter.nim(1, 1) Error: cannot attach converter to type (err Foo "undeclared identifier")
+../tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier
+../tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier

--- a/tests/nimony/errmsgs/tdot.msgs
+++ b/tests/nimony/errmsgs/tdot.msgs
@@ -1,2 +1,2 @@
-tests/nimony/errmsgs/tdot.nim(2, 12) Error: undeclared field: 'foo' for type (i -1)
-tests/nimony/errmsgs/tdot.nim(5, 12) Error: undeclared field: 'bar' for type (i -1)
+../tests/nimony/errmsgs/tdot.nim(2, 12) Error: undeclared field: 'foo' for type (i -1)
+../tests/nimony/errmsgs/tdot.nim(5, 12) Error: undeclared field: 'bar' for type (i -1)

--- a/tests/nimony/errmsgs/twrongsetelem.msgs
+++ b/tests/nimony/errmsgs/twrongsetelem.msgs
@@ -1,2 +1,2 @@
-tests/nimony/errmsgs/twrongsetelem.nim(1, 10) Error: set element type must be ordinal
-tests/nimony/errmsgs/twrongsetelem.nim(2, 10) Error: type (u +64) is too large to be a set element type
+../tests/nimony/errmsgs/twrongsetelem.nim(1, 10) Error: set element type must be ordinal
+../tests/nimony/errmsgs/twrongsetelem.nim(2, 10) Error: type (u +64) is too large to be a set element type

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,4 +1,4 @@
-tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.tfis16ujj
-tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.tfis16ujj
+../tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
+../tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
+../tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.tfis16ujj
+../tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.tfis16ujj

--- a/tests/nimony/nosystem/t2.nif
+++ b/tests/nimony/nosystem/t2.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/t2.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/t2.nim(stmts 2,1
  (type :int.0.t2er4ggt1
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tbinarytree.nif
+++ b/tests/nimony/nosystem/tbinarytree.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/tbinarytree.nim(stmts 5
+0,1,../tests/nimony/nosystem/tbinarytree.nim(stmts 5
  (type :int.0.tbimvo1d9
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tbool.nif
+++ b/tests/nimony/nosystem/tbool.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/tbool.nim(stmts 26
+0,1,../tests/nimony/nosystem/tbool.nim(stmts 26
  (type ~21 :bool.0.tbokvwxm9
   (bool) . ~16
   (pragmas 2

--- a/tests/nimony/nosystem/tcase_overlap.msgs
+++ b/tests/nimony/nosystem/tcase_overlap.msgs
@@ -1,1 +1,1 @@
-tests/nimony/nosystem/tcase_overlap.nim(32, 12) Error: value already handled
+../tests/nimony/nosystem/tcase_overlap.nim(32, 12) Error: value already handled

--- a/tests/nimony/nosystem/tcstring.nif
+++ b/tests/nimony/nosystem/tcstring.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/tcstring.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/tcstring.nim(stmts 2,1
  (type :int.0.tcsj45p9m
   (i -1) . 5
   (pragmas 2
@@ -60,5 +60,5 @@
    (suf "abc" "R"))) 4,20
  (var :zz.0.tcsj45p9m . . 4
   (cstring)
-  (hconv 8,22,tests/nimony/nosystem/tcstring.nim
-   (cstring) 18,22,tests/nimony/nosystem/tcstring.nim "xzy")))
+  (hconv 8,22,../tests/nimony/nosystem/tcstring.nim
+   (cstring) 18,22,../tests/nimony/nosystem/tcstring.nim "xzy")))

--- a/tests/nimony/nosystem/tdefinedarg.nif
+++ b/tests/nimony/nosystem/tdefinedarg.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/tdefinedarg.nim(stmts 5
+0,1,../tests/nimony/nosystem/tdefinedarg.nim(stmts 5
  (type :untyped.0.tdej0g1hh1
   (untyped) . 9
   (pragmas 2

--- a/tests/nimony/nosystem/tdistinct.nif
+++ b/tests/nimony/nosystem/tdistinct.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/tdistinct.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/tdistinct.nim(stmts 2,1
  (type :int.0.tdiuhv8dm
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tenumsizes.nif
+++ b/tests/nimony/nosystem/tenumsizes.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,3,tests/nimony/nosystem/tenumsizes.nim(stmts 7
+0,3,../tests/nimony/nosystem/tenumsizes.nim(stmts 7
  (type ~2 :A.0.tene657oj . . . 2
   (enum
    (u +8) ~7,1

--- a/tests/nimony/nosystem/tfib2.nif
+++ b/tests/nimony/nosystem/tfib2.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/tfib2.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/tfib2.nim(stmts 2,1
  (type :int.0.tfitjdpcx
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tforloop.nif
+++ b/tests/nimony/nosystem/tforloop.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/tforloop.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/tforloop.nim(stmts 2,1
  (type :int.0.tfov349y21
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/tgeneric_obj.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/tgeneric_obj.nim(stmts 2,1
  (type :int.0.tge7jvqqk1
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/tgenericbinarytree.nim(stmts 5
+0,1,../tests/nimony/nosystem/tgenericbinarytree.nim(stmts 5
  (type :int.0.tge70unlm
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tholeyenum.msgs
+++ b/tests/nimony/nosystem/tholeyenum.msgs
@@ -1,1 +1,1 @@
-tests/nimony/nosystem/tholeyenum.nim(15, 14) Error: invalid array index type: HoleyEnum.0.thobkwvgz
+../tests/nimony/nosystem/tholeyenum.nim(15, 14) Error: invalid array index type: HoleyEnum.0.thobkwvgz

--- a/tests/nimony/nosystem/timportfromexcept.nif
+++ b/tests/nimony/nosystem/timportfromexcept.nif
@@ -1,7 +1,7 @@
 (.nif24)
-0,1,tests/nimony/nosystem/timportfromexcept.nim(stmts 4,4
+0,1,../tests/nimony/nosystem/timportfromexcept.nim(stmts 4,4
  (let :allImported.0.timhjtr28 . .
-  (array 15,3,tests/nimony/nosystem/deps/modexcept.nim
+  (array 15,3,../tests/nimony/nosystem/deps/modexcept.nim
    (i -1)
    (rangetype
     (i -1) +0 +2)) 14

--- a/tests/nimony/nosystem/timportfromexcept.nif
+++ b/tests/nimony/nosystem/timportfromexcept.nif
@@ -6,7 +6,7 @@
    (rangetype
     (i -1) +0 +2)) 14
   (arr ~14
-   (array 15,3,tests/nimony/nosystem/deps/modexcept.nim
+   (array 15,3,../tests/nimony/nosystem/deps/modexcept.nim
     (i -1)
     (rangetype
      (i -1) +0 +2)) 1 exceptB.0.modvx9hpf 10 fromA.0.modepjal 17 fromC.0.modepjal)) 4,5

--- a/tests/nimony/nosystem/tinclude.msgs
+++ b/tests/nimony/nosystem/tinclude.msgs
@@ -1,1 +1,1 @@
-tests/nimony/nosystem/deps/includeb.nim(2, 1) Error: recursive include: tests/nimony/nosystem/deps/includea.nim -> tests/nimony/nosystem/deps/includeb.nim -> tests/nimony/nosystem/deps/includea.nim
+../tests/nimony/nosystem/deps/includeb.nim(2, 1) Error: recursive include: ../tests/nimony/nosystem/deps/includea.nim -> ../tests/nimony/nosystem/deps/includeb.nim -> ../tests/nimony/nosystem/deps/includea.nim

--- a/tests/nimony/nosystem/trefobject.nif
+++ b/tests/nimony/nosystem/trefobject.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/trefobject.nim(stmts 5
+0,1,../tests/nimony/nosystem/trefobject.nim(stmts 5
  (type :int.0.trerqi4zu
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tresemtype.nif
+++ b/tests/nimony/nosystem/tresemtype.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,3,tests/nimony/nosystem/tresemtype.nim(stmts
+0,3,../tests/nimony/nosystem/tresemtype.nim(stmts
  (proc 5 :foo.0.treckpe1i1 . . 8
   (typevars 1
    (typevar :T.0.treckpe1i1 . . . .)) 11

--- a/tests/nimony/nosystem/tsetter.nif
+++ b/tests/nimony/nosystem/tsetter.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/tsetter.nim(stmts 5
+0,1,../tests/nimony/nosystem/tsetter.nim(stmts 5
  (type :int.0.tseyic8ua1
   (i -1) . 4
   (pragmas 2

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/ttemplate.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/ttemplate.nim(stmts 2,1
  (type :int.0.tte5tld8n
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/tundeclaredarg.msgs
+++ b/tests/nimony/nosystem/tundeclaredarg.msgs
@@ -1,1 +1,1 @@
-tests/nimony/nosystem/tundeclaredarg.nim(5, 4) Error: undeclared identifier
+../tests/nimony/nosystem/tundeclaredarg.nim(5, 4) Error: undeclared identifier

--- a/tests/nimony/nosystem/tvarargs.nif
+++ b/tests/nimony/nosystem/tvarargs.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,2,tests/nimony/nosystem/tvarargs.nim(stmts 2,1
+0,2,../tests/nimony/nosystem/tvarargs.nim(stmts 2,1
  (type :int.0.tvah6culb
   (i -1) . 5
   (pragmas 2

--- a/tests/nimony/nosystem/twhen.nif
+++ b/tests/nimony/nosystem/twhen.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/nosystem/twhen.nim(stmts 2,3
+0,1,../tests/nimony/nosystem/twhen.nim(stmts 2,3
  (stmts
   (discard 8 "good")) 2,10
  (stmts

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -152,19 +152,19 @@
     (dot ~1 x.1 a.0.tbawx6nu81 +0)))) 4,42
  (var :a.1.tbawx6nu81 . . 12,~3 Foo1314.0.tbawx6nu81 11
   (obj 1,~3 Foo1314.0.tbawx6nu81
-   (kv a.0.tbawx6nu81 52,841,lib/std/system.nim
+   (kv a.0.tbawx6nu81 52,841,../lib/std/system.nim
     (expr
      (expr +0)))
-   (kv b.0.tbawx6nu81 52,841,lib/std/system.nim
+   (kv b.0.tbawx6nu81 52,841,../lib/std/system.nim
     (expr
      (expr +0)))
-   (kv c.0.tbawx6nu81 52,841,lib/std/system.nim
+   (kv c.0.tbawx6nu81 52,841,../lib/std/system.nim
     (expr
      (expr +0)))
-   (kv d.0.tbawx6nu81 52,841,lib/std/system.nim
+   (kv d.0.tbawx6nu81 52,841,../lib/std/system.nim
     (expr
      (expr +0)))
-   (kv e.0.tbawx6nu81 52,841,lib/std/system.nim
+   (kv e.0.tbawx6nu81 52,841,../lib/std/system.nim
     (expr
      (expr +0))))) 7,43
  (call ~7 foo1314.0.tbawx6nu81 1 a.1.tbawx6nu81))

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tbasics.nim(stmts 8,1
+0,1,../tests/nimony/sysbasics/tbasics.nim(stmts 8,1
  (type ~6 :Array.0.tbawx6nu81 . . . 7
   (array 4
    (i -1)

--- a/tests/nimony/sysbasics/tconstarrlen.nif
+++ b/tests/nimony/sysbasics/tconstarrlen.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tconstarrlen.nim(stmts 6
+0,1,../tests/nimony/sysbasics/tconstarrlen.nim(stmts 6
  (const :Len.0.tcoacwdbr . .
   (i -1) 6 +100) 4,1
  (var :a.0.tcoacwdbr . . 8
@@ -19,8 +19,8 @@
     (i -1) +0 +99)) .) ,7
  (if 3
   (elif 6
-   (eq 24,603,lib/std/system.nim
-    (i +64) 11,940,lib/std/system.nim
+   (eq 24,603,../lib/std/system.nim
+    (i +64) 11,940,../lib/std/system.nim
     (expr
      (expr ,~4
       (expr
@@ -32,10 +32,10 @@
           (conv 11,~48
            (i -1) ~13
            (conv
-            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +99)) 18
+            (i -1) 12,2,../tests/nimony/sysbasics/tconstarrlen.nim +99)) 18
           (conv ~12,~48
            (i -1) ~13
            (conv
-            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))))) 3 Len.0.tcoacwdbr) ~1,1
+            (i -1) 12,2,../tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))))) 3 Len.0.tcoacwdbr) ~1,1
    (stmts
     (discard .)))))

--- a/tests/nimony/sysbasics/tderefs.msgs
+++ b/tests/nimony/sysbasics/tderefs.msgs
@@ -1,1 +1,1 @@
-tests/nimony/sysbasics/tderefs.nim(2, 1) Error: cannot mutate expression x.0.tdex3tcd51
+../tests/nimony/sysbasics/tderefs.nim(2, 1) Error: cannot mutate expression x.0.tdex3tcd51

--- a/tests/nimony/sysbasics/tderefs1.msgs
+++ b/tests/nimony/sysbasics/tderefs1.msgs
@@ -1,1 +1,1 @@
-tests/nimony/sysbasics/tderefs1.nim(7, 8) Error: cannot pass $1 to var/out T parameter
+../tests/nimony/sysbasics/tderefs1.nim(7, 8) Error: cannot pass $1 to var/out T parameter

--- a/tests/nimony/sysbasics/tderefs2.nif
+++ b/tests/nimony/sysbasics/tderefs2.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tderefs2.nim(stmts
+0,1,../tests/nimony/sysbasics/tderefs2.nim(stmts
  (proc 5 :g.0.tdexr7cz81 . . . 6
   (params 1
    (param :x.0 . . 3

--- a/tests/nimony/sysbasics/tdollar.nif
+++ b/tests/nimony/sysbasics/tdollar.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tdollar.nim(stmts 9,1
+0,1,../tests/nimony/sysbasics/tdollar.nim(stmts 9,1
  (type ~7 :Color1.0.tdoqc0e0v . . . 2
   (enum
    (u +8) ~7,1

--- a/tests/nimony/sysbasics/temits.nif
+++ b/tests/nimony/sysbasics/temits.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/temits.nim(stmts 2
+0,1,../tests/nimony/sysbasics/temits.nim(stmts 2
  (emit 6 "int s = 12;") ,2
  (proc 5 :foo.0.temqwhg6j . . . 9
   (params) . . . 2,1

--- a/tests/nimony/sysbasics/tforloops.nif
+++ b/tests/nimony/sysbasics/tforloops.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tforloops.nim(stmts 4
+0,1,../tests/nimony/sysbasics/tforloops.nim(stmts 4
  (var :globalX.0.tfo6zftzj1 . .
   (i -1) 10 +12) ,2
  (iterator 9 :foo.0.tfo6zftzj1 . . . 12

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tforloops1.nim(stmts
+0,1,../tests/nimony/sysbasics/tforloops1.nim(stmts
  (iterator 9 :powers.0.tfo6yv57p . . . 15
   (params 1
    (param :n.0 . . 3
@@ -17,7 +17,7 @@
       (mul
        (i -1) ~1 i.0 1 i.0)) ,2
      (yld 9
-      (mul 20,279,lib/std/system.nim
+      (mul 20,279,../lib/std/system.nim
        (i +64) ~2
        (mul
         (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
@@ -75,10 +75,10 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 11,830,lib/std/system.nim
+    (elif 11,830,../lib/std/system.nim
      (expr 2,1
       (lt
-       (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.1)) ~1,1
+       (i -1) 9,26,../tests/nimony/sysbasics/tforloops1.nim +5 5,26,../tests/nimony/sysbasics/tforloops1.nim x.1)) ~1,1
      (stmts
       (break .))) 5,2
     (elif 2
@@ -121,7 +121,7 @@
       (mul ~1,~9
        (i -1) ~1 i.4 1 i.4)) ,2
      (yld 9
-      (mul 20,279,lib/std/system.nim
+      (mul 20,279,../lib/std/system.nim
        (i +64) ~2
        (mul ~1,~10
         (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,43
@@ -171,20 +171,20 @@
        (cstring) "Hello, world\3A %ld\0A") 25
       (add ~25,~6
        (i -1) ~1 m.2 1 n.3)))))) 4,20
- (proc :inc.0.tfo6yv57p . 5,551,lib/std/system.nim .
+ (proc :inc.0.tfo6yv57p . 5,551,../lib/std/system.nim .
   (at inc.1.sys9azlf 19,~4
-   (i -1)) 26,551,lib/std/system.nim
+   (i -1)) 26,551,../lib/std/system.nim
   (params 1
    (param :x.2 . . 3
-    (mut 23,17,tests/nimony/sysbasics/tforloops1.nim
-     (i -1)) .)) 5,551,lib/std/system.nim . 37,551,lib/std/system.nim
+    (mut 23,17,../tests/nimony/sysbasics/tforloops1.nim
+     (i -1)) .)) 5,551,../lib/std/system.nim . 37,551,../lib/std/system.nim
   (pragmas 2
-   (inline)) 5,551,lib/std/system.nim . 7,553,lib/std/system.nim
+   (inline)) 5,551,../lib/std/system.nim . 7,553,../lib/std/system.nim
   (stmts 2
    (asgn ~2
     (hderef x.2) 4
-    (add 23,17,tests/nimony/sysbasics/tforloops1.nim
+    (add 23,17,../tests/nimony/sysbasics/tforloops1.nim
      (i -1) ~2
      (hderef x.2) 3
-     (conv 23,17,tests/nimony/sysbasics/tforloops1.nim
+     (conv 23,17,../tests/nimony/sysbasics/tforloops1.nim
       (i -1) 1 +1))))))

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/thooks.nim(stmts 15,1
+0,1,../tests/nimony/sysbasics/thooks.nim(stmts 15,1
  (type ~13 :MyObjectBase.0.tho8gh7q4 . . . 2
   (object . ~13,1
    (fld :x.0.tho8gh7q4 . . 6

--- a/tests/nimony/sysbasics/tintlitmatch.nif
+++ b/tests/nimony/sysbasics/tintlitmatch.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tintlitmatch.nim(stmts
+0,1,../tests/nimony/sysbasics/tintlitmatch.nim(stmts
  (proc 5 :foo.0.tin4pj0od1 . . . 8
   (params 1
    (param :x.0 . . 3
@@ -38,19 +38,19 @@
  (discard 10
   (eq ~3,~4
    (i +32) ~2
-   (hconv 22,685,lib/std/system.nim
+   (hconv 22,685,../lib/std/system.nim
     (i +64) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
  (discard 10
   (eq ~3,~4
    (i -1) ~2 y.0.tin4pj0od1 6
-   (hconv 22,685,lib/std/system.nim
+   (hconv 22,685,../lib/std/system.nim
     (i +64)
     (conv 1
      (i +32) ~3 +123)))) ,15
  (discard 18
   (eq ~1,~1
    (i +32) ~7
-   (hconv 22,685,lib/std/system.nim
+   (hconv 22,685,../lib/std/system.nim
     (i +64)
     (conv 6,~1
      (i +32) ~3 +123)) 3 y.0.tin4pj0od1)) ,16
@@ -73,17 +73,17 @@
    (i +32) ~7
    (conv 6,~6
     (i +32) ~3 +123) 3
-   (hconv 22,683,lib/std/system.nim
+   (hconv 22,683,../lib/std/system.nim
     (i +32) +123))) ,21
  (discard 12
   (eq
    (i -1) ~4
-   (hconv 22,683,lib/std/system.nim
+   (hconv 22,683,../lib/std/system.nim
     (i +32) +123) 6
    (conv ~1,~7
     (i +32) ~3 +123))) ,22
  (discard 10
   (eq ~3,~13
    (i +32) ~2 x.0.tin4pj0od1 3
-   (hconv 22,683,lib/std/system.nim
+   (hconv 22,683,../lib/std/system.nim
     (i +32) +123))))

--- a/tests/nimony/sysbasics/tresultnoinit.nif
+++ b/tests/nimony/sysbasics/tresultnoinit.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tresultnoinit.nim(stmts
+0,1,../tests/nimony/sysbasics/tresultnoinit.nim(stmts
  (proc 5 :foo.0.tremd49gb1 . . . 8
   (params) 4
   (i -1) 16

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tsets.nim(stmts 9
+0,1,../tests/nimony/sysbasics/tsets.nim(stmts 9
  (type ~4 :Foo.0.tsefy5wha . . . 2
   (enum
    (u +8) ~9,1

--- a/tests/nimony/tunpack.nif
+++ b/tests/nimony/tunpack.nif
@@ -1,5 +1,5 @@
 (.nif24)
-,2,tests/nimony/tunpack.nim(stmts 2,1
+,2,../tests/nimony/tunpack.nim(stmts 2,1
  (type :int.0.tun857qmo1 
   (i -1) . 5
   (pragmas 2


### PR DESCRIPTION
- remove hardcoded nifcache path prefixes
- make nimony be able compile projects outside compiler folder
- allow locate a custom nifcache path using a `--nifcache:PATH` command line argument (`nimony` only)
- makefiles, nif files, and c files have paths relative to nifcache folder (ideal for tests)

this is an experiment so i don't think this would be a proper solution right now, at least this experiment could be useful to a proper implementation of this in a future.