### PR TITLE
make compat untyped templates/generics opt in via pragma for now

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -181,7 +181,7 @@
 | `(symkind UNUSED)` | NimonyType | `symkind` type |
 | `(typekind UNUSED)` | NimonyType | `typekind` type |
 | `(typedesc T)` | NimonyType | `typedesc` type |
-| `(untyped)` | NimonyType | `untyped` type |
+| `(untyped)` | NimonyPragma, NimonyType | `untyped` type |
 | `(typed)` | NimonyType | `typed` type |
 | `(cstring)` | NimonyType | `cstring` type |
 | `(pointer)` | NimonyType | `pointer` type |

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -578,7 +578,7 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
           inc c
         of NodeclP, SelectanyP, ThreadvarP, GlobalP, DiscardableP, NoReturnP,
            VarargsP, BorrowP, NoSideEffectP, NoDestroyP, ByCopyP, ByRefP,
-           InlineP, NoinlineP, NoInitP, InjectP, GensymP:
+           InlineP, NoinlineP, NoInitP, InjectP, GensymP, UntypedP:
           result.flags.incl pk
           inc c
         of HeaderP:

--- a/src/models/nimony_tags.nim
+++ b/src/models/nimony_tags.nim
@@ -258,6 +258,7 @@ type
     BitsP = (131, "bits")
     NodeclP = (134, "nodecl")  ## `nodecl` annotation
     RaisesP = (149, "raises")  ## proc annotation
+    UntypedP = (182, "untyped")  ## `untyped` type
     MagicP = (187, "magic")  ## `magic` pragma
     ImportcP = (188, "importc")  ## `importc` pragma
     ImportcppP = (189, "importcpp")  ## `importcpp` pragma
@@ -283,7 +284,7 @@ type
 
 proc rawTagIsNimonyPragma*(raw: uint32): bool {.inline.} =
   let r = raw - 75'u32
-  r <= 255'u32 and r.uint8 in {0'u8, 47'u8, 48'u8, 50'u8, 52'u8, 55'u8, 56'u8, 59'u8, 74'u8, 112'u8, 113'u8, 114'u8, 115'u8, 116'u8, 117'u8, 118'u8, 119'u8, 120'u8, 121'u8, 122'u8, 123'u8, 124'u8, 125'u8, 126'u8, 127'u8, 128'u8, 129'u8, 130'u8, 131'u8, 189'u8, 190'u8}
+  r <= 255'u32 and r.uint8 in {0'u8, 47'u8, 48'u8, 50'u8, 52'u8, 55'u8, 56'u8, 59'u8, 74'u8, 107'u8, 112'u8, 113'u8, 114'u8, 115'u8, 116'u8, 117'u8, 118'u8, 119'u8, 120'u8, 121'u8, 122'u8, 123'u8, 124'u8, 125'u8, 126'u8, 127'u8, 128'u8, 129'u8, 130'u8, 131'u8, 189'u8, 190'u8}
 
 type
   NimonySym* = enum

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2157,7 +2157,7 @@ proc semPragma(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kin
     c.dest.addParRi()
   of NodeclP, SelectanyP, ThreadvarP, GlobalP, DiscardableP, NoreturnP, BorrowP,
      NoSideEffectP, NodestroyP, BycopyP, ByrefP, InlineP, NoinlineP, NoinitP,
-     InjectP, GensymP:
+     InjectP, GensymP, UntypedP:
     crucial.flags.incl pk
     c.dest.add parLeToken(pk, n.info)
     c.dest.addParRi()
@@ -3403,7 +3403,8 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
           error "(stmts) expected, but got ", it.n
         c.openScope() # open body scope
         var resId = SymId(0)
-        if c.g.config.compat and c.routine.inGeneric > 0: # includes templates
+        if c.g.config.compat and c.routine.inGeneric > 0 and # includes templates
+            UntypedP in crucial.flags: # should be default eventually
           let mode = if kind == TemplateY: UntypedTemplate else: UntypedGeneric
           var ctx = createUntypedContext(addr c, mode)
           addParams(ctx, beforeGenericParams)

--- a/src/nimony/semuntyped.nim
+++ b/src/nimony/semuntyped.nim
@@ -394,6 +394,7 @@ proc semTemplBody*(c: var UntypedCtx; n: var Cursor) =
         takeParRi c.c[], n
       of WhileS:
         takeToken c.c[], n
+        semTemplBody c, n
         openScope c
         semTemplBody c, n
         closeScope c

--- a/tests/nimony/compat/tgenericproc.nim
+++ b/tests/nimony/compat/tgenericproc.nim
@@ -1,6 +1,6 @@
 proc printf(format: cstring) {.importc: "printf", varargs, header: "<stdio.h>", nodecl.}
 
-proc foo[T](x: T) =
+proc foo[T](x: T) {.untyped.} =
   printf("%s\n", x)
   let x = 123 # shadows
   printf("%d\n", x)

--- a/tests/nimony/compat/ttemplate.nim
+++ b/tests/nimony/compat/ttemplate.nim
@@ -1,6 +1,6 @@
 proc printf(format: cstring) {.importc: "printf", varargs, header: "<stdio.h>", nodecl.}
 
-template foo(cond: untyped) =
+template foo(cond: untyped) {.untyped.} =
   let x = 123
   printf("%d\n", x)
   if cond:


### PR DESCRIPTION
Unimplemented stuff etc can break these tests when new templates/generic procs are added to system, we can hold off on maintaining them until the feature is finished.