### PR TITLE
implement empty array/set literal matching

### DIFF
--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -279,6 +279,8 @@ proc genSetConstr(c: var Context; dest: var TokenBuf; n: var Cursor) =
     trSetType(c, dest, typ)
     for b in bytes:
       dest.addUintLit(b, info)
+    dest.addParRi()
+    skip n
 
 proc genInclExcl(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let info = n.info

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -503,11 +503,11 @@ proc maybeByConstRef(e: var EContext; c: var Cursor) =
   if passByConstRef(param.typ, param.pragmas, e.bits div 8):
     var paramBuf = createTokenBuf()
     paramBuf.add tagToken("param", c.info)
-    paramBuf.addSubtree param.name
-    paramBuf.addSubtree param.exported
-    paramBuf.addSubtree param.pragmas
+    paramBuf.add param.name
+    paramBuf.add param.exported
+    paramBuf.add param.pragmas
     copyIntoKind paramBuf, PtrT, param.typ.info:
-      paramBuf.addSubtree param.typ
+      paramBuf.add param.typ
     paramBuf.addDotToken()
     paramBuf.addParRi()
     var paramCursor = beginRead(paramBuf)

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -503,11 +503,11 @@ proc maybeByConstRef(e: var EContext; c: var Cursor) =
   if passByConstRef(param.typ, param.pragmas, e.bits div 8):
     var paramBuf = createTokenBuf()
     paramBuf.add tagToken("param", c.info)
-    paramBuf.add param.name
-    paramBuf.add param.exported
-    paramBuf.add param.pragmas
+    paramBuf.addSubtree param.name
+    paramBuf.addSubtree param.exported
+    paramBuf.addSubtree param.pragmas
     copyIntoKind paramBuf, PtrT, param.typ.info:
-      paramBuf.add param.typ
+      paramBuf.addSubtree param.typ
     paramBuf.addDotToken()
     paramBuf.addParRi()
     var paramCursor = beginRead(paramBuf)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -185,6 +185,7 @@ proc commonType(c: var SemContext; it: var Item; argBegin: int; expected: TypeCu
       if convMatch.genericConverter:
         let inst = c.requestRoutineInstance(convMatch.fn.sym, convMatch.typeArgs, convMatch.inferred, arg.n.info)
         c.dest[c.dest.len-1].setSymId inst.targetSym
+      # ignore genericEmpty case, probably environment is generic
       c.dest.add convMatch.args
       c.dest.addParRi()
       it.typ = expected
@@ -590,6 +591,7 @@ type
     PreferIterators
     AllowUndeclared
     AllowModuleSym
+    AllowEmpty
     InTypeContext
 
 proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {})
@@ -1200,7 +1202,7 @@ proc semReturnType(c: var SemContext; n: var Cursor): TypeCursor =
   result = semLocalType(c, n, InReturnTypeDecl)
 
 proc addArgsInstConverters(c: var SemContext; m: var Match; origArgs: openArray[Item]) =
-  if not m.genericConverter:
+  if not (m.genericConverter or m.genericEmpty):
     c.dest.add m.args
   else:
     m.args.addParRi()
@@ -1211,7 +1213,17 @@ proc addArgsInstConverters(c: var SemContext; m: var Match; origArgs: openArray[
       while arg.exprKind in {HconvX, OconvX, HderefX, HaddrX}:
         takeToken c, arg
         inc nested
-      if arg.exprKind == HcallX:
+      if m.genericEmpty and isEmptyLiteral(arg):
+        takeToken c, arg
+        inc nested
+        if containsGenericParams(arg):
+          let start = c.dest.len
+          c.dest.addSubtree instantiateType(c, arg, m.inferred)
+          skip arg
+        else:
+          takeTree c, arg
+        # leave ParRi token to while loop below
+      elif arg.exprKind == HcallX:
         let convInfo = arg.info
         takeToken c, arg
         inc nested
@@ -1595,7 +1607,7 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
   while it.n.kind != ParRi:
     var arg = Item(n: it.n, typ: c.types.autoType)
     argIndexes.add c.dest.len
-    semExpr c, arg
+    semExpr c, arg, {AllowEmpty}
     if arg.typ.typeKind == UntypedT:
       skipSemCheck = true
     # scope extension: If the type is Typevar and it has attached
@@ -3909,15 +3921,25 @@ proc semTypedUnaryArithmetic(c: var SemContext; it: var Item) =
   wantParRi c, it.n
   commonType c, it, beforeExpr, typ
 
-proc semBracket(c: var SemContext, it: var Item) =
+proc semBracket(c: var SemContext, it: var Item; flags: set[SemFlag]) =
   let exprStart = c.dest.len
   let info = it.n.info
   inc it.n
   c.dest.addParLe(AconstrX, info)
   if it.n.kind == ParRi:
     # empty array
-    if it.typ.typeKind in {AutoT, VoidT}:
-      buildErr c, it.n.info, "empty array needs a specified type"
+    if it.typ.typeKind == AutoT:
+      if AllowEmpty in flags:
+        # keep it.typ as auto, but build array[0..-1, auto] in the expression
+        c.dest.buildTree ArrayT, info:
+          c.dest.addSubtree it.typ
+          c.dest.addParLe(RangetypeT, info)
+          c.dest.addSubtree c.types.intType
+          c.dest.addIntLit(0, info)
+          c.dest.addIntLit(-1, info)
+          c.dest.addParRi()
+      else:
+        buildErr c, it.n.info, "empty array needs a specified type"
     else:
       c.dest.addSubtree it.typ
     wantParRi c, it.n
@@ -3955,15 +3977,20 @@ proc semBracket(c: var SemContext, it: var Item) =
   c.dest.insert it.typ, typeInsertPos
   commonType c, it, exprStart, expected
 
-proc semCurly(c: var SemContext, it: var Item) =
+proc semCurly(c: var SemContext, it: var Item; flags: set[SemFlag]) =
   let exprStart = c.dest.len
   let info = it.n.info
   inc it.n
   c.dest.addParLe(SetConstrX, info)
   if it.n.kind == ParRi:
     # empty set
-    if it.typ.typeKind in {AutoT, VoidT}:
-      buildErr c, it.n.info, "empty set needs a specified type"
+    if it.typ.typeKind == AutoT:
+      if AllowEmpty in flags:
+        # keep it.typ as auto, but build set[auto] in the expression
+        c.dest.buildTree SetT, it.n.info:
+          c.dest.addSubtree it.typ
+      else:
+        buildErr c, it.n.info, "empty set needs a specified type"
     else:
       c.dest.addSubtree it.typ
     wantParRi c, it.n
@@ -5326,9 +5353,9 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
     of CardX:
       semCardSet c, it
     of BracketX:
-      semBracket c, it
+      semBracket c, it, flags
     of CurlyX:
-      semCurly c, it
+      semCurly c, it, flags
     of AconstrX:
       semArrayConstr c, it
     of SetConstrX:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3930,14 +3930,8 @@ proc semBracket(c: var SemContext, it: var Item; flags: set[SemFlag]) =
     # empty array
     if it.typ.typeKind == AutoT:
       if AllowEmpty in flags:
-        # keep it.typ as auto, but build array[0..-1, auto] in the expression
-        c.dest.buildTree ArrayT, info:
-          c.dest.addSubtree it.typ
-          c.dest.addParLe(RangetypeT, info)
-          c.dest.addSubtree c.types.intType
-          c.dest.addIntLit(0, info)
-          c.dest.addIntLit(-1, info)
-          c.dest.addParRi()
+        # keep it.typ as auto
+        c.dest.addSubtree it.typ
       else:
         buildErr c, it.n.info, "empty array needs a specified type"
     else:
@@ -3986,9 +3980,8 @@ proc semCurly(c: var SemContext, it: var Item; flags: set[SemFlag]) =
     # empty set
     if it.typ.typeKind == AutoT:
       if AllowEmpty in flags:
-        # keep it.typ as auto, but build set[auto] in the expression
-        c.dest.buildTree SetT, it.n.info:
-          c.dest.addSubtree it.typ
+        # keep it.typ as auto
+        c.dest.addSubtree it.typ
       else:
         buildErr c, it.n.info, "empty set needs a specified type"
     else:

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -186,52 +186,6 @@ proc buildLocalErr*(dest: var TokenBuf; info: PackedLineInfo; msg: string) =
 
 # -------------------------- type handling ---------------------------
 
-proc typeToCanon*(buf: TokenBuf; start: int): string =
-  result = ""
-  for i in start..<buf.len:
-    case buf[i].kind
-    of ParLe:
-      result.add '('
-      result.addInt buf[i].tagId.int
-    of ParRi: result.add ')'
-    of Ident, StringLit:
-      result.add ' '
-      result.addInt buf[i].litId.int
-    of UnknownToken: result.add " unknown"
-    of EofToken: result.add " eof"
-    of DotToken: result.add '.'
-    of Symbol, SymbolDef:
-      result.add " s"
-      result.addInt buf[i].symId.int
-    of CharLit:
-      result.add " c"
-      result.addInt buf[i].uoperand.int
-    of IntLit:
-      result.add " i"
-      result.addInt buf[i].intId.int
-    of UIntLit:
-      result.add " u"
-      result.addInt buf[i].uintId.int
-    of FloatLit:
-      result.add " f"
-      result.addInt buf[i].floatId.int
-
-proc typeToCursor*(c: var SemContext; buf: TokenBuf; start: int): TypeCursor =
-  let key = typeToCanon(buf, start)
-  if c.typeMem.hasKey(key):
-    result = cursorAt(c.typeMem[key], 0)
-  else:
-    var newBuf = createTokenBuf(buf.len - start)
-    for i in start..<buf.len:
-      newBuf.add buf[i]
-    # make resilient against crashes:
-    #if newBuf.len == 0: newBuf.add dotToken(NoLineInfo)
-    result = cursorAt(newBuf, 0)
-    c.typeMem[key] = newBuf
-
-proc typeToCursor*(c: var SemContext; start: int): TypeCursor =
-  typeToCursor(c, c.dest, start)
-
 proc ptrTypeOf*(c: var SemContext; typ: TypeCursor): TypeCursor =
   let typeBegin = c.dest.len
   c.dest.buildTree PtrT, typ.info:

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -101,3 +101,49 @@ type
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking
     toBuild*: TokenBuf
     unoverloadableMagics*: HashSet[StrId]
+
+proc typeToCanon*(buf: TokenBuf; start: int): string =
+  result = ""
+  for i in start..<buf.len:
+    case buf[i].kind
+    of ParLe:
+      result.add '('
+      result.addInt buf[i].tagId.int
+    of ParRi: result.add ')'
+    of Ident, StringLit:
+      result.add ' '
+      result.addInt buf[i].litId.int
+    of UnknownToken: result.add " unknown"
+    of EofToken: result.add " eof"
+    of DotToken: result.add '.'
+    of Symbol, SymbolDef:
+      result.add " s"
+      result.addInt buf[i].symId.int
+    of CharLit:
+      result.add " c"
+      result.addInt buf[i].uoperand.int
+    of IntLit:
+      result.add " i"
+      result.addInt buf[i].intId.int
+    of UIntLit:
+      result.add " u"
+      result.addInt buf[i].uintId.int
+    of FloatLit:
+      result.add " f"
+      result.addInt buf[i].floatId.int
+
+proc typeToCursor*(c: var SemContext; buf: TokenBuf; start: int): TypeCursor =
+  let key = typeToCanon(buf, start)
+  if c.typeMem.hasKey(key):
+    result = cursorAt(c.typeMem[key], 0)
+  else:
+    var newBuf = createTokenBuf(buf.len - start)
+    for i in start..<buf.len:
+      newBuf.add buf[i]
+    # make resilient against crashes:
+    #if newBuf.len == 0: newBuf.add dotToken(NoLineInfo)
+    result = cursorAt(newBuf, 0)
+    c.typeMem[key] = newBuf
+
+proc typeToCursor*(c: var SemContext; start: int): TypeCursor =
+  typeToCursor(c, c.dest, start)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -743,7 +743,7 @@ proc singleArg(m: var Match; f: var Cursor; arg: Item) =
         if containsGenericParams(f): # maybe restrict to params of this routine
           m.genericEmpty = true
         let start = m.args.len
-        m.args.add arg.n # copy tag
+        m.args.add arg.n.load # copy tag
         m.args.takeTree f
         m.args.addParRi()
     else:

--- a/tests/nimony/generics/temptyliteral.nim
+++ b/tests/nimony/generics/temptyliteral.nim
@@ -1,0 +1,16 @@
+proc concreteArr(arr: array[0, int]) = discard
+proc genericArr[I, T](x: T, arr: array[I, T]) = discard
+proc genericIndexArr[I](arr: array[I, int]) = discard
+proc genericElemArr[T](x: T, arr: array[0, T]) = discard
+
+concreteArr([])
+genericArr(123, [])
+genericIndexArr([])
+genericElemArr(123, [])
+
+proc concreteSet(arr: set[int8]) = discard
+proc genericSet[T](x: T, arr: set[T]) = discard
+
+concreteSet({})
+genericSet(123'i8, {})
+

--- a/tests/nimony/generics/temptyliteral.nim
+++ b/tests/nimony/generics/temptyliteral.nim
@@ -8,9 +8,11 @@ genericArr(123, [])
 genericIndexArr([])
 genericElemArr(123, [])
 
-proc concreteSet(arr: set[int8]) = discard
-proc genericSet[T](x: T, arr: set[T]) = discard
+type Enum = enum a, b, c
+proc concreteSet(arr: set[Enum]) = discard
+proc genericSet[T](x: set[T], arr: set[T]) = discard
 
 concreteSet({})
-genericSet(123'i8, {})
+var x: set[Enum] = {}
+genericSet(x, {})
 


### PR DESCRIPTION
refs #470

* When semchecking call arguments, empty array/set literals without an inferred element type are allowed to compile and produce the type `auto`
* Expressions with type `auto` are detected in sigmatch and checked for being empty literals. If so, the param type is checked to be a matching array/set type and the literal is updated to have the param type. If the param type is generic, the match is marked as containing a generic empty literal.
* Then when the call matches, it is checked if the match was marked to contain a generic empty literal, in which case empty literal arguments instantiate their type when being added to the final call node.