### PR TITLE
compare instantiation keys in sigmatch for symbols

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2714,6 +2714,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
       var args = cursorAt(c.dest, beforeArgs)
       let targetSym = newSymId(c, headId)
       c.instantiatedTypes[key] = targetSym
+      c.instantiationKeys[targetSym] = key
       if genericArgs == 0:
         c.typeInstDecls.add targetSym
       var sub = createTokenBuf(30)

--- a/tests/nimony/generics/deps/mexternalinst1.nim
+++ b/tests/nimony/generics/deps/mexternalinst1.nim
@@ -1,0 +1,9 @@
+type
+  Foo[T] = object
+  Bar* = object
+    y: Foo[int]
+
+proc foo[T](): Foo[T] = discard
+
+proc initBar*[T]() =
+  discard Bar(y: foo[int]())

--- a/tests/nimony/generics/deps/mexternalinst2_0.nim
+++ b/tests/nimony/generics/deps/mexternalinst2_0.nim
@@ -1,0 +1,2 @@
+type Foo*[T] = object
+  val: T

--- a/tests/nimony/generics/deps/mexternalinst2_1.nim
+++ b/tests/nimony/generics/deps/mexternalinst2_1.nim
@@ -1,0 +1,3 @@
+import mexternalinst2_0
+
+type Inst1* = Foo[int]

--- a/tests/nimony/generics/deps/mexternalinst2_2.nim
+++ b/tests/nimony/generics/deps/mexternalinst2_2.nim
@@ -1,0 +1,3 @@
+import mexternalinst2_0
+
+type Inst2* = Foo[int]

--- a/tests/nimony/generics/texternalinst1.nim
+++ b/tests/nimony/generics/texternalinst1.nim
@@ -1,0 +1,5 @@
+# issue #715
+
+import deps/mexternalinst1
+
+initBar[int]()

--- a/tests/nimony/generics/texternalinst2.nim
+++ b/tests/nimony/generics/texternalinst2.nim
@@ -1,0 +1,7 @@
+import deps/[mexternalinst2_1, mexternalinst2_2]
+
+let x1: Inst1 = default(Inst1)
+let x2: Inst2 = default(Inst2)
+# compare to each other:
+let y1: Inst2 = x1
+let y2: Inst1 = x2


### PR DESCRIPTION
refs (closes but not yet) #715

Breaks in C, introducing casts wouldn't be possible with `linearMatch`. We probably do need to encode the instantiation in the symbol.