### PR TITLE
nifler: make nkEmpty opt in, fix some type tags

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -370,9 +370,12 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
       c.b.addEmpty
     c.b.endTree()
 
-  of nkProcTy:
+  of nkProcTy, nkIteratorTy:
     relLineInfo(n, parent, c)
-    c.b.addTree("proctype")
+    if n.kind == nkProcTy:
+      c.b.addTree("proctype")
+    else:
+      c.b.addTree("itertype")
 
     c.b.addEmpty 4 # 0: name
     # 1: export marker
@@ -602,7 +605,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
       toNif(n[i], n, c)
     c.b.endTree()
     c.depsEnabled = oldDepsEnabled
-  of nkBreakStmt, nkDiscardStmt, nkRaiseStmt, nkAsmStmt, nkBlockStmt, nkBlockExpr, nkBlockType, nkTypeClassTy, nkProcTy, nkIteratorTy:
+  of nkBreakStmt, nkDiscardStmt, nkRaiseStmt, nkAsmStmt, nkBlockStmt, nkBlockExpr, nkBlockType, nkTypeClassTy:
     relLineInfo(n, parent, c)
     c.b.addTree(nodeKindTranslation(n.kind))
     for i in 0..<n.len:

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -556,7 +556,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
         c.b.addTree "err"
         c.b.endTree()
 
-      toNif(n[n.len-2], n, c)
+      toNif(n[n.len-2], n, c, allowEmpty = true)
       let last {.cursor.} = n[n.len-1]
       if last.kind == nkRecList:
         for child in last:

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -152,6 +152,8 @@ proc addFloatLit*(b: var Builder; u: BiggestFloat; suffix: string) =
 proc toNif*(n, parent: PNode; c: var TranslationContext) =
   case n.kind
   of nkNone, nkEmpty:
+    writeStackTrace()
+    assert false
     c.b.addEmpty 1
   of nkNilLit:
     relLineInfo(n, parent, c)

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -602,11 +602,18 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
       toNif(n[i], n, c)
     c.b.endTree()
     c.depsEnabled = oldDepsEnabled
+  of nkBreakStmt, nkDiscardStmt, nkRaiseStmt, nkAsmStmt, nkBlockStmt, nkBlockExpr, nkBlockType, nkTypeClassTy, nkProcTy, nkIteratorTy:
+    relLineInfo(n, parent, c)
+    c.b.addTree(nodeKindTranslation(n.kind))
+    for i in 0..<n.len:
+      toNif(n[i], n, c, allowEmpty = true)
+    c.b.endTree()
   else:
     relLineInfo(n, parent, c)
     c.b.addTree(nodeKindTranslation(n.kind))
-    echo "in kind ", n.kind
     for i in 0..<n.len:
+      if n[i].kind == nkEmpty:
+        echo "in kind ", n.kind
       toNif(n[i], n, c)
     c.b.endTree()
 

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -605,6 +605,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
   else:
     relLineInfo(n, parent, c)
     c.b.addTree(nodeKindTranslation(n.kind))
+    echo "in kind ", n.kind
     for i in 0..<n.len:
       toNif(n[i], n, c)
     c.b.endTree()

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -605,7 +605,8 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
       toNif(n[i], n, c)
     c.b.endTree()
     c.depsEnabled = oldDepsEnabled
-  of nkBreakStmt, nkDiscardStmt, nkRaiseStmt, nkAsmStmt, nkBlockStmt, nkBlockExpr, nkBlockType, nkTypeClassTy:
+  of nkDiscardStmt, nkBreakStmt, nkContinueStmt, nkReturnStmt, nkRaiseStmt,
+      nkBlockStmt, nkBlockExpr, nkBlockType, nkTypeClassTy, nkAsmStmt:
     relLineInfo(n, parent, c)
     c.b.addTree(nodeKindTranslation(n.kind))
     for i in 0..<n.len:

--- a/tests/hexer/gear3_helloworld.nif
+++ b/tests/hexer/gear3_helloworld.nif
@@ -10,7 +10,7 @@
       (i -1) .)))
 
   (type ~9 :EmptyObj.0.tesg7afhq1 . . . 2
-    (object . .))
+    (object .))
 
  (type ~6 :Color.0.tesg7afhq1 . . . 2
   (enum (u +8) ,1

--- a/tests/nimony/nosystem/tsetter.nif
+++ b/tests/nimony/nosystem/tsetter.nif
@@ -5,7 +5,7 @@
   (pragmas 2
    (magic 7 Int)) .) 9,2
  (type ~4 :Foo.0.tseyic8ua1 . . . 2
-  (object . .)) ,4
+  (object .)) ,4
  (proc 5 :bar=.0.tseyic8ua1 . . . 11
   (params 1
    (param :x.0 . . 3 Foo.0.tseyic8ua1 .) 9

--- a/tests/nimony/nosystem/tvarargs.nif
+++ b/tests/nimony/nosystem/tvarargs.nif
@@ -59,7 +59,7 @@
   (pragmas 2
    (magic 7 "LeI")) . .) 8,17
  (type ~6 :File.0.tvah6culb x . . 2
-  (object . .)) 4,19
+  (object .)) 4,19
  (var :stdout.0.tvah6culb . . 8 File.0.tvah6culb .) ,21
  (proc 5 :write.0.tvah6culb . . . 10
   (params 1


### PR DESCRIPTION
`nkIteratorTy` handled the same as `nkProcTy`, has updated tag along with `nkOutTy` and `nkStaticTy` (only used in old concepts), `nkStaticStmt` changed to `staticstmt` instead of `static`