### PR TITLE
fixes #633; instantiates for loops defs

### DIFF
--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -1,5 +1,5 @@
 (.nif24)
-0,1,tests/nimony/sysbasics/tforloops1.nim(stmts
+0,1,tests/nimony/sysbasics/tforloops1.nim(stmts ,2
  (iterator 9 :powers.0.tfo6yv57p . . . 15
   (params 1
    (param :n.0 . . 3
@@ -23,7 +23,7 @@
         (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
      (asgn ~2 i.0 4
       (add
-       (i -1) ~2 i.0 2 +1)))))) ,8
+       (i -1) ~2 i.0 2 +1)))))) ,10
  (proc 5 :printf.0.tfo6yv57p . . . 11
   (params 1
    (param :format.0 . . 8
@@ -34,7 +34,7 @@
    (importc 9 "printf") 21
    (varargs) 30
    (header 8 "<stdio.h>") 51
-   (nodecl)) . .) 4,11
+   (nodecl)) . .) 4,13
  (for 11
   (call ~6 powers.0.tfo6yv57p 1 +5)
   (unpackflat
@@ -45,7 +45,7 @@
     (i -1) 4 i.1) 6,2
    (call ~6 printf.0.tfo6yv57p 1
     (hconv 11,~6
-     (cstring) "Hello, world\3A %ld\0A") 24 m.0))) ,16
+     (cstring) "Hello, world\3A %ld\0A") 24 m.0))) ,18
  (iterator 9 :countup.0.tfo6yv57p . . . 16
   (params 1
    (param :a.0 . . 6
@@ -62,7 +62,7 @@
     (stmts
      (yld 6 i.2) ,1
      (cmd inc.0.tfo6yv57p 4
-      (haddr i.2)))))) 4,22
+      (haddr i.2)))))) 4,24
  (for 12
   (call ~7 countup.0.tfo6yv57p 1 +1 4 +5)
   (unpackflat
@@ -78,7 +78,7 @@
     (elif 2,416,lib/std/system.nim
      (expr 2,1
       (lt
-       (i -1) 9,26,tests/nimony/sysbasics/tforloops1.nim +5 5,26,tests/nimony/sysbasics/tforloops1.nim x.1)) ~1,1
+       (i -1) 9,28,tests/nimony/sysbasics/tforloops1.nim +5 5,28,tests/nimony/sysbasics/tforloops1.nim x.1)) ~1,1
      (stmts
       (break .))) 5,2
     (elif 2
@@ -88,7 +88,7 @@
       (continue .)))) 6,6
    (call ~6 printf.0.tfo6yv57p 1
     (hconv 11,~21
-     (cstring) "countup end\3A %ld\0A") 23 m.1))) ,31
+     (cstring) "countup end\3A %ld\0A") 23 m.1))) ,33
  (iterator 9 :countup2.0.tfo6yv57p . . . 17
   (params 1
    (param :n.1 . . 3
@@ -103,7 +103,7 @@
     (stmts
      (yld 6 i.3) ,1
      (cmd inc.0.tfo6yv57p 4
-      (haddr i.3)))))) ,37
+      (haddr i.3)))))) ,39
  (iterator 9 :powers2.0.tfo6yv57p . . . 16
   (params 1
    (param :n.2 . . 3
@@ -124,7 +124,7 @@
       (mul 15,140,lib/std/system.nim
        (i +64) ~2
        (mul ~1,~10
-        (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,43
+        (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,45
  (for 12
   (call ~7 powers2.0.tfo6yv57p 1 +6)
   (unpackflat
@@ -133,14 +133,14 @@
   (stmts 6
    (call ~6 printf.0.tfo6yv57p 1
     (hconv 11,~36
-     (cstring) "Hello, world\3A %ld\0A") 24 i.5))) ,46
+     (cstring) "Hello, world\3A %ld\0A") 24 i.5))) ,48
  (iterator 9 :countup3.0.tfo6yv57p . . . 17
   (params 1
    (param :a.1 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts
-   (yld 6 +3))) ,49
+   (yld 6 +3))) ,51
  (iterator 9 :powers3.0.tfo6yv57p . . . 16
   (params 1
    (param :b.1 . . 3
@@ -153,7 +153,7 @@
      (let :j.0 . . 4,~4
       (i -1) .)) ~2,1
     (stmts
-     (yld 6 j.0))))) 4,53
+     (yld 6 j.0))))) 4,55
  (for 12
   (call ~7 powers3.0.tfo6yv57p 1 +5)
   (unpackflat
@@ -170,7 +170,7 @@
       (hconv 9,~47
        (cstring) "Hello, world\3A %ld\0A") 25
       (add ~25,~6
-       (i -1) ~1 m.2 1 n.3)))))) ,57
+       (i -1) ~1 m.2 1 n.3)))))) ,59
  (while 6
   (true) 2,1
   (stmts 4
@@ -181,14 +181,14 @@
       (i -1) .)) ~2,1
     (stmts
      (discard 8 i.6))) ,2
-   (break .))) ,63
+   (break .))) ,65
  (iterator 9 :countup4.0.tfo6yv57p . . . 17
   (params 1
    (param :a.2 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts
-   (yld 6 a.2))) ,66
+   (yld 6 a.2))) ,68
  (iterator 9 :powers4.0.tfo6yv57p . . . 16
   (params 1
    (param :a.3 . . 3
@@ -201,7 +201,7 @@
      (let :j.1 . . 4,~4
       (i -1) .)) ~2,1
     (stmts
-     (yld 6 j.1))))) 4,70
+     (yld 6 j.1))))) 4,72
  (for 12
   (call ~7 powers4.0.tfo6yv57p 1 +5)
   (unpackflat
@@ -218,21 +218,53 @@
       (hconv 9,~64
        (cstring) "Hello, world\3A %ld\0A") 25
       (add ~25,~6
-       (i -1) ~1 i.7 1 j.2)))))) 4,20
+       (i -1) ~1 i.7 1 j.2)))))) 4,77
+ (for 6
+  (infix \2E.<.0.sysvq0asl ~1 +0 3 +3)
+  (unpackflat
+   (let :i.8 . . 13,1,lib/std/system/iterators.nim
+    (i -1) .)) ~2,1
+  (stmts 4
+   (for 6
+    (infix \2E.<.0.sysvq0asl ~1 +0 3 +4)
+    (unpackflat
+     (let :j.3 . . 13,1,lib/std/system/iterators.nim
+      (i -1) .)) ~2,1
+    (stmts
+     (if 3
+      (elif 2
+       (eq 13,1,lib/std/system/iterators.nim
+        (i -1) ~2 j.3 3 +2) ~1,1
+       (stmts 2,104,lib/std/syncio.nim
+        (stmts 2,1
+         (stmts
+          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,81,tests/nimony/sysbasics/tforloops1.nim "left the loop!")) ,2
+         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (break .)))) 2,104,lib/std/syncio.nim
+     (stmts 2,1
+      (stmts
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/sysbasics/tforloops1.nim "A i ")) 2,1
+      (stmts
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/sysbasics/tforloops1.nim i.8)) 2,1
+      (stmts
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 20,83,tests/nimony/sysbasics/tforloops1.nim " j ")) 2,1
+      (stmts
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/sysbasics/tforloops1.nim j.3)) ,2
+      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
  (proc :inc.0.tfo6yv57p . 0,276,lib/std/system.nim .
   (at inc.1.sysvq0asl 19,~4
    (i -1)) 21,276,lib/std/system.nim
   (params 1
    (param :x.2 . . 3
-    (mut 23,17,tests/nimony/sysbasics/tforloops1.nim
+    (mut 23,19,tests/nimony/sysbasics/tforloops1.nim
      (i -1)) .)) 0,276,lib/std/system.nim . 32,276,lib/std/system.nim
   (pragmas 2
    (inline)) 0,276,lib/std/system.nim . 2,278,lib/std/system.nim
   (stmts 2
    (asgn ~2
     (hderef x.2) 4
-    (add 23,17,tests/nimony/sysbasics/tforloops1.nim
+    (add 23,19,tests/nimony/sysbasics/tforloops1.nim
      (i -1) ~2
      (hderef x.2) 3
-     (conv 23,17,tests/nimony/sysbasics/tforloops1.nim
+     (conv 23,19,tests/nimony/sysbasics/tforloops1.nim
       (i -1) 1 +1))))))

--- a/tests/nimony/sysbasics/tforloops1.nim
+++ b/tests/nimony/sysbasics/tforloops1.nim
@@ -1,3 +1,5 @@
+import std / [syncio]
+
 iterator powers(n: int): int =
   var i = 0
   while i <= n:
@@ -71,3 +73,11 @@ iterator powers4(a: int): int =
 for i in powers4(5):
   for j in countup4(4):
     printf("Hello, world: %ld\n", i+j)
+
+
+for i in 0..<3:
+  for j in 0..<4:
+    if j == 2:
+      echo "left the loop!"
+      break
+    echo "A i ", i, " j ", j

--- a/tests/nimony/sysbasics/tforloops1.output
+++ b/tests/nimony/sysbasics/tforloops1.output
@@ -47,3 +47,12 @@ Hello, world: 36
 Hello, world: 216
 Hello, world: 6
 Hello, world: 9
+A i 0 j 0
+A i 0 j 1
+left the loop!
+A i 1 j 0
+A i 1 j 1
+left the loop!
+A i 2 j 0
+A i 2 j 1
+left the loop!


### PR DESCRIPTION
fixes #633 

This PR instantiates each `symdefs` in the iterator with a different id.