### PR TITLE
make `set` type tag, constructors now `setconstr`

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -168,7 +168,7 @@
 | rangetype | TN | `rangetype` type |
 | uarray | TN | `uarray` type |
 | openarray | TN | `openarray` type |
-| sett | TN | `sett` type |
+| set | TN | `set` type |
 | auto | TN | `auto` type |
 | symkind | TN | `symkind` type |
 | typekind | TN | `typekind` type |
@@ -204,7 +204,7 @@
 | haddr | X | hidden address of operation |
 | newobj | X | new object constructor |
 | tup | X | tuple constructor |
-| set | X | set constructor |
+| setconstr | X | set constructor |
 | ashr | X | |
 | oconv | X | object conversion |
 | hconv | X | hidden basic type conversion |

--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -142,7 +142,7 @@ proc genSetOp(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let kind = n.exprKind
   inc n
   let typ = n
-  if typ.typeKind != SettT:
+  if typ.typeKind != SetT:
     error "expected set type for set op", n
   var baseType = typ
   inc baseType
@@ -285,7 +285,7 @@ proc genInclExcl(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let kind = n.stmtKind
   inc n
   let typ = n
-  if typ.typeKind != SettT:
+  if typ.typeKind != SetT:
     error "expected set type for incl/excl", n
   var baseType = typ
   inc baseType
@@ -387,7 +387,7 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
       case n.stmtKind
       of NoStmt:
         case n.typeKind
-        of SettT:
+        of SetT:
           #trSetType(c, dest, n)
           # leave this to nifcgen
           trSons(c, dest, n)
@@ -420,7 +420,7 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
         c.typeCache.closeScope()
       else:
         trSons(c, dest, n)
-    of SetX:
+    of SetConstrX:
       genSetConstr(c, dest, n)
     of PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardX:
       genSetOp(c, dest, n)

--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -642,7 +642,7 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
       trEnsureMove c, n, e
     of AconstrX, TupleConstrX:
       trRawConstructor c, n, e
-    of NilX, FalseX, TrueX, AndX, OrX, NotX, NegX, SizeofX, SetX,
+    of NilX, FalseX, TrueX, AndX, OrX, NotX, NegX, SizeofX, SetConstrX,
        OchoiceX, CchoiceX,
        AddX, SubX, MulX, DivX, ModX, ShrX, ShlX, AshrX, BitandX, BitorX, BitxorX, BitnotX,
        PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardX,

--- a/src/hexer/lifter.nim
+++ b/src/hexer/lifter.nim
@@ -105,7 +105,7 @@ proc isTrivial*(c: var LiftingCtx; typ: TypeCursor): bool =
 
   case typ.typeKind
   of IntT, UIntT, FloatT, BoolT, CharT, PtrT, PtrobjT,
-     MutT, OutT, SettT,
+     MutT, OutT, SetT,
      EnumT, HoleyEnumT, VoidT, AutoT, SymKindT, ProctypeT,
      CstringT, PointerT, OrdinalT, OpenArrayT,
      UncheckedArrayT, VarargsT, RangetypeT, TypedescT,

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -466,7 +466,7 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
         traverseEnumField(e, c, flags)
 
       wantParRi e, c
-    of SettT:
+    of SetT:
       let info = c.info
       inc c
       let sizeOrig = bitsetSizeInBytes(c)
@@ -970,7 +970,7 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
           e.dest.addParRi()
           traverseExpr e, c
         wantParRi e, c
-      of NewOconstrX, SetX, PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardX, BracketX, CurlyX:
+      of NewOconstrX, SetConstrX, PlusSetX, MinusSetX, MulSetX, XorSetX, EqSetX, LeSetX, LtSetX, InSetX, CardX, BracketX, CurlyX:
         error e, "BUG: not eliminated: ", c
       else:
         e.dest.add c

--- a/src/models/nimony_tags.nim
+++ b/src/models/nimony_tags.nim
@@ -56,7 +56,7 @@ type
     HaddrX = (202, "haddr")  ## hidden address of operation
     NewobjX = (203, "newobj")  ## new object constructor
     TupX = (204, "tup")  ## tuple constructor
-    SetX = (205, "set")  ## set constructor
+    SetconstrX = (205, "setconstr")  ## set constructor
     AshrX = (206, "ashr")
     OconvX = (207, "oconv")  ## object conversion
     HconvX = (208, "hconv")  ## hidden basic type conversion
@@ -186,7 +186,7 @@ type
     RangetypeT = (166, "rangetype")  ## `rangetype` type
     UarrayT = (167, "uarray")  ## `uarray` type
     OpenarrayT = (168, "openarray")  ## `openarray` type
-    SettT = (169, "sett")  ## `sett` type
+    SetT = (169, "set")  ## `set` type
     AutoT = (170, "auto")  ## `auto` type
     SymkindT = (171, "symkind")  ## `symkind` type
     TypekindT = (172, "typekind")  ## `typekind` type

--- a/src/models/tags.nim
+++ b/src/models/tags.nim
@@ -170,7 +170,7 @@ const
     ("rangetype", 166),
     ("uarray", 167),
     ("openarray", 168),
-    ("sett", 169),
+    ("set", 169),
     ("auto", 170),
     ("symkind", 171),
     ("typekind", 172),
@@ -206,7 +206,7 @@ const
     ("haddr", 202),
     ("newobj", 203),
     ("tup", 204),
-    ("set", 205),
+    ("setconstr", 205),
     ("ashr", 206),
     ("oconv", 207),
     ("hconv", 208),
@@ -415,7 +415,7 @@ const
   RangetypeTagId* = 166
   UarrayTagId* = 167
   OpenarrayTagId* = 168
-  SettTagId* = 169
+  SetTagId* = 169
   AutoTagId* = 170
   SymkindTagId* = 171
   TypekindTagId* = 172
@@ -451,7 +451,7 @@ const
   HaddrTagId* = 202
   NewobjTagId* = 203
   TupTagId* = 204
-  SetTagId* = 205
+  SetconstrTagId* = 205
   AshrTagId* = 206
   OconvTagId* = 207
   HconvTagId* = 208

--- a/src/nimony/controlflow.nim
+++ b/src/nimony/controlflow.nim
@@ -750,7 +750,7 @@ proc trExpr(c: var ControlFlow; n: var Cursor) =
       trExprLoop c, n
     of QuotedX, ParX,
        NilX, FalseX, TrueX, NotX, NegX, OconstrX, NewOconstrX, TupleConstrX,
-       AconstrX, SetX, OchoiceX, CchoiceX, KvX, AddX, SubX, MulX, DivX, ModX,
+       AconstrX, SetConstrX, OchoiceX, CchoiceX, KvX, AddX, SubX, MulX, DivX, ModX,
        ShrX, ShlX, AshrX, BitandX, BitorX, BitxorX, BitnotX, EqX, NeqX, LeX, LtX,
        CastX, ConvX, OconvX, HconvX, DconvX, InfX, NegInfX, NanX, SufX, RangeX, RangesX,
        UnpackX, EnumToStrX,

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -304,8 +304,8 @@ proc getArrayLen*(n: Cursor): xint =
 
 proc evalBitSet*(n, typ: Cursor): seq[uint8] =
   ## returns @[] if it could not be evaluated.
-  assert n.exprKind == SetX
-  assert typ.typeKind == SettT
+  assert n.exprKind == SetConstrX
+  assert typ.typeKind == SetT
   let size = bitsetSizeInBytes(typ.firstSon)
   var err = false
   let s = asSigned(size, err)

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -138,7 +138,7 @@ proc magicToTag*(m: TMagic): (string, int) =
   of mEnumToStr: res EnumToStrX
   of mArray: res ArrayT
   of mRange: res RangetypeT
-  of mSet: res SettT
+  of mSet: res SetT
   of mVarargs: res VarargsT
   of mRef: res RefT
   of mPtr: res PtrT

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -612,7 +612,7 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
     of ArrayT:
       var a = skipModifier(arg.typ)
       matchArrayType m, f, a
-    of SettT, UncheckedArrayT, OpenArrayT:
+    of SetT, UncheckedArrayT, OpenArrayT:
       var a = skipModifier(arg.typ)
       linearMatch m, f, a
     of CstringT:

--- a/src/nimony/sizeof.nim
+++ b/src/nimony/sizeof.nim
@@ -124,7 +124,7 @@ proc getSize(c: var SizeofValue; cache: var Table[SymId, SizeofValue]; n: Cursor
       c.overflow = c2.overflow
     if cacheKey != NoSymId: cache[cacheKey] = c2
 
-  of SettT:
+  of SetT:
     let size0 = bitsetSizeInBytes(n.firstSon)
     let size1 = asSigned(size0, c.overflow)
     update c, size1, 1

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -158,7 +158,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     result = c.builtins.intType
   of AddX, SubX, MulX, DivX, ModX, ShlX, ShrX, AshrX, BitandX, BitorX, BitxorX, BitnotX,
      PlusSetX, MinusSetX, MulSetX, XorSetX,
-     CastX, ConvX, OconvX, HconvX, DconvX, OconstrX, NewOconstrX, AconstrX, SetX:
+     CastX, ConvX, OconvX, HconvX, DconvX, OconstrX, NewOconstrX, AconstrX, SetConstrX:
     result = n.firstSon
   of ParX, EmoveX:
     result = getTypeImpl(c, n.firstSon)
@@ -188,7 +188,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
     # should not be encountered but keep this code for now
     let elemType = getTypeImpl(c, n.firstSon)
     var buf = createTokenBuf(4)
-    buf.add parLeToken(SettT, n.info)
+    buf.add parLeToken(SetT, n.info)
     buf.addSubtree elemType
     buf.addParRi()
     c.mem.add buf

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -17,7 +17,7 @@
   (pragmas 2
    (magic 7 UInt8)) .) 2,7
  (type :set.0.tge7jvqqk1
-  (sett) 4
+  (set) 4
   (typevars 1
    (typevar :T.0.tge7jvqqk1 . . . .)) 8
   (pragmas 2
@@ -46,7 +46,7 @@
    (magic 7 TypeOf)) . .) 10,14
  (type ~8 :string.0.tge7jvqqk1 x . . string.0.sys9azlf) 4,16
  (var :myset.0.tge7jvqqk1 . . 10
-  (sett 1
+  (set 1
    (u +8)) .) 4,17
  (var :myarr.0.tge7jvqqk1 . . 12
   (array 4
@@ -57,8 +57,8 @@
   (u +8) 5
   (suf +3u "u8")) 6,19
  (asgn ~6 myset.0.tge7jvqqk1 2
-  (set 6,~3
-   (sett 1
+  (setconstr 6,~3
+   (set 1
     (u +8)) 1
    (suf +1u "u8") 7 u8.0.tge7jvqqk1 11
    (suf +5u "u8") 17

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -47,57 +47,57 @@
       (ret "F"))))
    (ret result.0))) 4,3
  (var :s.0.tsefy5wha . . 10
-  (sett 1 Foo.0.tsefy5wha) .) 7,3
+  (set 1 Foo.0.tsefy5wha) .) 7,3
  (var :s1.0.tsefy5wha . . 7
-  (sett 1 Foo.0.tsefy5wha) .) 2,4
+  (set 1 Foo.0.tsefy5wha) .) 2,4
  (asgn ~2 s.0.tsefy5wha 2
-  (set 10,~1
-   (sett 1 Foo.0.tsefy5wha) 1
+  (setconstr 10,~1
+   (set 1 Foo.0.tsefy5wha) 1
    (range A.0.tsefy5wha 3 D.0.tsefy5wha))) 3,5
  (asgn ~3 s1.0.tsefy5wha 2
-  (set 9,~2
-   (sett 1 Foo.0.tsefy5wha) 1
+  (setconstr 9,~2
+   (set 1 Foo.0.tsefy5wha) 1
    (range A.0.tsefy5wha 3 C.0.tsefy5wha))) ,6
  (discard 11
   (ltset 3,~3
-   (sett 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,7
+   (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,7
  (let :y.0.tsefy5wha . . 10,~4
-  (sett 1 Foo.0.tsefy5wha) 7
+  (set 1 Foo.0.tsefy5wha) 7
   (mulset 3,~4
-   (sett 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,8
+   (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,8
  (let :z.0.tsefy5wha . . 10,~5
-  (sett 1 Foo.0.tsefy5wha) 14 y.0.tsefy5wha) ,9
+  (set 1 Foo.0.tsefy5wha) 14 y.0.tsefy5wha) ,9
  (discard 10
   (eqset 4,~6
-   (sett 1 Foo.0.tsefy5wha) ~2 y.0.tsefy5wha 3
-   (set 1,~6
-    (sett 1 Foo.0.tsefy5wha) 1
+   (set 1 Foo.0.tsefy5wha) ~2 y.0.tsefy5wha 3
+   (setconstr 1,~6
+    (set 1 Foo.0.tsefy5wha) 1
     (range A.0.tsefy5wha 3 C.0.tsefy5wha)))) ,10
  (discard 10
   (eqset 4,~7
-   (sett 1 Foo.0.tsefy5wha) ~2 z.0.tsefy5wha 3
-   (set 1,~7
-    (sett 1 Foo.0.tsefy5wha) 1
+   (set 1 Foo.0.tsefy5wha) ~2 z.0.tsefy5wha 3
+   (setconstr 1,~7
+    (set 1 Foo.0.tsefy5wha) 1
     (range A.0.tsefy5wha 3 C.0.tsefy5wha)))) ,11
  (discard 15
   (eqset ~1,~8
-   (sett 1 Foo.0.tsefy5wha) ~5
+   (set 1 Foo.0.tsefy5wha) ~5
    (minusset 4,~8
-    (sett 1 Foo.0.tsefy5wha) ~2 s.0.tsefy5wha 2 s1.0.tsefy5wha) 3
-   (set ~4,~8
-    (sett 1 Foo.0.tsefy5wha) 1 D.0.tsefy5wha))) ,12
+    (set 1 Foo.0.tsefy5wha) ~2 s.0.tsefy5wha 2 s1.0.tsefy5wha) 3
+   (setconstr ~4,~8
+    (set 1 Foo.0.tsefy5wha) 1 D.0.tsefy5wha))) ,12
  (discard 11
   (leset 3,~9
-   (sett 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 3 s.0.tsefy5wha)) ,14
+   (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 3 s.0.tsefy5wha)) ,14
  (template 9 :resem.0.tsefy5wha . . . 14
   (params) . . . 2,1
   (stmts 2
    (asgn ~2 s.0.tsefy5wha 2
-    (set 8,~12
-     (sett 1 Foo.0.tsefy5wha) 1 A.0.tsefy5wha 4
+    (setconstr 8,~12
+     (set 1 Foo.0.tsefy5wha) 1 A.0.tsefy5wha 4
      (range C.0.tsefy5wha 3 E.0.tsefy5wha) 10 F.0.tsefy5wha)))) 2,15
  (stmts 2
   (asgn ~2 s.0.tsefy5wha 2
-   (set 8,~12
-    (sett 1 Foo.0.tsefy5wha) 1 A.0.tsefy5wha 4
+   (setconstr 8,~12
+    (set 1 Foo.0.tsefy5wha) 1 A.0.tsefy5wha 4
     (range C.0.tsefy5wha 3 E.0.tsefy5wha) 10 F.0.tsefy5wha))))


### PR DESCRIPTION
`set` and `sett` were too close to each other and the set type is more common in the output than constructors. Other names would be fine too, we can define alias constants for readability in the compiler