### PR TITLE
handle `stmts` directly in semBlock

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2040,7 +2040,13 @@ proc semBlock(c: var SemContext; it: var Item) =
       c.addSym delayed
       publish c, delayed.s.name, declStart
 
-    semStmt c, it.n, true
+    if it.n.stmtKind == StmtsS:
+      takeToken c, it.n
+      while it.n.kind != ParRi:
+        semStmt c, it.n, true
+      takeParRi c, it.n
+    else:
+      semStmt c, it.n, true
   dec c.routine.inBlock
 
   takeParRi c, it.n

--- a/tests/nimony/errmsgs/tblocklineinfo.msgs
+++ b/tests/nimony/errmsgs/tblocklineinfo.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tblocklineinfo.nim(4, 3) Error: expression of type `(i -1)` must be discarded

--- a/tests/nimony/errmsgs/tblocklineinfo.nim
+++ b/tests/nimony/errmsgs/tblocklineinfo.nim
@@ -1,0 +1,4 @@
+block:
+  discard 0
+
+  0


### PR DESCRIPTION
fixes #545

When the `(stmts)` part of the block is passed to `semStmt`, it tries to semcheck it with an expected type of `auto`, which doesn't cause the semchecking of `(stmts)` to error. Instead the subsequent `void` check inside `semStmt` fails and thus the line info of the full `(stmts)` is given. Here this is handled by just iterating over `(stmts)` inside `semBlock`, another option would be to skip `(stmts)` etc to get the proper line info inside `semStmt`.