### PR TITLE
use `kv` with ident instead of `fld` for named tuple types, make it optional

### DIFF
--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -115,8 +115,7 @@ proc createYieldMapping(e: var EContext; c: var Cursor, vars: Cursor, yieldType:
         let symId = forvars[i].name.symId
         var tupBuf = createTupleAccess(tmpId, i, info)
         var tup = beginRead(tupBuf)
-        var field = takeLocal(typ, SkipFinalParRi)
-        var fieldTyp = field.typ
+        var fieldTyp = getTupleFieldType(typ)
         createDecl(e, symId, fieldTyp, tup, info, "let")
 
 proc transformBreakStmt(e: var EContext; c: var Cursor) =

--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -116,6 +116,7 @@ proc createYieldMapping(e: var EContext; c: var Cursor, vars: Cursor, yieldType:
         var tupBuf = createTupleAccess(tmpId, i, info)
         var tup = beginRead(tupBuf)
         var fieldTyp = getTupleFieldType(typ)
+        skip typ
         createDecl(e, symId, fieldTyp, tup, info, "let")
 
 proc transformBreakStmt(e: var EContext; c: var Cursor) =

--- a/src/hexer/lifter.nim
+++ b/src/hexer/lifter.nim
@@ -129,7 +129,7 @@ proc isTrivial*(c: var LiftingCtx; typ: TypeCursor): bool =
     inc tup
     while tup.kind != ParRi:
       let field = getTupleFieldType(tup)
-      if not isTrivial(c, tup):
+      if not isTrivial(c, field):
         return false
       skip tup
     result = true

--- a/src/hexer/lifter.nim
+++ b/src/hexer/lifter.nim
@@ -131,7 +131,7 @@ proc isTrivial*(c: var LiftingCtx; typ: TypeCursor): bool =
       let field = getTupleFieldType(tup)
       if not isTrivial(c, tup):
         return false
-      skip n
+      skip tup
     result = true
   of NoType, ErrT, NiltT, OrT, AndT, NotT, ConceptT, DistinctT, StaticT, InvokeT,
      TypeKindT, UntypedT, TypedT, IteratorT, ItertypeT:

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -201,23 +201,12 @@ proc traverseTupleBody(e: var EContext; c: var Cursor) =
   e.dest.addDotToken()
   var counter = 0
   while c.kind != ParRi:
-    if c.substructureKind == FldU:
-      inc c # skip fld
-      e.offer c.symId
-      skip c # skip name
-      skip c # skip export marker
-      skip c # skip pragmas
-      genTupleField(e, c, counter)
-      skip c # skip value
-      skipParRi e, c
-    elif c.substructureKind == KvU:
+    if c.substructureKind == KvU:
       inc c # skip tag
       skip c # skip name
       genTupleField(e, c, counter)
       skipParRi e, c
     else:
-      if c.kind == SymbolDef:
-        e.offer c.symId
       genTupleField(e, c, counter)
     inc counter
   takeParRi e, c

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -210,6 +210,11 @@ proc traverseTupleBody(e: var EContext; c: var Cursor) =
       genTupleField(e, c, counter)
       skip c # skip value
       skipParRi e, c
+    elif c.substructureKind == KvU:
+      inc c # skip tag
+      skip c # skip name
+      genTupleField(e, c, counter)
+      skipParRi e, c
     else:
       if c.kind == SymbolDef:
         e.offer c.symId

--- a/src/hexer/typekeys.nim
+++ b/src/hexer/typekeys.nim
@@ -26,6 +26,18 @@ proc mangleImpl(b: var Mangler; c: var Cursor) =
         mangleImpl b, c # type is interesting
         skip c # value
         inc c # ParRi
+      elif tag == "tuple":
+        b.addTree(tag)
+        inc c
+        while c.kind != ParRi:
+          if c.substructureKind == KvU:
+            inc c
+            skip c # name
+            mangleImpl b, c # type is interesting
+            inc c # ParRi
+          else:
+            mangleImpl b, c
+        inc c # ParRi
       elif tag == "array":
         b.addTree tag
         inc c

--- a/src/hexer/typekeys.nim
+++ b/src/hexer/typekeys.nim
@@ -26,18 +26,6 @@ proc mangleImpl(b: var Mangler; c: var Cursor) =
         mangleImpl b, c # type is interesting
         skip c # value
         inc c # ParRi
-      elif tag == "tuple":
-        b.addTree(tag)
-        inc c
-        while c.kind != ParRi:
-          if c.substructureKind == KvU:
-            inc c
-            skip c # name
-            mangleImpl b, c # type is interesting
-            inc c # ParRi
-          else:
-            mangleImpl b, c
-        inc c # ParRi
       elif tag == "array":
         b.addTree tag
         inc c
@@ -55,6 +43,18 @@ proc mangleImpl(b: var Mangler; c: var Cursor) =
           b.addIntLit(last - first + 1)
         else:
           mangleImpl b, c
+        inc nested
+      elif tag == "tuple":
+        b.addTree(tag)
+        inc c
+        while c.kind != ParRi:
+          if c.substructureKind == KvU:
+            inc c
+            skip c # name
+            mangleImpl b, c # type is interesting
+            inc c # ParRi
+          else:
+            mangleImpl b, c
         inc nested
       else:
         b.addTree(tag)

--- a/src/hexer/typekeys.nim
+++ b/src/hexer/typekeys.nim
@@ -56,7 +56,7 @@ proc mangleImpl(b: var Mangler; c: var Cursor) =
           else:
             mangleImpl b, c
         b.endTree()
-        inc c
+        inc c # ParRi
       else:
         b.addTree(tag)
         inc nested

--- a/src/hexer/typekeys.nim
+++ b/src/hexer/typekeys.nim
@@ -55,7 +55,8 @@ proc mangleImpl(b: var Mangler; c: var Cursor) =
             inc c # ParRi
           else:
             mangleImpl b, c
-        inc nested
+        b.endTree()
+        inc c
       else:
         b.addTree(tag)
         inc nested

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -566,11 +566,22 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
     c.b.endTree()
 
   of nkTupleTy, nkTupleClassTy:
-    c.section = FldL
     relLineInfo(n, parent, c)
     c.b.addTree(nodeKindTranslation(n.kind))
     for i in 0..<n.len:
-      toNif(n[i], n, c)
+      assert n[i].kind == nkIdentDefs
+      let def = n[i]
+      let last = def.len - 1
+      for j in 0..last - 2:
+        relLineInfo(def[j], parent, c)
+        c.b.addTree(KvL)
+        let split = splitIdentDefName(def[j])
+
+        toNif(split.name, def[j], c) # name
+
+        toNif(def[last-1], def[j], c, allowEmpty = true) # type
+
+        c.b.endTree()
     c.b.endTree()
 
   of nkImportStmt, nkFromStmt, nkExportStmt, nkExportExceptStmt, nkImportAs, nkImportExceptStmt, nkIncludeStmt:

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -207,13 +207,6 @@ proc asTupleField*(c: Cursor): TupleField =
     result.name = c
     skip c
     result.typ = c
-  of FldU:
-    inc c # tag
-    result.name = c
-    skip c
-    skip c # exported
-    skip c # pragmas
-    result.typ = c
   else:
     # unnamed
     result.typ = c
@@ -224,12 +217,6 @@ proc getTupleFieldType*(c: Cursor): Cursor =
     result = c
     inc result # tag
     skip result # name
-  of FldU:
-    result = c
-    inc result # tag
-    skip result # name
-    skip result # exported
-    skip result # pragmas
   else:
     result = c
 

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -192,6 +192,48 @@ proc asEnumDecl*(c: Cursor): EnumDecl =
     result.firstField = c
 
 type
+  TupleField* = object
+    kind*: SubstructureKind
+    name*: Cursor
+    typ*: Cursor
+
+proc asTupleField*(c: Cursor): TupleField =
+  var c = c
+  let kind = substructureKind c
+  result = TupleField(kind: kind)
+  case c.substructureKind
+  of KvU:
+    inc c # tag
+    result.name = c
+    skip c
+    result.typ = c
+  of FldU:
+    inc c # tag
+    result.name = c
+    skip c
+    skip c # exported
+    skip c # pragmas
+    result.typ = c
+  else:
+    # unnamed
+    result.typ = c
+
+proc getTupleFieldType*(c: Cursor): Cursor =
+  case c.substructureKind
+  of KvU:
+    result = c
+    inc c # tag
+    skip c # name
+  of FldU:
+    result = c
+    inc result # tag
+    skip c # name
+    skip c # exported
+    skip c # pragmas
+  else:
+    result = c
+
+type
   ForStmt* = object
     kind*: StmtKind
     iter*, vars*, body*: Cursor

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -222,14 +222,14 @@ proc getTupleFieldType*(c: Cursor): Cursor =
   case c.substructureKind
   of KvU:
     result = c
-    inc c # tag
-    skip c # name
+    inc result # tag
+    skip result # name
   of FldU:
     result = c
     inc result # tag
-    skip c # name
-    skip c # exported
-    skip c # pragmas
+    skip result # name
+    skip result # exported
+    skip result # pragmas
   else:
     result = c
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1951,7 +1951,7 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
         var field = asTupleField(tup)
         if field.kind in {KvU, FldU}:
           let name = getIdent(field.name)
-          if sameIdent(name, fieldName):
+          if name == fieldName:
             c.dest[exprStart] = parLeToken(TupAtX, info)
             c.dest.addIntLit(i, info)
             it.typ = field.typ # will be fit later with commonType

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2400,9 +2400,10 @@ proc semTupleType(c: var SemContext; n: var Cursor) =
         takeToken c, n
         let nameCursor = n
         let name = getIdent(n)
-        if name != StrId(0):
+        if name == StrId(0):
           c.buildErr nameCursor.info, "invalid tuple field name", nameCursor
-        c.dest.add identToken(name, nameCursor.info)
+        else:
+          c.dest.add identToken(name, nameCursor.info)
         semLocalTypeImpl c, n, InLocalDecl
         takeParRi c, n
       else:
@@ -4537,10 +4538,13 @@ proc semTupleConstr(c: var SemContext, it: var Item) =
         takeToken c, it.n
         let nameCursor = it.n
         let name = getIdent(it.n)
-        if name != StrId(0):
+        let nameStart = c.dest.len
+        if name == StrId(0):
           c.buildErr nameCursor.info, "invalid tuple field name", nameCursor
-        typ.add identToken(name, nameCursor.info)
-        c.dest.add identToken(name, nameCursor.info)
+        else:
+          c.dest.add identToken(name, nameCursor.info)
+        for tok in nameStart ..< c.dest.len:
+          typ.add c.dest[tok]
     var elem = Item(n: it.n, typ: c.types.autoType)
     if doExpected:
       elem.typ = getTupleFieldType(expected)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3978,7 +3978,7 @@ proc semForLoopTupleVar(c: var SemContext; it: var Item; tup: TypeCursor) =
   var tup = tup
   inc tup
   while it.n.kind != ParRi and tup.kind != ParRi:
-    let field = getTupleFieldType(field.typ)
+    let field = getTupleFieldType(tup)
     semForLoopVar c, it, field
     skip tup
   if it.n.kind == ParRi:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4777,8 +4777,8 @@ proc buildDefaultTuple(c: var SemContext; typ: Cursor; info: PackedLineInfo) =
   var currentField = typ
   inc currentField # skip tuple tag
   while currentField.kind != ParRi:
-    let field = asLocal(currentField)
-    callDefault c, field.typ, info
+    let field = getTupleFieldType(currentField)
+    callDefault c, field, info
     skip currentField
   c.dest.addParRi()
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1948,14 +1948,15 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
       inc tup
       var i = 0
       while tup.kind != ParRi:
-        let field = asTupleField(tup)
-        if field.kind in {KvU, FldU} and sameIdent(field.name.symId, fieldName):
-          c.dest[exprStart] = parLeToken(TupAtX, info)
-          c.dest.addIntLit(i, info)
-          it.typ = field.typ # will be fit later with commonType
-          it.kind = FldY
-          result = MatchedDotField
-          break
+        var field = asTupleField(tup)
+        if field.kind in {KvU, FldU}:
+          let name = getIdent(field.name)
+          if sameIdent(name, fieldName):
+            c.dest[exprStart] = parLeToken(TupAtX, info)
+            c.dest.addIntLit(i, info)
+            it.typ = field.typ # will be fit later with commonType
+            result = MatchedDotField
+            break
         skip tup
         inc i
       if result != MatchedDotField:
@@ -2387,30 +2388,25 @@ proc semObjectType(c: var SemContext; n: var Cursor) =
         semLocal(c, n, FldY)
   takeParRi c, n
 
-proc semTupleFieldType(c: var SemContext; elemType: var Cursor; i: int) =
-  var buf = createTokenBuf(32)
-  buf.add parLeToken(FldU, elemType.info) # start field
-  buf.add identToken(pool.strings.getOrIncl("Field" & $i), elemType.info)
-  buf.addDotToken() # export marker
-  buf.addDotToken() # pragmas
-  buf.takeTree elemType
-  buf.addDotToken() # value
-  buf.addParRi() # end field
-  var read = beginRead(buf)
-  semLocal(c, read, FldY)
-
 proc semTupleType(c: var SemContext; n: var Cursor) =
   c.dest.add parLeToken(TupleT, n.info)
   inc n
   # tuple fields:
   withNewScope c:
-    var i = 0
     while n.kind != ParRi:
       if n.substructureKind == FldU:
         semLocal(c, n, FldY)
+      elif n.substructureKind == KvU:
+        takeToken c, n
+        let nameCursor = n
+        let name = getIdent(n)
+        if name != StrId(0):
+          c.buildErr nameCursor.info, "invalid tuple field name", nameCursor
+        c.dest.add identToken(name, nameCursor.info)
+        semLocalTypeImpl c, n, InLocalDecl
+        takeParRi c, n
       else:
-        semTupleFieldType(c, n, i)
-        inc i
+        semLocalTypeImpl c, n, InLocalDecl
   takeParRi c, n
 
 type
@@ -4532,37 +4528,33 @@ proc semTupleConstr(c: var SemContext, it: var Item) =
   let named = it.n.substructureKind == KvU
   var typ = createTokenBuf(32)
   typ.add parLeToken(TupleT, it.n.info)
-  var i = 0
   while it.n.kind != ParRi:
-    typ.add parLeToken(FldU, it.n.info) # start field
     if named:
       if it.n.substructureKind != KvU:
         c.buildErr it.n.info, "expected field name for named tuple constructor"
       else:
+        typ.add it.n
         takeToken c, it.n
-        typ.addSubtree it.n # add name
-        takeToken c, it.n
-    else:
-      typ.add identToken(pool.strings.getOrIncl("Field" & $i), it.n.info)
-      inc i
-    typ.addDotToken() # export marker
-    typ.addDotToken() # pragmas
+        let nameCursor = it.n
+        let name = getIdent(it.n)
+        if name != StrId(0):
+          c.buildErr nameCursor.info, "invalid tuple field name", nameCursor
+        typ.add identToken(name, nameCursor.info)
+        c.dest.add identToken(name, nameCursor.info)
     var elem = Item(n: it.n, typ: c.types.autoType)
     if doExpected:
-      let fld = asLocal(expected)
-      elem.typ = fld.typ
+      elem.typ = getTupleFieldType(expected)
       skip expected
       if expected.kind == ParRi:
         # happens if expected tuple type has less fields than constructor
         doExpected = false
     semExpr c, elem
     it.n = elem.n
+    typ.addSubtree elem.typ # type
     if named:
       # should be KvX
       takeParRi c, it.n
-    typ.addSubtree elem.typ # type
-    typ.addDotToken() # value
-    typ.addParRi() # end field
+      typ.addParRi()
   takeParRi c, it.n
   typ.addParRi()
   let typeStart = c.dest.len

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1949,7 +1949,7 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
       var i = 0
       while tup.kind != ParRi:
         var field = asTupleField(tup)
-        if field.kind in {KvU, FldU}:
+        if field.kind == KvU:
           let name = getIdent(field.name)
           if name == fieldName:
             c.dest[exprStart] = parLeToken(TupAtX, info)
@@ -2394,9 +2394,7 @@ proc semTupleType(c: var SemContext; n: var Cursor) =
   # tuple fields:
   withNewScope c:
     while n.kind != ParRi:
-      if n.substructureKind == FldU:
-        semLocal(c, n, FldY)
-      elif n.substructureKind == KvU:
+      if n.substructureKind == KvU:
         takeToken c, n
         let nameCursor = n
         let name = getIdent(n)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1948,8 +1948,8 @@ proc tryBuiltinDot(c: var SemContext; it: var Item; lhs: Item; fieldName: StrId;
       inc tup
       var i = 0
       while tup.kind != ParRi:
-        let field = asLocal(tup)
-        if field.name.kind == SymbolDef and sameIdent(field.name.symId, fieldName):
+        let field = asTupleField(tup)
+        if field.kind in {KvU, FldU} and sameIdent(field.name.symId, fieldName):
           c.dest[exprStart] = parLeToken(TupAtX, info)
           c.dest.addIntLit(i, info)
           it.typ = field.typ # will be fit later with commonType
@@ -3978,8 +3978,8 @@ proc semForLoopTupleVar(c: var SemContext; it: var Item; tup: TypeCursor) =
   var tup = tup
   inc tup
   while it.n.kind != ParRi and tup.kind != ParRi:
-    let field = asLocal(tup)
-    semForLoopVar c, it, field.typ
+    let field = getTupleFieldType(field.typ)
+    semForLoopVar c, it, field
     skip tup
   if it.n.kind == ParRi:
     if tup.kind == ParRi:
@@ -4840,9 +4840,8 @@ proc semTupAt(c: var SemContext; it: var Item) =
         idxValue = idxValue - one
       else:
         break
-    if it.typ.substructureKind == FldU:
-      let fld = asLocal(it.typ)
-      it.typ = fld.typ
+    if it.typ.kind != ParRi:
+      it.typ = getTupleFieldType(it.typ)
     takeParRi c, it.n
     commonType c, it, exprStart, expected
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -755,8 +755,8 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
             # len(f) > len(a)
             m.error InvalidMatch, fOrig, aOrig
           # only the type of the field is important:
-          var ffld = asLocal(f).typ
-          var afld = asLocal(a).typ
+          var ffld = getTupleFieldType(f)
+          var afld = getTupleFieldType(a)
           linearMatch m, ffld, afld
           # skip fields:
           skip f

--- a/src/nimony/sizeof.nim
+++ b/src/nimony/sizeof.nim
@@ -136,12 +136,8 @@ proc getSize(c: var SizeofValue; cache: var Table[SymId, SizeofValue]; n: Cursor
     inc n
     var c2 = createSizeofValue(c.strict)
     while n.kind != ParRi:
-      if n.substructureKind == FldU:
-        let field = takeLocal(n, SkipFinalParRi)
-        getSize c2, cache, field.typ, ptrSize
-      else:
-        getSize c2, cache, n, ptrSize
-        skip n
+      getSize c2, cache, getTupleFieldType(n), ptrSize
+      skip n
     finish c2
     if cacheKey != NoSymId: cache[cacheKey] = c2
     combine c, c2

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -272,11 +272,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor): Cursor =
       while idx > 0:
         skip tupType
         dec idx
-      if tupType == "fld":
-        let field = asLocal(tupType)
-        result = field.typ
-      else:
-        result = tupType
+      result = getTupleFieldType(tupType)
   of BracketX:
     # should not be encountered but keep this code for now
     let elemType = getTypeImpl(c, n.firstSon)

--- a/tests/nimony/generics/ttuplecache.nif
+++ b/tests/nimony/generics/ttuplecache.nif
@@ -1,0 +1,143 @@
+(.nif24)
+0,3,tests/nimony/generics/ttuplecache.nim(stmts 9,1
+ (type ~7 :Foo.0.ttuv4zf4c1 . ~4
+  (typevars 1
+   (typevar :T.0.ttuv4zf4c1 . . . .)) . 2
+  (object . ~7,1
+   (fld :data.0.ttuv4zf4c1 . . 6 T.0.ttuv4zf4c1 .))) ,5
+ (proc 5 :initFooInt.0.ttuv4zf4c1 . . . 15
+  (params) 7 Foo.1.ttuv4zf4c1 . . 2,1
+  (stmts 8
+   (result :result.0 . . ~3,~1 Foo.1.ttuv4zf4c1 .) 8
+   (asgn result.0
+    (expr
+     (oconstr ~3,~1 Foo.1.ttuv4zf4c1 5
+      (kv ~5 data.1.ttuv4zf4c1 2 +0)))) ~2,~1
+   (ret result.0))) ,8
+ (proc 5 :initFooTup.0.ttuv4zf4c1 . . . 15
+  (params) 7 Foo.2.ttuv4zf4c1 . . 2,2
+  (stmts 15
+   (result :result.1 . . ~10,~2 Foo.2.ttuv4zf4c1 .) 15
+   (asgn result.1
+    (expr
+     (oconstr ~10,~2 Foo.2.ttuv4zf4c1 5
+      (kv ~5 data.2.ttuv4zf4c1 2
+       (tup 1 +0 4 +0))))) ~2,~2
+   (ret result.1))) ,12
+ (proc 5 :initFooGeneric.0.ttuv4zf4c1 . . 19
+  (typevars 1
+   (typevar :T.1.ttuv4zf4c1 . . . .)) 22
+  (params 1
+   (param :x.0 . . 3 T.1.ttuv4zf4c1 .)) 11
+  (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) . . 2,1
+  (stmts 6
+   (result :result.2 . . 3,~1
+    (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) .) 6
+   (asgn result.2
+    (expr
+     (oconstr 3,~1
+      (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
+      (kv ~5 data 2 x.0)))) ~2,~1
+   (ret result.2))) 4,15
+ (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.3.ttuv4zf4c1 18
+  (call ~14 initFooGeneric.1.ttuv4zf4c1 1
+   (tup 2
+    (kv ~1 a 2 +1) 8
+    (kv ~1 b 2 "abc")))) 4,16
+ (glet :x1.0.ttuv4zf4c1 . . 4,~11
+  (i -1) 16
+  (tupat ~5
+   (dot ~1 x.0.ttuv4zf4c1 data.3.ttuv4zf4c1 +0) +0)) 4,17
+ (glet :x2.0.ttuv4zf4c1 . . 4 string.0.sysvq0asl 19
+  (tupat ~5
+   (dot ~1 x.0.ttuv4zf4c1 data.3.ttuv4zf4c1 +0) +1)) 4,19
+ (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.4.ttuv4zf4c1 18
+  (call ~14 initFooGeneric.2.ttuv4zf4c1 1
+   (tup 2
+    (kv ~1 x 2 "def") 12
+    (kv ~1 y 2 +2)))) 4,20
+ (glet :y1.0.ttuv4zf4c1 . . 4,~3 string.0.sysvq0asl 19
+  (tupat ~5
+   (dot ~1 y.0.ttuv4zf4c1 data.4.ttuv4zf4c1 +0) +0)) 4,21
+ (glet :y2.0.ttuv4zf4c1 . . 4,~16
+  (i -1) 16
+  (tupat ~5
+   (dot ~1 y.0.ttuv4zf4c1 data.4.ttuv4zf4c1 +0) +1)) 22,15
+ (proc :initFooGeneric.1.ttuv4zf4c1 . ~22,~3 .
+  (at initFooGeneric.0.ttuv4zf4c1 3
+   (tuple
+    (kv ~1 a
+     (i -1)) 6
+    (kv ~1 b string.0.sysvq0asl))) ,~3
+  (params 1
+   (param :x.3 . . 2,3
+    (tuple
+     (kv ~1 a
+      (i -1)) 6
+     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.3.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
+  (stmts 6
+   (result :result.3 . . 3,~1 Foo.3.ttuv4zf4c1 .) 6
+   (asgn result.3
+    (expr
+     (oconstr 3,~1 Foo.3.ttuv4zf4c1 5
+      (kv ~5 data.3.ttuv4zf4c1 2 x.3)))) ~2,~1
+   (ret result.3))) 22,19
+ (proc :initFooGeneric.2.ttuv4zf4c1 . ~22,~7 .
+  (at initFooGeneric.0.ttuv4zf4c1 3
+   (tuple
+    (kv ~1 x string.0.sysvq0asl) 10
+    (kv ~1 y
+     (i -1)))) ,~7
+  (params 1
+   (param :x.4 . . 2,7
+    (tuple
+     (kv ~1 x string.0.sysvq0asl) 10
+     (kv ~1 y
+      (i -1))) .)) ~11,~7 Foo.4.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
+  (stmts 6
+   (result :result.4 . . 3,~1 Foo.4.ttuv4zf4c1 .) 6
+   (asgn result.4
+    (expr
+     (oconstr 3,~1 Foo.4.ttuv4zf4c1 5
+      (kv ~5 data.4.ttuv4zf4c1 2 x.4)))) ~2,~1
+   (ret result.4))) 7,5
+ (type :Foo.1.ttuv4zf4c1 .
+  (at Foo.0.ttuv4zf4c1 1
+   (i -1)) 2,~4 . 4,~4
+  (object . ~7,1
+   (fld :data.1.ttuv4zf4c1 . . 4,3
+    (i -1) .))) 7,8
+ (type :Foo.2.ttuv4zf4c1 .
+  (at Foo.0.ttuv4zf4c1 1
+   (tuple 1
+    (i -1) 6
+    (i -1))) 2,~7 . 4,~7
+  (object . ~7,1
+   (fld :data.2.ttuv4zf4c1 . . 4,6
+    (tuple 1
+     (i -1) 6
+     (i -1)) .))) 11,12
+ (type :Foo.3.ttuv4zf4c1 .
+  (at Foo.0.ttuv4zf4c1 14,3
+   (tuple
+    (kv ~1 a
+     (i -1)) 6
+    (kv ~1 b string.0.sysvq0asl))) ~2,~11 . ,~11
+  (object . ~7,1
+   (fld :data.3.ttuv4zf4c1 . . 21,13
+    (tuple
+     (kv ~1 a
+      (i -1)) 6
+     (kv ~1 b string.0.sysvq0asl)) .))) 11,12
+ (type :Foo.4.ttuv4zf4c1 .
+  (at Foo.0.ttuv4zf4c1 14,7
+   (tuple
+    (kv ~1 x string.0.sysvq0asl) 10
+    (kv ~1 y
+     (i -1)))) ~2,~11 . ,~11
+  (object . ~7,1
+   (fld :data.4.ttuv4zf4c1 . . 21,17
+    (tuple
+     (kv ~1 x string.0.sysvq0asl) 10
+     (kv ~1 y
+      (i -1))) .))))

--- a/tests/nimony/generics/ttuplecache.nim
+++ b/tests/nimony/generics/ttuplecache.nim
@@ -1,0 +1,13 @@
+# issue #692
+
+type
+  Foo[T] = object
+    data: T
+
+# Compiles without errors.
+proc initFooInt(): Foo[int] =
+  Foo[int](data: 0)
+
+proc initFooTup(): Foo[(int, int)] =
+  # Error: type mismatch
+  Foo[(int, int)](data: (0, 0))

--- a/tests/nimony/generics/ttuplecache.nim
+++ b/tests/nimony/generics/ttuplecache.nim
@@ -11,3 +11,14 @@ proc initFooInt(): Foo[int] =
 proc initFooTup(): Foo[(int, int)] =
   # Error: type mismatch
   Foo[(int, int)](data: (0, 0))
+
+proc initFooGeneric[T](x: T): Foo[T] =
+  Foo[T](data: x)
+
+let x = initFooGeneric((a: 1, b: "abc"))
+let x1: int = x.data.a
+let x2: string = x.data.b
+
+let y = initFooGeneric((x: "def", y: 2))
+let y1: string = y.data.x
+let y2: int = y.data.y

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -63,40 +63,27 @@
     (i -1) 4 +1) 4,1
    (var :s.0 . . 5
     (tuple
-     (fld :Field0.0.tbawx6nu81 . .
-      (i -1) .) 3
-     (fld :Field1.0.tbawx6nu81 . .
-      (i -1) .) 6
-     (fld :Field2.0.tbawx6nu81 . .
-      (i -1) .)) 4
+     (i -1)
+     (i -1)
+     (i -1)) 4
     (tup 1 x.3 4 +1 7 +2)) 4,2
    (let :m1.0 . . 6
-    (tuple
-     (fld :Field0.1.tbawx6nu81 . . 1,~3
-      (i -1) .) 3
-     (fld :Field1.1.tbawx6nu81 . .
-      (i -1) .)) 5
+    (tuple 1,~3
+     (i -1)
+     (i -1)) 5
     (tup 1 m.0 4 +6)) 6,3
    (const :y.0 . .
     (f +64) 4 +12.3) 4,4
    (let :z1.0 . . 6
     (tuple
-     (fld :Field0.2.tbawx6nu81 . .
-      (f +64) .) 3
-     (fld :Field1.2.tbawx6nu81 . . ~4,~3
-      (tuple
-       (fld :Field0.0.tbawx6nu81 . .
-        (i -1) .) 3
-       (fld :Field1.0.tbawx6nu81 . .
-        (i -1) .) 6
-       (fld :Field2.0.tbawx6nu81 . .
-        (i -1) .)) .) 6
-     (fld :Field2.1.tbawx6nu81 . . ~6,~2
-      (tuple
-       (fld :Field0.1.tbawx6nu81 . . 1,~3
-        (i -1) .) 3
-       (fld :Field1.1.tbawx6nu81 . .
-        (i -1) .)) .)) 5
+     (f +64) ~1,~3
+     (tuple
+      (i -1)
+      (i -1)
+      (i -1)) ,~2
+     (tuple 1,~3
+      (i -1)
+      (i -1))) 5
     (tup 1 y.0 4 s.0 7 m1.0)))) 4,20
  (call ~4 foo2.0.tbawx6nu81 1 +12) ,22
  (proc 5 :foo3.0.tbawx6nu81 . . . 9
@@ -189,10 +176,8 @@
   (stmts 4
    (var :t.0 . . 3
     (tuple 1
-     (fld :Field0.3.tbawx6nu81 . .
-      (i -1) .) 6
-     (fld :Field1.3.tbawx6nu81 . .
-      (i -1) .)) .) 2,1
+     (i -1) 6
+     (i -1)) .) 2,1
    (asgn ~2 t.0 2
     (tup 1 +1 4 +2)) 2,2
    (asgn ~2 t.0 2

--- a/tests/nimony/sysbasics/tforloops.nif
+++ b/tests/nimony/sysbasics/tforloops.nif
@@ -7,27 +7,21 @@
    (param :x.0 . . 3
     (i -1) .)) 10
   (tuple 1
-   (fld :Field0.0.tfo6zftzj1 . .
-    (i -1) .) 6
-   (fld :Field1.0.tfo6zftzj1 . .
-    (i -1) .)) . . 2,2
+   (i -1) 6
+   (i -1)) . . 2,2
   (stmts 4
    (let :ff.0 . . 5
-    (array 2
-     (tuple
-      (fld :Field0.1.tfo6zftzj1 . .
-       (i -1) .) 4
-      (fld :Field1.1.tfo6zftzj1 . .
-       (i -1) .))
+    (array ~1,~2
+     (tuple 1
+      (i -1) 6
+      (i -1))
      (rangetype
       (i -1) +0 +0)) 5
     (aconstr
-     (array 2
-      (tuple
-       (fld :Field0.1.tfo6zftzj1 . .
-        (i -1) .) 4
-       (fld :Field1.1.tfo6zftzj1 . .
-        (i -1) .))
+     (array ~1,~2
+      (tuple 1
+       (i -1) 6
+       (i -1))
       (rangetype
        (i -1) +0 +0)) 1
      (tup 1 +12 5 globalX.0.tfo6zftzj1))) ,1


### PR DESCRIPTION
fixes #692

Fields of named tuple types now have the representation `(kv name type)` where the name is an identifier rather than a symbol. Tuple types without field names now just have types themselves as the fields rather than anonymous `FieldN` fields.

Alternative representations are always generating a `kv` but with `.` or the old `FieldN` as the name, or adding a new tag like `(tfld)` that could also contain pragmas if we want them.