### PR TITLE
fixes #556

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1295,16 +1295,16 @@ proc importSymbol(e: var EContext; s: SymId) =
         if InlineP in prag.flags:
           transformInlineRoutines(e, c)
           return
+        if NodeclP in prag.flags:
+          if prag.externName.len > 0:
+            e.registerMangle(s, prag.externName & ".c")
+          if prag.header != StrId(0):
+            e.headers.incl prag.header
+          return
 
-      var dst = createTokenBuf(50)
-      swap e.dest, dst
+      e.dest.add tagToken("imp", c.info)
       traverseStmt e, c, TraverseSig
-      swap dst, e.dest
-
-      if dst.len > 0:
-        e.dest.add tagToken("imp", c.info)
-        e.dest.add dst
-        e.dest.addParRi()
+      e.dest.addParRi()
   else:
     error e, "could not find symbol: " & pool.syms[s]
 

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1296,9 +1296,15 @@ proc importSymbol(e: var EContext; s: SymId) =
           transformInlineRoutines(e, c)
           return
 
-      e.dest.add tagToken("imp", c.info)
+      var dst = createTokenBuf(50)
+      swap e.dest, dst
       traverseStmt e, c, TraverseSig
-      e.dest.addParRi()
+      swap dst, e.dest
+
+      if dst.len > 0:
+        e.dest.add tagToken("imp", c.info)
+        e.dest.add dst
+        e.dest.addParRi()
   else:
     error e, "could not find symbol: " & pool.syms[s]
 


### PR DESCRIPTION
Don't add `imp` when `importSymbol` was called with a proc symbol with header pragma or any other symbols that doesn't need to be added.