### PR TITLE
fixes `nimcall`

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -301,7 +301,7 @@ proc traverseProcTypeBody(e: var EContext; c: var Cursor) =
   let prag = parsePragmas(e, c)
   var genPragmas = openGenPragmas()
   if prag.callConv != NoCallConv:
-    let name = if prag.callConv == Nimcall: $Fastcall else: $prag.callConv
+    let name = $prag.callConv
     e.addKey genPragmas, name, pinfo
   closeGenPragmas e, genPragmas
 
@@ -665,7 +665,7 @@ proc traverseProc(e: var EContext; c: var Cursor; mode: TraverseMode) =
   let oldOwner = setOwner(e, s)
 
   var genPragmas = openGenPragmas()
-  if prag.callConv != NoCallConv and prag.callConv != Nimcall:
+  if prag.callConv != NoCallConv:
     let name = $prag.callConv
     e.addKey genPragmas, name, pinfo
   if InlineP in prag.flags:

--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -198,7 +198,7 @@ proc callingConvToStr(cc: CallConv): string =
   of Thiscall: "N_THISCALL"
   of Noconv: "N_NOCONV"
   of Member: "N_NOCONV"
-  of Nimcall: "N_FASTCALL"
+  of Nimcall: "N_NIMCALL"
 
 include gentypes
 

--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -237,6 +237,15 @@ typedef NU8 NU;
 #  define N_LIB_IMPORT  extern
 #endif
 
+#if defined(__BORLANDC__) || defined(_MSC_VER) || defined(WIN32) || defined(_WIN32)
+/* these compilers have a fastcall so use it: */
+#  define N_NIMCALL(rettype, name) rettype __fastcall name
+#  define N_NIMCALL_PTR(rettype, name) rettype (__fastcall *name)
+#else
+#  define N_NIMCALL(rettype, name) rettype name /* no modifier */
+#  define N_NIMCALL_PTR(rettype, name) rettype (*name)
+#endif
+
 #define N_NOCONV(rettype, name) rettype name
 /* specify no calling convention */
 #define N_NOCONV_PTR(rettype, name) rettype (*name)

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -167,4 +167,20 @@
    (kv e.0.tbawx6nu81 43,421,lib/std/system.nim
     (expr
      (expr +0))))) 7,43
- (call ~7 foo1314.0.tbawx6nu81 1 a.1.tbawx6nu81))
+ (call ~7 foo1314.0.tbawx6nu81 1 a.1.tbawx6nu81) ,45
+ (proc 5 :foo2233.0.tbawx6nu81 . . . 12
+  (params) . 15
+  (pragmas 2
+   (nimcall)) . 2,1
+  (stmts 4
+   (var :x.4 . . 8
+    (proctype . . . .
+     (params) . 3
+     (pragmas 2
+      (cdecl)) . .) .) 4,3
+   (var :y.1 . . 8
+    (proctype . . . .
+     (params) . 3
+     (pragmas 2
+      (nimcall)) . .) .))) 7,51
+ (call ~7 foo2233.0.tbawx6nu81))

--- a/tests/nimony/sysbasics/tbasics.nim
+++ b/tests/nimony/sysbasics/tbasics.nim
@@ -42,3 +42,11 @@ proc foo1314(x: Foo1314) =
 
 var a = Foo1314()
 foo1314(a)
+
+proc foo2233() {.nimcall.} =
+  var x: proc () {.cdecl.}
+
+# Compile error
+  var y: proc () {.nimcall.}
+
+foo2233()


### PR DESCRIPTION
It implements `nimcall` following the fashion of Nim. So it won't cause warnings on unsupported platforms. And it won't be treated as `NoCallConv` when used for functions.

Otherwise, it causes warnings on macOS: `warning: 'fastcall' calling convention is not supported for this target [-Wignored-attributes]` for `nimcall` which is quite commonly used

