### PR TITLE
fix issues with `add` for cursor

### DIFF
--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -130,6 +130,7 @@ proc transformBreakStmt(e: var EContext; c: var Cursor) =
     let lab = e.breaks[^1]
     e.dest.add symToken(lab, c.info)
   else:
+    assert c.kind in {DotToken, Symbol}
     e.dest.add c
   inc c
   wantParRi e, c

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -503,11 +503,11 @@ proc maybeByConstRef(e: var EContext; c: var Cursor) =
   if passByConstRef(param.typ, param.pragmas, e.bits div 8):
     var paramBuf = createTokenBuf()
     paramBuf.add tagToken("param", c.info)
-    paramBuf.add param.name
-    paramBuf.add param.exported
-    paramBuf.add param.pragmas
+    paramBuf.addSubtree param.name
+    paramBuf.addSubtree param.exported
+    paramBuf.addSubtree param.pragmas
     copyIntoKind paramBuf, PtrT, param.typ.info:
-      paramBuf.add param.typ
+      paramBuf.addSubtree param.typ
     paramBuf.addDotToken()
     paramBuf.addParRi()
     var paramCursor = beginRead(paramBuf)
@@ -908,8 +908,7 @@ proc traverseExpr(e: var EContext; c: var Cursor) =
         e.dest.add symToken(ithTupleField(pool.integers[c.intId]), c.info)
         inc c # skip index
         e.dest.addIntLit(0, c.info) # inheritance
-        e.dest.add c # add right paren
-        inc c # skip right paren
+        wantParRi e, c
       of DdotX:
         e.dest.add tagToken("dot", c.info)
         e.dest.add tagToken("deref", c.info)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4118,7 +4118,7 @@ proc semTupleConstr(c: var SemContext, it: var Item) =
         c.buildErr it.n.info, "expected field name for named tuple constructor"
       else:
         takeToken c, it.n
-        typ.add it.n # add name
+        typ.addSubtree it.n # add name
         takeToken c, it.n
     else:
       typ.add identToken(pool.strings.getOrIncl("Field" & $i), it.n.info)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1111,7 +1111,7 @@ proc semObjConstrFromCall(c: var SemContext; it: var Item; cs: CallState) =
   skipParRi it.n
   var objBuf = createTokenBuf()
   objBuf.add parLeToken(OconstrX, cs.callNode.info)
-  objBuf.add cs.fn.n
+  objBuf.addSubtree cs.fn.n
   objBuf.addParRi()
   var objConstr = Item(n: cursorAt(objBuf, 0), typ: it.typ)
   semObjConstr c, objConstr
@@ -1825,7 +1825,7 @@ proc semDot(c: var SemContext, it: var Item; flags: set[SemFlag]) =
     c.dest.shrink exprStart
     var callBuf = createTokenBuf(16)
     callBuf.addParLe(CallX, info)
-    callBuf.add fieldNameCursor
+    callBuf.addSubtree fieldNameCursor
     callBuf.addSubtree lhs.n # add lhs as first argument
     callBuf.addParRi()
     var call = Item(n: cursorAt(callBuf, 0), typ: expected)


### PR DESCRIPTION
The issues in sem were: Dot and tuple field names could be quoted/symchoice trees, object constructor types could be `InvokeT` trees if they have generic parameters.