### PR TITLE
Print the identifier when an undeclared proc is called

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1423,11 +1423,13 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
     var errorMsg: string
     if idx == -2:
       errorMsg = "ambiguous call: '"
-      errorMsg.add pool.strings[cs.fnName]
+      if cs.fnName != StrId(0):
+        errorMsg.add pool.strings[cs.fnName]
       errorMsg.add "'"
     elif cs.source in {DotCall, DotAsgnCall} and cs.fnName != StrId(0):
       errorMsg = "undeclared field: '"
-      errorMsg.add pool.strings[cs.fnName]
+      if cs.fnName != StrId(0):
+        errorMsg.add pool.strings[cs.fnName]
       errorMsg.add "'"
       if cs.args.len != 0: # just to be safe
         errorMsg.add " for type "
@@ -1439,7 +1441,8 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
         addErrorMsg errorMsg, m[i]
     else:
       errorMsg = "undeclared identifier: '"
-      errorMsg.add pool.strings[cs.fnName]
+      if cs.fnName != StrId(0):
+        errorMsg.add pool.strings[cs.fnName]
       errorMsg.add "'"
     var errored = createTokenBuf(4)
     buildCallSource errored, cs

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1422,7 +1422,9 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
     skipParRi it.n
     var errorMsg: string
     if idx == -2:
-      errorMsg = "ambiguous call"
+      errorMsg = "ambiguous call: '"
+      errorMsg.add pool.strings[cs.fnName]
+      errorMsg.add "'"
     elif cs.source in {DotCall, DotAsgnCall} and cs.fnName != StrId(0):
       errorMsg = "undeclared field: '"
       errorMsg.add pool.strings[cs.fnName]
@@ -1436,7 +1438,9 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
         errorMsg.add "\n"
         addErrorMsg errorMsg, m[i]
     else:
-      errorMsg = "undeclared identifier"
+      errorMsg = "undeclared identifier: '"
+      errorMsg.add pool.strings[cs.fnName]
+      errorMsg.add "'"
     var errored = createTokenBuf(4)
     buildCallSource errored, cs
     buildErr c, cs.callNode.info, errorMsg, cursorAt(errored, 0)


### PR DESCRIPTION
This fixes a part of https://github.com/nim-lang/nimony/issues/432
This PR prints the identifier only when there is an undeclared proc call and an ambiguous call.