### PR TITLE
ignore `defined` etc argument errors in debug mode

### DIFF
--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -162,9 +162,10 @@ template withErrorContext*(c: var SemContext; info: PackedLineInfo; body: untype
 
 proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string; orig: Cursor) =
   when defined(debug):
-    writeStackTrace()
-    echo infoToStr(info) & " Error: " & msg
-    quit msg
+    if not c.debugAllowErrors:
+      writeStackTrace()
+      echo infoToStr(info) & " Error: " & msg
+      quit msg
   c.dest.buildTree ErrT, info:
     c.dest.addSubtree orig
     for instFrom in items(c.instantiatedFrom):
@@ -178,9 +179,10 @@ proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string) =
 
 proc buildLocalErr*(dest: var TokenBuf; info: PackedLineInfo; msg: string; orig: Cursor) =
   when defined(debug):
-    writeStackTrace()
-    echo infoToStr(info) & " Error: " & msg
-    quit msg
+    if true: # not c.debugAllowErrors: - c not given
+      writeStackTrace()
+      echo infoToStr(info) & " Error: " & msg
+      quit msg
   dest.buildTree ErrT, info:
     dest.addSubtree orig
     dest.add strToken(pool.strings.getOrIncl(msg), info)

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -102,6 +102,7 @@ type
     freshSyms*: HashSet[SymId] ## symdefs that should count as new for semchecking
     toBuild*: TokenBuf
     unoverloadableMagics*: HashSet[StrId]
+    debugAllowErrors*: bool
 
 proc typeToCanon*(buf: TokenBuf; start: int): string =
   result = ""


### PR DESCRIPTION
fixes #613, tested locally

`unoverloadableMagics` is reused but could use a different method as well