### PR TITLE
fixes #588; NIFC generates &buf.a[0] for arrays

### DIFF
--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -204,6 +204,9 @@ proc genAddr(c: var GeneratedCode; n: var Cursor) =
   genx c, n
   if arrType.typeKind == ArrayT and not c.m.isImportC(arrType):
     c.add ".a"
+    c.add BracketLe
+    c.add "0"
+    c.add BracketRi
   c.add ParRi
   if n.kind != ParRi and n.typeQual == CppRefQ:
     if c.m.config.backend == backendCpp:


### PR DESCRIPTION
Fixes `getType` proc in `nifc/typenav.nim` to return the type of given variable correctly.
Adds `[0]` when generating the address of array.