### PR TITLE
test inserting default values from instantiated signature

### DIFF
--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -83,6 +83,7 @@ type
     typeMem*: Table[string, TokenBuf]
     instantiatedTypes*: OrderedTable[string, SymId]
     instantiatedProcs*: OrderedTable[(SymId, string), SymId]
+    instantiatedSigs*: OrderedTable[string, Cursor]
     thisModuleSuffix*: string
     moduleFlags*: set[ModuleFlag]
     processedModules*: HashSet[string]

--- a/tests/nimony/sysbasics/tdefaultparams.nim
+++ b/tests/nimony/sysbasics/tdefaultparams.nim
@@ -14,10 +14,10 @@ proc foo4(x: int, y: float, z: int = 23, a: float = 1.2) =
 proc foo5[T](x: T, y: int = 7) =
   discard
 
-proc foo6[T](x: T = 3, y: int = 7) =
+proc foo6[T](x: T = T(3), y: int = 7) =
   discard
 
-proc foo[T](x: T, y: T = 7) =
+proc foo[T](x: T, y: T = T(7)) =
   let s = x
   let j = y
 


### PR DESCRIPTION
Refs #542, just to test if this works. This would not make the commented out `foo6()` test work, but matching the param to the default value AST would not work either, it would match a generic type to itself which would make it infer to itself etc. The old compiler [special cases this](https://github.com/nim-lang/Nim/blob/1a7bc6d878ff04709ebb1002010fd53b4ba02179/compiler/sigmatch.nim#L3051-L3057) after matching, as evidenced by the error given in:

```nim
proc foo[T](x: T = 6, y: T) = discard

foo(y = "abc")
# error says "expected string but got 6" with line info in original proc declaration
```

Adapting this would mean we can't instantiate the full signature early as done here but rather instantiate the default value first then match it to its param when adding args (if this errors we can add an error token in place of the inserted arg).