### PR TITLE
import string type symbol for string literals in nifcgen

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -192,6 +192,7 @@ proc genStringType(e: var EContext; info: PackedLineInfo) =
 proc useStringType(e: var EContext; info: PackedLineInfo) =
   let s = pool.syms.getOrIncl(StringName)
   e.dest.add symToken(s, info)
+  e.demand s
 
 proc traverseTupleBody(e: var EContext; c: var Cursor) =
   let info = c.info
@@ -798,7 +799,7 @@ proc genStringLit(e: var EContext; s: string; info: PackedLineInfo) =
       e.dest.add symToken(strName, info)
   else:
     e.dest.add tagToken("oconstr", info)
-    e.dest.add symToken(pool.syms.getOrIncl(StringName), info)
+    useStringType e, info
 
     e.dest.add parLeToken(KvU, info)
     let strField = pool.syms.getOrIncl(StringAField)

--- a/tests/nimony/modules/deps/mstringuse.nim
+++ b/tests/nimony/modules/deps/mstringuse.nim
@@ -1,0 +1,2 @@
+proc usesString*() =
+  discard "abc"

--- a/tests/nimony/modules/timportedstringuse.nim
+++ b/tests/nimony/modules/timportedstringuse.nim
@@ -1,0 +1,3 @@
+import deps/mstringuse
+
+usesString()


### PR DESCRIPTION
Any case where the only occurence of the string type in a module was in a string literal would fail without this, caught from `discard "..."` but another case might be a call to a proc from another module with a string literal argument