### PR TITLE
treat inferred types containing generic params as concrete

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -532,6 +532,8 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
   let fs = f.symId
   if isTypevar(fs):
     if m.concreteMatch:
+      # generic param is from provided argument type
+      # instead of considering inference, treat as a standalone value
       if not matchesConstraint(m, fs, a):
         m.error ConstraintMismatch, f, a
     elif m.inferred.contains(fs):

--- a/tests/nimony/generics/targgenericrematch.nim
+++ b/tests/nimony/generics/targgenericrematch.nim
@@ -18,3 +18,12 @@ proc baz3[T]() =
 baz1[int, int]()
 baz2[int]()
 baz3[int]()
+
+proc barrec[T, U](x: T, y: U) =
+  if false:
+    barrec[T, U](x, y)
+    barrec[T, T](x, x)
+    barrec[U, T](y, x)
+    barrec[U, U](y, y)
+
+barrec[int, float](1, 2)

--- a/tests/nimony/generics/targgenericrematch.nim
+++ b/tests/nimony/generics/targgenericrematch.nim
@@ -1,0 +1,20 @@
+# issue #693
+
+proc foo[T](): T = discard
+proc bar[T](x: T) = discard
+
+# Compiles without errors
+proc baz1[T, U]() =
+  bar[(T, U)](foo[(T, U)]())
+
+# Compiles without errors
+proc baz2[T]() =
+  bar(foo[(T, T)]())
+
+# Error: call depth limit reached
+proc baz3[T]() =
+  bar[(T, T)](foo[(T, T)]())
+
+baz1[int, int]()
+baz2[int]()
+baz3[int]()


### PR DESCRIPTION
fixes #693

When matching to the inferred value of a typevar, do not consider typevar types inside it as types that need to be inferred/compared against inferred values, instead just check that the matched type matches the constraint of the typevar (as opposed to checking for equality as in #536). Types provided from the outside environment should have no effect on the inferences of the current match.

Previously I thought the typevar matching could have been restricted in some other way, like only inferring to typevars belonging to the routine of the current match. But this would not handle the case when the routine is a recursive generic routine, as it would be valid to infer a typevar to itself.