### PR TITLE
enables tests that didn't worked before

### DIFF
--- a/tests/nimony/stdlib/ttables.nim
+++ b/tests/nimony/stdlib/ttables.nim
@@ -1,30 +1,31 @@
 import std/[hashes, syncio, tables]
 
-var t = initTable[int, int]()
-assert not t.contains(123)
-assert not t.hasKey(123)
-assert t.getOrDefault(123) == 0
-assert t.len == 0
-t[123] = 321
-assert t.len == 1
-assert t.contains(123)
-assert t.hasKey(123)
-assert t.getOrDefault(123) == 321
-assert t[123] == 321
-assert t.mgetOrPut(123, -1) == 321
-inc t[123]
-assert t[123] == 322
+block:
+  var t = initTable[int, int]()
+  assert not t.contains(123)
+  assert not t.hasKey(123)
+  assert t.getOrDefault(123) == 0
+  assert t.len == 0
+  t[123] = 321
+  assert t.len == 1
+  assert t.contains(123)
+  assert t.hasKey(123)
+  assert t.getOrDefault(123) == 321
+  assert t[123] == 321
+  assert t.mgetOrPut(123, -1) == 321
+  inc t[123]
+  assert t[123] == 322
 
-#assert t.mgetOrPut(456, 654) == 654
-#assert t.len == 2
-#assert t.contains(456)
-#assert t.hasKey(456)
-#assert t.getOrDefault(456) == 654
-#assert t[456] == 654
+  assert t.mgetOrPut(456, 654) == 654
+  assert t.len == 2
+  assert t.contains(456)
+  assert t.hasKey(456)
+  assert t.getOrDefault(456) == 654
+  assert t[456] == 654
 
-const HC123 = (1 shl 31) + 123  # Hash collision to '123'
-assert not t.contains(HC123)
-assert t.getOrDefault(HC123) == 0
+  const HC123 = (1 shl 31) + 123  # Hash collision to '123'
+  assert not t.contains(HC123)
+  assert t.getOrDefault(HC123) == 0
 
-#for k, v in t:
-#  echo k, v
+  #for k, v in t:
+  #  echo k, v


### PR DESCRIPTION
Put tests under block statement so that we can easily add more tests later.
`pairs` iterator still doesn't work.
