### PR TITLE
implement int literal matching

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -488,7 +488,7 @@ proc checkIntLitRange(context: ptr SemContext; f: Cursor; intLit: Cursor): bool 
   if f.typeKind == FloatT:
     result = true
   else:
-    let i = createXint(pool.integers[intLit.litId])
+    let i = createXint(pool.integers[intLit.intId])
     result = i >= firstOrd(context[], f) and i <= lastOrd(context[], f)
 
 proc matchIntegralType(m: var Match; f: var Cursor; arg: Item) =

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -484,19 +484,19 @@ proc cmpTypeBits(context: ptr SemContext; f, a: Cursor): int =
   else:
     result = -1
 
-proc inTypeRange(context: ptr SemContext; f: Cursor; val: int64): bool =
+proc checkIntLitRange(context: ptr SemContext; f: Cursor; intLit: Cursor): bool =
   if f.typeKind == FloatT:
     result = true
   else:
-    let i = createXint(val)
+    let i = createXint(pool.integers[intLit.litId])
     result = i >= firstOrd(context[], f) and i <= lastOrd(context[], f)
 
 proc matchIntegralType(m: var Match; f: var Cursor; arg: Item) =
   var a = skipModifier(arg.typ)
-  let isLiteral = f.typeKind != CharT and
+  let isIntLit = f.typeKind != CharT and
     arg.n.kind == IntLit and sameTrees(a, m.context.types.intType)
-  let sameTag = f.tag == a.tag
-  if sameTag or isLiteral:
+  let sameKind = f.tag == a.tag
+  if sameKind or isIntLit:
     inc a
   else:
     m.error InvalidMatch, f, a
@@ -504,9 +504,9 @@ proc matchIntegralType(m: var Match; f: var Cursor; arg: Item) =
   let forig = f
   inc f
   let cmp = cmpTypeBits(m.context, f, a)
-  if cmp == 0 and sameTag:
+  if cmp == 0 and sameKind:
     discard "same types"
-  elif cmp > 0 or (isLiteral and inTypeRange(m.context, forig, pool.integers[arg.n.intId])):
+  elif cmp > 0 or (isIntLit and checkIntLitRange(m.context, forig, arg.n)):
     # f has more bits than a, great!
     if m.skippedMod in {MutT, OutT}:
       m.error ImplicitConversionNotMutable, forig, forig

--- a/tests/nimony/sysbasics/tintlitmatch.nim
+++ b/tests/nimony/sysbasics/tintlitmatch.nim
@@ -1,0 +1,7 @@
+proc foo(x: int16) = discard
+proc bar(x: float) = discard
+foo(123)
+bar(123)
+proc baz(x: int16) = discard
+proc baz(x: int) = discard
+baz(123)


### PR DESCRIPTION
Always considered a conversion match unless the original type is `int`/the equivalent sized int type.

The code is structured like this to prevent writing the conversion branch twice, not sure if it's inefficient