### PR TITLE
enable some tests, fix sigmatch for proc types

### DIFF
--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -80,11 +80,24 @@ proc skip*(c: var Cursor) =
   inc c
 
 proc skipToEnd*(c: var Cursor) =
+  ## skips `c` until an unmatched ParRi is found, then skips the ParRi and returns
   var nested = 0
   while true:
     if c.kind == ParRi:
       if nested == 0:
         inc c
+        break
+      dec nested
+    elif c.kind == ParLe:
+      inc nested
+    inc c
+
+proc skipUntilEnd*(c: var Cursor) =
+  ## skips `c` until an unmatched ParRi is found, then returns without skipping the ParRi
+  var nested = 0
+  while true:
+    if c.kind == ParRi:
+      if nested == 0:
         break
       dec nested
     elif c.kind == ParLe:

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -387,12 +387,12 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
     # 3: generics
 
     if n.len > 0:
-      toNif n[0], n, c  # 4: params
+      toNif n[0], n, c, allowEmpty = true  # 4: params
     else:
       c.b.addEmpty
 
     if n.len > 1:
-      toNif n[1], n, c  # 5: pragmas
+      toNif n[1], n, c, allowEmpty = true  # 5: pragmas
     else:
       c.b.addEmpty
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3500,7 +3500,6 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
         if AllowModuleSym notin flags:
           c.buildErr c.dest[start].info, "module symbol '" & pool.syms[s.name] & "' not allowed in this context"
       else:
-        # XXX enum field?
         assert false, "not implemented"
       it.typ = n
       commonType c, it, start, expected

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -387,17 +387,17 @@ proc procTypeMatch(m: var Match; f, a: var Cursor) =
         discard "ok"
       else:
         m.error FormalParamsMismatch, f, a
-        skipToEnd a
+        skipUntilEnd a
     else:
       m.error FormalParamsMismatch, f, a
-      skipToEnd f
-      skipToEnd a
+      skipUntilEnd f
+      skipUntilEnd a
   elif hasParams == 2:
     m.error FormalParamsMismatch, f, a
-    skipToEnd a
+    skipUntilEnd a
   elif hasParams == 1:
     m.error FormalParamsMismatch, f, a
-    skipToEnd f
+    skipUntilEnd f
 
   # also correct for the DotToken case:
   inc f

--- a/tests/nimony/lookups/tlocalcall.nim
+++ b/tests/nimony/lookups/tlocalcall.nim
@@ -3,8 +3,7 @@ proc foo(y: float) = discard
 proc bar(x: uint8) = discard
 
 proc main =
-  when false: # when proc types work
-    let foo = bar
-    foo(123) # does not consider overloads, always matches local
+  let foo: proc (x: uint8) = bar
+  foo(123) # does not consider overloads, always matches local
 
 main()

--- a/tests/nimony/nosystem/twhen.nim
+++ b/tests/nimony/nosystem/twhen.nim
@@ -38,26 +38,3 @@ when false: # enable when `isImportedMain2` works
     discard "good"
   else:
     discard "bad"
-
-when false:
-  proc defined*(x: untyped): bool {.magic: Defined.}
-
-  when defined(nimony):
-    discard "good"
-  else:
-    discard "bad"
-
-  when defined(undefinedDefine):
-    discard "bad"
-  else:
-    discard "good"
-
-  when defined(nimony) and not defined(undefinedDefine):
-    discard "good"
-  else:
-    discard "bad"
-
-  when defined(undefinedDefine) or not defined(nimony):
-    discard "bad"
-  else:
-    discard "good"

--- a/tests/nimony/sysbasics/tdefinedwhen.nif
+++ b/tests/nimony/sysbasics/tdefinedwhen.nif
@@ -1,0 +1,10 @@
+(.nif24)
+0,1,tests/nimony/sysbasics/tdefinedwhen.nim(stmts 2,1
+ (stmts
+  (discard 8 "good")) 2,8
+ (stmts
+  (discard 8 "good")) 2,11
+ (stmts
+  (discard 8 "good")) 2,18
+ (stmts
+  (discard 8 "good")))

--- a/tests/nimony/sysbasics/tdefinedwhen.nim
+++ b/tests/nimony/sysbasics/tdefinedwhen.nim
@@ -1,0 +1,19 @@
+when defined(nimony):
+  discard "good"
+else:
+  discard "bad"
+
+when defined(undefinedDefine):
+  discard "bad"
+else:
+  discard "good"
+
+when defined(nimony) and not defined(undefinedDefine):
+  discard "good"
+else:
+  discard "bad"
+
+when defined(undefinedDefine) or not defined(nimony):
+  discard "bad"
+else:
+  discard "good"

--- a/tests/nimony/sysbasics/tindex.nim
+++ b/tests/nimony/sysbasics/tindex.nim
@@ -5,10 +5,9 @@ proc main() =
   let x = arr[1]
   let xt: int = x
   arr[1] = x
-  when false:
-    let y = str[1]
-    let yt: char = y
-    str[1] = y
+  let y = str[1]
+  let yt: char = y
+  str[1] = y
   let z = cstr[1]
   let zt: char = z
   cstr[1] = zt


### PR DESCRIPTION
The test in `tlocalcall` is enabled but with an explicit `proc ()` annotation as otherwise its type gets inferred to `ParamsT` without the return type, so in the AST it becomes `(let foo . . (params ...) bar)`, so the return type of `foo` is skipped from the `params` to `bar` and so the type of `foo(123)` becomes literally `bar`. In any case the `proc ()` annotation has worked in other places for a while now.

A small fix is needed in sigmatch for proc types with empty pragmas to work: `skipToEnd` is called before `inc` which is supposed to skip the `ParRi`, but `skipToEnd` already skips the `ParRi`, so a new `skipUntilEnd` is added which doesn't skip it. Also `nkEmpty` params and pragmas for proc types in nifler are now allowed to generate `.`.

The disabled `when defined` tests in `twhen` are enabled and moved to a different test that imports system, just to not have to redefine `and`/`or` but it could be moved back to ensure it works without system.

The string index test in `tindex` is enabled as strings are now implemented. Although this is in a `main` proc that does not run as it does not allocate the string, it only tests that it compiles.