### PR TITLE
make linearMatch aware of special cases

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -409,8 +409,8 @@ template `>`*(x, y: untyped): untyped =
 
 template default*(x: typedesc[bool]): bool = false
 template default*(x: typedesc[char]): char = '\0'
-template default*(x: typedesc[int]): int = 0
-template default*(x: typedesc[uint]): uint = 0'u
+#template default*(x: typedesc[int]): int = 0
+#template default*(x: typedesc[uint]): uint = 0'u
 template default*(x: typedesc[int8]): int8 = 0'i8
 template default*(x: typedesc[uint8]): uint8 = 0'u8
 template default*(x: typedesc[int16]): int16 = 0'i16

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -409,8 +409,8 @@ template `>`*(x, y: untyped): untyped =
 
 template default*(x: typedesc[bool]): bool = false
 template default*(x: typedesc[char]): char = '\0'
-#template default*(x: typedesc[int]): int = 0
-#template default*(x: typedesc[uint]): uint = 0'u
+template default*(x: typedesc[int]): int = 0
+template default*(x: typedesc[uint]): uint = 0'u
 template default*(x: typedesc[int8]): int8 = 0'i8
 template default*(x: typedesc[uint8]): uint8 = 0'u8
 template default*(x: typedesc[int16]): int16 = 0'i16

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -348,7 +348,7 @@ proc linearMatch(m: var Match; f, a: var Cursor) =
           if a.typeKind notin {ProctypeT, ParamsT}:
             m.error(InvalidMatch, fOrig, aOrig)
             break
-          var a2 = a
+          var a2 = a # since procTypeMatch does not skip it properly
           procTypeMatch m, f, a2
           skip a # XXX consider when a is (params)
           if m.err: break # might not have fully skipped on error

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -387,7 +387,7 @@ proc linearMatch(m: var Match; f, a: var Cursor; flags: set[LinearMatchFlag] = {
           inc f
           inc a
       of ParRi:
-        if nested == 0: break
+        assert nested > 0
         dec nested
         inc f
         inc a

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -295,6 +295,21 @@ proc isTypevar(s: SymId): bool =
   let typevar = asTypevar(res.decl)
   result = typevar.kind == TypevarY
 
+proc cmpTypeBits(context: ptr SemContext; f, a: Cursor): int =
+  if (f.kind == IntLit or f.kind == InlineInt) and
+     (a.kind == IntLit or a.kind == InlineInt):
+    result = typebits(context.g.config, f.load) - typebits(context.g.config, a.load)
+  else:
+    result = -1
+
+proc expectParRi(m: var Match; f: var Cursor) =
+  if f.kind == ParRi:
+    inc f
+  else:
+    m.error FormalTypeNotAtEndBug, f, f
+
+proc procTypeMatch(m: var Match; f, a: var Cursor)
+
 proc linearMatch(m: var Match; f, a: var Cursor) =
   let fOrig = f
   let aOrig = a
@@ -308,7 +323,7 @@ proc linearMatch(m: var Match; f, a: var Cursor) =
         var prev = m.inferred[fs]
         linearMatch(m, prev, a) # skips a
         inc f
-        if m.err: break
+        if m.err: break # might not have fully skipped on error
       elif matchesConstraint(m, fs, a):
         m.inferred[fs] = a # NOTICE: Can introduce modifiers for a type var!
         inc f
@@ -324,27 +339,63 @@ proc linearMatch(m: var Match; f, a: var Cursor) =
         if f.uoperand != a.uoperand:
           m.error(InvalidMatch, fOrig, aOrig)
           break
+        inc f
+        inc a
       of ParLe:
-        if f.uoperand != a.uoperand:
-          m.error(InvalidMatch, fOrig, aOrig)
-          break
-        inc nested
+        # special cases:
+        case f.typeKind
+        of ProctypeT, ParamsT:
+          if a.typeKind notin {ProctypeT, ParamsT}:
+            m.error(InvalidMatch, fOrig, aOrig)
+            break
+          var a2 = a
+          procTypeMatch m, f, a2
+          skip a # XXX consider when a is (params)
+          if m.err: break # might not have fully skipped on error
+        of IntT, UIntT, FloatT, CharT:
+          if a.typeKind != f.typeKind:
+            m.error(InvalidMatch, fOrig, aOrig)
+            break
+          inc f
+          inc a
+          if cmpTypeBits(m.context, f, a) != 0:
+            m.error(InvalidMatch, fOrig, aOrig)
+            break
+          skip f
+          skip a
+          expectParRi m, f
+          expectParRi m, a
+        else:
+          if f.uoperand != a.uoperand:
+            m.error(InvalidMatch, fOrig, aOrig)
+            break
+          inc nested
+          inc f
+          inc a
       of ParRi:
         if nested == 0: break
         dec nested
-      inc f
-      inc a
+        inc f
+        inc a
+    elif f.typeKind == InvokeT and a.kind == Symbol:
+      # Keep in mind that (invok GenericHead Type1 Type2 ...)
+      # is tyGenericInvokation in the old Nim. A generic *instance*
+      # is always a nominal type ("Symbol") like
+      # `(type GeneratedName (invok MyInst ConcreteTypeA ConcreteTypeB) (object ...))`.
+      # This means a Symbol can match an InvokT.
+      var t = getTypeSection(a.symId)
+      if t.kind == TypeY and t.typevars.typeKind == InvokeT:
+        linearMatch m, f, t.typevars # skips f
+        inc a
+        if m.err: break # might not have fully skipped on error
+      else:
+        m.error(InvalidMatch, fOrig, aOrig)
+        break
     else:
       m.error(InvalidMatch, fOrig, aOrig)
       break
     # only match a single tree/token:
     if nested == 0: break
-
-proc expectParRi(m: var Match; f: var Cursor) =
-  if f.kind == ParRi:
-    inc f
-  else:
-    m.error FormalTypeNotAtEndBug, f, f
 
 proc extractCallConv(c: var Cursor): CallConv =
   result = Fastcall
@@ -411,14 +462,19 @@ proc procTypeMatch(m: var Match; f, a: var Cursor) =
     skip a
   else:
     linearMatch m, f, a
+    if m.err: return # might not have fully skipped on error
   # match calling conventions:
   let fcc = extractCallConv(f)
   let acc = extractCallConv(a)
   if fcc != acc:
     m.error CallConvMismatch, f, a
+  # XXX consider when f or a is (params):
   skip f # effects
+  #skip a # effects
   skip f # body
+  #skip a # body
   expectParRi m, f
+  #expectParRi m, a
 
 proc commonType(f, a: Cursor): Cursor =
   # XXX Refine
@@ -490,13 +546,6 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
           m.error InvalidMatch, f, a
         else:
           singleArgImpl(m, impl, arg)
-
-proc cmpTypeBits(context: ptr SemContext; f, a: Cursor): int =
-  if (f.kind == IntLit or f.kind == InlineInt) and
-     (a.kind == IntLit or a.kind == InlineInt):
-    result = typebits(context.g.config, f.load) - typebits(context.g.config, a.load)
-  else:
-    result = -1
 
 proc checkIntLitRange(context: ptr SemContext; f: Cursor; intLit: Cursor): bool =
   if f.typeKind == FloatT:
@@ -600,21 +649,10 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
       inc f
       expectParRi m, f
     of InvokeT:
-      # Keep in mind that (invok GenericHead Type1 Type2 ...)
-      # is tyGenericInvokation in the old Nim. A generic *instance*
-      # is always a nominal type ("Symbol") like
-      # `(type GeneratedName (invok MyInst ConcreteTypeA ConcreteTypeB) (object ...))`.
-      # This means a Symbol can match an InvokT.
+      # handled in linearMatch
+      # XXX except for inheritance
       var a = skipModifier(arg.typ)
-      if a.kind == Symbol:
-        var t = getTypeSection(a.symId)
-        if t.kind == TypeY and t.typevars.typeKind == InvokeT:
-          linearMatch m, f, t.typevars
-        else:
-          m.error InvalidMatch, f, a
-          skip f
-      else:
-        linearMatch m, f, a
+      linearMatch m, f, a
     of RangetypeT:
       # for now acts the same as base type
       var a = skipModifier(arg.typ)

--- a/tests/nimony/overload/tinvariantmatch.nim
+++ b/tests/nimony/overload/tinvariantmatch.nim
@@ -1,0 +1,17 @@
+type Foo[T] = object
+  val: T
+
+proc invoke[T](x: ptr Foo[T]): T = x[].val
+
+var concrete = Foo[int](val: 123)
+let x = invoke(addr concrete)
+let y: int = x
+
+proc dummy(x: int): int = discard
+proc procType(p: ptr proc (y: int): int) = discard
+var p: proc (z: int): int = dummy
+procType(addr p)
+
+proc intbit(i: ptr int64) = discard
+var i: int = 123
+intbit(addr i)

--- a/tests/nimony/sysbasics/tseqs.nim
+++ b/tests/nimony/sysbasics/tseqs.nim
@@ -2,7 +2,7 @@ import std/syncio
 
 proc main() =
   let x = newSeq[int](3)
-  var s = default(seq[int])
+  var s = newSeqUninit[int](0) # XXX `default(seq[int])` doesn't work due to lack of generic disambiguation
   s.add(123)
   s.add(456)
   #s.add(newSeq[int](3)) # not defined yet


### PR DESCRIPTION
closes #646

This makes `linearMatch` more a way of matching types invariantly to each other rather than just a check for tree equality that also considers typevars. Maybe `linearMatch` is not the best implementation for this but it's the expected behavior from `linearMatch` in the places where it's used.

For integral types, bits are now normalized, so `ptr int` now matches `ptr int64`. Edit: This is now disabled for `typedesc`, i.e. `typedesc[int]` and `typedesc[int64]` are considered different. In original Nim they match each other, they just match the equal versions better, but I remember this not being intended.

For procs, `procTypeMatch` is called directly since it currently basically checks for equality, but in the future if stuff like convertibility from `nimcall` to `closure` is implemented then this will have to be disallowed when it's called from `linearMatch`.

The behavior of `InvokeT` matching a symbol type is now moved to `linearMatch` (`InvokeT` matching `InvokeT` already calls linearMatch) but `singleArg` will probably need its own implementation in the future too so that generic inheritance can be implemented.

A problem with mixing other procs and `linearMatch` is that it stops iterating on an error, when procs expect it to fully skip the types in some cases; and when `linearMatch` calls other procs or recurses over itself, the only way it knows to stop iterating is by checking for an error, which may have been produced previously and not necessarily in the call to the proc. An option for this is to make `linearMatch` indicate if it stopped iterating due to an error via a flag, and add another version like `linearMatchAlwaysSkip` that skips `f` and `a` fully by checking for this flag (i.e. `if error: f = fOrig; skip f`). Could do this here or in a followup, or maybe there is a better idea - Edit: Always fully skips now