### PR TITLE
Fix handleLineInfo proc in lib/nifreader.nim to handle overflow corre…

### DIFF
--- a/src/lib/nifreader.nim
+++ b/src/lib/nifreader.nim
@@ -239,7 +239,7 @@ proc handleNumber(r: var Reader; result: var Token) =
 
 proc handleLineInfo(r: var Reader; result: var Token) =
   proc integerOutOfRangeError() {.noinline, noreturn.} =
-    raise newException(ValueError, "Parsed integer outside of valid range")
+    quit "Parsed integer outside of valid range"
 
   useCpuRegisters:
     var col = 0


### PR DESCRIPTION
…ctly

It seems `proc handleLineInfo(r: var Reader; result: var Token)` in `lib/nifreader.nim` trys to parse columns and line numbers in the same way as `rawParseInt` proc in `lib/pure/parseutils.nim` in Nim 2.
But it doesn't copy `rawParseInt` proc correctly and doesn't detect overflow.
`if col >= (low(int) + c) div 10` is always true because `col` is always positive.

This PR copys the implementation of `rawParseInt` excepts '+' and '-' prefix and '_' handling.