### PR TITLE
match directly to inferred value of generic param

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -423,22 +423,13 @@ proc procTypeMatch(m: var Match; f, a: var Cursor) =
   skip f # body
   expectParRi m, f
 
-proc commonType(c: var SemContext; f, a: Cursor): Cursor =
+proc commonType(f, a: Cursor): Cursor =
   # XXX Refine
-  if f.typeKind == AutoT:
-    result = a
-  elif a.typeKind == AutoT:
-    result = f
-  elif sameTrees(f, a):
-    result = f
-  else:
-    var buf = createTokenBuf(16)
-    buf.buildTree ErrT, a.info:
-      buf.addDotToken()
-    result = typeToCursor(c, buf, 0)
+  result = a
 
 proc typevarRematch(m: var Match; typeVar: SymId; f, a: Cursor) =
-  let com = commonType(m.context[], f, a)
+  # now unused, maybe bring back error message somehow
+  let com = commonType(f, a)
   if com.kind == ParLe and com.tagId == ErrT:
     m.errorTypevar InvalidRematch, f, a, typeVar
   elif matchesConstraint(m, typeVar, com):
@@ -456,6 +447,7 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
   let fs = f.symId
   if isTypevar(fs):
     if m.inferred.contains(fs):
+      # used to call typevarRematch
       var prev = m.inferred[fs]
       singleArgImpl(m, prev, arg)
     elif matchesConstraint(m, fs, a):

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -457,7 +457,7 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
   if isTypevar(fs):
     if m.inferred.contains(fs):
       var prev = m.inferred[fs]
-      singleArgImpl(m, prev, a)
+      singleArgImpl(m, prev, arg)
     elif matchesConstraint(m, fs, a):
       m.inferred[fs] = a
     else:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -456,7 +456,8 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
   let fs = f.symId
   if isTypevar(fs):
     if m.inferred.contains(fs):
-      typevarRematch(m, fs, m.inferred[fs], a)
+      var prev = m.inferred[fs]
+      singleArgImpl(m, prev, a)
     elif matchesConstraint(m, fs, a):
       m.inferred[fs] = a
     else:

--- a/tests/nimony/generics/texplicitprocinst.nif
+++ b/tests/nimony/generics/texplicitprocinst.nif
@@ -40,14 +40,14 @@
   (stmts
    (discard .))) 28,10
  (proc :importedGeneric.0.texhjoap . 0,1,tests/nimony/generics/deps/mgenericproc.nim .
-  (at importedGeneric.0.mgesx53wa1
+  (at importedGeneric.0.mgesx53wa1 ~4
    (i -1)) 24,1,tests/nimony/generics/deps/mgenericproc.nim
   (params 1
-   (param :x.7 . .
-    (i -1) .))
+   (param :x.7 . . 24,11,tests/nimony/generics/texplicitprocinst.nim
+    (i -1) .)) ~4
   (i -1) 0,1,tests/nimony/generics/deps/mgenericproc.nim . 0,1,tests/nimony/generics/deps/mgenericproc.nim . 2,2,tests/nimony/generics/deps/mgenericproc.nim
   (stmts 7
-   (result :result.0 . .
+   (result :result.0 . . 24,11,tests/nimony/generics/texplicitprocinst.nim
     (i -1) .) 7
    (asgn ~7 result.0 2 x.7) ~2,~1
    (ret result.0))))

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,0 +1,2 @@
+tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
+[2] Could not match again: T.1.twrt5xaak expected (i -1) but got Foo.1.twrt5xaak

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,2 +1,2 @@
 tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
-[2] Could not match again: T.1.twrt5xaak expected (i -1) but got Foo.1.twrt5xaak
+[2] expected: (i -1) but got: Foo.1.twrt5xaak

--- a/tests/nimony/generics/twronginference.nim
+++ b/tests/nimony/generics/twronginference.nim
@@ -1,0 +1,7 @@
+type Foo[T] = object
+
+proc foo[T](x: Foo[T], y: T) = discard
+
+proc main() =
+  var x = Foo[int]()
+  foo(x, x)

--- a/tests/nimony/nosystem/tfib2.nif
+++ b/tests/nimony/nosystem/tfib2.nif
@@ -104,8 +104,7 @@
     (else 2,1
      (stmts 7
       (asgn ~7 result.0 11
-       (add ~6,~21
-        (i -1) ~6
+       (infix \2B ~6
         (call ~3 fib.0.tfitjdpcx 2
          (infix \2D ~1 a.1 1 +1)) 5
         (call ~3 fib.0.tfitjdpcx 2

--- a/tests/nimony/sysbasics/tdefaultparams.nif
+++ b/tests/nimony/sysbasics/tdefaultparams.nif
@@ -84,14 +84,14 @@
  (call ~9 foo6.1.tdebp8hax 11,~19 +3 23,~19 +7) 4,36
  (call ~4 foo6.1.tdebp8hax 16,~20 +3 28,~20 +7) 3,23
  (proc :foo.1.tdebp8hax . ~3,~4 .
-  (at foo.0.tdebp8hax 10,~23
+  (at foo.0.tdebp8hax
    (i -1)) 8,~4
   (params 1
-   (param :x.10 . . 1,~19
+   (param :x.10 . .
     (i -1) .) 7
    (param :y.10 . . ~5,~19
     (i -1) 8
-    (conv ~13,~19
+    (conv
      (i -1) 1 +7))) ~3,~4 . ~3,~4 . ~3,~4 . ~1,~3
   (stmts 4
    (let :s.2 . . 7,~20


### PR DESCRIPTION
The current `sigmatch.commonType` just accepts any type for the rematch which can cause invalid matches. The rematch can be a conversion match as well which is not trivial to handle in `commonType`. So this is changed to just recurse over `singleArgImpl` same as how `linearMatch` recurses over itself. This does not give the `InvalidRematch` error message though, instead giving a normal match error.