### PR TITLE
instantiate field types of invocation object types in exprs

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4397,7 +4397,7 @@ proc buildDefaultObjConstr(c: var SemContext; typ: Cursor;
   if obj.parentType.kind != DotToken:
     # copy original bindings to bring back when iterating the original type:
     let origBindings = bindings
-    var bindingBuf = default(TokenBuf)
+    var bindingBuf = default(TokenBuf) # to store subsequent parent args
     var parentType = obj.parentType
     while parentType.kind != DotToken:
       var parentImpl = parentType
@@ -4419,13 +4419,13 @@ proc buildDefaultObjConstr(c: var SemContext; typ: Cursor;
       bindings = newBindings
 
       let parent = asObjectDecl(parentImpl)
-      parentType = parent.parentType
       var currentField = parent.firstField
       if currentField.kind != DotToken:
         while currentField.kind != ParRi:
           let field = asLocal(currentField)
           buildObjConstrField(c, field, setFields, info, bindings)
           skip currentField
+      parentType = parent.parentType
     # bring back original bindings:
     bindings = origBindings
   var currentField = obj.firstField

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1721,7 +1721,7 @@ proc objBody(td: TypeDecl): Cursor {.inline.} =
 proc skipInvoke(t: var Cursor): Cursor {.inline.} =
   ## if `t` is an invocation, skips to root sym and returns start of args,
   ## otherwise returns `default(Cursor)`
-  if t.kind == InvokeT:
+  if t.typeKind == InvokeT:
     inc t
     result = t
     inc result

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1738,8 +1738,6 @@ proc genericRootSym(td: TypeDecl): SymId =
 
 proc bindInvokeArgs(decl: TypeDecl; invokeArgs: Cursor): Table[SymId, Cursor] =
   ## returns a mapping of invocation arguments to typevars of a type
-  ## 
-  ## 
   result = initTable[SymId, Cursor]()
   if invokeArgs != default(Cursor):
     var typevar = decl.typevars

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4385,6 +4385,9 @@ proc buildDefaultObjConstr(c: var SemContext; typ: Cursor;
     else:
       c.buildErr info, "cannot build object constructor for type: " & typeToString(objImpl)
       return
+  else:
+    c.buildErr info, "cannot build object constructor for type: " & typeToString(objImpl)
+    return
   c.dest.addParLe(constrKind, info)
   c.dest.addSubtree typ
   var obj = asObjectDecl(objImpl)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4351,14 +4351,18 @@ proc buildDefaultObjConstr(c: var SemContext; typ: Cursor;
   if objImpl.kind == Symbol:
     objDecl = getTypeSection(objImpl.symId)
     objImpl = objDecl.objBody
-    if constrKind == NoExpr:
-      case objImpl.typeKind
-      of RefobjT:
-        constrKind = NewOconstrX
-      of ObjectT:
+    case objImpl.typeKind
+    of RefobjT:
+      if constrKind != NoExpr:
+        c.buildErr info, "cannot construct double ref object: " & typeToString(typ)
+        return
+      constrKind = NewOconstrX
+    of ObjectT:
+      if constrKind == NoExpr:
         constrKind = OconstrX
-      else:
-        error "cannot build object constructor for type", objImpl
+    else:
+      c.buildErr info, "cannot build object constructor for type: " & typeToString(objImpl)
+      return
   c.dest.addParLe(constrKind, info)
   c.dest.addSubtree typ
   var obj = asObjectDecl(objImpl)

--- a/tests/nimony/generics/taddobj.nim
+++ b/tests/nimony/generics/taddobj.nim
@@ -1,0 +1,19 @@
+type Foo[T] = object
+  val: T
+
+type Addable = concept
+  proc `+`(a, b: Self): Self
+
+proc foo[T: Addable](a: T): Foo[T] =
+  var x = Foo[T](val: a + a)
+  discard x.val + x.val
+  discard x.val + a
+  discard a + x.val
+  x.val = a + a
+  x.val = x.val + x.val
+  x.val = x.val + a
+  x.val = a + x.val
+  result = x
+
+let x = foo(123)
+let y: Foo[int] = x

--- a/tests/nimony/generics/tobjfield.nim
+++ b/tests/nimony/generics/tobjfield.nim
@@ -17,3 +17,14 @@ proc foo[T: Addable](a: T): Foo[T] =
 
 let x = foo(123)
 let y: Foo[int] = x
+
+type Bar[T] = object
+  field: ptr T
+
+proc bar[U](a: ptr U) =
+  var x = Bar[U](field: a)
+  if x.field == nil:
+    # typed magic here: needs to produce `(ptr U)` and not `(ptr T)`
+    discard
+
+bar(addr x)


### PR DESCRIPTION
fixes #543

The aim with #580 was to instantiate these fully in `semInvoke` then look up the impls from `instantiatedTypes` with the canon type of the invoke types, but we can't do this yet because of the problems with instantiating forward declared types.

Instead `findObjField` and `buildDefaultObjConstr` now accept/build bindings based on invocation type args and instantiate the final field type with them. They rebuild bindings for parent types as well when iterating over them, substituting their arguments with the existing bindings.