### PR TITLE
rename `add` for cursors, fix related bug

### DIFF
--- a/src/hexer/basics.nim
+++ b/src/hexer/basics.nim
@@ -72,7 +72,7 @@ proc tagToken*(tag: string; info: PackedLineInfo): PackedToken {.inline.} =
 
 proc wantParRi*(e: var EContext; c: var Cursor) =
   if c.kind == ParRi:
-    e.dest.add c
+    e.dest.addToken c
     inc c
   else:
     error e, "expected ')', but got: ", c
@@ -87,7 +87,7 @@ template loop*(e: var EContext; c: var Cursor; body: untyped) =
   while true:
     case c.kind
     of ParRi:
-      e.dest.add c
+      e.dest.addToken c
       inc c
       break
     of EofToken:

--- a/src/hexer/constparams.nim
+++ b/src/hexer/constparams.nim
@@ -75,7 +75,7 @@ proc trConstRef(c: var Context; dest: var TokenBuf; n: var Cursor) =
       tr c, dest, n
 
 proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
-  dest.add n
+  dest.addToken n
   inc n # skip `(call)`
   var fnType = skipProcTypeToParams(getType(c.typeCache, n))
   takeTree dest, n # skip `fn`
@@ -104,7 +104,7 @@ proc trLocal(c: var Context; dest: var TokenBuf; n: var Cursor) =
 
 proc trScope(c: var Context; dest: var TokenBuf; n: var Cursor) =
   c.typeCache.openScope()
-  dest.add n
+  dest.addToken n
   inc n
   while n.kind != ParRi:
     tr c, dest, n
@@ -118,12 +118,12 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
     of Symbol:
       if c.constRefParams.contains(n.symId):
         copyIntoKind dest, DerefX, n.info:
-          dest.add n
+          dest.addToken n
       else:
-        dest.add n
+        dest.addToken n
       inc n
     of SymbolDef, Ident, IntLit, UIntLit, FloatLit, CharLit, StringLit, UnknownToken, DotToken, EofToken:
-      dest.add n
+      dest.addToken n
       inc n
     of ParLe:
       if n.exprKind in CallKinds:
@@ -139,11 +139,11 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
         of TemplateS, TypeS:
           takeTree dest, n
         else:
-          dest.add n
+          dest.addToken n
           inc n
           inc nested
     of ParRi:
-      dest.add n
+      dest.addToken n
       inc n
       dec nested
     if nested == 0: break

--- a/src/hexer/destroyer.nim
+++ b/src/hexer/destroyer.nim
@@ -142,7 +142,7 @@ when not defined(nimony):
 
 proc trLocal(c: var Context; n: var Cursor) =
   let info = n.info
-  c.dest.add n
+  c.dest.addToken n
   var r = takeLocal(n, SkipFinalParRi)
   copyTree c.dest, r.name
   copyTree c.dest, r.exported
@@ -179,7 +179,7 @@ proc registerSinkParameters(c: var Context; params: Cursor) =
         c.currentScope.destroyOps.add DestructorOp(destroyProc: destructor, arg: r.name.symId)
 
 proc trProcDecl(c: var Context; n: var Cursor) =
-  c.dest.add n
+  c.dest.addToken n
   var r = takeRoutine(n, SkipFinalParRi)
   copyTree c.dest, r.name
   copyTree c.dest, r.exported
@@ -287,13 +287,13 @@ proc tr(c: var Context; n: var Cursor) =
       trProcDecl c, n
     else:
       if n.kind == ParLe:
-        c.dest.add n
+        c.dest.addToken n
         inc n
         while n.kind != ParRi:
           tr(c, n)
         wantParRi(c.dest, n)
       else:
-        c.dest.add n
+        c.dest.addToken n
         inc n
 
 proc injectDestructors*(n: Cursor; lifter: ref LiftingCtx): TokenBuf =

--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -108,7 +108,7 @@ when not defined(nimony):
 
 proc trSons(c: var Context; n: var Cursor; e: Expects) =
   assert n.kind == ParLe
-  c.dest.add n
+  c.dest.addToken n
   inc n
   while n.kind != ParRi:
     tr(c, n, e)
@@ -367,7 +367,7 @@ proc trOnlyEssentials(c: var Context; n: var Cursor) =
   while true:
     case n.kind
     of Symbol, UIntLit, StringLit, IntLit, FloatLit, CharLit, SymbolDef, UnknownToken, EofToken, DotToken, Ident:
-      c.dest.add n
+      c.dest.addToken n
       inc n
     of ParLe:
       case n.exprKind
@@ -384,17 +384,17 @@ proc trOnlyEssentials(c: var Context; n: var Cursor) =
       of TraceX:
         trExplicitTrace c, n
       else:
-        c.dest.add n
+        c.dest.addToken n
         inc n
         inc nested
     of ParRi:
-      c.dest.add n
+      c.dest.addToken n
       inc n
       dec nested
     if nested == 0: break
 
 proc trProcDecl(c: var Context; n: var Cursor) =
-  c.dest.add n
+  c.dest.addToken n
   var r = takeRoutine(n, SkipFinalParRi)
   copyTree c.dest, r.name
   copyTree c.dest, r.exported
@@ -455,7 +455,7 @@ proc trCall(c: var Context; n: var Cursor; e: Expects) =
   if hasDestructor(c, retType) and e == WantNonOwner:
     ow = bindToTemp(c, retType, n.info)
 
-  c.dest.add n
+  c.dest.addToken n
   inc n # skip `(call)`
   var fnType = skipProcTypeToParams(getType(c.typeCache, n))
   takeTree c.dest, n # skip `fn`
@@ -478,7 +478,7 @@ proc trCall(c: var Context; n: var Cursor; e: Expects) =
 proc trRawConstructor(c: var Context; n: var Cursor; e: Expects) =
   # Idioms like `echo ["ab", myvar, "xyz"]` are important to translate well.
   let e2 = if e == WillBeOwned: WantOwner else: e
-  c.dest.add n
+  c.dest.addToken n
   inc n
   while n.kind != ParRi:
     tr c, n, e2
@@ -550,7 +550,7 @@ proc trLocation(c: var Context; n: var Cursor; e: Expects) =
     trSons c, n, DontCare
 
 proc trLocal(c: var Context; n: var Cursor) =
-  c.dest.add n
+  c.dest.addToken n
   var r = takeLocal(n, SkipFinalParRi)
   copyTree c.dest, r.name
   copyTree c.dest, r.exported
@@ -576,7 +576,7 @@ proc trLocal(c: var Context; n: var Cursor) =
     c.dest.addParRi()
 
 proc trStmtListExpr(c: var Context; n: var Cursor; e: Expects) =
-  c.dest.add n
+  c.dest.addToken n
   inc n
   while n.kind != ParRi:
     if isLastSon(n):

--- a/src/hexer/inliner.nim
+++ b/src/hexer/inliner.nim
@@ -58,7 +58,7 @@ when not defined(nimony):
 
 proc trProcDecl(c: var Context; dest: var TokenBuf; n: var Cursor) =
   c.typeCache.openScope()
-  dest.add n
+  dest.addToken n
   var r = takeRoutine(n, SkipExclBody)
   let oldThisRoutine = c.thisRoutine
   c.thisRoutine = r.name.symId
@@ -151,10 +151,10 @@ proc inlineRoutineBody(c: var InlineContext; dest: var TokenBuf; n: var Cursor) 
       if toReplace.sym != NoSymId:
         addVarReplacement(dest, toReplace, info)
       else:
-        dest.add n
+        dest.addToken n
     inc n
   of Ident, IntLit, UIntLit, FloatLit, CharLit, StringLit, UnknownToken, DotToken, EofToken:
-    dest.add n
+    dest.addToken n
     inc n
   of ParRi:
     raiseAssert "unhandled ')' in inliner.nim"
@@ -312,7 +312,7 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
   while true:
     case n.kind
     of Symbol, SymbolDef, Ident, IntLit, UIntLit, FloatLit, CharLit, StringLit, UnknownToken, DotToken, EofToken:
-      dest.add n
+      dest.addToken n
       inc n
     of ParLe:
       case n.stmtKind
@@ -324,7 +324,7 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
         trProcDecl c, dest, n
       of ScopeS:
         c.typeCache.openScope()
-        dest.add n
+        dest.addToken n
         inc n
         while n.kind != ParRi:
           tr c, dest, n
@@ -336,17 +336,17 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
           if inlineCall:
             doInline(c, dest, n, routine, Target(kind: TargetIsNone))
           else:
-            dest.add n
+            dest.addToken n
             inc nested
             inc n
         elif isDeclarative(n):
           takeTree dest, n
         else:
-          dest.add n
+          dest.addToken n
           inc nested
           inc n
     of ParRi:
-      dest.add n
+      dest.addToken n
       dec nested
       inc n
     if nested == 0: break

--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -181,7 +181,7 @@ proc trIf(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
       inc n
       trExpr c, dest, n, t0
 
-      dest.add head
+      dest.addToken head
       inc toClose
       inc ifs
 
@@ -359,7 +359,7 @@ proc trStmt(c: var Context; dest: var TokenBuf; n: var Cursor) =
     let head = n
     inc n
     trExpr c, dest, n, tar
-    dest.add head
+    dest.addToken head
     dest.add tar
     dest.addParRi()
     skipParRi n
@@ -439,7 +439,7 @@ proc lowerExprs*(n: Cursor; moduleSuffix: string): TokenBuf =
   result = createTokenBuf(300)
   var n = n
   assert n.stmtKind == StmtsS, $n.kind
-  result.add n
+  result.addToken n
   inc n
   while n.kind != ParRi:
     trStmt c, result, n

--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -173,7 +173,7 @@ proc cursorToPosition*(base, c: Cursor): int {.inline.} =
   result = (c - base) div sizeof(PackedToken)
   assert result < 1_000_000
 
-proc add*(result: var TokenBuf; c: Cursor) =
+proc addToken*(result: var TokenBuf; c: Cursor) =
   result.add c.load
 
 proc addSubtree*(result: var TokenBuf; c: Cursor) =
@@ -222,7 +222,7 @@ proc add*(dest: var TokenBuf; src: TokenBuf) =
 
 proc fromCursor*(c: Cursor): TokenBuf =
   result = TokenBuf(data: cast[Storage](alloc(sizeof(PackedToken)*4)), len: 0, cap: 4)
-  result.add c
+  result.addToken c
 
 proc fromStream*(s: var Stream): TokenBuf =
   result = TokenBuf(data: cast[Storage](alloc(sizeof(PackedToken)*4)), len: 0, cap: 4)

--- a/src/nimony/controlflow.nim
+++ b/src/nimony/controlflow.nim
@@ -595,7 +595,7 @@ proc trCase(c: var ControlFlow; n: var Cursor; tar: Target) =
   for e in endings: c.patch e
 
 proc trCall(c: var ControlFlow; n: var Cursor) =
-  c.dest.add n
+  c.dest.addToken n
   inc n
   while n.kind != ParRi:
     trExpr c, n
@@ -617,7 +617,7 @@ proc trStmt(c: var ControlFlow; n: var Cursor) =
       trStmt c, n
     inc n
   of ScopeS:
-    c.dest.add n
+    c.dest.addToken n
     inc n
     c.typeCache.openScope()
     while n.kind != ParRi:
@@ -655,7 +655,7 @@ proc trStmt(c: var ControlFlow; n: var Cursor) =
   of CallS, CmdS:
     trCall c, n
   of YieldS, DiscardS, InclSetS, ExclSetS:
-    c.dest.add n
+    c.dest.addToken n
     inc n
     while n.kind != ParRi:
       trExpr c, n
@@ -718,7 +718,7 @@ proc trIfCaseTryBlockExpr(c: var ControlFlow; n: var Cursor; kind: ControlFlowAs
   c.dest.addSymUse tar, info
 
 proc trExprLoop(c: var ControlFlow; n: var Cursor) =
-  c.dest.add n
+  c.dest.addToken n
   inc n
   while n.kind != ParRi:
     trExpr c, n
@@ -729,7 +729,7 @@ proc trExpr(c: var ControlFlow; n: var Cursor) =
   case n.kind
   of Symbol, SymbolDef, IntLit, UIntLit, FloatLit, StringLit, CharLit,
      Ident, DotToken, EofToken, UnknownToken:
-    c.dest.add n
+    c.dest.addToken n
     inc n
   of ParRi:
     raiseAssert "unreachable"
@@ -780,7 +780,7 @@ proc toControlflow*(n: Cursor): TokenBuf =
   assert n.stmtKind == StmtsS
   c.typeCache.openScope()
   var n = n
-  c.dest.add n
+  c.dest.addToken n
   inc n
   while n.kind != ParRi:
     trStmt c, n

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -47,12 +47,12 @@ type
     typeCache: TypeCache
 
 proc takeToken(c: var Context; n: var Cursor) {.inline.} =
-  c.dest.add n
+  c.dest.addToken n
   inc n
 
 proc wantParRi(c: var Context; n: var Cursor) =
   if n.kind == ParRi:
-    c.dest.add n
+    c.dest.addToken n
     inc n
   else:
     error "expected ')', but got: ", n

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -157,7 +157,7 @@ template copyIntoKinds*(dest: var TokenBuf; kinds: array[2, StmtKind]; info: Pac
 
 template copyInto*(dest: var TokenBuf; n: var Cursor; body: untyped) =
   assert n.kind == ParLe
-  dest.add n
+  dest.addToken n
   inc n
   body
   dest.addParRi()
@@ -191,12 +191,12 @@ proc addEmpty3*(dest: var TokenBuf; info: PackedLineInfo = NoLineInfo) =
 
 proc takeTree*(dest: var TokenBuf; n: var Cursor) =
   if n.kind != ParLe:
-    dest.add n
+    dest.addToken n
     inc n
   else:
     var nested = 0
     while true:
-      dest.add n
+      dest.addToken n
       case n.kind
       of ParLe: inc nested
       of ParRi:

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -194,7 +194,7 @@ proc setupProgram*(infile, outfile: string; hasIndex=false): Cursor =
 
 proc wantParRi*(dest: var TokenBuf; n: var Cursor) =
   if n.kind == ParRi:
-    dest.add n
+    dest.addToken n
     inc n
   else:
     error "expected ')', but got: ", n

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -331,7 +331,7 @@ proc declareOverloadableSym*(c: var SemContext; it: var Item; kind: SymKind): (S
     if not c.freshSyms.missingOrExcl(it.n.symId):
       status = OkExistingFresh
     result = (it.n.symId, status)
-    c.dest.add it.n
+    c.dest.addToken it.n
     inc it.n
   else:
     let lit = getIdent(it.n)
@@ -367,7 +367,7 @@ proc handleSymDef*(c: var SemContext; n: var Cursor; kind: SymKind): DelayedSym 
 
     let s = Sym(kind: kind, name: n.symId, pos: c.dest.len)
     result = DelayedSym(status: status, lit: symToIdent(s.name), s: s, info: info)
-    c.dest.add n
+    c.dest.addToken n
     inc n
   elif n.kind == DotToken:
     var name = "`anon"
@@ -418,18 +418,18 @@ proc takeTree*(c: var SemContext; n: var Cursor) =
 
 proc wantParRi*(c: var SemContext; n: var Cursor) =
   if n.kind == ParRi:
-    c.dest.add n
+    c.dest.addToken n
     inc n
   else:
     error "expected ')', but got: ", n
 
 proc takeToken*(c: var SemContext; n: var Cursor) {.inline.} =
-  c.dest.add n
+  c.dest.addToken n
   inc n
 
 proc wantDot*(c: var SemContext; n: var Cursor) =
   if n.kind == DotToken:
-    c.dest.add n
+    c.dest.addToken n
     inc n
   else:
     buildErr c, n.info, "expected '.'"

--- a/src/nimony/templates.nim
+++ b/src/nimony/templates.nim
@@ -23,7 +23,7 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
   while true:
     case body.kind
     of UnknownToken, EofToken, DotToken, Ident:
-      dest.add body
+      dest.addToken body
     of Symbol:
       let s = body.symId
       let arg = e.formalParams.getOrDefault(s)
@@ -38,14 +38,14 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
           if tv != default(Cursor):
             dest.addSubtree tv
           else:
-            dest.add body # keep Symbol as it was
+            dest.addToken body # keep Symbol as it was
     of SymbolDef:
       let s = body.symId
       let newDef = newSymId(c, s)
       e.newVars[s] = newDef
       dest.add symdefToken(newDef, body.info)
     of StringLit, CharLit, IntLit, UIntLit, FloatLit:
-      dest.add body
+      dest.addToken body
     of ParLe:
       let forStmt = asForStmt(body)
       if forStmt.kind == ForS and forStmt.iter.exprKind == UnpackX:
@@ -80,10 +80,10 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
           skip body
           unsafeDec body
       else:
-        dest.add body
+        dest.addToken body
         inc nested
     of ParRi:
-      dest.add body
+      dest.addToken body
       dec nested
       if nested == 0: break
     if isAtom: break


### PR DESCRIPTION
Bug is in `maybeByConstRef`, `addSubtree` needed to be used.

A lot of these uses are `takeToken` analogs, could also add a version of it for `TokenBuf` to reduce the increased code length in followup.