### PR TITLE
add separate int conv matches

### DIFF
--- a/tests/nimony/sysbasics/tintlitmatch.nif
+++ b/tests/nimony/sysbasics/tintlitmatch.nif
@@ -1,0 +1,89 @@
+(.nif24)
+0,1,tests/nimony/sysbasics/tintlitmatch.nim(stmts
+ (proc 5 :foo.0.tin4pj0od1 . . . 8
+  (params 1
+   (param :x.0 . . 3
+    (i +16) .)) . . . 21
+  (stmts
+   (discard .))) ,1
+ (proc 5 :bar.0.tin4pj0od1 . . . 8
+  (params 1
+   (param :x.1 . . 3
+    (f +64) .)) . . . 21
+  (stmts
+   (discard .))) 3,2
+ (call ~3 foo.0.tin4pj0od1 1
+  (hconv 8,~2
+   (i +16) +123)) 3,3
+ (call ~3 bar.0.tin4pj0od1 1
+  (hconv 8,~2
+   (f +64) +123)) ,4
+ (proc 5 :baz.0.tin4pj0od1 . . . 8
+  (params 1
+   (param :x.2 . . 3
+    (i +16) .)) . . . 21
+  (stmts
+   (discard .))) ,5
+ (proc 5 :baz.1.tin4pj0od1 . . . 8
+  (params 1
+   (param :x.3 . . 3
+    (i -1) .)) . . . 19
+  (stmts
+   (discard .))) 3,6
+ (call ~3 baz.1.tin4pj0od1 1 +123) 4,9
+ (var :x.0.tin4pj0od1 . . 3
+  (i +32) .) 4,10
+ (var :y.0.tin4pj0od1 . . 3
+  (i -1) .) ,13
+ (discard 10
+  (eq ~3,~4
+   (i +32) ~2
+   (hconv 22,685,lib/std/system.nim
+    (i +64) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
+ (discard 10
+  (eq ~3,~4
+   (i -1) ~2 y.0.tin4pj0od1 6
+   (hconv 22,685,lib/std/system.nim
+    (i +64)
+    (conv 1
+     (i +32) ~3 +123)))) ,15
+ (discard 18
+  (eq ~1,~1
+   (i +32) ~7
+   (hconv 22,685,lib/std/system.nim
+    (i +64)
+    (conv 6,~1
+     (i +32) ~3 +123)) 3 y.0.tin4pj0od1)) ,16
+ (discard 16
+  (eq ~4
+   (i -1) ~5
+   (conv 1
+    (i -1) ~3 +123) 6
+   (conv ~10
+    (i -1) ~3 +123))) ,17
+ (discard 18
+  (eq ~1,~3
+   (i +32) ~7
+   (conv 6,~3
+    (i +32) ~3 +123) 6
+   (conv ~7,~3
+    (i +32) ~3 +123))) ,20
+ (discard 18
+  (eq ~1,~6
+   (i +32) ~7
+   (conv 6,~6
+    (i +32) ~3 +123) 3
+   (hconv 22,683,lib/std/system.nim
+    (i +32) +123))) ,21
+ (discard 12
+  (eq
+   (i -1) ~4
+   (hconv 22,683,lib/std/system.nim
+    (i +32) +123) 6
+   (conv ~1,~7
+    (i +32) ~3 +123))) ,22
+ (discard 10
+  (eq ~3,~13
+   (i +32) ~2 x.0.tin4pj0od1 3
+   (hconv 22,683,lib/std/system.nim
+    (i +32) +123))))

--- a/tests/nimony/sysbasics/tintlitmatch.nim
+++ b/tests/nimony/sysbasics/tintlitmatch.nim
@@ -5,3 +5,19 @@ bar(123)
 proc baz(x: int16) = discard
 proc baz(x: int) = discard
 baz(123)
+
+# issue #477
+var x: int32
+var y: int
+
+# Following code compiles without errors.
+discard x == y
+discard y == 123.int32
+discard 123.int32 == y
+discard 123.int == 123.int
+discard 123.int32 == 123.int32
+
+# Following code causes compile error: "Error: ambiguous call"
+discard 123.int32 == 123
+discard 123 == 123.int32
+discard x == 123


### PR DESCRIPTION
fixes #477

Supposed to match the old compiler, which reuses `intConvCosts` instead of separate `intLitCosts`. `intConvCosts` seems to mostly exist so a `int32` matches `int` better than `float`. Could rename `intLitCosts` to `literalCosts` if it makes sense to generalize it.

The order of `cmpMatches` had to be reversed into checking the most expensive conversions first, unlike the order in the old compiler `cmpCandidates` because the `equalMatches`/`convMatches` etc in the old compiler complement/are negatives of the costs.