### PR TITLE
fix linearMatch for typevars not breaking when `nested == 0`

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -296,15 +296,13 @@ proc linearMatch(m: var Match; f, a: var Cursor) =
       if m.inferred.contains(fs):
         # rematch?
         var prev = m.inferred[fs]
-        linearMatch(m, prev, a)
+        linearMatch(m, prev, a) # skips a
         inc f
         if m.err: break
-        continue
       elif matchesConstraint(m, fs, a):
         m.inferred[fs] = a # NOTICE: Can introduce modifiers for a type var!
         inc f
         skip a
-        continue
       else:
         m.error(ConstraintMismatch, f, a)
         break
@@ -324,11 +322,11 @@ proc linearMatch(m: var Match; f, a: var Cursor) =
       of ParRi:
         if nested == 0: break
         dec nested
+      inc f
+      inc a
     else:
       m.error(InvalidMatch, fOrig, aOrig)
       break
-    inc f
-    inc a
     # only match a single tree/token:
     if nested == 0: break
 


### PR DESCRIPTION
Doing `continue` here misses the `if nested == 0: break` part, so instead of continuing, the `inc f`/`inc a` are moved into the other branch.