### PR TITLE
build typeArgs for explicit generics

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3323,7 +3323,7 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
         c.buildErr it.n.info, "undeclared identifier", cursorAt(orig, 0)
     it.typ = c.types.autoType
   elif s.kind == CchoiceY:
-    if AllowOverloads notin flags and c.routine.kind != TemplateY:
+    if KeepMagics notin flags and c.routine.kind != TemplateY:
       c.buildErr it.n.info, "ambiguous identifier"
     it.typ = c.types.autoType
   elif s.kind in {TypeY, TypevarY}:
@@ -4546,6 +4546,7 @@ proc tryExplicitRoutineInst(c: var SemContext; syms: Cursor; it: var Item): bool
       var m = createMatch(addr c)
       m.fn = candidate
       matchTypevars m, candidate, args
+      buildTypeArgs(m)
       if not m.err:
         # match
         c.dest.add symToken(sym, syms.info)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -930,8 +930,6 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
     inc f
     m.returnType = f # return type follows the parameters in the token stream
 
-  buildTypeArgs(m)
-
 type
   DisambiguationResult* = enum
     NobodyWins,

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -895,16 +895,6 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.error0 RoutineIsNotGeneric
       return
 
-proc buildTypeArgs*(m: var Match) =
-  # check all type vars have a value:
-  if not m.err and m.fn.kind in RoutineKinds:
-    for v in typeVars(m.fn.sym):
-      let inf = m.inferred.getOrDefault(v)
-      if inf == default(Cursor):
-        m.error0Typevar CouldNotInferTypeVar, v
-        break
-      m.typeArgs.addSubtree inf
-
 proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
                explicitTypeVars: Cursor) =
   assert fn.kind != NoSym or fn.sym == SymId(0)
@@ -929,6 +919,16 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
   if f.kind == ParRi:
     inc f
     m.returnType = f # return type follows the parameters in the token stream
+
+proc buildTypeArgs*(m: var Match) =
+  # check all type vars have a value:
+  if not m.err and m.fn.kind in RoutineKinds:
+    for v in typeVars(m.fn.sym):
+      let inf = m.inferred.getOrDefault(v)
+      if inf == default(Cursor):
+        m.error0Typevar CouldNotInferTypeVar, v
+        break
+      m.typeArgs.addSubtree inf
 
 type
   DisambiguationResult* = enum

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -894,6 +894,16 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.error0 RoutineIsNotGeneric
       return
 
+proc buildTypeArgs*(m: var Match) =
+  # check all type vars have a value:
+  if not m.err and m.fn.kind in RoutineKinds:
+    for v in typeVars(m.fn.sym):
+      let inf = m.inferred.getOrDefault(v)
+      if inf == default(Cursor):
+        m.error0Typevar CouldNotInferTypeVar, v
+        break
+      m.typeArgs.addSubtree inf
+
 proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
                explicitTypeVars: Cursor) =
   assert fn.kind != NoSym or fn.sym == SymId(0)
@@ -919,14 +929,7 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[Item];
     inc f
     m.returnType = f # return type follows the parameters in the token stream
 
-  # check all type vars have a value:
-  if not m.err and fn.kind in RoutineKinds:
-    for v in typeVars(fn.sym):
-      let inf = m.inferred.getOrDefault(v)
-      if inf == default(Cursor):
-        m.error0Typevar CouldNotInferTypeVar, v
-        break
-      m.typeArgs.addSubtree inf
+  buildTypeArgs(m)
 
 type
   DisambiguationResult* = enum

--- a/tests/nimony/generics/deps/mgenericproc.nim
+++ b/tests/nimony/generics/deps/mgenericproc.nim
@@ -1,0 +1,2 @@
+proc importedGeneric*[T](x: T): T =
+  result = x

--- a/tests/nimony/generics/texplicitprocinst.nif
+++ b/tests/nimony/generics/texplicitprocinst.nif
@@ -1,0 +1,53 @@
+(.nif24)
+0,1,tests/nimony/generics/texplicitprocinst.nim(stmts
+ (proc 5 :foo.0.texhjoap . . 8
+  (typevars 1
+   (typevar :T.0.texhjoap . . . .)) 11
+  (params 1
+   (param :x.0 . . 3 T.0.texhjoap .)) . . . 20
+  (stmts
+   (discard .))) ,1
+ (proc 5 :foo.1.texhjoap . . 8
+  (typevars 1
+   (typevar :T.1.texhjoap . . . .) 4
+   (typevar :U.0.texhjoap . . . .)) 14
+  (params 1
+   (param :x.1 . . 3 T.1.texhjoap .) 7
+   (param :y.0 . . 3 U.0.texhjoap .)) . . . 29
+  (stmts
+   (discard .))) ,3
+ (discard 8 foo.2.texhjoap) ,4
+ (discard 8 foo.3.texhjoap) 8,5
+ (call ~8 foo.2.texhjoap 1 +123) 16,6
+ (call ~16 foo.3.texhjoap 1 +123 6 "abc") ,10
+ (discard 28
+  (call ~20 importedGeneric.0.texhjoap 1 +123)) 8,3
+ (proc :foo.2.texhjoap . ~8,~3 .
+  (at foo.0.texhjoap 4
+   (i -1)) 3,~3
+  (params 1
+   (param :x.5 . . ,3
+    (i -1) .)) ~8,~3 . ~8,~3 . ~8,~3 . 12,~3
+  (stmts
+   (discard .))) 8,4
+ (proc :foo.3.texhjoap . ~8,~3 .
+  (at foo.1.texhjoap 4,~1
+   (i -1) 9 string.0.sys9azlf) 6,~3
+  (params 1
+   (param :x.6 . . ~3,2
+    (i -1) .) 7
+   (param :y.2 . . ~4,3 string.0.sys9azlf .)) ~8,~3 . ~8,~3 . ~8,~3 . 21,~3
+  (stmts
+   (discard .))) 28,10
+ (proc :importedGeneric.0.texhjoap . 0,1,tests/nimony/generics/deps/mgenericproc.nim .
+  (at importedGeneric.0.mgesx53wa1
+   (i -1)) 24,1,tests/nimony/generics/deps/mgenericproc.nim
+  (params 1
+   (param :x.7 . .
+    (i -1) .))
+  (i -1) 0,1,tests/nimony/generics/deps/mgenericproc.nim . 0,1,tests/nimony/generics/deps/mgenericproc.nim . 2,2,tests/nimony/generics/deps/mgenericproc.nim
+  (stmts 7
+   (result :result.0 . .
+    (i -1) .) 7
+   (asgn ~7 result.0 2 x.7) ~2,~1
+   (ret result.0))))

--- a/tests/nimony/generics/texplicitprocinst.nim
+++ b/tests/nimony/generics/texplicitprocinst.nim
@@ -5,3 +5,7 @@ discard foo[int]
 discard foo[int, string]
 foo[int](123)
 foo[int, string](123, "abc")
+
+import deps/mgenericproc
+
+discard importedGeneric[int](123)


### PR DESCRIPTION
`matchTypevars` only builds the `tvars` and `inferred` tables, `m.typeArgs` still has to be built after the match because it is used in `requestRoutineInstance` for the proc signature lookup key (and to build the invoke node in the signature AST but this is rebuilt in the final instantiated routine).