### PR TITLE
nifc: suppresses `-Wswitch-bool` warnings

### DIFF
--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -162,6 +162,13 @@ typedef NU8 NU;
 #endif
 
 
+/* ------------ ignore typical warnings in Nim-generated files ------------- */
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic ignored "-Wswitch-bool"
+#endif
+
+
+
 /* ------------------------------------------------------------------- */
 #ifdef  __cplusplus
 #  define NIM_EXTERNC extern "C"


### PR DESCRIPTION
It is also suppressed in the Nim

```c
nifcache/sys9azlf.c:312:3: warning: switch condition has boolean value [-Wswitch-bool]
  312 |   switch (e_0){
```