### PR TITLE
fix empty object constructors

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1316,7 +1316,7 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
   elif cs.fn.typ.typeKind == TypedescT and cs.args.len == 1:
     semConvFromCall c, it, cs
     return
-  elif cs.fn.kind == TypeY and cs.args.len == 0:
+  elif cs.fn.typ.typeKind == TypedescT and cs.args.len == 0:
     semObjConstrFromCall c, it, cs
     return
   else:
@@ -4208,15 +4208,17 @@ proc buildDefaultObjConstr(c: var SemContext; typ: Cursor; setFields: Table[SymI
     let parent = asObjectDecl(parentImpl)
     obj.parentType = parent.parentType
     var currentField = parent.firstField
+    if currentField.kind != DotToken:
+      while currentField.kind != ParRi:
+        let field = asLocal(currentField)
+        buildObjConstrField(c, field, setFields, info)
+        skip currentField
+  var currentField = obj.firstField
+  if currentField.kind != DotToken:
     while currentField.kind != ParRi:
       let field = asLocal(currentField)
       buildObjConstrField(c, field, setFields, info)
       skip currentField
-  var currentField = obj.firstField
-  while currentField.kind != ParRi:
-    let field = asLocal(currentField)
-    buildObjConstrField(c, field, setFields, info)
-    skip currentField
   c.dest.addParRi()
 
 proc semObjConstr(c: var SemContext, it: var Item) =

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -43,3 +43,8 @@ proc genericProc[T](x: T): GenericObj[T] =
   result = GenericObj[T](x: x)
   result.x = x
 generic = genericProc(456)
+
+type EmptyObj = object
+let empty = EmptyObj()
+type EmptyGenericObj[T] = object
+let emptyGeneric = EmptyGenericObj[int]()


### PR DESCRIPTION
1. `firstField` of empty object types is `.`, not `)`, has to be checked before iterating
2. For calls with no arguments being handled as object constructors, checking that the callee is a type symbol does not handle the case where it is a generic invocation i.e. `Foo[int]()`, so a type of `TypedescT` is checked instead same as for conversions