### PR TITLE
split type inst cache and module type inst declaration list

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2560,7 +2560,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
       let targetSym = newSymId(c, headId)
       c.instantiatedTypes[key] = targetSym
       if genericArgs == 0:
-        c.typeInstantiations.add targetSym
+        c.typeInstDecls.add targetSym
       var sub = createTokenBuf(30)
       subsGenericTypeFromArgs c, sub, info, headId, targetSym, decl, args
       c.dest.endRead()
@@ -5650,7 +5650,7 @@ proc semcheck*(infile, outfile: string; config: sink NifConfig; moduleFlags: set
   while n.kind != ParRi:
     semStmt c, n, false
   instantiateGenerics c
-  for val in c.typeInstantiations:
+  for val in c.typeInstDecls:
     let s = fetchSym(c, val)
     let res = declToCursor(c, s)
     if res.status == LacksNothing:

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -73,7 +73,9 @@ type
     routine*: SemRoutine
     currentScope*: Scope
     g*: ProgramContext
-    typeRequests*, procRequests*: seq[InstRequest]
+    procRequests*: seq[InstRequest]
+    typeInstDecls*: seq[SymId]
+      ## syms of type instantiations to add their declarations to module
     includeStack*: seq[string]
     importedModules*: Table[SymId, ImportedModule]
     instantiatedFrom*: seq[PackedLineInfo]
@@ -81,8 +83,8 @@ type
     globals*, locals*: Table[string, int]
     types*: BuiltinTypes
     typeMem*: Table[string, TokenBuf]
-    instantiatedTypes*: OrderedTable[string, SymId]
-    instantiatedProcs*: OrderedTable[(SymId, string), SymId]
+    instantiatedTypes*: Table[string, SymId]
+    instantiatedProcs*: Table[(SymId, string), SymId]
     thisModuleSuffix*: string
     moduleFlags*: set[ModuleFlag]
     processedModules*: HashSet[string]

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -112,7 +112,7 @@
    (asgn ~6
     (ddot ~6 result.1 data.1.tge70unlm +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
- (type :Node.4.tge70unlm .
+ (type :Node.3.tge70unlm .
   (at Node.0.tge70unlm 1
    (i -1)) ~2,~5 . ,~5
   (ref 11 NodeObj.1.tge70unlm)) 23,3


### PR DESCRIPTION
refs #543

The list of type instantiation syms which need their declarations appended to a module is now separated from the mapping of canonical invocations to their instantiated values. Only types which are fully instantiated i.e. without their generic arguments containing generic parameters themselves are appended to the module.

This allows us to cache partially instantiated types in `instantiatedTypes`, i.e. `Foo[U]` where `U` is a generic parameter of the current context now only substitutes the body of `Foo` with `U` once rather than every time `Foo[U]` is invoked. Maybe these shouldn't generate syms either but idk if it would be worth it to try to change that.

This would also allow us to repeatedly alternate over iterating the type instantiation requests and the proc instantiation requests so if one adds to the other they are all considered (the intended behavior of `instantiateGenerics`). But this is not done for now to not disturb the current behavior, it will be needed if instantiating generic hooks creates new type instantiations. `typeRequests` is still removed as it was not used.

`instantiatedTypes` also no longer needs to be ordered for this reason, `instantiatedProcs` already did not need to be ordered as it was never iterated. But could be changed back.