### PR TITLE
fix enum imports in nifcgen and forward uses in nifc

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1375,6 +1375,7 @@ proc importSymbol(e: var EContext; s: SymId) =
     of TypeY:
       traverseTypeDecl e, c
     of EfldY:
+      # import full enum type:
       let typ = asLocal(c).typ
       assert typ.kind == Symbol
       e.demand typ.symId

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1370,11 +1370,17 @@ proc importSymbol(e: var EContext; s: SymId) =
   let res = tryLoadSym(s)
   if res.status == LacksNothing:
     var c = res.decl
-    if c.stmtKind == TypeS:
+    let kind = c.symKind
+    case kind
+    of TypeY:
       traverseTypeDecl e, c
+    of EfldY:
+      let typ = asLocal(c).typ
+      assert typ.kind == Symbol
+      e.demand typ.symId
     else:
-      let isR = isRoutine(c.symKind)
-      if isR or isLocal(c.symKind):
+      let isR = isRoutine(kind)
+      if isR or isLocal(kind):
         var pragmas = if isR:
                         asRoutine(c).pragmas
                       else:

--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -60,6 +60,9 @@ proc recordDependencyImpl(m: Module; o: var TypeOrder; parent, child: Cursor;
          var viaPointer = false
          recordDependencyImpl m, o, ch, ch.firstSon, viaPointer
       o.ordered.add tracebackTypeC(ch), TypedefStruct
+  of EnumT:
+    # enums do not depend on anything so always safe to generate them
+    o.ordered.add tracebackTypeC(ch), TypedefKeyword
   else:
     if ch.kind == Symbol:
       # follow the symbol to its definition:

--- a/src/nifc/nifc_model.nim
+++ b/src/nifc/nifc_model.nim
@@ -133,7 +133,7 @@ proc symKind*(c: Cursor): NifcSym {.inline.} =
     result = NoSym
 
 proc tracebackTypeC*(n: Cursor): Cursor =
-  assert n.typeKind in {ObjectT, UnionT, ArrayT}
+  assert n.typeKind in {ObjectT, UnionT, ArrayT, EnumT}
   result = n
   while result.stmtKind != TypeS:
     unsafeDec result

--- a/tests/nimony/modules/deps/menumiter.nim
+++ b/tests/nimony/modules/deps/menumiter.nim
@@ -1,0 +1,10 @@
+type
+  FooEnum = enum
+    abc
+
+  BarObj = object
+    kind: FooEnum
+
+iterator testIter*(): int =
+  var f: BarObj
+  f.kind = abc

--- a/tests/nimony/modules/tenumiter.nim
+++ b/tests/nimony/modules/tenumiter.nim
@@ -1,0 +1,7 @@
+import deps/menumiter
+
+proc main() =
+  for x in testIter():
+    discard
+
+main()


### PR DESCRIPTION
fixes #617

Imported enum fields in nifcgen queue the full enum type to be imported rather than attempting to generate an extern declaration for the enum field.

Enum types used before their declarations in object fields in nifc is also fixed: previously they were considered structural and so not added to `e.ordered` which would generate the object type first if it was encountered first. Now they are always added to `e.ordered`, since they do not depend on other types it should be safe to generate them as early as they are encountered. Proc types are also not handled here but I don't know what would be done for them.

Sorry for abrupt PR, figured it would be more effort to explain this than to do it