### PR TITLE
separate typed and untyped array/set literals, make case always use `ranges`

### DIFF
--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -276,7 +276,7 @@ proc genSetConstr(c: var Context; dest: var TokenBuf; n: var Cursor) =
     skip n
   else:
     dest.addParLe(AconstrX, info)
-    #trSetType(c, dest, typ)
+    trSetType(c, dest, typ)
     for b in bytes:
       dest.addUintLit(b, info)
 

--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -640,7 +640,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
       trStmtListExpr c, n, e
     of EnsureMoveX:
       trEnsureMove c, n, e
-    of AconstrX, TupleConstrX:
+    of AconstrX, TupleConstrX, BracketX, CurlyX:
       trRawConstructor c, n, e
     of NilX, FalseX, TrueX, AndX, OrX, NotX, NegX, SizeofX, SetX,
        OchoiceX, CchoiceX, KvX,

--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -640,7 +640,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
       trStmtListExpr c, n, e
     of EnsureMoveX:
       trEnsureMove c, n, e
-    of AconstrX, TupleConstrX, BracketX, CurlyX:
+    of AconstrX, TupleConstrX:
       trRawConstructor c, n, e
     of NilX, FalseX, TrueX, AndX, OrX, NotX, NegX, SizeofX, SetX,
        OchoiceX, CchoiceX, KvX,
@@ -650,7 +650,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
        DefinedX, HighX, LowX, TypeofX, UnpackX, EnumToStrX, IsMainModuleX, QuotedX,
        DerefX, HderefX, AddrX, HaddrX:
       trSons c, n, WantNonOwner
-    of DefaultObjX, DefaultTupX:
+    of DefaultObjX, DefaultTupX, BracketX, CurlyX:
       raiseAssert "nodekind should have been eliminated in sem.nim"
     of NoExpr:
       case n.stmtKind

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -858,9 +858,8 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         skipParRi(e, c)
       of AconstrX:
         e.dest.add tagToken("aconstr", c.info)
-        var arrayType = e.typeCache.getType(c)
         inc c
-        e.traverseType(arrayType, {})
+        traverseType(e, c)
         inc nested
       of OconstrX:
         e.dest.add tagToken("oconstr", c.info)
@@ -950,7 +949,7 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
           e.dest.addParRi()
           traverseExpr e, c
         wantParRi e, c
-      of NewOconstrX, SetX, PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardSetX:
+      of NewOconstrX, SetX, PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardSetX, BracketX, CurlyX:
         error e, "BUG: not eliminated: ", c
       else:
         e.dest.add c
@@ -1117,7 +1116,7 @@ proc traverseCase(e: var EContext; c: var Cursor) =
     of OfS:
       e.dest.add c
       inc c
-      if c.kind == ParLe and pool.tags[c.tag] == $SetX:
+      if c.kind == ParLe and pool.tags[c.tag] == $CurlyX:
         inc c
         e.add "ranges", c.info
         while c.kind != ParRi:

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1116,7 +1116,7 @@ proc traverseCase(e: var EContext; c: var Cursor) =
     of OfS:
       e.dest.add c
       inc c
-      if c.kind == ParLe and pool.tags[c.tag] == $CurlyX:
+      if c.kind == ParLe and pool.tags[c.tag] == $RangesX:
         inc c
         e.add "ranges", c.info
         while c.kind != ParRi:

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -30,9 +30,9 @@ proc nodeKindTranslation(k: TNodeKind): string =
   of nkExprColonExpr: "kv"
   of nkPar: "par"
   of nkObjConstr: "obj"
-  of nkCurly: "set"
+  of nkCurly: "curly"
   of nkCurlyExpr: "curlyx"
-  of nkBracket: "arr"
+  of nkBracket: "bracket"
   of nkBracketExpr: "at"
   of nkPragmaBlock, nkPragmaExpr: "pragmax"
   of nkDotExpr: "dot"
@@ -342,7 +342,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
   of nkOfBranch:
     relLineInfo(n, parent, c)
     c.b.addTree("of")
-    c.b.addTree("set")
+    c.b.addTree("curly")
     for i in 0..<n.len-1:
       toNif(n[i], n, c)
     c.b.endTree()

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -342,7 +342,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
   of nkOfBranch:
     relLineInfo(n, parent, c)
     c.b.addTree("of")
-    c.b.addTree("curly")
+    c.b.addTree("ranges")
     for i in 0..<n.len-1:
       toNif(n[i], n, c)
     c.b.endTree()

--- a/src/nimony/controlflow.nim
+++ b/src/nimony/controlflow.nim
@@ -502,9 +502,9 @@ proc trAsgn(c: var ControlFlow; n: var Cursor) =
   else:
     endRead c.dest
 
-proc trCaseSet(c: var ControlFlow; n: var Cursor; selector: SymId; selectorType: Cursor;
+proc trCaseRanges(c: var ControlFlow; n: var Cursor; selector: SymId; selectorType: Cursor;
                tjmp, fjmp: var FixupList) =
-  assert n.exprKind == CurlyX
+  assert n.exprKind == RangesX
   inc n
   var nextAttempt = Label(-1)
   var nextAttemptB = Label(-1)
@@ -581,7 +581,7 @@ proc trCase(c: var ControlFlow; n: var Cursor; tar: Target) =
     inc n
     var tjmp: FixupList = @[]
     var fjmp: FixupList = @[]
-    trCaseSet c, n, selector, selectorType, tjmp, fjmp
+    trCaseRanges c, n, selector, selectorType, tjmp, fjmp
     for t in tjmp: c.patch t
     trStmtOrExpr c, n, tar
     endings.add c.jmpForw(n.info)

--- a/src/nimony/controlflow.nim
+++ b/src/nimony/controlflow.nim
@@ -504,7 +504,7 @@ proc trAsgn(c: var ControlFlow; n: var Cursor) =
 
 proc trCaseSet(c: var ControlFlow; n: var Cursor; selector: SymId; selectorType: Cursor;
                tjmp, fjmp: var FixupList) =
-  assert n.exprKind == SetX
+  assert n.exprKind == CurlyX
   inc n
   var nextAttempt = Label(-1)
   var nextAttemptB = Label(-1)
@@ -756,7 +756,7 @@ proc trExpr(c: var ControlFlow; n: var Cursor) =
        UnpackX, EnumToStrX,
        IsMainModuleX, DefaultObjX, DefaultTupX, PlusSetX, MinusSetX,
        MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardSetX, EnsureMoveX,
-       DestroyX, DupX, CopyX, WasMovedX, SinkHookX, TraceX:
+       DestroyX, DupX, CopyX, WasMovedX, SinkHookX, TraceX, BracketX, CurlyX:
       trExprLoop c, n
     of CompilesX, DeclaredX, DefinedX, HighX, LowX, TypeofX, SizeofX:
       # we want to avoid false dependencies for `sizeof(var)` as it doesn't really "use" the variable:

--- a/src/nimony/enumtostr.nim
+++ b/src/nimony/enumtostr.nim
@@ -22,7 +22,7 @@ proc genEnumToStrProcCase(c: var SemContext; enumDecl: var Cursor; symId, enumSy
     let enumDeclInfo = enumDecl.info
     c.dest.add tagToken("of", enumDeclInfo)
 
-    c.dest.add tagToken("curly", enumDeclInfo)
+    c.dest.add tagToken("ranges", enumDeclInfo)
 
     inc enumDecl
     let symId = enumDecl.symId

--- a/src/nimony/enumtostr.nim
+++ b/src/nimony/enumtostr.nim
@@ -13,7 +13,7 @@ import decls, nimony_model, semdata, sembasics
 proc tagToken(tag: string; info: PackedLineInfo): PackedToken {.inline.} =
   parLeToken(pool.tags.getOrIncl(tag), info)
 
-proc genEnumToStrProcCase(c: var SemContext; enumDecl: var Cursor; symId: SymId) =
+proc genEnumToStrProcCase(c: var SemContext; enumDecl: var Cursor; symId, enumSymId: SymId) =
   c.dest.add tagToken("case", enumDecl.info)
   c.dest.add symToken(symId, enumDecl.info)
   inc enumDecl # skips enum
@@ -22,7 +22,7 @@ proc genEnumToStrProcCase(c: var SemContext; enumDecl: var Cursor; symId: SymId)
     let enumDeclInfo = enumDecl.info
     c.dest.add tagToken("of", enumDeclInfo)
 
-    c.dest.add tagToken("set", enumDeclInfo)
+    c.dest.add tagToken("curly", enumDeclInfo)
 
     inc enumDecl
     let symId = enumDecl.symId
@@ -89,7 +89,7 @@ proc genEnumToStrProc*(c: var SemContext; typeDecl: var Cursor) =
 
   c.dest.add tagToken("stmts", enumSymInfo)
   var body = decl.body
-  genEnumToStrProcCase(c, body, paramSymId)
+  genEnumToStrProcCase(c, body, paramSymId, enumSymId)
   c.dest.addParRi() # stmts
 
   c.dest.addParRi() # proc

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -314,6 +314,7 @@ proc evalBitSet*(n, typ: Cursor): seq[uint8] =
   result = newSeq[uint8](s)
   var n = n
   inc n # skip set tag
+  skip n # skip set type
   while n.kind != ParRi:
     if n.exprKind == RangeX:
       inc n

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -99,6 +99,8 @@ type
     OconstrX = "obj"
     NewOconstrX = "newobj"
     TupleConstrX = "tup"
+    BracketX = "bracket"
+    CurlyX = "curly"
     AconstrX = "arr"
     SetX = "set"
     OchoiceX = "ochoice"

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4008,6 +4008,7 @@ proc semArrayConstr(c: var SemContext; it: var Item) =
   let info = it.n.info
   takeToken c, it.n
   it.typ = semLocalType(c, it.n)
+  # XXX type length not enforced
   var elem = Item(n: it.n, typ: c.types.autoType)
   if it.typ.typeKind == ArrayT:
     elem.typ = it.typ

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3569,7 +3569,7 @@ proc semWhen(c: var SemContext; it: var Item) =
 
 proc semCaseOfValue(c: var SemContext; it: var Item; selectorType: TypeCursor;
                     seen: var seq[(xint, xint)]) =
-  if it.n == "curly":
+  if it.n == "ranges":
     takeToken c, it.n
     while it.n.kind != ParRi:
       let info = it.n.info

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3904,9 +3904,12 @@ proc semBracket(c: var SemContext, it: var Item) =
     # empty array
     if it.typ.typeKind in {AutoT, VoidT}:
       buildErr c, it.n.info, "empty array needs a specified type"
+    else:
+      c.dest.addSubtree it.typ
     wantParRi c, it.n
     return
 
+  let typeInsertPos = c.dest.len
   var elem = Item(n: it.n, typ: c.types.autoType)
   case it.typ.typeKind
   of ArrayT: # , SeqT, OpenArrayT
@@ -3935,6 +3938,7 @@ proc semBracket(c: var SemContext, it: var Item) =
   let expected = it.typ
   it.typ = typeToCursor(c, typeStart)
   c.dest.shrink typeStart
+  c.dest.insert it.typ, typeInsertPos
   commonType c, it, exprStart, expected
 
 proc semCurly(c: var SemContext, it: var Item) =
@@ -3946,8 +3950,12 @@ proc semCurly(c: var SemContext, it: var Item) =
     # empty set
     if it.typ.typeKind in {AutoT, VoidT}:
       buildErr c, it.n.info, "empty set needs a specified type"
+    else:
+      c.dest.addSubtree it.typ
     wantParRi c, it.n
     return
+
+  let typeInsertPos = c.dest.len
   var elem = Item(n: it.n, typ: c.types.autoType)
   case it.typ.typeKind
   of SetT:
@@ -3991,6 +3999,7 @@ proc semCurly(c: var SemContext, it: var Item) =
   let expected = it.typ
   it.typ = typeToCursor(c, typeStart)
   c.dest.shrink typeStart
+  c.dest.insert it.typ, typeInsertPos
   commonType c, it, exprStart, expected
 
 proc semArrayConstr(c: var SemContext; it: var Item) =

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -194,7 +194,7 @@ proc filenameVal*(n: var Cursor; res: var seq[ImportedFilename]; hasError: var b
             hasError = true
         if suffix.len == 0:
           hasError = true
-    of ParX, AconstrX:
+    of ParX, AconstrX, BracketX:
       inc n
       if n.kind != ParRi:
         while n.kind != ParRi:

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -150,7 +150,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     result = c.builtins.intType
   of AddX, SubX, MulX, DivX, ModX, ShlX, ShrX, AshrX, BitandX, BitorX, BitxorX, BitnotX,
      PlusSetX, MinusSetX, MulSetX, XorSetX,
-     CastX, ConvX, OconvX, HconvX, DconvX, OconstrX, NewOconstrX:
+     CastX, ConvX, OconvX, HconvX, DconvX, OconstrX, NewOconstrX, AconstrX, SetX:
     result = n.firstSon
   of ParX, EnsureMoveX:
     result = getTypeImpl(c, n.firstSon)
@@ -183,7 +183,8 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     buf.addParRi()
     c.mem.add buf
     result = cursorAt(c.mem[c.mem.len-1], 0)
-  of SetX:
+  of CurlyX:
+    # should not be encountered but keep this code for now
     let elemType = getTypeImpl(c, n.firstSon)
     var buf = createTokenBuf(4)
     buf.add parLeToken(SetT, n.info)
@@ -218,14 +219,15 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
         result = field.typ
       else:
         result = tupType
-  of AconstrX:
+  of BracketX:
+    # should not be encountered but keep this code for now
     let elemType = getTypeImpl(c, n.firstSon)
     var buf = createTokenBuf(4)
     buf.add parLeToken(ArrayT, n.info)
     buf.addSubtree elemType
     var n = n
     var arrayLen = 0
-    inc n # skips AconstrX
+    inc n # skips BracketX
     while n.kind != ParRi:
       skip n
       inc arrayLen

--- a/tests/nimony/nosystem/tbool.nif
+++ b/tests/nimony/nosystem/tbool.nif
@@ -22,12 +22,12 @@
    (result :result.0 . . string.0.sys9azlf .) 23
    (case e.0 ~18,1
     (of
-     (set ~8
+     (ranges ~8
       (false))
      (stmts
       (ret "false"))) ~8,1
     (of
-     (set ~7
+     (ranges ~7
       (true))
      (stmts
       (ret "true"))))

--- a/tests/nimony/nosystem/tenumsizes.nif
+++ b/tests/nimony/nosystem/tenumsizes.nif
@@ -18,19 +18,19 @@
    (result :result.0 . . string.0.sys9azlf .) 4
    (case e.0 ~7,1
     (of
-     (set a0.0.tene657oj)
+     (ranges a0.0.tene657oj)
      (stmts
       (ret "a0"))) ~3,1
     (of
-     (set a1.0.tene657oj)
+     (ranges a1.0.tene657oj)
      (stmts
       (ret "a1"))) 1,1
     (of
-     (set a2.0.tene657oj)
+     (ranges a2.0.tene657oj)
      (stmts
       (ret "a2"))) 5,1
     (of
-     (set a3.0.tene657oj)
+     (ranges a3.0.tene657oj)
      (stmts
       (ret "a3"))))
    (ret result.0))) 7,2
@@ -52,19 +52,19 @@
    (result :result.1 . . string.0.sys9azlf .) 4
    (case e.1 ~2,1
     (of
-     (set ~5 b0.0.tene657oj)
+     (ranges ~5 b0.0.tene657oj)
      (stmts
       (ret "b0"))) 2,1
     (of
-     (set b1.0.tene657oj)
+     (ranges b1.0.tene657oj)
      (stmts
       (ret "b1"))) 6,1
     (of
-     (set b2.0.tene657oj)
+     (ranges b2.0.tene657oj)
      (stmts
       (ret "b2"))) 15,1
     (of
-     (set ~5 b3.0.tene657oj)
+     (ranges ~5 b3.0.tene657oj)
      (stmts
       (ret "b3"))))
    (ret result.1))) 7,4
@@ -86,19 +86,19 @@
    (result :result.2 . . string.0.sys9azlf .) 4
    (case e.2 ~7,1
     (of
-     (set c0.0.tene657oj)
+     (ranges c0.0.tene657oj)
      (stmts
       (ret "c0"))) ~3,1
     (of
-     (set c1.0.tene657oj)
+     (ranges c1.0.tene657oj)
      (stmts
       (ret "c1"))) 6,1
     (of
-     (set ~5 c2.0.tene657oj)
+     (ranges ~5 c2.0.tene657oj)
      (stmts
       (ret "c2"))) 14,1
     (of
-     (set c3.0.tene657oj)
+     (ranges c3.0.tene657oj)
      (stmts
       (ret "c3"))))
    (ret result.2))))

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -57,14 +57,20 @@
   (u +8) 5
   (suf +3u "u8")) 6,19
  (asgn ~6 myset.0.tge7jvqqk1 2
-  (set 1
+  (set 6,~3
+   (sett 1
+    (u +8)) 1
    (suf +1u "u8") 7 u8.0.tge7jvqqk1 11
    (suf +5u "u8") 17
    (range
     (suf +7u "u8") 6
     (suf +9u "u8")))) 6,20
  (asgn ~6 myarr.0.tge7jvqqk1 2
-  (arr 1 +1 4 +2 7 +3)) 15,23
+  (arr 8,~3
+   (array 4
+    (i -1)
+    (rangetype
+     (i -1) +0 +2)) 1 +1 4 +2 7 +3)) 15,23
  (type ~13 :MyGeneric.0.tge7jvqqk1 . ~4
   (typevars 1
    (typevar :T.4.tge7jvqqk1 . . . .)) . 2
@@ -144,20 +150,32 @@
    (rangetype
     (i -1) +0 +2)) 27 myarr.0.tge7jvqqk1) 7,57
  (asgn ~7 myarr2.0.tge7jvqqk1 2
-  (arr 1 +4 4 +5 7 +6)) 4,59
+  (arr 7,~40
+   (array 4
+    (i -1)
+    (rangetype
+     (i -1) +0 +2)) 1 +4 4 +5 7 +6)) 4,59
  (var :m3.0.tge7jvqqk1 . . 9
   (array 4
    (i -1)
    (rangetype
     (i -1) +0 +3)) 20
-  (arr 1 +1 4 +2 7 +3 10 +45)) 4,60
+  (arr ~11
+   (array 4
+    (i -1)
+    (rangetype
+     (i -1) +0 +3)) 1 +1 4 +2 7 +3 10 +45)) 4,60
  (var :x3.0.tge7jvqqk1 . . 9
   (array 7
    (i -1)
    (rangetype
     (i -1) 1 +4 4 +7)) 23 m3.0.tge7jvqqk1) 3,61
  (asgn ~3 x3.0.tge7jvqqk1 2
-  (arr 1 +2 4 +3 7 +4 10 +5)) ,63
+  (arr 8,~2
+   (array 4
+    (i -1)
+    (rangetype
+     (i -1) +0 +3)) 1 +2 4 +3 7 +4 10 +5)) ,63
  (proc 5 :foo.1.tge7jvqqk1 . . 8
   (typevars 1
    (typevar :I.0.tge7jvqqk1 . . . .) 4

--- a/tests/nimony/nosystem/timportfromexcept.nif
+++ b/tests/nimony/nosystem/timportfromexcept.nif
@@ -5,13 +5,21 @@
    (i -1)
    (rangetype
     (i -1) +0 +2)) 14
-  (arr 1 exceptB.0.modvx9hpf 10 fromA.0.modepjal 17 fromC.0.modepjal)) 4,5
+  (arr ~14
+   (array 15,3,tests/nimony/nosystem/deps/modexcept.nim
+    (i -1)
+    (rangetype
+     (i -1) +0 +2)) 1 exceptB.0.modvx9hpf 10 fromA.0.modepjal 17 fromC.0.modepjal)) 4,5
  (let :exceptDeclared.0.timhjtr28 . .
   (array
    (bool)
    (rangetype
     (i -1) +0 +2)) 17
-  (arr 9
+  (arr ~17
+   (array
+    (bool)
+    (rangetype
+     (i -1) +0 +2)) 9
    (false) 29
    (true) 47
    (false))) 4,6
@@ -20,7 +28,11 @@
    (bool)
    (rangetype
     (i -1) +0 +2)) 15
-  (arr 10
+  (arr ~15,~1
+   (array
+    (bool)
+    (rangetype
+     (i -1) +0 +2)) 10
    (true) 26
    (false) 44
    (true))))

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -10,7 +10,11 @@
    (i -1)
    (rangetype
     (i -1) +0 +2)) 4
-  (arr 1 +1 4 +2 7 +3)) 4,4
+  (arr ~4
+   (array
+    (i -1)
+    (rangetype
+     (i -1) +0 +2)) 1 +1 4 +2 7 +3)) 4,4
  (var :s2.0.tbawx6nu81 . . 11,~3
   (array 4
    (i -1)
@@ -21,7 +25,11 @@
    (i -1)
    (rangetype
     (i -1) +0 +4)) 12
-  (arr 1 +1 4 +2 7 +3 10 +4 13 +5)) ,7
+  (arr ~1,~4
+   (array 4
+    (i -1)
+    (rangetype
+     (i -1) +0 +4)) 1 +1 4 +2 7 +3 10 +4 13 +5)) ,7
  (proc 5 :foo.0.tbawx6nu81 . . . 9
   (params) . . . 2,1
   (stmts 4
@@ -30,13 +38,21 @@
      (i -1)
      (rangetype
       (i -1) +0 +2)) 19
-    (arr 1 +5 4 +6 7 +7)) 4,1
+    (arr ~21,~5
+     (array
+      (i -1)
+      (rangetype
+       (i -1) +0 +2)) 1 +5 4 +6 7 +7)) 4,1
    (var :m.1 . .
     (array
      (i -1)
      (rangetype
       (i -1) +0 +3)) 4
-    (arr 1 +5 4 +6 7 +7 10 +8)))) 3,11
+    (arr ~4
+     (array
+      (i -1)
+      (rangetype
+       (i -1) +0 +3)) 1 +5 4 +6 7 +7 10 +8)))) 3,11
  (call ~3 foo.0.tbawx6nu81) ,13
  (proc 5 :foo2.0.tbawx6nu81 . . . 9
   (params 1

--- a/tests/nimony/sysbasics/tdollar.nif
+++ b/tests/nimony/sysbasics/tdollar.nif
@@ -16,15 +16,15 @@
    (result :result.0 . . string.0.sys9azlf .) 9
    (case e.0 ~7,1
     (of
-     (set Red1.0.tdoqc0e0v)
+     (ranges Red1.0.tdoqc0e0v)
      (stmts
       (ret "Red1"))) ~1,1
     (of
-     (set Blue1.0.tdoqc0e0v)
+     (ranges Blue1.0.tdoqc0e0v)
      (stmts
       (ret "Blue1"))) 6,1
     (of
-     (set Green1.0.tdoqc0e0v)
+     (ranges Green1.0.tdoqc0e0v)
      (stmts
       (ret "Green1"))))
    (ret result.0))) ,5

--- a/tests/nimony/sysbasics/tforloops.nif
+++ b/tests/nimony/sysbasics/tforloops.nif
@@ -21,7 +21,15 @@
        (i -1) .))
      (rangetype
       (i -1) +0 +0)) 5
-    (arr 1
+    (arr ~5
+     (array 7
+      (tuple
+       (fld :Field0.1.tfo6zftzj1 . .
+        (i -1) .) 4
+       (fld :Field1.1.tfo6zftzj1 . .
+        (i -1) .))
+      (rangetype
+       (i -1) +0 +0)) 1
      (tup 1 +12 5 globalX.0.tfo6zftzj1))) ,1
    (yld 6
     (arrat ff.0 3 +0)) ,2


### PR DESCRIPTION
Refs #470, empty array/set literals need this to work in hexer.

Not sure if there is a reason why `case of` branches didn't change their selectors from `set` to `ranges` until `nifcgen`, would have had to make them always `curly` here which requires `curly` to be traversed without erroring in the rest of hexer.