### PR TITLE
nifc: fixes `genCLineDir` for call expressions

### DIFF
--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -54,7 +54,6 @@ proc typedUnOp(c: var GeneratedCode; n: var Cursor; opr: string) =
   skipParRi n
 
 proc genCall(c: var GeneratedCode; n: var Cursor) =
-  genCLineDir(c, info(n))
   inc n
   genx c, n
   c.add ParLe
@@ -67,7 +66,6 @@ proc genCall(c: var GeneratedCode; n: var Cursor) =
   skipParRi n
 
 proc genCallCanRaise(c: var GeneratedCode; n: var Cursor) =
-  genCLineDir(c, info(n))
   inc n
   skip n # skip error action
   genx c, n

--- a/src/nifc/genstmts.nim
+++ b/src/nifc/genstmts.nim
@@ -236,6 +236,7 @@ proc genStmt(c: var GeneratedCode; n: var Cursor) =
   of ScopeS:
     genScope c, n
   of CallS:
+    genCLineDir(c, info(n))
     genCall c, n
     c.add Semicolon
   of VarS:
@@ -297,6 +298,7 @@ proc genStmt(c: var GeneratedCode; n: var Cursor) =
   of OnErrS:
     var onErrAction = n
     inc onErrAction
+    genCLineDir(c, info(n))
     genCallCanRaise c, n
     c.add Semicolon
     if onErrAction.kind != DotToken:


### PR DESCRIPTION
don't generate c lineinfo for call expressions