### PR TITLE
skip field visibility on resem and fix some generics issues

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3915,6 +3915,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
         c.phase != SemcheckTopLevelSyms):
     var isGeneric: bool
     let prevGeneric = c.routine.inGeneric
+    let prevInst = c.routine.inInst
     if n.kind == DotToken:
       takeToken c, n
       isGeneric = false
@@ -3942,6 +3943,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
     if isGeneric:
       closeScope c
       c.routine.inGeneric = prevGeneric # revert increase by semGenericParams
+      c.routine.inInst = prevInst
   else:
     c.takeTree n # generics
     discard semTypePragmas(c, n, delayed.s.name, beforeExportMarker)

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -17,7 +17,7 @@ type
   TypeCursor* = Cursor
   SemRoutine* {.acyclic.} = ref object
     kind*: SymKind
-    inGeneric*, inLoop*, inBlock*: int
+    inGeneric*, inLoop*, inBlock*, inInst*: int
     returnType*: TypeCursor
     pragmas*: set[PragmaKind]
     resId*: SymId

--- a/tests/nimony/modules/deps/mfieldvis.nim
+++ b/tests/nimony/modules/deps/mfieldvis.nim
@@ -6,8 +6,15 @@ type Generic*[T] = object
   public*: T
   private: T
 
-proc getPrivate*(x: Foo): int = x.private
-proc getPrivate*[T](x: Generic[T]): T = x.private
+proc getPrivate*(x: Foo): int =
+  let y = Foo(public: x.public, private: x.private)
+  result = y.private
+proc getPrivate*[T](x: Generic[T]): T =
+  let y = Generic[T](public: x.public, private: x.private)
+  result = y.private
 
 template getPrivateTempl*(x: Foo): int = x.private
 template getPrivateTempl*[T](x: Generic[T]): T = T(x.private)
+
+proc createGeneric*[T](x: int): Generic[T] =
+  result = Generic[T](public: x, private: x)

--- a/tests/nimony/modules/deps/mfieldvis.nim
+++ b/tests/nimony/modules/deps/mfieldvis.nim
@@ -17,4 +17,4 @@ template getPrivateTempl*(x: Foo): int = x.private
 template getPrivateTempl*[T](x: Generic[T]): T = T(x.private)
 
 proc createGeneric*[T](x: int): Generic[T] =
-  result = Generic[T](public: x, private: x)
+  result = Generic[T](public: T(x), private: T(x))

--- a/tests/nimony/modules/tfieldviserr.nim
+++ b/tests/nimony/modules/tfieldviserr.nim
@@ -5,17 +5,3 @@ discard foo.private
 
 var generic = Generic[int](private: 123)
 discard generic.private
-
-when false: # compiles and should compile but cannot test yet
-  var foo = Foo(public: 123)
-  discard getPrivate(foo)
-  discard getPrivateTempl(foo)
-
-  var generic = Generic[int](public: 123)
-  discard getPrivate(foo)
-  discard getPrivateTempl(foo)
-
-  template resem() =
-    foo = Foo(public: 123)
-    generic = Generic[int](public: 123)
-  resem()

--- a/tests/nimony/modules/tfieldvisworking.nim
+++ b/tests/nimony/modules/tfieldvisworking.nim
@@ -15,3 +15,6 @@ template resem() =
   discard getPrivateTempl(generic)
   generic = createGeneric[int](456)
 resem()
+
+proc scope() =
+  let differentGeneric = createGeneric[float](123)

--- a/tests/nimony/modules/tfieldvisworking.nim
+++ b/tests/nimony/modules/tfieldvisworking.nim
@@ -1,0 +1,17 @@
+import deps/mfieldvis
+
+var foo = Foo(public: 123)
+discard getPrivate(foo)
+discard getPrivateTempl(foo)
+
+var generic = Generic[int](public: 123)
+discard getPrivate(foo)
+discard getPrivateTempl(foo)
+generic = createGeneric[int](456)
+
+template resem() =
+  foo = Foo(public: 123)
+  generic = Generic[int](public: 123)
+  discard getPrivateTempl(generic)
+  generic = createGeneric[int](456)
+resem()


### PR DESCRIPTION
fixes #563

`inGenericInst` as described in https://github.com/nim-lang/nimony/issues/563#issuecomment-2662784550 is generalized to `inInst` to include template instantiations, and this way of doing it in `semGenericParams` happens to include type instantiations which is hopefully fine.

Explicit generic calls in generic/template contexts now rebuild the explicit instantiation after matching since they cannot instantiate it fully, previously they would just leave the sym node of the generic proc and the generic params would have to be inferred from the args on resem.

Type instantiations now temporarily change their scope to the top level scope for exported fields to work when creating an instantiation in a scope. Not sure if this is a hack.