### PR TITLE
special symbol scheme for type instantiations

### DIFF
--- a/src/gear2/modnames.nim
+++ b/src/gear2/modnames.nim
@@ -41,6 +41,14 @@ const
 const
   Base36 = "0123456789abcdefghijklmnopqrstuvwxyz"
 
+proc uhashBase36*(s: string): string =
+  var id = uhash(s)
+  result = newStringOfCap(8)
+  # Convert decimal number to base 36, reversed since it does not matter:
+  while id > 0'u32:
+    result.add Base36[int(id mod 36'u32)]
+    id = id div 36'u32
+
 proc moduleSuffix*(path: string; searchPaths: openArray[string]): string =
   var f = relativePath(path, getCurrentDir(), '/')
   # Select the path that is shortest relative to the searchPath:

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1520,6 +1520,7 @@ proc writeOutput(c: var EContext, rootInfo: PackedLineInfo) =
       else:
         let s = pool.syms[n.symId]
         if isInstantiation(s):
+          # ensure instantiations have the same name across modules:
           b.addSymbol(removeModule(s))
         else:
           b.addSymbol(s)
@@ -1530,6 +1531,7 @@ proc writeOutput(c: var EContext, rootInfo: PackedLineInfo) =
       else:
         let s = pool.syms[n.symId]
         if isInstantiation(s):
+          # ensure instantiations have the same name across modules:
           b.addSymbolDef(removeModule(s))
         else:
           b.addSymbolDef(s)

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -10,6 +10,7 @@
 import std / [hashes, os, tables, sets, assertions]
 
 include nifprelude
+import symparser
 import typekeys
 import ".." / nimony / [nimony_model, programs, typenav, expreval, xints, decls, builtintypes, sizeof, typeprops]
 from ".." / nimony / sigmatch import isSomeStringType, isStringType
@@ -1517,13 +1518,21 @@ proc writeOutput(c: var EContext, rootInfo: PackedLineInfo) =
       if val.len > 0:
         b.addSymbol(val)
       else:
-        b.addSymbol(pool.syms[n.symId])
+        let s = pool.syms[n.symId]
+        if isInstantiation(s):
+          b.addSymbol(removeModule(s))
+        else:
+          b.addSymbol(s)
     of SymbolDef:
       let val = c.maybeMangle(n.symId)
       if val.len > 0:
         b.addSymbolDef(val)
       else:
-        b.addSymbolDef(pool.syms[n.symId])
+        let s = pool.syms[n.symId]
+        if isInstantiation(s):
+          b.addSymbolDef(removeModule(s))
+        else:
+          b.addSymbolDef(s)
       if nextIsOwner >= 0:
         ownerStack.add (n.symId, nextIsOwner)
         nextIsOwner = -1

--- a/src/lib/symparser.nim
+++ b/src/lib/symparser.nim
@@ -40,3 +40,30 @@ proc extractModule*(s: string): string =
         return substr(s, i+1)
     dec i
   return ""
+
+proc isInstantiation*(s: string): bool =
+  # abc.12.mod1.Iabcdefghi.mod2
+  var i = s.len - 2
+  var dots = 4
+  while i > 0:
+    if s[i] == '.':
+      dec dots
+      if s[i+1] in {'0'..'9'}:
+        return dots == 0
+      elif dots == 2 and s[i+1] != 'I':
+        return false
+    dec i
+  result = false
+
+proc removeModule*(s: string): string =
+  # From "abc.12.Mod132a3bc" extract "abc.12".
+  # From "abc.12" extract "abc.12".
+  var i = s.len - 2
+  while i > 0:
+    if s[i] == '.':
+      if s[i+1] in {'0'..'9'}:
+        return s
+      else:
+        return substr(s, 0, i-1)
+    dec i
+  return s

--- a/src/lib/symparser.nim
+++ b/src/lib/symparser.nim
@@ -42,9 +42,9 @@ proc extractModule*(s: string): string =
   return ""
 
 proc isInstantiation*(s: string): bool =
-  # abc.12.mod1.Iabcdefghi.mod2
+  # abc.12.Iabcdefghi.mod2
   var i = s.len - 2
-  var dots = 4
+  var dots = 3
   while i > 0:
     if s[i] == '.':
       dec dots

--- a/src/lib/symparser.nim
+++ b/src/lib/symparser.nim
@@ -50,7 +50,7 @@ proc isInstantiation*(s: string): bool =
       dec dots
       if s[i+1] in {'0'..'9'}:
         return dots == 0
-      elif dots == 2 and s[i+1] != 'I':
+      elif dots == 1 and s[i+1] != 'I':
         return false
     dec i
   result = false

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -483,6 +483,7 @@ proc instToSuffix(buf: TokenBuf, start: int): string =
   result = uhashBase36(instToString(buf, start))
 
 proc newInstSymId(c: var SemContext; orig: SymId; suffix: string): SymId =
+  # abc.123.origmod.Iabcdefgh.instmod
   var name = pool.syms[orig]
   name.add(".I")
   name.add(suffix)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -483,8 +483,8 @@ proc instToSuffix(buf: TokenBuf, start: int): string =
   result = uhashBase36(instToString(buf, start))
 
 proc newInstSymId(c: var SemContext; orig: SymId; suffix: string): SymId =
-  # abc.123.origmod.Iabcdefgh.instmod
-  var name = pool.syms[orig]
+  # abc.123.Iabcdefgh.instmod
+  var name = removeModule(pool.syms[orig])
   name.add(".I")
   name.add(suffix)
   name.add '.'

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -316,8 +316,10 @@ proc sameSymbol(a, b: SymId): bool =
     return true
   # symbols might be different for instantiations from different modules,
   # consider this case by checking if the instantiation keys are equal:
-  result = isInstantiation(pool.syms[a]) and isInstantiation(pool.syms[b]) and
-    removeModule(pool.syms[a]) == removeModule(pool.syms[b])
+  let sa = pool.syms[a]
+  let sb = pool.syms[b]
+  result = isInstantiation(sa) and isInstantiation(sb) and
+    removeModule(sa) == removeModule(sb)
 
 proc expectParRi(m: var Match; f: var Cursor) =
   if f.kind == ParRi:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -8,7 +8,7 @@ import std / [sets, tables, assertions]
 
 import bitabs, nifreader, nifstreams, nifcursors, lineinfos
 
-import nimony_model, decls, programs, semdata, typeprops, xints, builtintypes, renderer
+import nimony_model, decls, programs, semdata, typeprops, xints, builtintypes, renderer, symparser
 
 type
   Item* = object
@@ -311,6 +311,14 @@ proc cmpExactTypeBits(f, a: Cursor): int =
   else:
     result = -1
 
+proc sameSymbol(a, b: SymId): bool =
+  if a == b:
+    return true
+  # symbols might be different for instantiations from different modules,
+  # consider this case by checking if the instantiation keys are equal:
+  result = isInstantiation(pool.syms[a]) and isInstantiation(pool.syms[b]) and
+    removeModule(pool.syms[a]) == removeModule(pool.syms[b])
+
 proc expectParRi(m: var Match; f: var Cursor) =
   if f.kind == ParRi:
     inc f
@@ -357,9 +365,15 @@ proc linearMatch(m: var Match; f, a: var Cursor; flags: set[LinearMatchFlag] = {
     elif f.kind == a.kind:
       case f.kind
       of UnknownToken, EofToken,
-          DotToken, Ident, Symbol, SymbolDef,
+          DotToken, Ident, SymbolDef,
           StringLit, CharLit, IntLit, UIntLit, FloatLit:
         if f.uoperand != a.uoperand:
+          m.error(InvalidMatch, fOrig, aOrig)
+          break
+        inc f
+        inc a
+      of Symbol:
+        if not sameSymbol(f.symId, a.symId):
           m.error(InvalidMatch, fOrig, aOrig)
           break
         inc f
@@ -550,12 +564,12 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
   elif isObjectType(fs):
     if a.kind != Symbol:
       m.error InvalidMatch, f, a
-    elif a.symId == fs:
+    elif sameSymbol(fs, a.symId):
       discard "direct match, no annotation required"
     else:
       var diff = 1
       for fparent in inheritanceChain(fs):
-        if fparent == a.symId:
+        if sameSymbol(fparent, a.symId):
           m.args.addParLe OconvX, m.argInfo
           m.args.addIntLit diff, m.argInfo
           if m.flipped:
@@ -574,7 +588,7 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
     m.error NotImplementedConcept, f, a
   else:
     # fast check that works for aliases too:
-    if a.kind == Symbol and a.symId == fs:
+    if a.kind == Symbol and sameSymbol(a.symId, fs):
       discard "perfect match"
     else:
       var impl = typeImpl(fs)

--- a/tests/nimony/generics/deps/mexternalinst1.nim
+++ b/tests/nimony/generics/deps/mexternalinst1.nim
@@ -1,0 +1,9 @@
+type
+  Foo[T] = object
+  Bar* = object
+    y: Foo[int]
+
+proc foo[T](): Foo[T] = discard
+
+proc initBar*[T]() =
+  discard Bar(y: foo[int]())

--- a/tests/nimony/generics/deps/mexternalinst2_0.nim
+++ b/tests/nimony/generics/deps/mexternalinst2_0.nim
@@ -1,0 +1,2 @@
+type Foo*[T] = object
+  val: T

--- a/tests/nimony/generics/deps/mexternalinst2_1.nim
+++ b/tests/nimony/generics/deps/mexternalinst2_1.nim
@@ -1,0 +1,3 @@
+import mexternalinst2_0
+
+type Inst1* = Foo[int]

--- a/tests/nimony/generics/deps/mexternalinst2_2.nim
+++ b/tests/nimony/generics/deps/mexternalinst2_2.nim
@@ -1,0 +1,3 @@
+import mexternalinst2_0
+
+type Inst2* = Foo[int]

--- a/tests/nimony/generics/texternalinst1.nim
+++ b/tests/nimony/generics/texternalinst1.nim
@@ -1,0 +1,5 @@
+# issue #715
+
+import deps/mexternalinst1
+
+initBar[int]()

--- a/tests/nimony/generics/texternalinst2.nim
+++ b/tests/nimony/generics/texternalinst2.nim
@@ -1,0 +1,7 @@
+import deps/[mexternalinst2_1, mexternalinst2_2]
+
+let x1: Inst1 = default(Inst1)
+let x2: Inst2 = default(Inst2)
+# compare to each other:
+let y1: Inst2 = x1
+let y2: Inst1 = x2

--- a/tests/nimony/generics/ttuplecache.nif
+++ b/tests/nimony/generics/ttuplecache.nif
@@ -6,22 +6,22 @@
   (object . ~7,1
    (fld :data.0.ttuv4zf4c1 . . 6 T.0.ttuv4zf4c1 .))) ,5
  (proc 5 :initFooInt.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.1.ttuv4zf4c1 . . 2,1
+  (params) 7 Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 . . 2,1
   (stmts 8
-   (result :result.0 . . ~3,~1 Foo.1.ttuv4zf4c1 .) 8
+   (result :result.0 . . ~3,~1 Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 .) 8
    (asgn result.0
     (expr
-     (oconstr ~3,~1 Foo.1.ttuv4zf4c1 5
-      (kv ~5 data.1.ttuv4zf4c1 2 +0)))) ~2,~1
+     (oconstr ~3,~1 Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 2 +0)))) ~2,~1
    (ret result.0))) ,8
  (proc 5 :initFooTup.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.2.ttuv4zf4c1 . . 2,2
+  (params) 7 Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 . . 2,2
   (stmts 15
-   (result :result.1 . . ~10,~2 Foo.2.ttuv4zf4c1 .) 15
+   (result :result.1 . . ~10,~2 Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 .) 15
    (asgn result.1
     (expr
-     (oconstr ~10,~2 Foo.2.ttuv4zf4c1 5
-      (kv ~5 data.2.ttuv4zf4c1 2
+     (oconstr ~10,~2 Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 2
        (tup 1 +0 4 +0))))) ~2,~2
    (ret result.1))) ,12
  (proc 5 :initFooGeneric.0.ttuv4zf4c1 . . 19
@@ -39,7 +39,7 @@
       (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
       (kv ~5 data 2 x.0)))) ~2,~1
    (ret result.2))) 4,15
- (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.3.ttuv4zf4c1 18
+ (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 18
   (call ~14 initFooGeneric.1.ttuv4zf4c1 1
    (tup 2
     (kv ~1 a 2 +1) 8
@@ -47,22 +47,22 @@
  (glet :x1.0.ttuv4zf4c1 . . 4,~11
   (i -1) 16
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.3.ttuv4zf4c1 +0) +0)) 4,17
+   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 +0) +0)) 4,17
  (glet :x2.0.ttuv4zf4c1 . . 4 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.3.ttuv4zf4c1 +0) +1)) 4,19
- (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.4.ttuv4zf4c1 18
+   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 +0) +1)) 4,19
+ (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 18
   (call ~14 initFooGeneric.2.ttuv4zf4c1 1
    (tup 2
     (kv ~1 x 2 "def") 12
     (kv ~1 y 2 +2)))) 4,20
  (glet :y1.0.ttuv4zf4c1 . . 4,~3 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.4.ttuv4zf4c1 +0) +0)) 4,21
+   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 +0) +0)) 4,21
  (glet :y2.0.ttuv4zf4c1 . . 4,~16
   (i -1) 16
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.4.ttuv4zf4c1 +0) +1)) 22,15
+   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 +0) +1)) 22,15
  (proc :initFooGeneric.1.ttuv4zf4c1 . ~22,~3 .
   (at initFooGeneric.0.ttuv4zf4c1 3
    (tuple
@@ -74,13 +74,13 @@
     (tuple
      (kv ~1 a
       (i -1)) 6
-     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.3.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
+     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
   (stmts 6
-   (result :result.3 . . 3,~1 Foo.3.ttuv4zf4c1 .) 6
+   (result :result.3 . . 3,~1 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 .) 6
    (asgn result.3
     (expr
-     (oconstr 3,~1 Foo.3.ttuv4zf4c1 5
-      (kv ~5 data.3.ttuv4zf4c1 2 x.3)))) ~2,~1
+     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 2 x.3)))) ~2,~1
    (ret result.3))) 22,19
  (proc :initFooGeneric.2.ttuv4zf4c1 . ~22,~7 .
   (at initFooGeneric.0.ttuv4zf4c1 3
@@ -93,50 +93,50 @@
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y
-      (i -1))) .)) ~11,~7 Foo.4.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
+      (i -1))) .)) ~11,~7 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
   (stmts 6
-   (result :result.4 . . 3,~1 Foo.4.ttuv4zf4c1 .) 6
+   (result :result.4 . . 3,~1 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 .) 6
    (asgn result.4
     (expr
-     (oconstr 3,~1 Foo.4.ttuv4zf4c1 5
-      (kv ~5 data.4.ttuv4zf4c1 2 x.4)))) ~2,~1
+     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 2 x.4)))) ~2,~1
    (ret result.4))) 7,5
- (type :Foo.1.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1
    (i -1)) 2,~4 . 4,~4
   (object . ~7,1
-   (fld :data.1.ttuv4zf4c1 . . 4,3
+   (fld :data.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 . . 4,3
     (i -1) .))) 7,8
- (type :Foo.2.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1
    (tuple 1
     (i -1) 6
     (i -1))) 2,~7 . 4,~7
   (object . ~7,1
-   (fld :data.2.ttuv4zf4c1 . . 4,6
+   (fld :data.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 . . 4,6
     (tuple 1
      (i -1) 6
      (i -1)) .))) 11,12
- (type :Foo.3.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 14,3
    (tuple
     (kv ~1 a
      (i -1)) 6
     (kv ~1 b string.0.sysvq0asl))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.3.ttuv4zf4c1 . . 21,13
+   (fld :data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 . . 21,13
     (tuple
      (kv ~1 a
       (i -1)) 6
      (kv ~1 b string.0.sysvq0asl)) .))) 11,12
- (type :Foo.4.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 14,7
    (tuple
     (kv ~1 x string.0.sysvq0asl) 10
     (kv ~1 y
      (i -1)))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.4.ttuv4zf4c1 . . 21,17
+   (fld :data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 . . 21,17
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y

--- a/tests/nimony/generics/ttuplecache.nif
+++ b/tests/nimony/generics/ttuplecache.nif
@@ -6,22 +6,22 @@
   (object . ~7,1
    (fld :data.0.ttuv4zf4c1 . . 6 T.0.ttuv4zf4c1 .))) ,5
  (proc 5 :initFooInt.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 . . 2,1
+  (params) 7 Foo.0.Iw8bgj.ttuv4zf4c1 . . 2,1
   (stmts 8
-   (result :result.0 . . ~3,~1 Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 .) 8
+   (result :result.0 . . ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 .) 8
    (asgn result.0
     (expr
-     (oconstr ~3,~1 Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 2 +0)))) ~2,~1
+     (oconstr ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 5
+      (kv ~5 data.0.Iw8bgj.ttuv4zf4c1 2 +0)))) ~2,~1
    (ret result.0))) ,8
  (proc 5 :initFooTup.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 . . 2,2
+  (params) 7 Foo.0.Ildbpdf1.ttuv4zf4c1 . . 2,2
   (stmts 15
-   (result :result.1 . . ~10,~2 Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 .) 15
+   (result :result.1 . . ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 .) 15
    (asgn result.1
     (expr
-     (oconstr ~10,~2 Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 2
+     (oconstr ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 5
+      (kv ~5 data.0.Ildbpdf1.ttuv4zf4c1 2
        (tup 1 +0 4 +0))))) ~2,~2
    (ret result.1))) ,12
  (proc 5 :initFooGeneric.0.ttuv4zf4c1 . . 19
@@ -39,7 +39,7 @@
       (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
       (kv ~5 data 2 x.0)))) ~2,~1
    (ret result.2))) 4,15
- (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 18
+ (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.Iv5bnz4.ttuv4zf4c1 18
   (call ~14 initFooGeneric.1.ttuv4zf4c1 1
    (tup 2
     (kv ~1 a 2 +1) 8
@@ -47,22 +47,22 @@
  (glet :x1.0.ttuv4zf4c1 . . 4,~11
   (i -1) 16
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 +0) +0)) 4,17
+   (dot ~1 x.0.ttuv4zf4c1 data.0.Iv5bnz4.ttuv4zf4c1 +0) +0)) 4,17
  (glet :x2.0.ttuv4zf4c1 . . 4 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 +0) +1)) 4,19
- (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 18
+   (dot ~1 x.0.ttuv4zf4c1 data.0.Iv5bnz4.ttuv4zf4c1 +0) +1)) 4,19
+ (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.0.Iarhs7y1.ttuv4zf4c1 18
   (call ~14 initFooGeneric.2.ttuv4zf4c1 1
    (tup 2
     (kv ~1 x 2 "def") 12
     (kv ~1 y 2 +2)))) 4,20
  (glet :y1.0.ttuv4zf4c1 . . 4,~3 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 +0) +0)) 4,21
+   (dot ~1 y.0.ttuv4zf4c1 data.0.Iarhs7y1.ttuv4zf4c1 +0) +0)) 4,21
  (glet :y2.0.ttuv4zf4c1 . . 4,~16
   (i -1) 16
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 +0) +1)) 22,15
+   (dot ~1 y.0.ttuv4zf4c1 data.0.Iarhs7y1.ttuv4zf4c1 +0) +1)) 22,15
  (proc :initFooGeneric.1.ttuv4zf4c1 . ~22,~3 .
   (at initFooGeneric.0.ttuv4zf4c1 3
    (tuple
@@ -74,13 +74,13 @@
     (tuple
      (kv ~1 a
       (i -1)) 6
-     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
+     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.Iv5bnz4.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
   (stmts 6
-   (result :result.3 . . 3,~1 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 .) 6
+   (result :result.3 . . 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 .) 6
    (asgn result.3
     (expr
-     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 2 x.3)))) ~2,~1
+     (oconstr 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 5
+      (kv ~5 data.0.Iv5bnz4.ttuv4zf4c1 2 x.3)))) ~2,~1
    (ret result.3))) 22,19
  (proc :initFooGeneric.2.ttuv4zf4c1 . ~22,~7 .
   (at initFooGeneric.0.ttuv4zf4c1 3
@@ -93,50 +93,50 @@
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y
-      (i -1))) .)) ~11,~7 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
+      (i -1))) .)) ~11,~7 Foo.0.Iarhs7y1.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
   (stmts 6
-   (result :result.4 . . 3,~1 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 .) 6
+   (result :result.4 . . 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 .) 6
    (asgn result.4
     (expr
-     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 2 x.4)))) ~2,~1
+     (oconstr 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 5
+      (kv ~5 data.0.Iarhs7y1.ttuv4zf4c1 2 x.4)))) ~2,~1
    (ret result.4))) 7,5
- (type :Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 .
+ (type :Foo.0.Iw8bgj.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1
    (i -1)) 2,~4 . 4,~4
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 . . 4,3
+   (fld :data.0.Iw8bgj.ttuv4zf4c1 . . 4,3
     (i -1) .))) 7,8
- (type :Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 .
+ (type :Foo.0.Ildbpdf1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1
    (tuple 1
     (i -1) 6
     (i -1))) 2,~7 . 4,~7
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 . . 4,6
+   (fld :data.0.Ildbpdf1.ttuv4zf4c1 . . 4,6
     (tuple 1
      (i -1) 6
      (i -1)) .))) 11,12
- (type :Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 .
+ (type :Foo.0.Iv5bnz4.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 14,3
    (tuple
     (kv ~1 a
      (i -1)) 6
     (kv ~1 b string.0.sysvq0asl))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 . . 21,13
+   (fld :data.0.Iv5bnz4.ttuv4zf4c1 . . 21,13
     (tuple
      (kv ~1 a
       (i -1)) 6
      (kv ~1 b string.0.sysvq0asl)) .))) 11,12
- (type :Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 .
+ (type :Foo.0.Iarhs7y1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 14,7
    (tuple
     (kv ~1 x string.0.sysvq0asl) 10
     (kv ~1 y
      (i -1)))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 . . 21,17
+   (fld :data.0.Iarhs7y1.ttuv4zf4c1 . . 21,17
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y

--- a/tests/nimony/generics/ttuplecache.nif
+++ b/tests/nimony/generics/ttuplecache.nif
@@ -6,22 +6,22 @@
   (object . ~7,1
    (fld :data.0.ttuv4zf4c1 . . 6 T.0.ttuv4zf4c1 .))) ,5
  (proc 5 :initFooInt.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 . . 2,1
+  (params) 7 Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 . . 2,1
   (stmts 8
-   (result :result.0 . . ~3,~1 Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 .) 8
+   (result :result.0 . . ~3,~1 Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 .) 8
    (asgn result.0
     (expr
-     (oconstr ~3,~1 Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 2 +0)))) ~2,~1
+     (oconstr ~3,~1 Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 2 +0)))) ~2,~1
    (ret result.0))) ,8
  (proc 5 :initFooTup.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 . . 2,2
+  (params) 7 Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 . . 2,2
   (stmts 15
-   (result :result.1 . . ~10,~2 Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 .) 15
+   (result :result.1 . . ~10,~2 Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 .) 15
    (asgn result.1
     (expr
-     (oconstr ~10,~2 Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 2
+     (oconstr ~10,~2 Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 2
        (tup 1 +0 4 +0))))) ~2,~2
    (ret result.1))) ,12
  (proc 5 :initFooGeneric.0.ttuv4zf4c1 . . 19
@@ -39,7 +39,7 @@
       (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
       (kv ~5 data 2 x.0)))) ~2,~1
    (ret result.2))) 4,15
- (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 18
+ (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 18
   (call ~14 initFooGeneric.1.ttuv4zf4c1 1
    (tup 2
     (kv ~1 a 2 +1) 8
@@ -47,22 +47,22 @@
  (glet :x1.0.ttuv4zf4c1 . . 4,~11
   (i -1) 16
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 +0) +0)) 4,17
+   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 +0) +0)) 4,17
  (glet :x2.0.ttuv4zf4c1 . . 4 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 +0) +1)) 4,19
- (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 18
+   (dot ~1 x.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 +0) +1)) 4,19
+ (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 18
   (call ~14 initFooGeneric.2.ttuv4zf4c1 1
    (tup 2
     (kv ~1 x 2 "def") 12
     (kv ~1 y 2 +2)))) 4,20
  (glet :y1.0.ttuv4zf4c1 . . 4,~3 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 +0) +0)) 4,21
+   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 +0) +0)) 4,21
  (glet :y2.0.ttuv4zf4c1 . . 4,~16
   (i -1) 16
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 +0) +1)) 22,15
+   (dot ~1 y.0.ttuv4zf4c1 data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 +0) +1)) 22,15
  (proc :initFooGeneric.1.ttuv4zf4c1 . ~22,~3 .
   (at initFooGeneric.0.ttuv4zf4c1 3
    (tuple
@@ -74,13 +74,13 @@
     (tuple
      (kv ~1 a
       (i -1)) 6
-     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
+     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
   (stmts 6
-   (result :result.3 . . 3,~1 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 .) 6
+   (result :result.3 . . 3,~1 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 .) 6
    (asgn result.3
     (expr
-     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 2 x.3)))) ~2,~1
+     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 2 x.3)))) ~2,~1
    (ret result.3))) 22,19
  (proc :initFooGeneric.2.ttuv4zf4c1 . ~22,~7 .
   (at initFooGeneric.0.ttuv4zf4c1 3
@@ -93,50 +93,50 @@
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y
-      (i -1))) .)) ~11,~7 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
+      (i -1))) .)) ~11,~7 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
   (stmts 6
-   (result :result.4 . . 3,~1 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 .) 6
+   (result :result.4 . . 3,~1 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 .) 6
    (asgn result.4
     (expr
-     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 5
-      (kv ~5 data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 2 x.4)))) ~2,~1
+     (oconstr 3,~1 Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 5
+      (kv ~5 data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 2 x.4)))) ~2,~1
    (ret result.4))) 7,5
- (type :Foo.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1
    (i -1)) 2,~4 . 4,~4
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Ij3nb6v.ttuv4zf4c1 . . 4,3
+   (fld :data.0.ttuv4zf4c1.Iw8bgj.ttuv4zf4c1 . . 4,3
     (i -1) .))) 7,8
- (type :Foo.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1
    (tuple 1
     (i -1) 6
     (i -1))) 2,~7 . 4,~7
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Ihswyxm1.ttuv4zf4c1 . . 4,6
+   (fld :data.0.ttuv4zf4c1.Ildbpdf1.ttuv4zf4c1 . . 4,6
     (tuple 1
      (i -1) 6
      (i -1)) .))) 11,12
- (type :Foo.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 14,3
    (tuple
     (kv ~1 a
      (i -1)) 6
     (kv ~1 b string.0.sysvq0asl))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Ixupxoo1.ttuv4zf4c1 . . 21,13
+   (fld :data.0.ttuv4zf4c1.Iv5bnz4.ttuv4zf4c1 . . 21,13
     (tuple
      (kv ~1 a
       (i -1)) 6
      (kv ~1 b string.0.sysvq0asl)) .))) 11,12
- (type :Foo.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 .
+ (type :Foo.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 14,7
    (tuple
     (kv ~1 x string.0.sysvq0asl) 10
     (kv ~1 y
      (i -1)))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1.Ifd345a1.ttuv4zf4c1 . . 21,17
+   (fld :data.0.ttuv4zf4c1.Iarhs7y1.ttuv4zf4c1 . . 21,17
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,2 +1,2 @@
 tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
-[2] expected: (i -1) but got: Foo.0.twrt5xaak.Io9wik5.twrt5xaak
+[2] expected: (i -1) but got: Foo.0.twrt5xaak.Iy40vk81.twrt5xaak

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,2 +1,2 @@
 tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
-[2] expected: (i -1) but got: Foo.0.twrt5xaak.Iy40vk81.twrt5xaak
+[2] expected: (i -1) but got: Foo.0.Iy40vk81.twrt5xaak

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,2 +1,2 @@
 tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
-[2] expected: (i -1) but got: Foo.1.twrt5xaak
+[2] expected: (i -1) but got: Foo.0.twrt5xaak.Io9wik5.twrt5xaak

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,4 +1,4 @@
 tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
 tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Ik9amei.tfis16ujj
-tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Ik9amei.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Iect8g8.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Iect8g8.tfis16ujj

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,4 +1,4 @@
 tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
 tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Iect8g8.tfis16ujj
-tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Iect8g8.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.Iect8g8.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.Iect8g8.tfis16ujj

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,4 +1,4 @@
 tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
 tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.tfis16ujj
-tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Ik9amei.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.mfil3x52c.Ik9amei.tfis16ujj

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -76,12 +76,12 @@
    (typevar :T.4.tge7jvqqk1 . . . .)) . 2
   (object . ~13,1
    (fld :x.0.tge7jvqqk1 . . 3 T.4.tge7jvqqk1 .))) 2,27
- (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.1.tge7jvqqk1 .) 2,28
- (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.2.tge7jvqqk1 .) 9,30
+ (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 .) 2,28
+ (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 .) 9,30
  (asgn ~3
-  (dot ~6 myglob.0.tge7jvqqk1 x.1.tge7jvqqk1 +0) 2 +56) 8,31
+  (dot ~6 myglob.0.tge7jvqqk1 x.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 +0) 2 +56) 8,31
  (asgn ~3
-  (dot ~5 other.0.tge7jvqqk1 x.2.tge7jvqqk1 +0) 2 +79.0) ,33
+  (dot ~5 other.0.tge7jvqqk1 x.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 +0) 2 +79.0) ,33
  (proc 5 :\2B.0.tge7jvqqk1
   (add -3) . . 9
   (params 1
@@ -237,15 +237,15 @@
       (i -1) +0 +2)) .) 7
    (asgn ~7 result.3 2 x.9) ~2,~1
    (ret result.3))) 19,27
- (type :MyGeneric.1.tge7jvqqk1 .
+ (type :MyGeneric.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 .
   (at MyGeneric.0.tge7jvqqk1 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.1.tge7jvqqk1 . . 16,3
+   (fld :x.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 . . 16,3
     (i -1) .))) 18,28
- (type :MyGeneric.2.tge7jvqqk1 .
+ (type :MyGeneric.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 .
   (at MyGeneric.0.tge7jvqqk1 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.2.tge7jvqqk1 . . 15,4
+   (fld :x.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -76,12 +76,12 @@
    (typevar :T.4.tge7jvqqk1 . . . .)) . 2
   (object . ~13,1
    (fld :x.0.tge7jvqqk1 . . 3 T.4.tge7jvqqk1 .))) 2,27
- (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 .) 2,28
- (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 .) 9,30
+ (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.I8smrpu.tge7jvqqk1 .) 2,28
+ (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.Iliphp3.tge7jvqqk1 .) 9,30
  (asgn ~3
-  (dot ~6 myglob.0.tge7jvqqk1 x.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 +0) 2 +56) 8,31
+  (dot ~6 myglob.0.tge7jvqqk1 x.0.I8smrpu.tge7jvqqk1 +0) 2 +56) 8,31
  (asgn ~3
-  (dot ~5 other.0.tge7jvqqk1 x.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 +0) 2 +79.0) ,33
+  (dot ~5 other.0.tge7jvqqk1 x.0.Iliphp3.tge7jvqqk1 +0) 2 +79.0) ,33
  (proc 5 :\2B.0.tge7jvqqk1
   (add -3) . . 9
   (params 1
@@ -237,15 +237,15 @@
       (i -1) +0 +2)) .) 7
    (asgn ~7 result.3 2 x.9) ~2,~1
    (ret result.3))) 19,27
- (type :MyGeneric.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 .
+ (type :MyGeneric.0.I8smrpu.tge7jvqqk1 .
   (at MyGeneric.0.tge7jvqqk1 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 . . 16,3
+   (fld :x.0.I8smrpu.tge7jvqqk1 . . 16,3
     (i -1) .))) 18,28
- (type :MyGeneric.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 .
+ (type :MyGeneric.0.Iliphp3.tge7jvqqk1 .
   (at MyGeneric.0.tge7jvqqk1 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 . . 15,4
+   (fld :x.0.Iliphp3.tge7jvqqk1 . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -76,12 +76,12 @@
    (typevar :T.4.tge7jvqqk1 . . . .)) . 2
   (object . ~13,1
    (fld :x.0.tge7jvqqk1 . . 3 T.4.tge7jvqqk1 .))) 2,27
- (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 .) 2,28
- (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 .) 9,30
+ (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 .) 2,28
+ (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 .) 9,30
  (asgn ~3
-  (dot ~6 myglob.0.tge7jvqqk1 x.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 +0) 2 +56) 8,31
+  (dot ~6 myglob.0.tge7jvqqk1 x.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 +0) 2 +56) 8,31
  (asgn ~3
-  (dot ~5 other.0.tge7jvqqk1 x.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 +0) 2 +79.0) ,33
+  (dot ~5 other.0.tge7jvqqk1 x.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 +0) 2 +79.0) ,33
  (proc 5 :\2B.0.tge7jvqqk1
   (add -3) . . 9
   (params 1
@@ -237,15 +237,15 @@
       (i -1) +0 +2)) .) 7
    (asgn ~7 result.3 2 x.9) ~2,~1
    (ret result.3))) 19,27
- (type :MyGeneric.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 .
+ (type :MyGeneric.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 .
   (at MyGeneric.0.tge7jvqqk1 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.0.tge7jvqqk1.Igegqa11.tge7jvqqk1 . . 16,3
+   (fld :x.0.tge7jvqqk1.I8smrpu.tge7jvqqk1 . . 16,3
     (i -1) .))) 18,28
- (type :MyGeneric.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 .
+ (type :MyGeneric.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 .
   (at MyGeneric.0.tge7jvqqk1 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.0.tge7jvqqk1.Ivx8fa61.tge7jvqqk1 . . 15,4
+   (fld :x.0.tge7jvqqk1.Iliphp3.tge7jvqqk1 . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -21,49 +21,49 @@
     (ref 11
      (at ~7 NodeObj.0.tge70unlm ~1,3 T.1.tge70unlm)) .))) 4,8
  (gvar :x.0.tge70unlm . . 8,~5
-  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 13
+  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 13
   (newobj ~5,~5
-   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 +123) 16
-   (kv ~16 left.0.tge70unlm.Inywjcl.tge70unlm 2
+   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 +123) 16
+   (kv ~16 left.0.tge70unlm.Itet59r.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.0.tge70unlm.Inywjcl.tge70unlm 2
+   (kv ~28 right.0.tge70unlm.Itet59r.tge70unlm 2
     (nil)))) 7,9
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm data.0.tge70unlm.Inywjcl.tge70unlm +0) 2 +456) 7,10
+  (ddot ~1 x.0.tge70unlm data.0.tge70unlm.Itet59r.tge70unlm +0) 2 +456) 7,10
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Inywjcl.tge70unlm +0) 11
+  (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Itet59r.tge70unlm +0) 11
   (newobj ~6,~7
-   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 +123) 16
-   (kv ~16 left.0.tge70unlm.Inywjcl.tge70unlm 2
+   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 +123) 16
+   (kv ~16 left.0.tge70unlm.Itet59r.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.0.tge70unlm.Inywjcl.tge70unlm 2
+   (kv ~28 right.0.tge70unlm.Itet59r.tge70unlm 2
     (nil)))) 8,11
  (asgn ~7
-  (ddot ~1 x.0.tge70unlm right.0.tge70unlm.Inywjcl.tge70unlm +0) 2
+  (ddot ~1 x.0.tge70unlm right.0.tge70unlm.Itet59r.tge70unlm +0) 2
   (nil)) 13,12
  (asgn ~7
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Inywjcl.tge70unlm +0) right.0.tge70unlm.Inywjcl.tge70unlm +0) 2
+   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Itet59r.tge70unlm +0) right.0.tge70unlm.Itet59r.tge70unlm +0) 2
   (nil)) 4,13
  (gvar :y.0.tge70unlm . . 8,~10
-  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 13
+  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 13
   (newobj ~5,~10
-   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 +987) 16
-   (kv ~16 left.0.tge70unlm.Inywjcl.tge70unlm 2
+   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 +987) 16
+   (kv ~16 left.0.tge70unlm.Itet59r.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.0.tge70unlm.Inywjcl.tge70unlm 2
+   (kv ~28 right.0.tge70unlm.Itet59r.tge70unlm 2
     (nil)))) 12,14
  (asgn ~6
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Inywjcl.tge70unlm +0) left.0.tge70unlm.Inywjcl.tge70unlm +0) 11
+   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Itet59r.tge70unlm +0) left.0.tge70unlm.Itet59r.tge70unlm +0) 11
   (newobj ~11,~11
-   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 -123) 17
-   (kv ~17 left.0.tge70unlm.Inywjcl.tge70unlm 2 y.0.tge70unlm) 27
-   (kv ~27 right.0.tge70unlm.Inywjcl.tge70unlm 2 y.0.tge70unlm))) ,16
+   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 -123) 17
+   (kv ~17 left.0.tge70unlm.Itet59r.tge70unlm 2 y.0.tge70unlm) 27
+   (kv ~27 right.0.tge70unlm.Itet59r.tge70unlm 2 y.0.tge70unlm))) ,16
  (proc 5 :foo.0.tge70unlm . . 8
   (typevars 1
    (typevar :T.2.tge70unlm . . . .)) 11
@@ -88,7 +88,7 @@
     (ddot ~6 result.0 data.0.tge70unlm +0) 2 data.0) ~2,~1
    (ret result.0))) 4,19
  (glet :a.0.tge70unlm . . 8,~16
-  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 7
+  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 7
   (call ~3 foo.1.tge70unlm 1 +123)) 2,20
  (asgn ~2 x.0.tge70unlm 2 a.0.tge70unlm) 11,19
  (proc :foo.1.tge70unlm . ~11,~3 .
@@ -97,32 +97,32 @@
   (params 1
    (param :data.2 . .
     (i -1) .)) 1,~16
-  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
+  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
   (stmts 7
    (result :result.1 . . 3,~14
-    (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) .) 7
+    (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) .) 7
    (asgn ~7 result.1 9
     (newobj ~6,~14
-     (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
-     (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 data.2) 17
-     (kv ~17 left.0.tge70unlm.Inywjcl.tge70unlm 2
+     (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
+     (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 data.2) 17
+     (kv ~17 left.0.tge70unlm.Itet59r.tge70unlm 2
       (nil)) 29
-     (kv ~29 right.0.tge70unlm.Inywjcl.tge70unlm 2
+     (kv ~29 right.0.tge70unlm.Itet59r.tge70unlm 2
       (nil)))) 12,1
    (asgn ~6
-    (ddot ~6 result.1 data.0.tge70unlm.Inywjcl.tge70unlm +0) 2 data.2) ~2,~1
+    (ddot ~6 result.1 data.0.tge70unlm.Itet59r.tge70unlm +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
- (type :Node.0.tge70unlm.Io2tpjh.tge70unlm .
+ (type :Node.0.tge70unlm.Ikmiisb.tge70unlm .
   (at Node.0.tge70unlm 1
    (i -1)) ~2,~5 . ,~5
-  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm)) 23,3
- (type :NodeObj.0.tge70unlm.Inywjcl.tge70unlm .
+  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm)) 23,3
+ (type :NodeObj.0.tge70unlm.Itet59r.tge70unlm .
   (at NodeObj.0.tge70unlm ~10,5
    (i -1)) ~10,1 . ~8,1
   (object . ~11,1
-   (fld :data.0.tge70unlm.Inywjcl.tge70unlm . . 9,3
+   (fld :data.0.tge70unlm.Itet59r.tge70unlm . . 9,3
     (i -1) .) ~11,2
-   (fld :left.0.tge70unlm.Inywjcl.tge70unlm . . 8,~3
-    (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) .) ~5,2
-   (fld :right.0.tge70unlm.Inywjcl.tge70unlm . . 2,~3
-    (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) .))))
+   (fld :left.0.tge70unlm.Itet59r.tge70unlm . . 8,~3
+    (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) .) ~5,2
+   (fld :right.0.tge70unlm.Itet59r.tge70unlm . . 2,~3
+    (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) .))))

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -21,49 +21,49 @@
     (ref 11
      (at ~7 NodeObj.0.tge70unlm ~1,3 T.1.tge70unlm)) .))) 4,8
  (gvar :x.0.tge70unlm . . 8,~5
-  (ref 11 NodeObj.1.tge70unlm) 13
+  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 13
   (newobj ~5,~5
-   (ref 11 NodeObj.1.tge70unlm) 5
-   (kv ~5 data.1.tge70unlm 2 +123) 16
-   (kv ~16 left.1.tge70unlm 2
+   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 +123) 16
+   (kv ~16 left.0.tge70unlm.Inywjcl.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.1.tge70unlm 2
+   (kv ~28 right.0.tge70unlm.Inywjcl.tge70unlm 2
     (nil)))) 7,9
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm data.1.tge70unlm +0) 2 +456) 7,10
+  (ddot ~1 x.0.tge70unlm data.0.tge70unlm.Inywjcl.tge70unlm +0) 2 +456) 7,10
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm left.1.tge70unlm +0) 11
+  (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Inywjcl.tge70unlm +0) 11
   (newobj ~6,~7
-   (ref 11 NodeObj.1.tge70unlm) 5
-   (kv ~5 data.1.tge70unlm 2 +123) 16
-   (kv ~16 left.1.tge70unlm 2
+   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 +123) 16
+   (kv ~16 left.0.tge70unlm.Inywjcl.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.1.tge70unlm 2
+   (kv ~28 right.0.tge70unlm.Inywjcl.tge70unlm 2
     (nil)))) 8,11
  (asgn ~7
-  (ddot ~1 x.0.tge70unlm right.1.tge70unlm +0) 2
+  (ddot ~1 x.0.tge70unlm right.0.tge70unlm.Inywjcl.tge70unlm +0) 2
   (nil)) 13,12
  (asgn ~7
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.1.tge70unlm +0) right.1.tge70unlm +0) 2
+   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Inywjcl.tge70unlm +0) right.0.tge70unlm.Inywjcl.tge70unlm +0) 2
   (nil)) 4,13
  (gvar :y.0.tge70unlm . . 8,~10
-  (ref 11 NodeObj.1.tge70unlm) 13
+  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 13
   (newobj ~5,~10
-   (ref 11 NodeObj.1.tge70unlm) 5
-   (kv ~5 data.1.tge70unlm 2 +987) 16
-   (kv ~16 left.1.tge70unlm 2
+   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 +987) 16
+   (kv ~16 left.0.tge70unlm.Inywjcl.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.1.tge70unlm 2
+   (kv ~28 right.0.tge70unlm.Inywjcl.tge70unlm 2
     (nil)))) 12,14
  (asgn ~6
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.1.tge70unlm +0) left.1.tge70unlm +0) 11
+   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Inywjcl.tge70unlm +0) left.0.tge70unlm.Inywjcl.tge70unlm +0) 11
   (newobj ~11,~11
-   (ref 11 NodeObj.1.tge70unlm) 5
-   (kv ~5 data.1.tge70unlm 2 -123) 17
-   (kv ~17 left.1.tge70unlm 2 y.0.tge70unlm) 27
-   (kv ~27 right.1.tge70unlm 2 y.0.tge70unlm))) ,16
+   (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
+   (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 -123) 17
+   (kv ~17 left.0.tge70unlm.Inywjcl.tge70unlm 2 y.0.tge70unlm) 27
+   (kv ~27 right.0.tge70unlm.Inywjcl.tge70unlm 2 y.0.tge70unlm))) ,16
  (proc 5 :foo.0.tge70unlm . . 8
   (typevars 1
    (typevar :T.2.tge70unlm . . . .)) 11
@@ -88,7 +88,7 @@
     (ddot ~6 result.0 data.0.tge70unlm +0) 2 data.0) ~2,~1
    (ret result.0))) 4,19
  (glet :a.0.tge70unlm . . 8,~16
-  (ref 11 NodeObj.1.tge70unlm) 7
+  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 7
   (call ~3 foo.1.tge70unlm 1 +123)) 2,20
  (asgn ~2 x.0.tge70unlm 2 a.0.tge70unlm) 11,19
  (proc :foo.1.tge70unlm . ~11,~3 .
@@ -97,32 +97,32 @@
   (params 1
    (param :data.2 . .
     (i -1) .)) 1,~16
-  (ref 11 NodeObj.1.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
+  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
   (stmts 7
    (result :result.1 . . 3,~14
-    (ref 11 NodeObj.1.tge70unlm) .) 7
+    (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) .) 7
    (asgn ~7 result.1 9
     (newobj ~6,~14
-     (ref 11 NodeObj.1.tge70unlm) 5
-     (kv ~5 data.1.tge70unlm 2 data.2) 17
-     (kv ~17 left.1.tge70unlm 2
+     (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) 5
+     (kv ~5 data.0.tge70unlm.Inywjcl.tge70unlm 2 data.2) 17
+     (kv ~17 left.0.tge70unlm.Inywjcl.tge70unlm 2
       (nil)) 29
-     (kv ~29 right.1.tge70unlm 2
+     (kv ~29 right.0.tge70unlm.Inywjcl.tge70unlm 2
       (nil)))) 12,1
    (asgn ~6
-    (ddot ~6 result.1 data.1.tge70unlm +0) 2 data.2) ~2,~1
+    (ddot ~6 result.1 data.0.tge70unlm.Inywjcl.tge70unlm +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
- (type :Node.3.tge70unlm .
+ (type :Node.0.tge70unlm.Io2tpjh.tge70unlm .
   (at Node.0.tge70unlm 1
    (i -1)) ~2,~5 . ,~5
-  (ref 11 NodeObj.1.tge70unlm)) 23,3
- (type :NodeObj.1.tge70unlm .
+  (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm)) 23,3
+ (type :NodeObj.0.tge70unlm.Inywjcl.tge70unlm .
   (at NodeObj.0.tge70unlm ~10,5
    (i -1)) ~10,1 . ~8,1
   (object . ~11,1
-   (fld :data.1.tge70unlm . . 9,3
+   (fld :data.0.tge70unlm.Inywjcl.tge70unlm . . 9,3
     (i -1) .) ~11,2
-   (fld :left.1.tge70unlm . . 8,~3
-    (ref 11 NodeObj.1.tge70unlm) .) ~5,2
-   (fld :right.1.tge70unlm . . 2,~3
-    (ref 11 NodeObj.1.tge70unlm) .))))
+   (fld :left.0.tge70unlm.Inywjcl.tge70unlm . . 8,~3
+    (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) .) ~5,2
+   (fld :right.0.tge70unlm.Inywjcl.tge70unlm . . 2,~3
+    (ref 11 NodeObj.0.tge70unlm.Inywjcl.tge70unlm) .))))

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -21,49 +21,49 @@
     (ref 11
      (at ~7 NodeObj.0.tge70unlm ~1,3 T.1.tge70unlm)) .))) 4,8
  (gvar :x.0.tge70unlm . . 8,~5
-  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 13
+  (ref 11 NodeObj.0.Itet59r.tge70unlm) 13
   (newobj ~5,~5
-   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 +123) 16
-   (kv ~16 left.0.tge70unlm.Itet59r.tge70unlm 2
+   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.Itet59r.tge70unlm 2 +123) 16
+   (kv ~16 left.0.Itet59r.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.0.tge70unlm.Itet59r.tge70unlm 2
+   (kv ~28 right.0.Itet59r.tge70unlm 2
     (nil)))) 7,9
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm data.0.tge70unlm.Itet59r.tge70unlm +0) 2 +456) 7,10
+  (ddot ~1 x.0.tge70unlm data.0.Itet59r.tge70unlm +0) 2 +456) 7,10
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Itet59r.tge70unlm +0) 11
+  (ddot ~1 x.0.tge70unlm left.0.Itet59r.tge70unlm +0) 11
   (newobj ~6,~7
-   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 +123) 16
-   (kv ~16 left.0.tge70unlm.Itet59r.tge70unlm 2
+   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.Itet59r.tge70unlm 2 +123) 16
+   (kv ~16 left.0.Itet59r.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.0.tge70unlm.Itet59r.tge70unlm 2
+   (kv ~28 right.0.Itet59r.tge70unlm 2
     (nil)))) 8,11
  (asgn ~7
-  (ddot ~1 x.0.tge70unlm right.0.tge70unlm.Itet59r.tge70unlm +0) 2
+  (ddot ~1 x.0.tge70unlm right.0.Itet59r.tge70unlm +0) 2
   (nil)) 13,12
  (asgn ~7
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Itet59r.tge70unlm +0) right.0.tge70unlm.Itet59r.tge70unlm +0) 2
+   (ddot ~1 x.0.tge70unlm left.0.Itet59r.tge70unlm +0) right.0.Itet59r.tge70unlm +0) 2
   (nil)) 4,13
  (gvar :y.0.tge70unlm . . 8,~10
-  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 13
+  (ref 11 NodeObj.0.Itet59r.tge70unlm) 13
   (newobj ~5,~10
-   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 +987) 16
-   (kv ~16 left.0.tge70unlm.Itet59r.tge70unlm 2
+   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.Itet59r.tge70unlm 2 +987) 16
+   (kv ~16 left.0.Itet59r.tge70unlm 2
     (nil)) 28
-   (kv ~28 right.0.tge70unlm.Itet59r.tge70unlm 2
+   (kv ~28 right.0.Itet59r.tge70unlm 2
     (nil)))) 12,14
  (asgn ~6
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.0.tge70unlm.Itet59r.tge70unlm +0) left.0.tge70unlm.Itet59r.tge70unlm +0) 11
+   (ddot ~1 x.0.tge70unlm left.0.Itet59r.tge70unlm +0) left.0.Itet59r.tge70unlm +0) 11
   (newobj ~11,~11
-   (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 -123) 17
-   (kv ~17 left.0.tge70unlm.Itet59r.tge70unlm 2 y.0.tge70unlm) 27
-   (kv ~27 right.0.tge70unlm.Itet59r.tge70unlm 2 y.0.tge70unlm))) ,16
+   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
+   (kv ~5 data.0.Itet59r.tge70unlm 2 -123) 17
+   (kv ~17 left.0.Itet59r.tge70unlm 2 y.0.tge70unlm) 27
+   (kv ~27 right.0.Itet59r.tge70unlm 2 y.0.tge70unlm))) ,16
  (proc 5 :foo.0.tge70unlm . . 8
   (typevars 1
    (typevar :T.2.tge70unlm . . . .)) 11
@@ -88,7 +88,7 @@
     (ddot ~6 result.0 data.0.tge70unlm +0) 2 data.0) ~2,~1
    (ret result.0))) 4,19
  (glet :a.0.tge70unlm . . 8,~16
-  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 7
+  (ref 11 NodeObj.0.Itet59r.tge70unlm) 7
   (call ~3 foo.1.tge70unlm 1 +123)) 2,20
  (asgn ~2 x.0.tge70unlm 2 a.0.tge70unlm) 11,19
  (proc :foo.1.tge70unlm . ~11,~3 .
@@ -97,32 +97,32 @@
   (params 1
    (param :data.2 . .
     (i -1) .)) 1,~16
-  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
+  (ref 11 NodeObj.0.Itet59r.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
   (stmts 7
    (result :result.1 . . 3,~14
-    (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) .) 7
+    (ref 11 NodeObj.0.Itet59r.tge70unlm) .) 7
    (asgn ~7 result.1 9
     (newobj ~6,~14
-     (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) 5
-     (kv ~5 data.0.tge70unlm.Itet59r.tge70unlm 2 data.2) 17
-     (kv ~17 left.0.tge70unlm.Itet59r.tge70unlm 2
+     (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
+     (kv ~5 data.0.Itet59r.tge70unlm 2 data.2) 17
+     (kv ~17 left.0.Itet59r.tge70unlm 2
       (nil)) 29
-     (kv ~29 right.0.tge70unlm.Itet59r.tge70unlm 2
+     (kv ~29 right.0.Itet59r.tge70unlm 2
       (nil)))) 12,1
    (asgn ~6
-    (ddot ~6 result.1 data.0.tge70unlm.Itet59r.tge70unlm +0) 2 data.2) ~2,~1
+    (ddot ~6 result.1 data.0.Itet59r.tge70unlm +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
- (type :Node.0.tge70unlm.Ikmiisb.tge70unlm .
+ (type :Node.0.Ikmiisb.tge70unlm .
   (at Node.0.tge70unlm 1
    (i -1)) ~2,~5 . ,~5
-  (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm)) 23,3
- (type :NodeObj.0.tge70unlm.Itet59r.tge70unlm .
+  (ref 11 NodeObj.0.Itet59r.tge70unlm)) 23,3
+ (type :NodeObj.0.Itet59r.tge70unlm .
   (at NodeObj.0.tge70unlm ~10,5
    (i -1)) ~10,1 . ~8,1
   (object . ~11,1
-   (fld :data.0.tge70unlm.Itet59r.tge70unlm . . 9,3
+   (fld :data.0.Itet59r.tge70unlm . . 9,3
     (i -1) .) ~11,2
-   (fld :left.0.tge70unlm.Itet59r.tge70unlm . . 8,~3
-    (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) .) ~5,2
-   (fld :right.0.tge70unlm.Itet59r.tge70unlm . . 2,~3
-    (ref 11 NodeObj.0.tge70unlm.Itet59r.tge70unlm) .))))
+   (fld :left.0.Itet59r.tge70unlm . . 8,~3
+    (ref 11 NodeObj.0.Itet59r.tge70unlm) .) ~5,2
+   (fld :right.0.Itet59r.tge70unlm . . 2,~3
+    (ref 11 NodeObj.0.Itet59r.tge70unlm) .))))

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -40,12 +40,12 @@
    (typevar :T.3.tte5tld8n . . . .)) . 2
   (object . ~13,1
    (fld :x.0.tte5tld8n . . 3 T.3.tte5tld8n .))) 2,19
- (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.tte5tld8n.Igj236q.tte5tld8n .) 2,20
- (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.tte5tld8n.Ibr3ivb1.tte5tld8n .) 9,22
+ (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.Igj236q.tte5tld8n .) 2,20
+ (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.Ibr3ivb1.tte5tld8n .) 9,22
  (asgn ~3
-  (dot ~6 myglob.0.tte5tld8n x.0.tte5tld8n.Igj236q.tte5tld8n +0) 2 +56) 8,23
+  (dot ~6 myglob.0.tte5tld8n x.0.Igj236q.tte5tld8n +0) 2 +56) 8,23
  (asgn ~3
-  (dot ~5 other.0.tte5tld8n x.0.tte5tld8n.Ibr3ivb1.tte5tld8n +0) 2 +79.0) ,25
+  (dot ~5 other.0.tte5tld8n x.0.Ibr3ivb1.tte5tld8n +0) 2 +79.0) ,25
  (proc 5 :\2B.0.tte5tld8n
   (add -3) . . 9
   (params 1
@@ -119,15 +119,15 @@
    (expr
     (conv ~18,3
      (u -1) ~12,3 val.0.tte5tld8n)))) 19,19
- (type :MyGeneric.0.tte5tld8n.Igj236q.tte5tld8n .
+ (type :MyGeneric.0.Igj236q.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.0.tte5tld8n.Igj236q.tte5tld8n . . 16,3
+   (fld :x.0.Igj236q.tte5tld8n . . 16,3
     (i -1) .))) 18,20
- (type :MyGeneric.0.tte5tld8n.Ibr3ivb1.tte5tld8n .
+ (type :MyGeneric.0.Ibr3ivb1.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.0.tte5tld8n.Ibr3ivb1.tte5tld8n . . 15,4
+   (fld :x.0.Ibr3ivb1.tte5tld8n . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -40,12 +40,12 @@
    (typevar :T.3.tte5tld8n . . . .)) . 2
   (object . ~13,1
    (fld :x.0.tte5tld8n . . 3 T.3.tte5tld8n .))) 2,19
- (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.tte5tld8n.Iaerh5i1.tte5tld8n .) 2,20
- (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.tte5tld8n.Iih7x741.tte5tld8n .) 9,22
+ (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.tte5tld8n.Igj236q.tte5tld8n .) 2,20
+ (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.tte5tld8n.Ibr3ivb1.tte5tld8n .) 9,22
  (asgn ~3
-  (dot ~6 myglob.0.tte5tld8n x.0.tte5tld8n.Iaerh5i1.tte5tld8n +0) 2 +56) 8,23
+  (dot ~6 myglob.0.tte5tld8n x.0.tte5tld8n.Igj236q.tte5tld8n +0) 2 +56) 8,23
  (asgn ~3
-  (dot ~5 other.0.tte5tld8n x.0.tte5tld8n.Iih7x741.tte5tld8n +0) 2 +79.0) ,25
+  (dot ~5 other.0.tte5tld8n x.0.tte5tld8n.Ibr3ivb1.tte5tld8n +0) 2 +79.0) ,25
  (proc 5 :\2B.0.tte5tld8n
   (add -3) . . 9
   (params 1
@@ -119,15 +119,15 @@
    (expr
     (conv ~18,3
      (u -1) ~12,3 val.0.tte5tld8n)))) 19,19
- (type :MyGeneric.0.tte5tld8n.Iaerh5i1.tte5tld8n .
+ (type :MyGeneric.0.tte5tld8n.Igj236q.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.0.tte5tld8n.Iaerh5i1.tte5tld8n . . 16,3
+   (fld :x.0.tte5tld8n.Igj236q.tte5tld8n . . 16,3
     (i -1) .))) 18,20
- (type :MyGeneric.0.tte5tld8n.Iih7x741.tte5tld8n .
+ (type :MyGeneric.0.tte5tld8n.Ibr3ivb1.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.0.tte5tld8n.Iih7x741.tte5tld8n . . 15,4
+   (fld :x.0.tte5tld8n.Ibr3ivb1.tte5tld8n . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -40,12 +40,12 @@
    (typevar :T.3.tte5tld8n . . . .)) . 2
   (object . ~13,1
    (fld :x.0.tte5tld8n . . 3 T.3.tte5tld8n .))) 2,19
- (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.1.tte5tld8n .) 2,20
- (gvar :other.0.tte5tld8n . . 16 MyGeneric.2.tte5tld8n .) 9,22
+ (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.tte5tld8n.Iaerh5i1.tte5tld8n .) 2,20
+ (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.tte5tld8n.Iih7x741.tte5tld8n .) 9,22
  (asgn ~3
-  (dot ~6 myglob.0.tte5tld8n x.1.tte5tld8n +0) 2 +56) 8,23
+  (dot ~6 myglob.0.tte5tld8n x.0.tte5tld8n.Iaerh5i1.tte5tld8n +0) 2 +56) 8,23
  (asgn ~3
-  (dot ~5 other.0.tte5tld8n x.2.tte5tld8n +0) 2 +79.0) ,25
+  (dot ~5 other.0.tte5tld8n x.0.tte5tld8n.Iih7x741.tte5tld8n +0) 2 +79.0) ,25
  (proc 5 :\2B.0.tte5tld8n
   (add -3) . . 9
   (params 1
@@ -119,15 +119,15 @@
    (expr
     (conv ~18,3
      (u -1) ~12,3 val.0.tte5tld8n)))) 19,19
- (type :MyGeneric.1.tte5tld8n .
+ (type :MyGeneric.0.tte5tld8n.Iaerh5i1.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.1.tte5tld8n . . 16,3
+   (fld :x.0.tte5tld8n.Iaerh5i1.tte5tld8n . . 16,3
     (i -1) .))) 18,20
- (type :MyGeneric.2.tte5tld8n .
+ (type :MyGeneric.0.tte5tld8n.Iih7x741.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.2.tte5tld8n . . 15,4
+   (fld :x.0.tte5tld8n.Iih7x741.tte5tld8n . . 15,4
     (f +64) .))))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -2,7 +2,7 @@
 0,1,tests/nimony/sysbasics/temptyseq.nim(stmts
  (proc 5 :foo.0.temd2l7vy . . . 8
   (params 1
-   (param :x.0 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) . . . 24
+   (param :x.0 . . 6 seq.0.Ipe57hg.temd2l7vy .)) . . . 24
   (stmts
    (discard .))) 3,2
  (call ~3 foo.0.temd2l7vy 43,147,lib/std/system/seqimpl.nim
@@ -22,7 +22,7 @@
   (expr 15
    (expr
     (call ~15 newSeqUninit.1.temd2l7vy 1 +0)))) 4,8
- (gvar :s.0.temd2l7vy . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 43,147,lib/std/system/seqimpl.nim
+ (gvar :s.0.temd2l7vy . . 6 seq.0.Iq4ofkp1.temd2l7vy 43,147,lib/std/system/seqimpl.nim
   (expr 15
    (expr
     (call ~15 newSeqUninit.2.temd2l7vy 1 +0)))) 58,147,lib/std/system/seqimpl.nim
@@ -31,21 +31,21 @@
    (i -1)) ~37,~92
   (params 1
    (param :size.3 . . 6
-    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Ipe57hg.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.Ipe57hg.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.0 . . 14,~1 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)
+   (result :result.0 . . 14,~1 seq.0.Ipe57hg.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.3 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Ipe57hg.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Ipe57hg.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.sysvq0asl.Ipe57hg.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temd2l7vy 4
+        (kv ~4 len.4.Ipe57hg.temd2l7vy 2 size.3) 16
+        (kv ~16 data.0.Ipe57hg.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -56,9 +56,9 @@
         (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
          (i -1)))) 7,1
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Ipe57hg.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Ipe57hg.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.sysvq0asl.Ipe57hg.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temd2l7vy 4
+        (kv ~4 len.4.Ipe57hg.temd2l7vy 2 size.3) 16
+        (kv ~16 data.0.Ipe57hg.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -72,14 +72,14 @@
            (ptr 18
             (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
              (i -1))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.0 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.0 data.0.Ipe57hg.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.0 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.0 len.4.Ipe57hg.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.0))))))) ~2,~1
    (ret result.0))) 58,147,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.1.temd2l7vy . ~58,~92 .
@@ -87,21 +87,21 @@
    (f +64)) ~37,~92
   (params 1
    (param :size.4 . . 6
-    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.Iw9f2pq.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.1 . . 14,~1 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)
+   (result :result.1 . . 14,~1 seq.0.Iw9f2pq.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.4 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.1 8
-       (oconstr ~3,~2 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy 2 size.4) 16
-        (kv ~16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy 2
+       (oconstr ~3,~2 seq.0.Iw9f2pq.temd2l7vy 4
+        (kv ~4 len.4.Iw9f2pq.temd2l7vy 2 size.4) 16
+        (kv ~16 data.0.Iw9f2pq.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -112,9 +112,9 @@
         (sizeof
          (f +64)))) 7,1
       (asgn ~7 result.1 8
-       (oconstr ~3,~5 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy 2 size.4) 16
-        (kv ~16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy 2
+       (oconstr ~3,~5 seq.0.Iw9f2pq.temd2l7vy 4
+        (kv ~4 len.4.Iw9f2pq.temd2l7vy 2 size.4) 16
+        (kv ~16 data.0.Iw9f2pq.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray
@@ -128,14 +128,14 @@
            (ptr 18
             (uarray
              (f +64))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.1 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.1 data.0.Iw9f2pq.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.1 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.1 len.4.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.1))))))) ~2,~1
    (ret result.1))) 3,6
  (proc :bar.1.temd2l7vy . ~3,~2 .
@@ -144,7 +144,7 @@
   (params 1
    (param :x.3 . .
     (f +64) .) 7
-   (param :y.2 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
+   (param :y.2 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
   (stmts
    (discard .))) 58,147,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.2.temd2l7vy . ~58,~92 .
@@ -152,21 +152,21 @@
    (u +8)) ~37,~92
   (params 1
    (param :size.5 . . 6
-    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.Iq4ofkp1.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.2 . . 14,~1 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)
+   (result :result.2 . . 14,~1 seq.0.Iq4ofkp1.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.5 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy 2 size.5) 16
-        (kv ~16 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temd2l7vy 4
+        (kv ~4 len.4.Iq4ofkp1.temd2l7vy 2 size.5) 16
+        (kv ~16 data.0.Iq4ofkp1.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -177,9 +177,9 @@
         (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
          (u +8)))) 7,1
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy 2 size.5) 16
-        (kv ~16 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temd2l7vy 4
+        (kv ~4 len.4.Iq4ofkp1.temd2l7vy 2 size.5) 16
+        (kv ~16 data.0.Iq4ofkp1.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -193,43 +193,43 @@
            (ptr 18
             (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
              (u +8))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.2 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.2 data.0.Iq4ofkp1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.2 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.2 len.4.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.2))))))) ~2,~1
    (ret result.2))) 15
- (type :seq.0.sysvq0asl.Ipe57hg.temd2l7vy .
+ (type :seq.0.Ipe57hg.temd2l7vy .
   (at seq.0.sysvq0asl 1
    (i -1)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.4.sysvq0asl.Ipe57hg.temd2l7vy . . 5
+   (fld :len.4.Ipe57hg.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.sysvq0asl.Ipe57hg.temd2l7vy . . 6
+   (fld :data.0.Ipe57hg.temd2l7vy . . 6
     (ptr 18
      (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
       (i -1))) .))) 16,55,lib/std/system/seqimpl.nim
- (type :seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .
+ (type :seq.0.Iw9f2pq.temd2l7vy .
   (at seq.0.sysvq0asl
    (f +64)) ~6,~51 . ~4,~51
   (object . ~8,1
-   (fld :len.4.sysvq0asl.Iw9f2pq.temd2l7vy . . 5
+   (fld :len.4.Iw9f2pq.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.sysvq0asl.Iw9f2pq.temd2l7vy . . 6
+   (fld :data.0.Iw9f2pq.temd2l7vy . . 6
     (ptr 18
      (uarray
       (f +64))) .))) 10,8
- (type :seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .
+ (type :seq.0.Iq4ofkp1.temd2l7vy .
   (at seq.0.sysvq0asl 1
    (u +8)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.4.sysvq0asl.Iq4ofkp1.temd2l7vy . . 5
+   (fld :len.4.Iq4ofkp1.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.sysvq0asl.Iq4ofkp1.temd2l7vy . . 6
+   (fld :data.0.Iq4ofkp1.temd2l7vy . . 6
     (ptr 18
      (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
       (u +8))) .))) 0,11,lib/std/system/seqimpl.nim
@@ -237,18 +237,18 @@
   (at =destroy.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 19
   (params 1
-   (param :s.6 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) . . . 2,1
+   (param :s.6 . . 6 seq.0.Ipe57hg.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.0 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.0 3
-     (dot ~1 s.6 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
+     (dot ~1 s.6 len.4.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.6 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.0)) ,1
+       (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0) 6 i.0)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.0)))) ,4
    (if 3
@@ -259,7 +259,7 @@
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
           (i -1))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.6 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -267,48 +267,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.6 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.0.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 20
   (params 1
    (param :s.7 . . 3
-    (mut 7 seq.0.sysvq0asl.Ipe57hg.temd2l7vy) .)) . 36
+    (mut 7 seq.0.Ipe57hg.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.7) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.7) len.4.Ipe57hg.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.7) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 2
+     (hderef s.7) data.0.Ipe57hg.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.0.temd2l7vy . .
   (at =dup.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 15
   (params 1
-   (param :a.3 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) 16 seq.0.sysvq0asl.Ipe57hg.temd2l7vy 35
+   (param :a.3 . . 6 seq.0.Ipe57hg.temd2l7vy .)) 16 seq.0.Ipe57hg.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.3 . . 13,~1 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .) 7
+   (result :result.3 . . 13,~1 seq.0.Ipe57hg.temd2l7vy .) 7
    (asgn ~7 result.3 17
     (call ~15 newSeqUninit.0.temd2l7vy 2
-     (dot ~1 a.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0))) 4,1
+     (dot ~1 a.3 len.4.Ipe57hg.temd2l7vy +0))) 4,1
    (var :i.1 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.1 3
-     (dot ~1 a.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
+     (dot ~1 a.3 len.4.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.1) 8
+       (dot ~6 result.3 data.0.Ipe57hg.temd2l7vy +0) 6 i.1) 8
       (dup 2
        (pat
-        (dot ~1 a.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.1))) ,1
+        (dot ~1 a.3 data.0.Ipe57hg.temd2l7vy +0) 6 i.1))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.1)))) ~2,~1
    (ret result.3))) 0,93,lib/std/system/seqimpl.nim
@@ -317,8 +317,8 @@
    (i -1)) 16
   (params 1
    (param :dest.3 . . 6
-    (mut 7 seq.0.sysvq0asl.Ipe57hg.temd2l7vy) .) 19
-   (param :src.3 . . 8 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) . 48
+    (mut 7 seq.0.Ipe57hg.temd2l7vy) .) 19
+   (param :src.3 . . 8 seq.0.Ipe57hg.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -329,31 +329,31 @@
        (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1))) ~6
       (dot ~4
-       (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6
-      (dot ~3 src.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0)) 23
+       (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 6
+      (dot ~3 src.3 data.0.Ipe57hg.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 6
+      (dot ~3 src.3 len.4.Ipe57hg.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) ~1,1
+       (hderef dest.3) len.4.Ipe57hg.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.2 . . 1,~91
        (i -1) 7
-       (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) ,1
+       (dot ~3 src.3 len.4.Ipe57hg.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.2 6
         (dot ~4
-         (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
+         (hderef dest.3) len.4.Ipe57hg.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.2)) ,1
+           (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 6 i.2)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.2)))))) 5,5
     (elif 16
@@ -363,7 +363,7 @@
        (hderef dest.3)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 8
+       (dot ~3 src.3 len.4.Ipe57hg.temd2l7vy +0) 8
        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1)))) ~3,1
      (stmts 4
@@ -380,7 +380,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.0 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 oldCap.0))) 4,2
+         (dot ~3 src.3 len.4.Ipe57hg.temd2l7vy +0) 2 oldCap.0))) 4,2
       (let :memSize.3 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -389,7 +389,7 @@
          (i -1)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 2
+        (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -400,7 +400,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0))) 12 memSize.3))) ,4
+            (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0))) 12 memSize.3))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -408,52 +408,52 @@
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) ~6
          (dot ~4
-          (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 3
+          (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.3) len.4.Ipe57hg.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.3) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 5
-    (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 4,16
+     (hderef dest.3) len.4.Ipe57hg.temd2l7vy +0) 5
+    (dot ~3 src.3 len.4.Ipe57hg.temd2l7vy +0)) 4,16
    (var :i.3 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.3 6
      (dot ~4
-      (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
+      (hderef dest.3) len.4.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.3)))) ,1
+         (dot ~3 src.3 data.0.Ipe57hg.temd2l7vy +0) 6 i.3)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.3)))))) 0,11,lib/std/system/seqimpl.nim
  (proc :=destroy.1.temd2l7vy . .
   (at =destroy.2.sysvq0asl
    (f +64)) 19
   (params 1
-   (param :s.9 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) . . . 2,1
+   (param :s.9 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.4 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.4 3
-     (dot ~1 s.9 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
+     (dot ~1 s.9 len.4.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.9 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.4)) ,1
+       (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0) 6 i.4)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.4)))) ,4
    (if 3
@@ -464,7 +464,7 @@
         (ptr 18
          (uarray
           (f +64))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.9 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -472,48 +472,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.9 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.1.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl
    (f +64)) 20
   (params 1
    (param :s.10 . . 3
-    (mut 7 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy) .)) . 36
+    (mut 7 seq.0.Iw9f2pq.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.10) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.10) len.4.Iw9f2pq.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.10) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2
+     (hderef s.10) data.0.Iw9f2pq.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.1.temd2l7vy . .
   (at =dup.2.sysvq0asl
    (f +64)) 15
   (params 1
-   (param :a.4 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) 16 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy 35
+   (param :a.4 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) 16 seq.0.Iw9f2pq.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.4 . . 13,~1 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .) 7
+   (result :result.4 . . 13,~1 seq.0.Iw9f2pq.temd2l7vy .) 7
    (asgn ~7 result.4 17
     (call ~15 newSeqUninit.1.temd2l7vy 2
-     (dot ~1 a.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0))) 4,1
+     (dot ~1 a.4 len.4.Iw9f2pq.temd2l7vy +0))) 4,1
    (var :i.5 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.5 3
-     (dot ~1 a.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
+     (dot ~1 a.4 len.4.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.5) 8
+       (dot ~6 result.4 data.0.Iw9f2pq.temd2l7vy +0) 6 i.5) 8
       (dup 2
        (pat
-        (dot ~1 a.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.5))) ,1
+        (dot ~1 a.4 data.0.Iw9f2pq.temd2l7vy +0) 6 i.5))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.5)))) ~2,~1
    (ret result.4))) 0,93,lib/std/system/seqimpl.nim
@@ -522,8 +522,8 @@
    (f +64)) 16
   (params 1
    (param :dest.4 . . 6
-    (mut 7 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy) .) 19
-   (param :src.4 . . 8 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) . 48
+    (mut 7 seq.0.Iw9f2pq.temd2l7vy) .) 19
+   (param :src.4 . . 8 seq.0.Iw9f2pq.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -534,31 +534,31 @@
        (uarray
         (f +64))) ~6
       (dot ~4
-       (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6
-      (dot ~3 src.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 23
+       (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 6
+      (dot ~3 src.4 data.0.Iw9f2pq.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6
+      (dot ~3 src.4 len.4.Iw9f2pq.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) ~1,1
+       (hderef dest.4) len.4.Iw9f2pq.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.6 . . 1,~91
        (i -1) 7
-       (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) ,1
+       (dot ~3 src.4 len.4.Iw9f2pq.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.6 6
         (dot ~4
-         (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
+         (hderef dest.4) len.4.Iw9f2pq.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.6)) ,1
+           (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 6 i.6)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.6)))))) 5,5
     (elif 16
@@ -568,7 +568,7 @@
        (hderef dest.4)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 8
+       (dot ~3 src.4 len.4.Iw9f2pq.temd2l7vy +0) 8
        (sizeof
         (f +64)))) ~3,1
      (stmts 4
@@ -585,7 +585,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.1 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 oldCap.1))) 4,2
+         (dot ~3 src.4 len.4.Iw9f2pq.temd2l7vy +0) 2 oldCap.1))) 4,2
       (let :memSize.4 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -594,7 +594,7 @@
          (f +64)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2
+        (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray
@@ -605,7 +605,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0))) 12 memSize.4))) ,4
+            (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0))) 12 memSize.4))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -613,52 +613,52 @@
           (uarray
            (f +64))) ~6
          (dot ~4
-          (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 3
+          (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.4) len.4.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.4) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 5
-    (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 4,16
+     (hderef dest.4) len.4.Iw9f2pq.temd2l7vy +0) 5
+    (dot ~3 src.4 len.4.Iw9f2pq.temd2l7vy +0)) 4,16
    (var :i.7 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.7 6
      (dot ~4
-      (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
+      (hderef dest.4) len.4.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.7)))) ,1
+         (dot ~3 src.4 data.0.Iw9f2pq.temd2l7vy +0) 6 i.7)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.7)))))) 0,11,lib/std/system/seqimpl.nim
  (proc :=destroy.2.temd2l7vy . .
   (at =destroy.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 19
   (params 1
-   (param :s.12 . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) . . . 2,1
+   (param :s.12 . . 6 seq.0.Iq4ofkp1.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.8 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.8 3
-     (dot ~1 s.12 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
+     (dot ~1 s.12 len.4.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.12 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.8)) ,1
+       (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.8)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.8)))) ,4
    (if 3
@@ -669,7 +669,7 @@
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
           (u +8))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.12 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -677,48 +677,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.12 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.2.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 20
   (params 1
    (param :s.13 . . 3
-    (mut 7 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy) .)) . 36
+    (mut 7 seq.0.Iq4ofkp1.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.13) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.13) len.4.Iq4ofkp1.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.13) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2
+     (hderef s.13) data.0.Iq4ofkp1.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.2.temd2l7vy . .
   (at =dup.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 15
   (params 1
-   (param :a.5 . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) 16 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 35
+   (param :a.5 . . 6 seq.0.Iq4ofkp1.temd2l7vy .)) 16 seq.0.Iq4ofkp1.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.5 . . 13,~1 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .) 7
+   (result :result.5 . . 13,~1 seq.0.Iq4ofkp1.temd2l7vy .) 7
    (asgn ~7 result.5 17
     (call ~15 newSeqUninit.2.temd2l7vy 2
-     (dot ~1 a.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0))) 4,1
+     (dot ~1 a.5 len.4.Iq4ofkp1.temd2l7vy +0))) 4,1
    (var :i.9 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.9 3
-     (dot ~1 a.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
+     (dot ~1 a.5 len.4.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.9) 8
+       (dot ~6 result.5 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.9) 8
       (dup 2
        (pat
-        (dot ~1 a.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.9))) ,1
+        (dot ~1 a.5 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.9))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.9)))) ~2,~1
    (ret result.5))) 0,93,lib/std/system/seqimpl.nim
@@ -727,8 +727,8 @@
    (u +8)) 16
   (params 1
    (param :dest.5 . . 6
-    (mut 7 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy) .) 19
-   (param :src.5 . . 8 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) . 48
+    (mut 7 seq.0.Iq4ofkp1.temd2l7vy) .) 19
+   (param :src.5 . . 8 seq.0.Iq4ofkp1.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -739,31 +739,31 @@
        (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8))) ~6
       (dot ~4
-       (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6
-      (dot ~3 src.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 23
+       (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 6
+      (dot ~3 src.5 data.0.Iq4ofkp1.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6
+      (dot ~3 src.5 len.4.Iq4ofkp1.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) ~1,1
+       (hderef dest.5) len.4.Iq4ofkp1.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.10 . . 1,~91
        (i -1) 7
-       (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) ,1
+       (dot ~3 src.5 len.4.Iq4ofkp1.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.10 6
         (dot ~4
-         (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
+         (hderef dest.5) len.4.Iq4ofkp1.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.10)) ,1
+           (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 6 i.10)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.10)))))) 5,5
     (elif 16
@@ -773,7 +773,7 @@
        (hderef dest.5)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 8
+       (dot ~3 src.5 len.4.Iq4ofkp1.temd2l7vy +0) 8
        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8)))) ~3,1
      (stmts 4
@@ -790,7 +790,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.2 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 oldCap.2))) 4,2
+         (dot ~3 src.5 len.4.Iq4ofkp1.temd2l7vy +0) 2 oldCap.2))) 4,2
       (let :memSize.5 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -799,7 +799,7 @@
          (u +8)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2
+        (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -810,7 +810,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0))) 12 memSize.5))) ,4
+            (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0))) 12 memSize.5))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -818,34 +818,34 @@
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) ~6
          (dot ~4
-          (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 3
+          (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.5) len.4.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.5) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 5
-    (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 4,16
+     (hderef dest.5) len.4.Iq4ofkp1.temd2l7vy +0) 5
+    (dot ~3 src.5 len.4.Iq4ofkp1.temd2l7vy +0)) 4,16
    (var :i.11 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.11 6
      (dot ~4
-      (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
+      (hderef dest.5) len.4.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.11)))) ,1
+         (dot ~3 src.5 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.11)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.11)))))) 4,15,lib/std/system/seqimpl.nim
  (proc :inc.0.temd2l7vy . 0,276,lib/std/system.nim .
@@ -869,7 +869,7 @@
   (at capInBytes.0.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 7,~92
   (params 1
-   (param :s.15 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) 2,~92
+   (param :s.15 . . 6 seq.0.Ipe57hg.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -885,7 +885,7 @@
          (ptr 18
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.15 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.15 data.0.Ipe57hg.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -893,7 +893,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.15 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0)))))) 40
+          (dot ~1 s.15 data.0.Ipe57hg.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.6))) 11,100,lib/std/system/seqimpl.nim
@@ -901,7 +901,7 @@
   (at capInBytes.0.sysvq0asl
    (f +64)) 7,~92
   (params 1
-   (param :s.16 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) 2,~92
+   (param :s.16 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -917,7 +917,7 @@
          (ptr 18
           (uarray
            (f +64))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.16 data.0.Iw9f2pq.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -925,7 +925,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0)))))) 40
+          (dot ~1 s.16 data.0.Iw9f2pq.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.7))) 11,100,lib/std/system/seqimpl.nim
@@ -933,7 +933,7 @@
   (at capInBytes.0.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 7,~92
   (params 1
-   (param :s.17 . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) 2,~92
+   (param :s.17 . . 6 seq.0.Iq4ofkp1.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -949,7 +949,7 @@
          (ptr 18
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.17 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.17 data.0.Iq4ofkp1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -957,7 +957,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.17 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0)))))) 40
+          (dot ~1 s.17 data.0.Iq4ofkp1.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.8))))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -2,7 +2,7 @@
 0,1,tests/nimony/sysbasics/temptyseq.nim(stmts
  (proc 5 :foo.0.temd2l7vy . . . 8
   (params 1
-   (param :x.0 . . 6 seq.0.temd2l7vy .)) . . . 24
+   (param :x.0 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) . . . 24
   (stmts
    (discard .))) 3,2
  (call ~3 foo.0.temd2l7vy 43,147,lib/std/system/seqimpl.nim
@@ -22,7 +22,7 @@
   (expr 15
    (expr
     (call ~15 newSeqUninit.1.temd2l7vy 1 +0)))) 4,8
- (gvar :s.0.temd2l7vy . . 6 seq.2.temd2l7vy 43,147,lib/std/system/seqimpl.nim
+ (gvar :s.0.temd2l7vy . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy 43,147,lib/std/system/seqimpl.nim
   (expr 15
    (expr
     (call ~15 newSeqUninit.2.temd2l7vy 1 +0)))) 58,147,lib/std/system/seqimpl.nim
@@ -31,21 +31,21 @@
    (i -1)) ~37,~92
   (params 1
    (param :size.3 . . 6
-    (i -1) .)) ~42,~92 seq.0.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Is27ul41.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.0 . . 14,~1 seq.0.temd2l7vy .)
+   (result :result.0 . . 14,~1 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.3 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.temd2l7vy 4
-        (kv ~4 len.0.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Is27ul41.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Is27ul41.temd2l7vy 2 size.3) 16
+        (kv ~16 data.0.sysvq0asl.Is27ul41.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -56,9 +56,9 @@
         (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
          (i -1)))) 7,1
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.temd2l7vy 4
-        (kv ~4 len.0.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Is27ul41.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Is27ul41.temd2l7vy 2 size.3) 16
+        (kv ~16 data.0.sysvq0asl.Is27ul41.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -72,14 +72,14 @@
            (ptr 18
             (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
              (i -1))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.0 data.0.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.0 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.0 len.0.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.0 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.0))))))) ~2,~1
    (ret result.0))) 58,147,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.1.temd2l7vy . ~58,~92 .
@@ -87,21 +87,21 @@
    (f +64)) ~37,~92
   (params 1
    (param :size.4 . . 6
-    (i -1) .)) ~42,~92 seq.1.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.sysvq0asl.I9qk85v1.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.1 . . 14,~1 seq.1.temd2l7vy .)
+   (result :result.1 . . 14,~1 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.4 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.1 8
-       (oconstr ~3,~2 seq.1.temd2l7vy 4
-        (kv ~4 len.1.temd2l7vy 2 size.4) 16
-        (kv ~16 data.1.temd2l7vy 2
+       (oconstr ~3,~2 seq.0.sysvq0asl.I9qk85v1.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.I9qk85v1.temd2l7vy 2 size.4) 16
+        (kv ~16 data.0.sysvq0asl.I9qk85v1.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -112,9 +112,9 @@
         (sizeof
          (f +64)))) 7,1
       (asgn ~7 result.1 8
-       (oconstr ~3,~5 seq.1.temd2l7vy 4
-        (kv ~4 len.1.temd2l7vy 2 size.4) 16
-        (kv ~16 data.1.temd2l7vy 2
+       (oconstr ~3,~5 seq.0.sysvq0asl.I9qk85v1.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.I9qk85v1.temd2l7vy 2 size.4) 16
+        (kv ~16 data.0.sysvq0asl.I9qk85v1.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray
@@ -128,14 +128,14 @@
            (ptr 18
             (uarray
              (f +64))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.1 data.1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.1 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.1 len.1.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.1 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.1))))))) ~2,~1
    (ret result.1))) 3,6
  (proc :bar.1.temd2l7vy . ~3,~2 .
@@ -144,7 +144,7 @@
   (params 1
    (param :x.3 . .
     (f +64) .) 7
-   (param :y.2 . . 6 seq.1.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
+   (param :y.2 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
   (stmts
    (discard .))) 58,147,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.2.temd2l7vy . ~58,~92 .
@@ -152,21 +152,21 @@
    (u +8)) ~37,~92
   (params 1
    (param :size.5 . . 6
-    (i -1) .)) ~42,~92 seq.2.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.sysvq0asl.I596vqx.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.2 . . 14,~1 seq.2.temd2l7vy .)
+   (result :result.2 . . 14,~1 seq.0.sysvq0asl.I596vqx.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.5 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.2.temd2l7vy 4
-        (kv ~4 len.2.temd2l7vy 2 size.5) 16
-        (kv ~16 data.2.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.I596vqx.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.I596vqx.temd2l7vy 2 size.5) 16
+        (kv ~16 data.0.sysvq0asl.I596vqx.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -177,9 +177,9 @@
         (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
          (u +8)))) 7,1
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.2.temd2l7vy 4
-        (kv ~4 len.2.temd2l7vy 2 size.5) 16
-        (kv ~16 data.2.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.I596vqx.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.I596vqx.temd2l7vy 2 size.5) 16
+        (kv ~16 data.0.sysvq0asl.I596vqx.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -193,43 +193,43 @@
            (ptr 18
             (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
              (u +8))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.2 data.2.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.2 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.2 len.2.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.2 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.2))))))) ~2,~1
    (ret result.2))) 15
- (type :seq.0.temd2l7vy .
+ (type :seq.0.sysvq0asl.Is27ul41.temd2l7vy .
   (at seq.0.sysvq0asl 1
    (i -1)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.0.temd2l7vy . . 5
+   (fld :len.4.sysvq0asl.Is27ul41.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.temd2l7vy . . 6
+   (fld :data.0.sysvq0asl.Is27ul41.temd2l7vy . . 6
     (ptr 18
      (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
       (i -1))) .))) 16,55,lib/std/system/seqimpl.nim
- (type :seq.1.temd2l7vy .
+ (type :seq.0.sysvq0asl.I9qk85v1.temd2l7vy .
   (at seq.0.sysvq0asl
    (f +64)) ~6,~51 . ~4,~51
   (object . ~8,1
-   (fld :len.1.temd2l7vy . . 5
+   (fld :len.4.sysvq0asl.I9qk85v1.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.1.temd2l7vy . . 6
+   (fld :data.0.sysvq0asl.I9qk85v1.temd2l7vy . . 6
     (ptr 18
      (uarray
       (f +64))) .))) 10,8
- (type :seq.2.temd2l7vy .
+ (type :seq.0.sysvq0asl.I596vqx.temd2l7vy .
   (at seq.0.sysvq0asl 1
    (u +8)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.2.temd2l7vy . . 5
+   (fld :len.4.sysvq0asl.I596vqx.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.2.temd2l7vy . . 6
+   (fld :data.0.sysvq0asl.I596vqx.temd2l7vy . . 6
     (ptr 18
      (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
       (u +8))) .))) 0,11,lib/std/system/seqimpl.nim
@@ -237,18 +237,18 @@
   (at =destroy.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 19
   (params 1
-   (param :s.6 . . 6 seq.0.temd2l7vy .)) . . . 2,1
+   (param :s.6 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.0 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.0 3
-     (dot ~1 s.6 len.0.temd2l7vy +0)) 2,1
+     (dot ~1 s.6 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.6 data.0.temd2l7vy +0) 6 i.0)) ,1
+       (dot ~1 s.6 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.0)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.0)))) ,4
    (if 3
@@ -259,7 +259,7 @@
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
           (i -1))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.6 data.0.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.6 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -267,48 +267,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.6 data.0.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.6 data.0.sysvq0asl.Is27ul41.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.0.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 20
   (params 1
    (param :s.7 . . 3
-    (mut 7 seq.0.temd2l7vy) .)) . 36
+    (mut 7 seq.0.sysvq0asl.Is27ul41.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.7) len.0.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.7) len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.7) data.0.temd2l7vy +0) 2
+     (hderef s.7) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.0.temd2l7vy . .
   (at =dup.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 15
   (params 1
-   (param :a.3 . . 6 seq.0.temd2l7vy .)) 16 seq.0.temd2l7vy 35
+   (param :a.3 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) 16 seq.0.sysvq0asl.Is27ul41.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.3 . . 13,~1 seq.0.temd2l7vy .) 7
+   (result :result.3 . . 13,~1 seq.0.sysvq0asl.Is27ul41.temd2l7vy .) 7
    (asgn ~7 result.3 17
     (call ~15 newSeqUninit.0.temd2l7vy 2
-     (dot ~1 a.3 len.0.temd2l7vy +0))) 4,1
+     (dot ~1 a.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0))) 4,1
    (var :i.1 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.1 3
-     (dot ~1 a.3 len.0.temd2l7vy +0)) 2,1
+     (dot ~1 a.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.3 data.0.temd2l7vy +0) 6 i.1) 8
+       (dot ~6 result.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.1) 8
       (dup 2
        (pat
-        (dot ~1 a.3 data.0.temd2l7vy +0) 6 i.1))) ,1
+        (dot ~1 a.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.1))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.1)))) ~2,~1
    (ret result.3))) 0,93,lib/std/system/seqimpl.nim
@@ -317,8 +317,8 @@
    (i -1)) 16
   (params 1
    (param :dest.3 . . 6
-    (mut 7 seq.0.temd2l7vy) .) 19
-   (param :src.3 . . 8 seq.0.temd2l7vy .)) . 48
+    (mut 7 seq.0.sysvq0asl.Is27ul41.temd2l7vy) .) 19
+   (param :src.3 . . 8 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -329,31 +329,31 @@
        (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1))) ~6
       (dot ~4
-       (hderef dest.3) data.0.temd2l7vy +0) 6
-      (dot ~3 src.3 data.0.temd2l7vy +0)) 23
+       (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6
+      (dot ~3 src.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.3 len.0.temd2l7vy +0) 6
+      (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.3) len.0.temd2l7vy +0)) ~1,1
+       (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.2 . . 1,~91
        (i -1) 7
-       (dot ~3 src.3 len.0.temd2l7vy +0)) ,1
+       (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.2 6
         (dot ~4
-         (hderef dest.3) len.0.temd2l7vy +0)) 2,1
+         (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.3) data.0.temd2l7vy +0) 6 i.2)) ,1
+           (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.2)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.2)))))) 5,5
     (elif 16
@@ -363,7 +363,7 @@
        (hderef dest.3)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.3 len.0.temd2l7vy +0) 8
+       (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 8
        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1)))) ~3,1
      (stmts 4
@@ -380,7 +380,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.0 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.3 len.0.temd2l7vy +0) 2 oldCap.0))) 4,2
+         (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 oldCap.0))) 4,2
       (let :memSize.3 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -389,7 +389,7 @@
          (i -1)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.3) data.0.temd2l7vy +0) 2
+        (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -400,7 +400,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.3) data.0.temd2l7vy +0))) 12 memSize.3))) ,4
+            (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0))) 12 memSize.3))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -408,52 +408,52 @@
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) ~6
          (dot ~4
-          (hderef dest.3) data.0.temd2l7vy +0) 3
+          (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.3) len.0.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.3) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.3) len.0.temd2l7vy +0) 5
-    (dot ~3 src.3 len.0.temd2l7vy +0)) 4,16
+     (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 5
+    (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 4,16
    (var :i.3 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.3 6
      (dot ~4
-      (hderef dest.3) len.0.temd2l7vy +0)) 2,1
+      (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.3) data.0.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.3 data.0.temd2l7vy +0) 6 i.3)))) ,1
+         (dot ~3 src.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.3)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.3)))))) 0,11,lib/std/system/seqimpl.nim
  (proc :=destroy.1.temd2l7vy . .
   (at =destroy.2.sysvq0asl
    (f +64)) 19
   (params 1
-   (param :s.9 . . 6 seq.1.temd2l7vy .)) . . . 2,1
+   (param :s.9 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.4 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.4 3
-     (dot ~1 s.9 len.1.temd2l7vy +0)) 2,1
+     (dot ~1 s.9 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.9 data.1.temd2l7vy +0) 6 i.4)) ,1
+       (dot ~1 s.9 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.4)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.4)))) ,4
    (if 3
@@ -464,7 +464,7 @@
         (ptr 18
          (uarray
           (f +64))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.9 data.1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.9 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -472,48 +472,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.9 data.1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.9 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.1.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl
    (f +64)) 20
   (params 1
    (param :s.10 . . 3
-    (mut 7 seq.1.temd2l7vy) .)) . 36
+    (mut 7 seq.0.sysvq0asl.I9qk85v1.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.10) len.1.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.10) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.10) data.1.temd2l7vy +0) 2
+     (hderef s.10) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.1.temd2l7vy . .
   (at =dup.2.sysvq0asl
    (f +64)) 15
   (params 1
-   (param :a.4 . . 6 seq.1.temd2l7vy .)) 16 seq.1.temd2l7vy 35
+   (param :a.4 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) 16 seq.0.sysvq0asl.I9qk85v1.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.4 . . 13,~1 seq.1.temd2l7vy .) 7
+   (result :result.4 . . 13,~1 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .) 7
    (asgn ~7 result.4 17
     (call ~15 newSeqUninit.1.temd2l7vy 2
-     (dot ~1 a.4 len.1.temd2l7vy +0))) 4,1
+     (dot ~1 a.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0))) 4,1
    (var :i.5 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.5 3
-     (dot ~1 a.4 len.1.temd2l7vy +0)) 2,1
+     (dot ~1 a.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.4 data.1.temd2l7vy +0) 6 i.5) 8
+       (dot ~6 result.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.5) 8
       (dup 2
        (pat
-        (dot ~1 a.4 data.1.temd2l7vy +0) 6 i.5))) ,1
+        (dot ~1 a.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.5))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.5)))) ~2,~1
    (ret result.4))) 0,93,lib/std/system/seqimpl.nim
@@ -522,8 +522,8 @@
    (f +64)) 16
   (params 1
    (param :dest.4 . . 6
-    (mut 7 seq.1.temd2l7vy) .) 19
-   (param :src.4 . . 8 seq.1.temd2l7vy .)) . 48
+    (mut 7 seq.0.sysvq0asl.I9qk85v1.temd2l7vy) .) 19
+   (param :src.4 . . 8 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -534,31 +534,31 @@
        (uarray
         (f +64))) ~6
       (dot ~4
-       (hderef dest.4) data.1.temd2l7vy +0) 6
-      (dot ~3 src.4 data.1.temd2l7vy +0)) 23
+       (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6
+      (dot ~3 src.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.4 len.1.temd2l7vy +0) 6
+      (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.4) len.1.temd2l7vy +0)) ~1,1
+       (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.6 . . 1,~91
        (i -1) 7
-       (dot ~3 src.4 len.1.temd2l7vy +0)) ,1
+       (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.6 6
         (dot ~4
-         (hderef dest.4) len.1.temd2l7vy +0)) 2,1
+         (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.4) data.1.temd2l7vy +0) 6 i.6)) ,1
+           (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.6)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.6)))))) 5,5
     (elif 16
@@ -568,7 +568,7 @@
        (hderef dest.4)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.4 len.1.temd2l7vy +0) 8
+       (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 8
        (sizeof
         (f +64)))) ~3,1
      (stmts 4
@@ -585,7 +585,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.1 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.4 len.1.temd2l7vy +0) 2 oldCap.1))) 4,2
+         (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 oldCap.1))) 4,2
       (let :memSize.4 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -594,7 +594,7 @@
          (f +64)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.4) data.1.temd2l7vy +0) 2
+        (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray
@@ -605,7 +605,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.4) data.1.temd2l7vy +0))) 12 memSize.4))) ,4
+            (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0))) 12 memSize.4))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -613,52 +613,52 @@
           (uarray
            (f +64))) ~6
          (dot ~4
-          (hderef dest.4) data.1.temd2l7vy +0) 3
+          (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.4) len.1.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.4) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.4) len.1.temd2l7vy +0) 5
-    (dot ~3 src.4 len.1.temd2l7vy +0)) 4,16
+     (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 5
+    (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 4,16
    (var :i.7 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.7 6
      (dot ~4
-      (hderef dest.4) len.1.temd2l7vy +0)) 2,1
+      (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.4) data.1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.4 data.1.temd2l7vy +0) 6 i.7)))) ,1
+         (dot ~3 src.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.7)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.7)))))) 0,11,lib/std/system/seqimpl.nim
  (proc :=destroy.2.temd2l7vy . .
   (at =destroy.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 19
   (params 1
-   (param :s.12 . . 6 seq.2.temd2l7vy .)) . . . 2,1
+   (param :s.12 . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.8 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.8 3
-     (dot ~1 s.12 len.2.temd2l7vy +0)) 2,1
+     (dot ~1 s.12 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.12 data.2.temd2l7vy +0) 6 i.8)) ,1
+       (dot ~1 s.12 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.8)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.8)))) ,4
    (if 3
@@ -669,7 +669,7 @@
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
           (u +8))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.12 data.2.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.12 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -677,48 +677,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.12 data.2.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.12 data.0.sysvq0asl.I596vqx.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.2.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 20
   (params 1
    (param :s.13 . . 3
-    (mut 7 seq.2.temd2l7vy) .)) . 36
+    (mut 7 seq.0.sysvq0asl.I596vqx.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.13) len.2.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.13) len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.13) data.2.temd2l7vy +0) 2
+     (hderef s.13) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.2.temd2l7vy . .
   (at =dup.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 15
   (params 1
-   (param :a.5 . . 6 seq.2.temd2l7vy .)) 16 seq.2.temd2l7vy 35
+   (param :a.5 . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) 16 seq.0.sysvq0asl.I596vqx.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.5 . . 13,~1 seq.2.temd2l7vy .) 7
+   (result :result.5 . . 13,~1 seq.0.sysvq0asl.I596vqx.temd2l7vy .) 7
    (asgn ~7 result.5 17
     (call ~15 newSeqUninit.2.temd2l7vy 2
-     (dot ~1 a.5 len.2.temd2l7vy +0))) 4,1
+     (dot ~1 a.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0))) 4,1
    (var :i.9 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.9 3
-     (dot ~1 a.5 len.2.temd2l7vy +0)) 2,1
+     (dot ~1 a.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.5 data.2.temd2l7vy +0) 6 i.9) 8
+       (dot ~6 result.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.9) 8
       (dup 2
        (pat
-        (dot ~1 a.5 data.2.temd2l7vy +0) 6 i.9))) ,1
+        (dot ~1 a.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.9))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.9)))) ~2,~1
    (ret result.5))) 0,93,lib/std/system/seqimpl.nim
@@ -727,8 +727,8 @@
    (u +8)) 16
   (params 1
    (param :dest.5 . . 6
-    (mut 7 seq.2.temd2l7vy) .) 19
-   (param :src.5 . . 8 seq.2.temd2l7vy .)) . 48
+    (mut 7 seq.0.sysvq0asl.I596vqx.temd2l7vy) .) 19
+   (param :src.5 . . 8 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -739,31 +739,31 @@
        (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8))) ~6
       (dot ~4
-       (hderef dest.5) data.2.temd2l7vy +0) 6
-      (dot ~3 src.5 data.2.temd2l7vy +0)) 23
+       (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6
+      (dot ~3 src.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.5 len.2.temd2l7vy +0) 6
+      (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.5) len.2.temd2l7vy +0)) ~1,1
+       (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.10 . . 1,~91
        (i -1) 7
-       (dot ~3 src.5 len.2.temd2l7vy +0)) ,1
+       (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.10 6
         (dot ~4
-         (hderef dest.5) len.2.temd2l7vy +0)) 2,1
+         (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.5) data.2.temd2l7vy +0) 6 i.10)) ,1
+           (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.10)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.10)))))) 5,5
     (elif 16
@@ -773,7 +773,7 @@
        (hderef dest.5)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.5 len.2.temd2l7vy +0) 8
+       (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 8
        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8)))) ~3,1
      (stmts 4
@@ -790,7 +790,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.2 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.5 len.2.temd2l7vy +0) 2 oldCap.2))) 4,2
+         (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 oldCap.2))) 4,2
       (let :memSize.5 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -799,7 +799,7 @@
          (u +8)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.5) data.2.temd2l7vy +0) 2
+        (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -810,7 +810,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.5) data.2.temd2l7vy +0))) 12 memSize.5))) ,4
+            (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0))) 12 memSize.5))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -818,34 +818,34 @@
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) ~6
          (dot ~4
-          (hderef dest.5) data.2.temd2l7vy +0) 3
+          (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.5) len.2.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.5) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.5) len.2.temd2l7vy +0) 5
-    (dot ~3 src.5 len.2.temd2l7vy +0)) 4,16
+     (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0) 5
+    (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 4,16
    (var :i.11 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.11 6
      (dot ~4
-      (hderef dest.5) len.2.temd2l7vy +0)) 2,1
+      (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.5) data.2.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.5 data.2.temd2l7vy +0) 6 i.11)))) ,1
+         (dot ~3 src.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.11)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.11)))))) 4,15,lib/std/system/seqimpl.nim
  (proc :inc.0.temd2l7vy . 0,276,lib/std/system.nim .
@@ -869,7 +869,7 @@
   (at capInBytes.0.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 7,~92
   (params 1
-   (param :s.15 . . 6 seq.0.temd2l7vy .)) 2,~92
+   (param :s.15 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -885,7 +885,7 @@
          (ptr 18
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.15 data.0.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.15 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -893,7 +893,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.15 data.0.temd2l7vy +0)))))) 40
+          (dot ~1 s.15 data.0.sysvq0asl.Is27ul41.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.6))) 11,100,lib/std/system/seqimpl.nim
@@ -901,7 +901,7 @@
   (at capInBytes.0.sysvq0asl
    (f +64)) 7,~92
   (params 1
-   (param :s.16 . . 6 seq.1.temd2l7vy .)) 2,~92
+   (param :s.16 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -917,7 +917,7 @@
          (ptr 18
           (uarray
            (f +64))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.16 data.1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.16 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -925,7 +925,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.16 data.1.temd2l7vy +0)))))) 40
+          (dot ~1 s.16 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.7))) 11,100,lib/std/system/seqimpl.nim
@@ -933,7 +933,7 @@
   (at capInBytes.0.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 7,~92
   (params 1
-   (param :s.17 . . 6 seq.2.temd2l7vy .)) 2,~92
+   (param :s.17 . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -949,7 +949,7 @@
          (ptr 18
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.17 data.2.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.17 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -957,7 +957,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.17 data.2.temd2l7vy +0)))))) 40
+          (dot ~1 s.17 data.0.sysvq0asl.I596vqx.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.8))))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -2,7 +2,7 @@
 0,1,tests/nimony/sysbasics/temptyseq.nim(stmts
  (proc 5 :foo.0.temd2l7vy . . . 8
   (params 1
-   (param :x.0 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) . . . 24
+   (param :x.0 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) . . . 24
   (stmts
    (discard .))) 3,2
  (call ~3 foo.0.temd2l7vy 43,147,lib/std/system/seqimpl.nim
@@ -22,7 +22,7 @@
   (expr 15
    (expr
     (call ~15 newSeqUninit.1.temd2l7vy 1 +0)))) 4,8
- (gvar :s.0.temd2l7vy . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy 43,147,lib/std/system/seqimpl.nim
+ (gvar :s.0.temd2l7vy . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 43,147,lib/std/system/seqimpl.nim
   (expr 15
    (expr
     (call ~15 newSeqUninit.2.temd2l7vy 1 +0)))) 58,147,lib/std/system/seqimpl.nim
@@ -31,21 +31,21 @@
    (i -1)) ~37,~92
   (params 1
    (param :size.3 . . 6
-    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Is27ul41.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Ipe57hg.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.0 . . 14,~1 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)
+   (result :result.0 . . 14,~1 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.3 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Is27ul41.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Is27ul41.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.sysvq0asl.Is27ul41.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Ipe57hg.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Ipe57hg.temd2l7vy 2 size.3) 16
+        (kv ~16 data.0.sysvq0asl.Ipe57hg.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -56,9 +56,9 @@
         (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
          (i -1)))) 7,1
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Is27ul41.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.Is27ul41.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.sysvq0asl.Is27ul41.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Ipe57hg.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Ipe57hg.temd2l7vy 2 size.3) 16
+        (kv ~16 data.0.sysvq0asl.Ipe57hg.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -72,14 +72,14 @@
            (ptr 18
             (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
              (i -1))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.0 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.0 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.0 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.0 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.0))))))) ~2,~1
    (ret result.0))) 58,147,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.1.temd2l7vy . ~58,~92 .
@@ -87,21 +87,21 @@
    (f +64)) ~37,~92
   (params 1
    (param :size.4 . . 6
-    (i -1) .)) ~42,~92 seq.0.sysvq0asl.I9qk85v1.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.1 . . 14,~1 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)
+   (result :result.1 . . 14,~1 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.4 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.1 8
-       (oconstr ~3,~2 seq.0.sysvq0asl.I9qk85v1.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.I9qk85v1.temd2l7vy 2 size.4) 16
-        (kv ~16 data.0.sysvq0asl.I9qk85v1.temd2l7vy 2
+       (oconstr ~3,~2 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy 2 size.4) 16
+        (kv ~16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -112,9 +112,9 @@
         (sizeof
          (f +64)))) 7,1
       (asgn ~7 result.1 8
-       (oconstr ~3,~5 seq.0.sysvq0asl.I9qk85v1.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.I9qk85v1.temd2l7vy 2 size.4) 16
-        (kv ~16 data.0.sysvq0asl.I9qk85v1.temd2l7vy 2
+       (oconstr ~3,~5 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy 2 size.4) 16
+        (kv ~16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray
@@ -128,14 +128,14 @@
            (ptr 18
             (uarray
              (f +64))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.1 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.1 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.1 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.1 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.1))))))) ~2,~1
    (ret result.1))) 3,6
  (proc :bar.1.temd2l7vy . ~3,~2 .
@@ -144,7 +144,7 @@
   (params 1
    (param :x.3 . .
     (f +64) .) 7
-   (param :y.2 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
+   (param :y.2 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
   (stmts
    (discard .))) 58,147,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.2.temd2l7vy . ~58,~92 .
@@ -152,21 +152,21 @@
    (u +8)) ~37,~92
   (params 1
    (param :size.5 . . 6
-    (i -1) .)) ~42,~92 seq.0.sysvq0asl.I596vqx.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.2 . . 14,~1 seq.0.sysvq0asl.I596vqx.temd2l7vy .)
+   (result :result.2 . . 14,~1 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.5 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.I596vqx.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.I596vqx.temd2l7vy 2 size.5) 16
-        (kv ~16 data.0.sysvq0asl.I596vqx.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy 2 size.5) 16
+        (kv ~16 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -177,9 +177,9 @@
         (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
          (u +8)))) 7,1
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.I596vqx.temd2l7vy 4
-        (kv ~4 len.4.sysvq0asl.I596vqx.temd2l7vy 2 size.5) 16
-        (kv ~16 data.0.sysvq0asl.I596vqx.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 4
+        (kv ~4 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy 2 size.5) 16
+        (kv ~16 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy 2
          (cast 5
           (ptr 18
            (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -193,43 +193,43 @@
            (ptr 18
             (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
              (u +8))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.2 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.2 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.2 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.2 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.2))))))) ~2,~1
    (ret result.2))) 15
- (type :seq.0.sysvq0asl.Is27ul41.temd2l7vy .
+ (type :seq.0.sysvq0asl.Ipe57hg.temd2l7vy .
   (at seq.0.sysvq0asl 1
    (i -1)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.4.sysvq0asl.Is27ul41.temd2l7vy . . 5
+   (fld :len.4.sysvq0asl.Ipe57hg.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.sysvq0asl.Is27ul41.temd2l7vy . . 6
+   (fld :data.0.sysvq0asl.Ipe57hg.temd2l7vy . . 6
     (ptr 18
      (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
       (i -1))) .))) 16,55,lib/std/system/seqimpl.nim
- (type :seq.0.sysvq0asl.I9qk85v1.temd2l7vy .
+ (type :seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .
   (at seq.0.sysvq0asl
    (f +64)) ~6,~51 . ~4,~51
   (object . ~8,1
-   (fld :len.4.sysvq0asl.I9qk85v1.temd2l7vy . . 5
+   (fld :len.4.sysvq0asl.Iw9f2pq.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.sysvq0asl.I9qk85v1.temd2l7vy . . 6
+   (fld :data.0.sysvq0asl.Iw9f2pq.temd2l7vy . . 6
     (ptr 18
      (uarray
       (f +64))) .))) 10,8
- (type :seq.0.sysvq0asl.I596vqx.temd2l7vy .
+ (type :seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .
   (at seq.0.sysvq0asl 1
    (u +8)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.4.sysvq0asl.I596vqx.temd2l7vy . . 5
+   (fld :len.4.sysvq0asl.Iq4ofkp1.temd2l7vy . . 5
     (i -1) .) ~8,2
-   (fld :data.0.sysvq0asl.I596vqx.temd2l7vy . . 6
+   (fld :data.0.sysvq0asl.Iq4ofkp1.temd2l7vy . . 6
     (ptr 18
      (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
       (u +8))) .))) 0,11,lib/std/system/seqimpl.nim
@@ -237,18 +237,18 @@
   (at =destroy.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 19
   (params 1
-   (param :s.6 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) . . . 2,1
+   (param :s.6 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.0 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.0 3
-     (dot ~1 s.6 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
+     (dot ~1 s.6 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.6 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.0)) ,1
+       (dot ~1 s.6 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.0)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.0)))) ,4
    (if 3
@@ -259,7 +259,7 @@
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
           (i -1))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.6 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.6 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -267,48 +267,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.6 data.0.sysvq0asl.Is27ul41.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.6 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.0.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 20
   (params 1
    (param :s.7 . . 3
-    (mut 7 seq.0.sysvq0asl.Is27ul41.temd2l7vy) .)) . 36
+    (mut 7 seq.0.sysvq0asl.Ipe57hg.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.7) len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.7) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.7) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 2
+     (hderef s.7) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.0.temd2l7vy . .
   (at =dup.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 15
   (params 1
-   (param :a.3 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) 16 seq.0.sysvq0asl.Is27ul41.temd2l7vy 35
+   (param :a.3 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) 16 seq.0.sysvq0asl.Ipe57hg.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.3 . . 13,~1 seq.0.sysvq0asl.Is27ul41.temd2l7vy .) 7
+   (result :result.3 . . 13,~1 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .) 7
    (asgn ~7 result.3 17
     (call ~15 newSeqUninit.0.temd2l7vy 2
-     (dot ~1 a.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0))) 4,1
+     (dot ~1 a.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0))) 4,1
    (var :i.1 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.1 3
-     (dot ~1 a.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
+     (dot ~1 a.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.1) 8
+       (dot ~6 result.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.1) 8
       (dup 2
        (pat
-        (dot ~1 a.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.1))) ,1
+        (dot ~1 a.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.1))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.1)))) ~2,~1
    (ret result.3))) 0,93,lib/std/system/seqimpl.nim
@@ -317,8 +317,8 @@
    (i -1)) 16
   (params 1
    (param :dest.3 . . 6
-    (mut 7 seq.0.sysvq0asl.Is27ul41.temd2l7vy) .) 19
-   (param :src.3 . . 8 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) . 48
+    (mut 7 seq.0.sysvq0asl.Ipe57hg.temd2l7vy) .) 19
+   (param :src.3 . . 8 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -329,31 +329,31 @@
        (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1))) ~6
       (dot ~4
-       (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6
-      (dot ~3 src.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0)) 23
+       (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6
+      (dot ~3 src.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 6
+      (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) ~1,1
+       (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.2 . . 1,~91
        (i -1) 7
-       (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) ,1
+       (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.2 6
         (dot ~4
-         (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
+         (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.2)) ,1
+           (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.2)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.2)))))) 5,5
     (elif 16
@@ -363,7 +363,7 @@
        (hderef dest.3)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 8
+       (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 8
        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1)))) ~3,1
      (stmts 4
@@ -380,7 +380,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.0 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 oldCap.0))) 4,2
+         (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 oldCap.0))) 4,2
       (let :memSize.3 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -389,7 +389,7 @@
          (i -1)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 2
+        (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -400,7 +400,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0))) 12 memSize.3))) ,4
+            (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0))) 12 memSize.3))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -408,52 +408,52 @@
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) ~6
          (dot ~4
-          (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 3
+          (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.3) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0) 5
-    (dot ~3 src.3 len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 4,16
+     (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0) 5
+    (dot ~3 src.3 len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 4,16
    (var :i.3 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.3 6
      (dot ~4
-      (hderef dest.3) len.4.sysvq0asl.Is27ul41.temd2l7vy +0)) 2,1
+      (hderef dest.3) len.4.sysvq0asl.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.3) data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.3) data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.3 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 6 i.3)))) ,1
+         (dot ~3 src.3 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 6 i.3)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.3)))))) 0,11,lib/std/system/seqimpl.nim
  (proc :=destroy.1.temd2l7vy . .
   (at =destroy.2.sysvq0asl
    (f +64)) 19
   (params 1
-   (param :s.9 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) . . . 2,1
+   (param :s.9 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.4 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.4 3
-     (dot ~1 s.9 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
+     (dot ~1 s.9 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.9 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.4)) ,1
+       (dot ~1 s.9 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.4)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.4)))) ,4
    (if 3
@@ -464,7 +464,7 @@
         (ptr 18
          (uarray
           (f +64))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.9 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.9 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -472,48 +472,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.9 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.9 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.1.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl
    (f +64)) 20
   (params 1
    (param :s.10 . . 3
-    (mut 7 seq.0.sysvq0asl.I9qk85v1.temd2l7vy) .)) . 36
+    (mut 7 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.10) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.10) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.10) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 2
+     (hderef s.10) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.1.temd2l7vy . .
   (at =dup.2.sysvq0asl
    (f +64)) 15
   (params 1
-   (param :a.4 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) 16 seq.0.sysvq0asl.I9qk85v1.temd2l7vy 35
+   (param :a.4 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) 16 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.4 . . 13,~1 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .) 7
+   (result :result.4 . . 13,~1 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .) 7
    (asgn ~7 result.4 17
     (call ~15 newSeqUninit.1.temd2l7vy 2
-     (dot ~1 a.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0))) 4,1
+     (dot ~1 a.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0))) 4,1
    (var :i.5 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.5 3
-     (dot ~1 a.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
+     (dot ~1 a.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.5) 8
+       (dot ~6 result.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.5) 8
       (dup 2
        (pat
-        (dot ~1 a.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.5))) ,1
+        (dot ~1 a.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.5))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.5)))) ~2,~1
    (ret result.4))) 0,93,lib/std/system/seqimpl.nim
@@ -522,8 +522,8 @@
    (f +64)) 16
   (params 1
    (param :dest.4 . . 6
-    (mut 7 seq.0.sysvq0asl.I9qk85v1.temd2l7vy) .) 19
-   (param :src.4 . . 8 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) . 48
+    (mut 7 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy) .) 19
+   (param :src.4 . . 8 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -534,31 +534,31 @@
        (uarray
         (f +64))) ~6
       (dot ~4
-       (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6
-      (dot ~3 src.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0)) 23
+       (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6
+      (dot ~3 src.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 6
+      (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) ~1,1
+       (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.6 . . 1,~91
        (i -1) 7
-       (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) ,1
+       (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.6 6
         (dot ~4
-         (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
+         (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.6)) ,1
+           (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.6)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.6)))))) 5,5
     (elif 16
@@ -568,7 +568,7 @@
        (hderef dest.4)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 8
+       (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 8
        (sizeof
         (f +64)))) ~3,1
      (stmts 4
@@ -585,7 +585,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.1 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 oldCap.1))) 4,2
+         (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 oldCap.1))) 4,2
       (let :memSize.4 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -594,7 +594,7 @@
          (f +64)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 2
+        (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray
@@ -605,7 +605,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0))) 12 memSize.4))) ,4
+            (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0))) 12 memSize.4))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -613,52 +613,52 @@
           (uarray
            (f +64))) ~6
          (dot ~4
-          (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 3
+          (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.4) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0) 5
-    (dot ~3 src.4 len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 4,16
+     (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0) 5
+    (dot ~3 src.4 len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 4,16
    (var :i.7 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.7 6
      (dot ~4
-      (hderef dest.4) len.4.sysvq0asl.I9qk85v1.temd2l7vy +0)) 2,1
+      (hderef dest.4) len.4.sysvq0asl.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.4) data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.4) data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.4 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 6 i.7)))) ,1
+         (dot ~3 src.4 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 6 i.7)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.7)))))) 0,11,lib/std/system/seqimpl.nim
  (proc :=destroy.2.temd2l7vy . .
   (at =destroy.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 19
   (params 1
-   (param :s.12 . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) . . . 2,1
+   (param :s.12 . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) . . . 2,1
   (stmts 4
    (var :i.8 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.8 3
-     (dot ~1 s.12 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
+     (dot ~1 s.12 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.12 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.8)) ,1
+       (dot ~1 s.12 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.8)) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.8)))) ,4
    (if 3
@@ -669,7 +669,7 @@
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
           (u +8))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.12 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.12 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -677,48 +677,48 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.12 data.0.sysvq0asl.I596vqx.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
+         (dot ~1 s.12 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.2.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 20
   (params 1
    (param :s.13 . . 3
-    (mut 7 seq.0.sysvq0asl.I596vqx.temd2l7vy) .)) . 36
+    (mut 7 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.13) len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.13) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.13) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 2
+     (hderef s.13) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
  (proc :=dup.2.temd2l7vy . .
   (at =dup.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 15
   (params 1
-   (param :a.5 . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) 16 seq.0.sysvq0asl.I596vqx.temd2l7vy 35
+   (param :a.5 . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) 16 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.5 . . 13,~1 seq.0.sysvq0asl.I596vqx.temd2l7vy .) 7
+   (result :result.5 . . 13,~1 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .) 7
    (asgn ~7 result.5 17
     (call ~15 newSeqUninit.2.temd2l7vy 2
-     (dot ~1 a.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0))) 4,1
+     (dot ~1 a.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0))) 4,1
    (var :i.9 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.9 3
-     (dot ~1 a.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
+     (dot ~1 a.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.9) 8
+       (dot ~6 result.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.9) 8
       (dup 2
        (pat
-        (dot ~1 a.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.9))) ,1
+        (dot ~1 a.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.9))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.9)))) ~2,~1
    (ret result.5))) 0,93,lib/std/system/seqimpl.nim
@@ -727,8 +727,8 @@
    (u +8)) 16
   (params 1
    (param :dest.5 . . 6
-    (mut 7 seq.0.sysvq0asl.I596vqx.temd2l7vy) .) 19
-   (param :src.5 . . 8 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) . 48
+    (mut 7 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy) .) 19
+   (param :src.5 . . 8 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -739,31 +739,31 @@
        (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8))) ~6
       (dot ~4
-       (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6
-      (dot ~3 src.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0)) 23
+       (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6
+      (dot ~3 src.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 6
+      (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6
       (dot ~4
-       (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0)) ~1,1
+       (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) ~1,1
      (stmts 4
       (var :i.10 . . 1,~91
        (i -1) 7
-       (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) ,1
+       (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.10 6
         (dot ~4
-         (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
+         (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.10)) ,1
+           (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.10)) ,1
         (cmd inc.0.temd2l7vy 4
          (haddr i.10)))))) 5,5
     (elif 16
@@ -773,7 +773,7 @@
        (hderef dest.5)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 8
+       (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 8
        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8)))) ~3,1
      (stmts 4
@@ -790,7 +790,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.2 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 oldCap.2))) 4,2
+         (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 oldCap.2))) 4,2
       (let :memSize.5 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -799,7 +799,7 @@
          (u +8)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 2
+        (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2
        (cast 5
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -810,7 +810,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0))) 12 memSize.5))) ,4
+            (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0))) 12 memSize.5))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -818,34 +818,34 @@
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) ~6
          (dot ~4
-          (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 3
+          (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.5) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0) 5
-    (dot ~3 src.5 len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 4,16
+     (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 5
+    (dot ~3 src.5 len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 4,16
    (var :i.11 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.11 6
      (dot ~4
-      (hderef dest.5) len.4.sysvq0asl.I596vqx.temd2l7vy +0)) 2,1
+      (hderef dest.5) len.4.sysvq0asl.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.5) data.0.sysvq0asl.I596vqx.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.5) data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.5 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 6 i.11)))) ,1
+         (dot ~3 src.5 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 6 i.11)))) ,1
      (cmd inc.0.temd2l7vy 4
       (haddr i.11)))))) 4,15,lib/std/system/seqimpl.nim
  (proc :inc.0.temd2l7vy . 0,276,lib/std/system.nim .
@@ -869,7 +869,7 @@
   (at capInBytes.0.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 7,~92
   (params 1
-   (param :s.15 . . 6 seq.0.sysvq0asl.Is27ul41.temd2l7vy .)) 2,~92
+   (param :s.15 . . 6 seq.0.sysvq0asl.Ipe57hg.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -885,7 +885,7 @@
          (ptr 18
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.15 data.0.sysvq0asl.Is27ul41.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.15 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -893,7 +893,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.15 data.0.sysvq0asl.Is27ul41.temd2l7vy +0)))))) 40
+          (dot ~1 s.15 data.0.sysvq0asl.Ipe57hg.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.6))) 11,100,lib/std/system/seqimpl.nim
@@ -901,7 +901,7 @@
   (at capInBytes.0.sysvq0asl
    (f +64)) 7,~92
   (params 1
-   (param :s.16 . . 6 seq.0.sysvq0asl.I9qk85v1.temd2l7vy .)) 2,~92
+   (param :s.16 . . 6 seq.0.sysvq0asl.Iw9f2pq.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -917,7 +917,7 @@
          (ptr 18
           (uarray
            (f +64))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.16 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -925,7 +925,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.16 data.0.sysvq0asl.I9qk85v1.temd2l7vy +0)))))) 40
+          (dot ~1 s.16 data.0.sysvq0asl.Iw9f2pq.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.7))) 11,100,lib/std/system/seqimpl.nim
@@ -933,7 +933,7 @@
   (at capInBytes.0.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 7,~92
   (params 1
-   (param :s.17 . . 6 seq.0.sysvq0asl.I596vqx.temd2l7vy .)) 2,~92
+   (param :s.17 . . 6 seq.0.sysvq0asl.Iq4ofkp1.temd2l7vy .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -949,7 +949,7 @@
          (ptr 18
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.17 data.0.sysvq0asl.I596vqx.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.17 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -957,7 +957,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.17 data.0.sysvq0asl.I596vqx.temd2l7vy +0)))))) 40
+          (dot ~1 s.17 data.0.sysvq0asl.Iq4ofkp1.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.8))))

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -98,8 +98,8 @@
  (proc 5 :foo.0.tho8gh7q4 . . . 9
   (params) . . . 2,1
   (stmts 4
-   (var :obj.0 . . 13 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .) 4,2
-   (var :obj2.0 . . 14 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .) 10,4
+   (var :obj.0 . . 13 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .) 4,2
+   (var :obj2.0 . . 14 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .) 10,4
    (destroy 1 obj.0) 4,6
    (var :objbase.0 . . 9 MyObjectBase.0.tho8gh7q4 .) 4,7
    (var :objbase2.0 . . 10 MyObjectBase.0.tho8gh7q4 .) 10,8
@@ -115,40 +115,40 @@
     (at ~8 MyObject.0.tho8gh7q4 1 T.5.tho8gh7q4 4 Y.5.tho8gh7q4) .)) . . . 2,1
   (stmts
    (discard .))) 4,52
- (gvar :obj.0.tho8gh7q4 . . 13 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .) 12,53
+ (gvar :obj.0.tho8gh7q4 . . 13 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .) 12,53
  (call 1 =checkHook.1.tho8gh7q4 1 obj.0.tho8gh7q4) 12,53
  (proc :=checkHook.1.tho8gh7q4 . ~12,~4 .
   (at =checkHook.0.tho8gh7q4 8,~17
    (i -1) 13,~17
    (f +64)) 11,~4
   (params 1
-   (param :x.13 . . 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
+   (param :x.13 . . 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
   (stmts
    (discard .))) 19,36
- (type :MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .
+ (type :MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .
   (at MyObject.0.tho8gh7q4 1
    (i -1) 6
    (f +64)) ~2,~32 . ,~32
   (object . ~15,1
-   (fld :x.1.tho8gh7q4.Imors5e.tho8gh7q4 . . 6
+   (fld :x.1.tho8gh7q4.I76zger.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.tho8gh7q4.Imors5e.tho8gh7q4 . . 3
+   (fld :y.1.tho8gh7q4.I76zger.tho8gh7q4 . . 3
     (i -1) .))) 20,38
- (type :MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .
+ (type :MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .
   (at MyObject.0.tho8gh7q4 1
    (f +64) 8
    (i -1)) ~3,~34 . ~1,~34
   (object . ~15,1
-   (fld :x.1.tho8gh7q4.Iph6hf21.tho8gh7q4 . . 6
+   (fld :x.1.tho8gh7q4.I3kvyeb.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.tho8gh7q4.Iph6hf21.tho8gh7q4 . . 3
+   (fld :y.1.tho8gh7q4.I3kvyeb.tho8gh7q4 . . 3
     (i -1) .))) ,32
  (proc :=destroy.2.tho8gh7q4 . .
   (at =destroy.1.tho8gh7q4 20,4
    (i -1) 25,4
    (f +64)) 21
   (params 1
-   (param :x.22 . . 11 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) . . . 2,1
+   (param :x.22 . . 11 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) . . . 2,1
   (stmts 4
    (let :x.23 . . 4,~31
     (i -1) 4 +12))) ,22
@@ -158,7 +158,7 @@
    (f +64)) 22
   (params 1
    (param :x.24 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4) .)) . . . 2,1
   (stmts 4
    (let :x.25 . . 4,~21
     (i -1) 4 +12) 4,1
@@ -170,8 +170,8 @@
    (f +64)) 18
   (params 1
    (param :x.26 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4) .) 24
-   (param :y.10 . . 11 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4) .) 24
+   (param :y.10 . . 11 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,29
  (proc :=sink.2.tho8gh7q4 . .
@@ -180,8 +180,8 @@
    (f +64)) 18
   (params 1
    (param :x.27 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4) .) 24
-   (param :y.11 . . 11 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4) .) 24
+   (param :y.11 . . 11 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,32
  (proc :=destroy.3.tho8gh7q4 . .
@@ -189,7 +189,7 @@
    (f +64) 28,6
    (i -1)) 21
   (params 1
-   (param :x.28 . . 11 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .)) . . . 2,1
+   (param :x.28 . . 11 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .)) . . . 2,1
   (stmts 4
    (let :x.29 . . 4,~31
     (i -1) 4 +12))) ,22
@@ -199,7 +199,7 @@
    (i -1)) 22
   (params 1
    (param :x.30 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4) .)) . . . 2,1
   (stmts 4
    (let :x.31 . . 4,~21
     (i -1) 4 +12) 4,1
@@ -211,8 +211,8 @@
    (i -1)) 18
   (params 1
    (param :x.32 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4) .) 24
-   (param :y.13 . . 11 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4) .) 24
+   (param :y.13 . . 11 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,29
  (proc :=sink.3.tho8gh7q4 . .
@@ -221,7 +221,7 @@
    (i -1)) 18
   (params 1
    (param :x.33 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4) .) 24
-   (param :y.14 . . 11 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4) .) 24
+   (param :y.14 . . 11 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))))

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -98,8 +98,8 @@
  (proc 5 :foo.0.tho8gh7q4 . . . 9
   (params) . . . 2,1
   (stmts 4
-   (var :obj.0 . . 13 MyObject.1.tho8gh7q4 .) 4,2
-   (var :obj2.0 . . 14 MyObject.2.tho8gh7q4 .) 10,4
+   (var :obj.0 . . 13 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .) 4,2
+   (var :obj2.0 . . 14 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .) 10,4
    (destroy 1 obj.0) 4,6
    (var :objbase.0 . . 9 MyObjectBase.0.tho8gh7q4 .) 4,7
    (var :objbase2.0 . . 10 MyObjectBase.0.tho8gh7q4 .) 10,8
@@ -115,40 +115,40 @@
     (at ~8 MyObject.0.tho8gh7q4 1 T.5.tho8gh7q4 4 Y.5.tho8gh7q4) .)) . . . 2,1
   (stmts
    (discard .))) 4,52
- (gvar :obj.0.tho8gh7q4 . . 13 MyObject.1.tho8gh7q4 .) 12,53
+ (gvar :obj.0.tho8gh7q4 . . 13 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .) 12,53
  (call 1 =checkHook.1.tho8gh7q4 1 obj.0.tho8gh7q4) 12,53
  (proc :=checkHook.1.tho8gh7q4 . ~12,~4 .
   (at =checkHook.0.tho8gh7q4 8,~17
    (i -1) 13,~17
    (f +64)) 11,~4
   (params 1
-   (param :x.13 . . 12 MyObject.1.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
+   (param :x.13 . . 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
   (stmts
    (discard .))) 19,36
- (type :MyObject.1.tho8gh7q4 .
+ (type :MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .
   (at MyObject.0.tho8gh7q4 1
    (i -1) 6
    (f +64)) ~2,~32 . ,~32
   (object . ~15,1
-   (fld :x.2.tho8gh7q4 . . 6
+   (fld :x.1.tho8gh7q4.Imors5e.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.2.tho8gh7q4 . . 3
+   (fld :y.1.tho8gh7q4.Imors5e.tho8gh7q4 . . 3
     (i -1) .))) 20,38
- (type :MyObject.2.tho8gh7q4 .
+ (type :MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .
   (at MyObject.0.tho8gh7q4 1
    (f +64) 8
    (i -1)) ~3,~34 . ~1,~34
   (object . ~15,1
-   (fld :x.3.tho8gh7q4 . . 6
+   (fld :x.1.tho8gh7q4.Iph6hf21.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.3.tho8gh7q4 . . 3
+   (fld :y.1.tho8gh7q4.Iph6hf21.tho8gh7q4 . . 3
     (i -1) .))) ,32
  (proc :=destroy.2.tho8gh7q4 . .
   (at =destroy.1.tho8gh7q4 20,4
    (i -1) 25,4
    (f +64)) 21
   (params 1
-   (param :x.22 . . 11 MyObject.1.tho8gh7q4 .)) . . . 2,1
+   (param :x.22 . . 11 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) . . . 2,1
   (stmts 4
    (let :x.23 . . 4,~31
     (i -1) 4 +12))) ,22
@@ -158,7 +158,7 @@
    (f +64)) 22
   (params 1
    (param :x.24 . . 3
-    (mut 12 MyObject.1.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4) .)) . . . 2,1
   (stmts 4
    (let :x.25 . . 4,~21
     (i -1) 4 +12) 4,1
@@ -170,8 +170,8 @@
    (f +64)) 18
   (params 1
    (param :x.26 . . 3
-    (mut 12 MyObject.1.tho8gh7q4) .) 24
-   (param :y.10 . . 11 MyObject.1.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4) .) 24
+   (param :y.10 . . 11 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,29
  (proc :=sink.2.tho8gh7q4 . .
@@ -180,8 +180,8 @@
    (f +64)) 18
   (params 1
    (param :x.27 . . 3
-    (mut 12 MyObject.1.tho8gh7q4) .) 24
-   (param :y.11 . . 11 MyObject.1.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4) .) 24
+   (param :y.11 . . 11 MyObject.0.tho8gh7q4.Imors5e.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,32
  (proc :=destroy.3.tho8gh7q4 . .
@@ -189,7 +189,7 @@
    (f +64) 28,6
    (i -1)) 21
   (params 1
-   (param :x.28 . . 11 MyObject.2.tho8gh7q4 .)) . . . 2,1
+   (param :x.28 . . 11 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .)) . . . 2,1
   (stmts 4
    (let :x.29 . . 4,~31
     (i -1) 4 +12))) ,22
@@ -199,7 +199,7 @@
    (i -1)) 22
   (params 1
    (param :x.30 . . 3
-    (mut 12 MyObject.2.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4) .)) . . . 2,1
   (stmts 4
    (let :x.31 . . 4,~21
     (i -1) 4 +12) 4,1
@@ -211,8 +211,8 @@
    (i -1)) 18
   (params 1
    (param :x.32 . . 3
-    (mut 12 MyObject.2.tho8gh7q4) .) 24
-   (param :y.13 . . 11 MyObject.2.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4) .) 24
+   (param :y.13 . . 11 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,29
  (proc :=sink.3.tho8gh7q4 . .
@@ -221,7 +221,7 @@
    (i -1)) 18
   (params 1
    (param :x.33 . . 3
-    (mut 12 MyObject.2.tho8gh7q4) .) 24
-   (param :y.14 . . 11 MyObject.2.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4) .) 24
+   (param :y.14 . . 11 MyObject.0.tho8gh7q4.Iph6hf21.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))))

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -98,8 +98,8 @@
  (proc 5 :foo.0.tho8gh7q4 . . . 9
   (params) . . . 2,1
   (stmts 4
-   (var :obj.0 . . 13 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .) 4,2
-   (var :obj2.0 . . 14 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .) 10,4
+   (var :obj.0 . . 13 MyObject.0.I76zger.tho8gh7q4 .) 4,2
+   (var :obj2.0 . . 14 MyObject.0.I3kvyeb.tho8gh7q4 .) 10,4
    (destroy 1 obj.0) 4,6
    (var :objbase.0 . . 9 MyObjectBase.0.tho8gh7q4 .) 4,7
    (var :objbase2.0 . . 10 MyObjectBase.0.tho8gh7q4 .) 10,8
@@ -115,40 +115,40 @@
     (at ~8 MyObject.0.tho8gh7q4 1 T.5.tho8gh7q4 4 Y.5.tho8gh7q4) .)) . . . 2,1
   (stmts
    (discard .))) 4,52
- (gvar :obj.0.tho8gh7q4 . . 13 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .) 12,53
+ (gvar :obj.0.tho8gh7q4 . . 13 MyObject.0.I76zger.tho8gh7q4 .) 12,53
  (call 1 =checkHook.1.tho8gh7q4 1 obj.0.tho8gh7q4) 12,53
  (proc :=checkHook.1.tho8gh7q4 . ~12,~4 .
   (at =checkHook.0.tho8gh7q4 8,~17
    (i -1) 13,~17
    (f +64)) 11,~4
   (params 1
-   (param :x.13 . . 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
+   (param :x.13 . . 12 MyObject.0.I76zger.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
   (stmts
    (discard .))) 19,36
- (type :MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .
+ (type :MyObject.0.I76zger.tho8gh7q4 .
   (at MyObject.0.tho8gh7q4 1
    (i -1) 6
    (f +64)) ~2,~32 . ,~32
   (object . ~15,1
-   (fld :x.1.tho8gh7q4.I76zger.tho8gh7q4 . . 6
+   (fld :x.1.I76zger.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.tho8gh7q4.I76zger.tho8gh7q4 . . 3
+   (fld :y.1.I76zger.tho8gh7q4 . . 3
     (i -1) .))) 20,38
- (type :MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .
+ (type :MyObject.0.I3kvyeb.tho8gh7q4 .
   (at MyObject.0.tho8gh7q4 1
    (f +64) 8
    (i -1)) ~3,~34 . ~1,~34
   (object . ~15,1
-   (fld :x.1.tho8gh7q4.I3kvyeb.tho8gh7q4 . . 6
+   (fld :x.1.I3kvyeb.tho8gh7q4 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.tho8gh7q4.I3kvyeb.tho8gh7q4 . . 3
+   (fld :y.1.I3kvyeb.tho8gh7q4 . . 3
     (i -1) .))) ,32
  (proc :=destroy.2.tho8gh7q4 . .
   (at =destroy.1.tho8gh7q4 20,4
    (i -1) 25,4
    (f +64)) 21
   (params 1
-   (param :x.22 . . 11 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) . . . 2,1
+   (param :x.22 . . 11 MyObject.0.I76zger.tho8gh7q4 .)) . . . 2,1
   (stmts 4
    (let :x.23 . . 4,~31
     (i -1) 4 +12))) ,22
@@ -158,7 +158,7 @@
    (f +64)) 22
   (params 1
    (param :x.24 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.I76zger.tho8gh7q4) .)) . . . 2,1
   (stmts 4
    (let :x.25 . . 4,~21
     (i -1) 4 +12) 4,1
@@ -170,8 +170,8 @@
    (f +64)) 18
   (params 1
    (param :x.26 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4) .) 24
-   (param :y.10 . . 11 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.I76zger.tho8gh7q4) .) 24
+   (param :y.10 . . 11 MyObject.0.I76zger.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,29
  (proc :=sink.2.tho8gh7q4 . .
@@ -180,8 +180,8 @@
    (f +64)) 18
   (params 1
    (param :x.27 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4) .) 24
-   (param :y.11 . . 11 MyObject.0.tho8gh7q4.I76zger.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.I76zger.tho8gh7q4) .) 24
+   (param :y.11 . . 11 MyObject.0.I76zger.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,32
  (proc :=destroy.3.tho8gh7q4 . .
@@ -189,7 +189,7 @@
    (f +64) 28,6
    (i -1)) 21
   (params 1
-   (param :x.28 . . 11 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .)) . . . 2,1
+   (param :x.28 . . 11 MyObject.0.I3kvyeb.tho8gh7q4 .)) . . . 2,1
   (stmts 4
    (let :x.29 . . 4,~31
     (i -1) 4 +12))) ,22
@@ -199,7 +199,7 @@
    (i -1)) 22
   (params 1
    (param :x.30 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.I3kvyeb.tho8gh7q4) .)) . . . 2,1
   (stmts 4
    (let :x.31 . . 4,~21
     (i -1) 4 +12) 4,1
@@ -211,8 +211,8 @@
    (i -1)) 18
   (params 1
    (param :x.32 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4) .) 24
-   (param :y.13 . . 11 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.I3kvyeb.tho8gh7q4) .) 24
+   (param :y.13 . . 11 MyObject.0.I3kvyeb.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))) ,29
  (proc :=sink.3.tho8gh7q4 . .
@@ -221,7 +221,7 @@
    (i -1)) 18
   (params 1
    (param :x.33 . . 3
-    (mut 12 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4) .) 24
-   (param :y.14 . . 11 MyObject.0.tho8gh7q4.I3kvyeb.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.I3kvyeb.tho8gh7q4) .) 24
+   (param :y.14 . . 11 MyObject.0.I3kvyeb.tho8gh7q4 .)) . . . 2,1
   (stmts
    (discard .))))

--- a/tests/nimony/sysbasics/trefobject.nif
+++ b/tests/nimony/sysbasics/trefobject.nif
@@ -27,18 +27,18 @@
     (ref 4
      (at Node.Obj.0.tre8amq6m 6,2 T.1.tre8amq6m)) .))) 4,11
  (gvar :node.0.tre8amq6m . . 8,~4
-  (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m) .) 14,11
- (type :Node.0.tre8amq6m.Isesnzm1.tre8amq6m .
+  (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) 14,11
+ (type :Node.0.Isesnzm1.tre8amq6m .
   (at Node.0.tre8amq6m 1
    (i -1)) ~4,~4 . ~2,~4
-  (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m)) 16,7
- (type :Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m .
+  (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m)) 16,7
+ (type :Node.Obj.0.Iiz3k2p1.tre8amq6m .
   (at Node.Obj.0.tre8amq6m ~1,4
    (i -1)) ~6 .
   (object . ~12,1
-   (fld :val.0.tre8amq6m.Iiz3k2p1.tre8amq6m . . 11,3
+   (fld :val.0.Iiz3k2p1.tre8amq6m . . 11,3
     (i -1) .) ~12,2
-   (fld :left.0.tre8amq6m.Iiz3k2p1.tre8amq6m . . 8,~2
-    (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m) .) ~6,2
-   (fld :right.0.tre8amq6m.Iiz3k2p1.tre8amq6m . . 2,~2
-    (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m) .))))
+   (fld :left.0.Iiz3k2p1.tre8amq6m . . 8,~2
+    (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) ~6,2
+   (fld :right.0.Iiz3k2p1.tre8amq6m . . 2,~2
+    (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .))))

--- a/tests/nimony/sysbasics/trefobject.nif
+++ b/tests/nimony/sysbasics/trefobject.nif
@@ -27,18 +27,18 @@
     (ref 4
      (at Node.Obj.0.tre8amq6m 6,2 T.1.tre8amq6m)) .))) 4,11
  (gvar :node.0.tre8amq6m . . 8,~4
-  (ref 4 Node.Obj.1.tre8amq6m) .) 14,11
- (type :Node.2.tre8amq6m .
+  (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m) .) 14,11
+ (type :Node.0.tre8amq6m.I7nvoru.tre8amq6m .
   (at Node.0.tre8amq6m 1
    (i -1)) ~4,~4 . ~2,~4
-  (ref 4 Node.Obj.1.tre8amq6m)) 16,7
- (type :Node.Obj.1.tre8amq6m .
+  (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m)) 16,7
+ (type :Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m .
   (at Node.Obj.0.tre8amq6m ~1,4
    (i -1)) ~6 .
   (object . ~12,1
-   (fld :val.1.tre8amq6m . . 11,3
+   (fld :val.0.tre8amq6m.Ioh0axy1.tre8amq6m . . 11,3
     (i -1) .) ~12,2
-   (fld :left.1.tre8amq6m . . 8,~2
-    (ref 4 Node.Obj.1.tre8amq6m) .) ~6,2
-   (fld :right.1.tre8amq6m . . 2,~2
-    (ref 4 Node.Obj.1.tre8amq6m) .))))
+   (fld :left.0.tre8amq6m.Ioh0axy1.tre8amq6m . . 8,~2
+    (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m) .) ~6,2
+   (fld :right.0.tre8amq6m.Ioh0axy1.tre8amq6m . . 2,~2
+    (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m) .))))

--- a/tests/nimony/sysbasics/trefobject.nif
+++ b/tests/nimony/sysbasics/trefobject.nif
@@ -27,18 +27,18 @@
     (ref 4
      (at Node.Obj.0.tre8amq6m 6,2 T.1.tre8amq6m)) .))) 4,11
  (gvar :node.0.tre8amq6m . . 8,~4
-  (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m) .) 14,11
- (type :Node.0.tre8amq6m.I7nvoru.tre8amq6m .
+  (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m) .) 14,11
+ (type :Node.0.tre8amq6m.Isesnzm1.tre8amq6m .
   (at Node.0.tre8amq6m 1
    (i -1)) ~4,~4 . ~2,~4
-  (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m)) 16,7
- (type :Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m .
+  (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m)) 16,7
+ (type :Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m .
   (at Node.Obj.0.tre8amq6m ~1,4
    (i -1)) ~6 .
   (object . ~12,1
-   (fld :val.0.tre8amq6m.Ioh0axy1.tre8amq6m . . 11,3
+   (fld :val.0.tre8amq6m.Iiz3k2p1.tre8amq6m . . 11,3
     (i -1) .) ~12,2
-   (fld :left.0.tre8amq6m.Ioh0axy1.tre8amq6m . . 8,~2
-    (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m) .) ~6,2
-   (fld :right.0.tre8amq6m.Ioh0axy1.tre8amq6m . . 2,~2
-    (ref 4 Node.Obj.0.tre8amq6m.Ioh0axy1.tre8amq6m) .))))
+   (fld :left.0.tre8amq6m.Iiz3k2p1.tre8amq6m . . 8,~2
+    (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m) .) ~6,2
+   (fld :right.0.tre8amq6m.Iiz3k2p1.tre8amq6m . . 2,~2
+    (ref 4 Node.Obj.0.tre8amq6m.Iiz3k2p1.tre8amq6m) .))))


### PR DESCRIPTION
fixes #715, supersedes #724

The scheme is:

```
abc.123.origmod.Iabcdefgh.instmod
```

where `abcdefgh` is the encoded hash of the invocation NIF string (`typeToCanon` depends on runtime literal IDs). The first 3 parts are the same as the original symbol. But the original symbol being preserved isn't necessary, it can be included in the hash, so we could have something as bare as:

```
abc.Iabcdefgh.instmod
```

or any other arrangement in between if the current one is too ugly.

The final `.instmod` part is ignored both in `sigmatch` for comparisons, and removed in the NIFC output by hexer, so that the type is generated under the same name. The scheme also applies to any symbol declared inside instantiations so that fields are the same across instantiations too.

I also tried including proc instantiations but it broke for inline procs and isn't really necessary to make procs work.