### PR TITLE
fix typevar error info in sigmatch

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -85,6 +85,19 @@ proc error0(m: var Match; k: MatchErrorKind) =
   m.err = true
   m.error = MatchError(info: m.argInfo, kind: k, pos: m.pos+1)
 
+proc errorTypevar(m: var Match; k: MatchErrorKind; expected, got: Cursor; typevar: SymId) =
+  if m.err: return # first error is the important one
+  m.err = true
+  m.error = MatchError(info: m.argInfo, kind: k,
+                       typeVar: typevar,
+                       expected: expected, got: got, pos: m.pos+1)
+
+proc error0Typevar(m: var Match; k: MatchErrorKind; typevar: SymId) =
+  if m.err: return # first error is the important one
+  m.err = true
+  m.error = MatchError(info: m.argInfo, kind: k,
+                       typeVar: typevar, pos: m.pos+1)
+
 proc getErrorMsg(m: Match): string =
   case m.error.kind
   of InvalidMatch:
@@ -417,10 +430,7 @@ proc commonType(f, a: Cursor): Cursor =
 proc typevarRematch(m: var Match; typeVar: SymId; f, a: Cursor) =
   let com = commonType(f, a)
   if com.kind == ParLe and com.tagId == ErrT:
-    let firstErr = not m.err
-    m.error InvalidRematch, f, a
-    if firstErr:
-      m.error.typeVar = typeVar
+    m.errorTypevar InvalidRematch, f, a, typeVar
   elif matchesConstraint(m, typeVar, com):
     m.inferred[typeVar] = skipModifier(com)
   else:
@@ -864,10 +874,7 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.tvars.incl v
       if e.kind == DotToken: discard
       elif e.kind == ParRi:
-        let firstErr = not m.err
-        m.error0 MissingExplicitGenericParameter
-        if firstErr:
-          m.error.typeVar = v
+        m.error0Typevar MissingExplicitGenericParameter, v
         break
       else:
         if matchesConstraint(m, v, e):
@@ -917,8 +924,7 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
     for v in typeVars(fn.sym):
       let inf = m.inferred.getOrDefault(v)
       if inf == default(Cursor):
-        m.error0 CouldNotInferTypeVar
-        m.error.typeVar = v
+        m.error0Typevar CouldNotInferTypeVar, v
         break
       m.typeArgs.addSubtree inf
 

--- a/tests/nimony/errmsgs/tunderspecifiedgeneric.msgs
+++ b/tests/nimony/errmsgs/tunderspecifiedgeneric.msgs
@@ -1,0 +1,2 @@
+tests/nimony/errmsgs/tunderspecifiedgeneric.nim(3, 4) Error: Type mismatch at [position]
+[2] could not infer type for T.0.tunsd0i13

--- a/tests/nimony/errmsgs/tunderspecifiedgeneric.nim
+++ b/tests/nimony/errmsgs/tunderspecifiedgeneric.nim
@@ -1,0 +1,3 @@
+proc foo[T, U](x: U) = discard
+
+foo(123)


### PR DESCRIPTION
Call to `error0` would reset the match object