### PR TITLE
implement mutual generic disambiguation

### DIFF
--- a/tests/nimony/overload/tgenericdisamb.nim
+++ b/tests/nimony/overload/tgenericdisamb.nim
@@ -1,0 +1,21 @@
+import std/syncio
+
+type Foo[T] = object
+
+proc foo[T](x: T) = echo "broad"
+proc foo[T](x: Foo[T]) = echo "specific Foo[T]"
+
+# test linearmatch:
+proc fooPtr[T](x: T) = echo "broad ptr"
+proc fooPtr[T](x: ptr T) = echo "ptr"
+proc fooPtr[T](x: ptr Foo[T]) = echo "specific ptr Foo[T]"
+
+proc bar[T](x: Foo[T]) =
+  foo(123)
+  foo(x)
+  var i = 456
+  fooPtr(i)
+  fooPtr(addr i)
+  fooPtr(addr x)
+
+bar(Foo[int]())

--- a/tests/nimony/overload/tgenericdisamb.output
+++ b/tests/nimony/overload/tgenericdisamb.output
@@ -1,0 +1,5 @@
+broad
+specific Foo[T]
+broad ptr
+ptr
+specific ptr Foo[T]


### PR DESCRIPTION
closes #647

The params of the callees are matched against each other, to check if they match either as a generic match and the other one doesn't. I don't exactly know why only generic matches are counted in the original compiler and not also equal matches as in the case of `var T` matching `T` (though the vice versa also matches for now so this wouldn't disambiguate it yet). To get `var T` disambiguation we also need the specificity counter method but that can be done in a followup.