### PR TITLE
overload lookup fixes

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1349,11 +1349,12 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
     elif sym != SymId(0):
       # non-callable symbol, look up all overloads
       assert cs.fnName != StrId(0)
-      let choiceStart = cs.dest.len
-      swap c.dest, cs.dest
+      var choiceBuf = createTokenBuf(16)
+      swap c.dest, choiceBuf
       discard buildSymChoice(c, cs.fnName, cs.fn.n.info, FindAll)
-      swap c.dest, cs.dest
-      cs.fn = Item(n: cursorAt(cs.dest, choiceStart), typ: c.types.autoType, kind: CchoiceY)
+      swap c.dest, choiceBuf
+      # could store choiceBuf in CallState but cs.fn should not outlive it
+      cs.fn = Item(n: beginRead(choiceBuf), typ: c.types.autoType, kind: CchoiceY)
       resolveOverloads(c, it, cs)
       return
     else:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3611,6 +3611,7 @@ proc semWhen(c: var SemContext; it: var Item) =
   if not leaveUnresolved:
     # none of the branches evaluated, output nothing
     c.dest.shrink start
+    producesVoid c, info, it.typ
 
 proc semCaseOfValue(c: var SemContext; it: var Item; selectorType: TypeCursor;
                     seen: var seq[(xint, xint)]) =

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -109,15 +109,11 @@ proc rawBuildSymChoice(c: var SemContext; identifier: StrId; info: PackedLineInf
       inc result
       if sym.kind.isNonOverloadable:
         inc nonOverloadable
-    if result == 1:
-      case option
-      of InnerMost:
-        return
-      of FindOverloads:
-        if nonOverloadable == 1:
-          # unambiguous local symbol found
-          return
-      else: discard
+    if result == 1 and (option == InnerMost or
+        (option == FindOverloads and nonOverloadable == 1)):
+      # unambiguous local symbol found
+      # in case of FindOverloads, if symbol is overloadable, consider other overloads
+      return
     it = it.up
   inc result, considerImportedSymbols(c, identifier, info)
 

--- a/tests/nimony/lookups/deps/mambtype1.nim
+++ b/tests/nimony/lookups/deps/mambtype1.nim
@@ -1,0 +1,1 @@
+type Foo* = int

--- a/tests/nimony/lookups/deps/mambtype2.nim
+++ b/tests/nimony/lookups/deps/mambtype2.nim
@@ -1,0 +1,1 @@
+type Foo* = float

--- a/tests/nimony/lookups/tambtype.msgs
+++ b/tests/nimony/lookups/tambtype.msgs
@@ -1,0 +1,2 @@
+tests/nimony/lookups/tambtype.nim(3, 8) Error: ambiguous identifier
+tests/nimony/lookups/tambtype.nim(3, 5) Error: type mismatch: got: (i -1) but wanted: (ochoice Foo.0.mamdoporf Foo.0.mamiajb2h)

--- a/tests/nimony/lookups/tambtype.nim
+++ b/tests/nimony/lookups/tambtype.nim
@@ -1,0 +1,3 @@
+import deps/[mambtype1, mambtype2]
+
+var x: Foo = 123

--- a/tests/nimony/lookups/tambtypeconv.msgs
+++ b/tests/nimony/lookups/tambtypeconv.msgs
@@ -1,0 +1,2 @@
+tests/nimony/lookups/tambtypeconv.nim(3, 13) Error: ambiguous identifier: 'Foo'
+tests/nimony/lookups/tambtypeconv.nim(3, 12) Error: undeclared field: 'Foo' for type (i -1)

--- a/tests/nimony/lookups/tambtypeconv.msgs
+++ b/tests/nimony/lookups/tambtypeconv.msgs
@@ -1,2 +1,2 @@
-tests/nimony/lookups/tambtypeconv.nim(3, 13) Error: ambiguous identifier: 'Foo'
+tests/nimony/lookups/tambtypeconv.nim(3, 13) Error: attempt to call routine: 'Foo'
 tests/nimony/lookups/tambtypeconv.nim(3, 12) Error: undeclared field: 'Foo' for type (i -1)

--- a/tests/nimony/lookups/tambtypeconv.nim
+++ b/tests/nimony/lookups/tambtypeconv.nim
@@ -1,0 +1,3 @@
+import deps/[mambtype1, mambtype2]
+
+var x = 123.Foo

--- a/tests/nimony/lookups/tlocalcall.nim
+++ b/tests/nimony/lookups/tlocalcall.nim
@@ -1,0 +1,10 @@
+proc foo(x: int) = discard
+proc foo(y: float) = discard
+proc bar(x: uint8) = discard
+
+proc main =
+  when false: # when proc types work
+    let foo = bar
+    foo(123) # does not consider overloads, always matches local
+
+main()

--- a/tests/nimony/lookups/tscopedtype.nim
+++ b/tests/nimony/lookups/tscopedtype.nim
@@ -1,0 +1,6 @@
+import deps/mambtype1
+
+type Foo* = uint8
+
+var x: Foo = 123
+let y: uint8 = x


### PR DESCRIPTION
Overload lookup is changed to match the old compiler: Callee symbols no longer use `FindAll`, they use a new lookup mode `FindOverloads`, which only considers overloads of unambiguous symbols if they are overloadable. `InnerMost` always returns a symbol if it is unambiguous, even if it is overloadable. (before `InnerMost` behaved like `FindOverloads`)

This means callee symbols prefer local unambiguous symbols to outer overloads. To deal with this when the local symbols are not procs (i.e. `let len = arr.len`), in the case where the callee symbol is not callable, all overloads are considered.

For this to work, symchoice callees now ignore non-callable symbols and give an error if none of the choices were callable (the previous error would have been "undeclared identifier").

This also means when local unoverloadable symbols do have proc types, they are matched directly and outer overloads are not considered, which is also the behavior of the old compiler (local types are the same):

```nim
proc foo(x: int) = discard

proc main =
  let foo = proc (x: string) = discard
  foo(123) # error
```

But it's open how this should behave. https://github.com/nim-lang/Nim/issues/24357

Also `when` where no branch is evaluated is fixed to produce a `void` type instead of `auto`.