### PR TITLE
fixes #691

### DIFF
--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -456,7 +456,6 @@ proc generateTypes(c: var GeneratedCode; o: TypeOrder) =
     let decl = takeTypeDecl(n)
     let s = mangle(pool.syms[decl.name.symId])
     c.add declKeyword
-    c.add "Q1_"
     c.add s
     c.add Space
     c.add s
@@ -470,6 +469,7 @@ proc generateTypes(c: var GeneratedCode; o: TypeOrder) =
       case decl.body.typeKind
       of ArrayT:
         c.add declKeyword
+        c.add s
         c.add CurlyLe
         var n = decl.body.firstSon
         genType c, n, "a"
@@ -491,7 +491,6 @@ proc generateTypes(c: var GeneratedCode; o: TypeOrder) =
         c.add Semicolon
       else:
         c.add declKeyword
-        c.add "Q1_"
         c.add s
         c.add CurlyLe
         # XXX generate attributes and pragmas here


### PR DESCRIPTION
This PR produces code like this:
```c
typedef struct array array;
typedef struct seq{
  int len;
  array* data;}
seq;
typedef struct array {
  int a[1];}
array;
```

This compiles without error with gcc 14.2 and clang 19.1.0:
https://godbolt.org/z/5Yf3Wa6h8
https://godbolt.org/z/Yo19ba9c3

But fails to compile with gcc 4.5.3 and clang 3.5.2 and older:
https://godbolt.org/z/KWz8MG4ha
https://godbolt.org/z/Krq9Prjev

If it must be compiled without error with older gcc and clang, `array` must be defined without `typedef` if it is forward declared like this:
```c
typedef struct array array;
typedef struct seq{
  int len;
  array* data;}
seq;
struct array {
  int a[1];};
```
https://godbolt.org/z/dY9ncvYW4
https://godbolt.org/z/GfT6aK53a

Checking if it is forward declared and changing how to generate C array type definition would makes `src/nifc/gentypes.nim` more complicated.
