### PR TITLE
attempt to clean up some errors, separate type kind for error types

### DIFF
--- a/src/hexer/lifter.nim
+++ b/src/hexer/lifter.nim
@@ -120,7 +120,7 @@ proc isTrivial*(c: var LiftingCtx; typ: TypeCursor): bool =
     var tup = typ
     inc tup
     result = isTrivialForFields(c, tup)
-  of NoType, NilT, OrT, AndT, NotT, ConceptT, DistinctT, StaticT, IterT, InvokeT,
+  of NoType, ErrorType, NilT, OrT, AndT, NotT, ConceptT, DistinctT, StaticT, IterT, InvokeT,
      TypeKindT, UntypedT, TypedT:
     raiseAssert "bug here"
 

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -369,7 +369,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
       error e, "could not find symbol: " & pool.syms[s]
   of ParLe:
     case c.typeKind
-    of NoType, OrT, AndT, NotT, TypedescT, UntypedT, TypedT, TypeKindT, OrdinalT:
+    of NoType, ErrorType, OrT, AndT, NotT, TypedescT, UntypedT, TypedT, TypeKindT, OrdinalT:
       error e, "type expected but got: ", c
     of IntT, UIntT, FloatT, CharT, BoolT, AutoT, SymKindT:
       e.loop c:

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -170,6 +170,7 @@ type
 
   TypeKind* = enum
     NoType
+    ErrorType = "err"
     ObjectT = "object"
     RefObjectT = "refobj"
     PtrObjectT = "ptrobj"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3188,7 +3188,8 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
         c.converters.mgetOrPut(root, @[]).add(symId)
         if c.dest[beforeExportMarker].kind != DotToken:
           # exported
-          if c.dest[beforeGenericParams].kind != $InvokeT:
+          if not (c.dest[beforeGenericParams].kind == ParLe and
+              pool.tags[c.dest[beforeGenericParams].tagId] == $InvokeT):
             # don't register instances
             c.converterIndexMap.add((root, symId))
     if it.n.kind != DotToken:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -682,7 +682,7 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
         skip f
       else:
         procTypeMatch m, f, a
-    of NoType, ObjectT, RefObjectT, PtrObjectT, EnumT, HoleyEnumT, VoidT, OutT, LentT, SinkT, NilT, OrT, AndT, NotT,
+    of NoType, ErrorType, ObjectT, RefObjectT, PtrObjectT, EnumT, HoleyEnumT, VoidT, OutT, LentT, SinkT, NilT, OrT, AndT, NotT,
         ConceptT, DistinctT, StaticT, IterT, AutoT, SymKindT, TypeKindT, OrdinalT:
       m.error UnhandledTypeBug, f, f
   else:

--- a/src/nimony/sizeof.nim
+++ b/src/nimony/sizeof.nim
@@ -145,7 +145,7 @@ proc getSize(c: var SizeofValue; cache: var Table[SymId, SizeofValue]; n: Cursor
     update c, ptrSize*2, ptrSize
   of RangeT:
     getSize c, cache, n.firstSon, ptrSize
-  of NoType, VoidT, VarargsT, OrT, AndT, NotT,
+  of NoType, ErrorType, VoidT, VarargsT, OrT, AndT, NotT,
      ConceptT, StaticT, IterT, InvokeT, UncheckedArrayT,
      AutoT, SymKindT, TypeKindT, TypedescT, UntypedT, TypedT, OrdinalT:
     raiseAssert "BUG: valid type kind for sizeof computation: " & $n.typeKind

--- a/tests/nimony/errmsgs/tbadconverter.msgs
+++ b/tests/nimony/errmsgs/tbadconverter.msgs
@@ -1,0 +1,3 @@
+tests/nimony/errmsgs/tbadconverter.nim(1, 1) Error: cannot attach converter to type (err Foo "undeclared identifier")
+tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier
+tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier

--- a/tests/nimony/errmsgs/tbadconverter.nim
+++ b/tests/nimony/errmsgs/tbadconverter.nim
@@ -1,0 +1,1 @@
+converter toFoo(x: int): Foo = discard


### PR DESCRIPTION
Previously the test code would crash from a `wantParRi` due to multiple error nodes being generated

Converters are refactored to register as soon as possible to not generate multiple errors, second `undeclared identifier` error is due to the `(result)` variable type, maybe we can "hide" reuses of error tokens like this somehow.

`declareSym` refactor should also fix quoted ident definitions that aren't procs