### PR TITLE
nifc: fixes #745; fixes getType of `AtC`

### DIFF
--- a/src/nifc/typenav.nim
+++ b/src/nifc/typenav.nim
@@ -72,6 +72,14 @@ proc getTypeImpl(m: var Module; n: Cursor): Cursor =
       let a = n.firstSon
       let arrayType = getTypeImpl(m, a)
       result = arrayType
+      # array type is an alias
+      if result.kind == Symbol:
+        let d = m.defs.getOrDefault(result.symId)
+        if d.pos != 0:
+          let dd = m.src.cursorAt(d.pos)
+          if dd.stmtKind == TypeS:
+            let decl = asTypeDecl(dd)
+            result = decl.body
       inc result # (arr ...)
     of DotC:
       var a = n.firstSon

--- a/tests/nimony/sysbasics/tarrays.nim
+++ b/tests/nimony/sysbasics/tarrays.nim
@@ -1,0 +1,4 @@
+import std/syncio
+
+var a: array[1, array[1, int]] = [[0]]
+echo a[0][0]


### PR DESCRIPTION
fixes #745

```
 (gvar :a.0.tes3wd9hn1 . 8 AarrayAR0AiS-1ZS1ZS1.0.t 29
  (aconstr ~21 AarrayAR0AiS-1ZS1ZS1.0.t 1
   (aconstr AarrayAiS-1ZS1.0.t 1 +0))) 4,105,lib/std/syncio.nim
 (call write.2.syn1lfpjv 6 stdout.c 5,4,test4.nim
  (at
   (at a.0.tes3wd9hn1 2 +0) 5 +0)) 2,106,lib/std/syncio.nim

 (type :AarrayAR0AiS-1ZS1ZS1.0.t .
  (array 9 AarrayAiS-1ZS1.0.t +1)))
```

In `AtC`, `getTypeImpl` returns the type of the firstSon of the construct, which means the type of a variable. Because array types exist in the form of alises. We need to skip it