### PR TITLE
Fix compile error from MinGW

### DIFF
--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -105,7 +105,7 @@ template echo*() {.varargs.} =
     write stdout, x
   write stdout, '\n'
 
-proc writeLine*(f: var File; s: string) =
+proc writeLine*(f: File; s: string) =
   write f, s
   write f, '\n'
 


### PR DESCRIPTION
`writeLine` proc in `lib/std/syncio.nim` has `f: var File` parameter.
```nim
proc writeLine*(f: var File; s: string) =
```
`writeLine stdout, "foo"` is compiled to C code `writeLine_0_syn1lfpjv((&stdout),`.
But `&stdout` causes compile error in MinGW: `error: lvalue required as unary '&' operand`