### PR TITLE
nifcgen: add pending named types after imported symbols

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1473,7 +1473,6 @@ proc expand*(infile: string, bits: int) =
     #genStringType e, c.info
     while c.kind != ParRi:
       traverseStmt e, c, TraverseTopLevel
-    e.dest.add e.pending
   else:
     error e, "expected (stmts) but got: ", c
 
@@ -1484,6 +1483,7 @@ proc expand*(infile: string, bits: int) =
     if not e.declared.contains(imp):
       importSymbol(e, imp)
     inc i
+  e.dest.add e.pending
   skipParRi e, c
   writeOutput e, rootInfo
   e.closeMangleScope()

--- a/tests/nimony/modules/deps/mprocvar.nim
+++ b/tests/nimony/modules/deps/mprocvar.nim
@@ -1,0 +1,1 @@
+var procvar*: proc (size: int) {.nimcall.}

--- a/tests/nimony/modules/timportedprocvar.nim
+++ b/tests/nimony/modules/timportedprocvar.nim
@@ -1,0 +1,4 @@
+import deps/mprocvar
+
+proc main() =
+  procvar(123)


### PR DESCRIPTION
Declarations of named structural types i.e. arrays, procs etc are appended to `e.pending` in `traverseAsNamedType`. Since this can also occur when traversing types of imported symbols, the pending buffer is now flushed after the imported symbols are processed.