### PR TITLE
fix commonType line info

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -162,9 +162,9 @@ proc commonType(c: var SemContext; it: var Item; argBegin: int; expected: TypeCu
     it.typ = expected
     return
 
-  let info = it.n.info
   var m = createMatch(addr c)
   var arg = Item(n: cursorAt(c.dest, argBegin), typ: it.typ)
+  let info = arg.n.info
   if typeKind(arg.typ) == VoidT and isNoReturn(arg.n):
     # noreturn allowed in expression context
     # maybe use sem flags to restrict this to statement branches

--- a/tests/nimony/errmsgs/tcommontype.msgs
+++ b/tests/nimony/errmsgs/tcommontype.msgs
@@ -1,0 +1,3 @@
+tests/nimony/errmsgs/tcommontype.nim(6, 26) Error: type mismatch: got: (ptr
+ (i -1)) but wanted: (ptr
+ (uarray T.1.tcoq7zxn71))

--- a/tests/nimony/errmsgs/tcommontype.nim
+++ b/tests/nimony/errmsgs/tcommontype.nim
@@ -1,0 +1,6 @@
+type Foo[T] = object
+  x: ptr UncheckedArray[T]
+
+proc foo[T]() =
+  var y: int
+  discard Foo[T](x: addr y)

--- a/tests/nimony/lookups/tambtype.msgs
+++ b/tests/nimony/lookups/tambtype.msgs
@@ -1,2 +1,2 @@
 tests/nimony/lookups/tambtype.nim(3, 8) Error: ambiguous identifier
-tests/nimony/lookups/tambtype.nim(3, 5) Error: type mismatch: got: (i -1) but wanted: (ochoice Foo.0.mamdoporf Foo.0.mamiajb2h)
+tests/nimony/lookups/tambtype.nim(3, 14) Error: type mismatch: got: (i -1) but wanted: (ochoice Foo.0.mamdoporf Foo.0.mamiajb2h)


### PR DESCRIPTION
refs #649

Unsure if this is the same memory corruption mentioned in the issue but `it.n` in this case is skipped beyond the ParRi by `semAddr` by the time it calls `commonType` which gives it a random, potentially invalid line info for some reason