### PR TITLE
test disallowing implicit conversion to generic types

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -191,6 +191,8 @@ proc commonType(c: var SemContext; it: var Item; argBegin: int; expected: TypeCu
       it.typ = expected
     else:
       c.typeMismatch info, it.typ, expected
+  elif m.isGeneric:
+    c.buildErr info, "cannot implicitly convert expression of type " & typeToString(it.typ) & " to generic type " & typeToString(expected)
   else:
     shrink c.dest, argBegin
     c.dest.add m.args

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -421,8 +421,10 @@ proc commonType(f, a: Cursor): Cursor =
 proc typevarRematch(m: var Match; typeVar: SymId; f, a: Cursor) =
   let com = commonType(f, a)
   if com.kind == ParLe and com.tagId == ErrT:
+    let firstErr = m.err
     m.error InvalidRematch, f, a
-    m.error.typeVar = typeVar
+    if firstErr:
+      m.error.typeVar = typeVar
   elif matchesConstraint(m, typeVar, com):
     m.inferred[typeVar] = skipModifier(com)
   else:
@@ -872,8 +874,10 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.tvars.incl v
       if e.kind == DotToken: discard
       elif e.kind == ParRi:
-        m.error.typeVar = v
+        let firstErr = not m.err
         m.error0 MissingExplicitGenericParameter
+        if firstErr:
+          m.error.typeVar = v
         break
       else:
         if matchesConstraint(m, v, e):
@@ -923,8 +927,8 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
     for v in typeVars(fn.sym):
       let inf = m.inferred.getOrDefault(v)
       if inf == default(Cursor):
-        m.error.typeVar = v
         m.error0 CouldNotInferTypeVar
+        m.error.typeVar = v
         break
       m.typeArgs.addSubtree inf
 

--- a/tests/nimony/nosystem/tfib.nim
+++ b/tests/nimony/nosystem/tfib.nim
@@ -15,9 +15,9 @@ type
     proc `-`(x, y: Self): Self
 
 proc fib[T: Fibable](a: T): T =
-  if a <= 2:
-    result = 1
+  if a <= T(2):
+    result = T(1)
   else:
-    result = fib(a-1) + fib(a-2)
+    result = fib(a-T(1)) + fib(a-T(2))
 
 discard fib(8)

--- a/tests/nimony/nosystem/tfib2.nim
+++ b/tests/nimony/nosystem/tfib2.nim
@@ -22,10 +22,10 @@ type
     proc `-`(x, y: Self): Self
 
 proc fib[T: Fibable](a: T): T =
-  if a <= 2:
-    result = 1
+  if a <= T(2):
+    result = T(1)
   else:
-    result = fib(a-1) + fib(a-2)
+    result = fib(a-T(1)) + fib(a-T(2))
 
 discard fib(8)
 discard fib[int](8)

--- a/tests/nimony/sysbasics/tdefaultparams.nim
+++ b/tests/nimony/sysbasics/tdefaultparams.nim
@@ -14,7 +14,7 @@ proc foo4(x: int, y: float, z: int = 23, a: float = 1.2) =
 proc foo5[T](x: T, y: int = 7) =
   discard
 
-proc foo6[T](x: T = 3, y: int = 7) =
+proc foo6[T](x: T = T(3), y: int = 7) =
   discard
 
 proc foo[T](x: T, y: T = T(7)) =

--- a/tests/nimony/sysbasics/tdefaultparams.nim
+++ b/tests/nimony/sysbasics/tdefaultparams.nim
@@ -17,7 +17,7 @@ proc foo5[T](x: T, y: int = 7) =
 proc foo6[T](x: T = 3, y: int = 7) =
   discard
 
-proc foo[T](x: T, y: T = 7) =
+proc foo[T](x: T, y: T = T(7)) =
   let s = x
   let j = y
 


### PR DESCRIPTION
refs https://github.com/nim-lang/nimony/pull/531#discussion_r1954485562

Another option might be to disable generic param inference for these or a general rule to only infer generic params included in `m.tvars`.

Type conversions might not be the best way to do this due to the overlap with normal type conversions, same for casts.