### PR TITLE
build inst request binding cursors from signature invocation

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -149,7 +149,7 @@ proc isNoReturn(n: Cursor): bool {.inline.} =
 
 proc requestRoutineInstance(c: var SemContext; origin: SymId;
                             typeArgs: TokenBuf;
-                            inferred: var Table[SymId, Cursor];
+                            inferred: Table[SymId, Cursor];
                             info: PackedLineInfo): ProcInstance
 
 proc tryConverterMatch(c: var SemContext; convMatch: var Match; f: TypeCursor, arg: Item): bool
@@ -943,7 +943,7 @@ proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; candidates: FnCa
 
 proc requestRoutineInstance(c: var SemContext; origin: SymId;
                             typeArgs: TokenBuf;
-                            inferred: var Table[SymId, Cursor];
+                            inferred: Table[SymId, Cursor];
                             info: PackedLineInfo): ProcInstance =
   let key = typeToCanon(typeArgs, 0)
   var targetSym = c.instantiatedProcs.getOrDefault((origin, key))
@@ -4617,13 +4617,7 @@ proc tryExplicitRoutineInst(c: var SemContext; syms: Cursor; it: var Item): bool
   elif matches == 1 and c.routine.inGeneric == 0 and instLastMatch:
     # can instantiate single match
     c.dest.shrink exprStart
-    # inferred table outlives proc but argsBuf is ephemeral:
-    var inferred = lastMatch.inferred
-    for _, value in inferred.mpairs:
-      c.dest.addSubtree value
-      value = typeToCursor(c, exprStart)
-      c.dest.shrink exprStart
-    let inst = c.requestRoutineInstance(lastMatch.fn.sym, lastMatch.typeArgs, inferred, info)
+    let inst = c.requestRoutineInstance(lastMatch.fn.sym, lastMatch.typeArgs, lastMatch.inferred, info)
     c.dest.add symToken(inst.targetSym, info)
     it.typ = asRoutine(inst.procType).params
     it.kind = lastMatch.fn.kind

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1283,6 +1283,8 @@ proc addArgsInstConverters(c: var SemContext; m: var Match; origArgs: openArray[
                 sigmatch convMatch, conv, [Item(n: arg, typ: origArgs[i].typ)], emptyNode(c)
                 # ^ could also use origArgs[i] directly but commonType would have to keep the expression alive
                 assert not convMatch.err
+                buildTypeArgs(convMatch)
+                assert not convMatch.err
                 let inst = c.requestRoutineInstance(conv.sym, convMatch.typeArgs, convMatch.inferred, convInfo)
                 c.dest[c.dest.len-1].setSymId inst.targetSym
         while true:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1291,7 +1291,7 @@ proc addArgsInstConverters(c: var SemContext; m: var Match; origArgs: openArray[
                 buildTypeArgs(convMatch)
                 if convMatch.err:
                   # adding type args errored
-                  buildErr c, info, getErrorMsg(convMatch)
+                  buildErr c, convInfo, getErrorMsg(convMatch)
                 else:
                   let inst = c.requestRoutineInstance(conv.sym, convMatch.typeArgs, convMatch.inferred, convInfo)
                   c.dest[c.dest.len-1].setSymId inst.targetSym

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -993,7 +993,7 @@ proc requestRoutineInstance(c: var SemContext; origin: SymId;
     var req = InstRequest(
       origin: origin,
       targetSym: targetSym,
-      inferred: move(inferred)
+      inferred: move(newInferred)
     )
     for ins in c.instantiatedFrom: req.requestFrom.add ins
     req.requestFrom.add info

--- a/tests/nimony/generics/texplicitprocinst.nif
+++ b/tests/nimony/generics/texplicitprocinst.nif
@@ -31,10 +31,10 @@
   (stmts
    (discard .))) 8,4
  (proc :foo.3.texhjoap . ~8,~3 .
-  (at foo.1.texhjoap 4,~1
+  (at foo.1.texhjoap 4
    (i -1) 9 string.0.sysvq0asl) 6,~3
   (params 1
-   (param :x.6 . . ~3,2
+   (param :x.6 . . ~3,3
     (i -1) .) 7
    (param :y.2 . . ~4,3 string.0.sysvq0asl .)) ~8,~3 . ~8,~3 . ~8,~3 . 21,~3
   (stmts


### PR DESCRIPTION
follows up #566

The `inferred` table passed to `requestRoutineInstance` is added to global memory, hence every type cursor included in it also has to be in global memory. To ensure this, we rebuild the cursors from the added invocation node in the signature, so that the cursors live as long as the signature does.

Another way might be to ensure everything saved to `inferred` in sigmatch passes through `typeToCursor`, but maybe this would be slower.