### PR TITLE
declare typevars and use untyped prepass for generic forward decls

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4279,8 +4279,8 @@ proc invokeInnerObj(c: var SemContext; genericsPos: int; objSym: SymId; info: Pa
         if typevar.kind == SymbolDef:
           invokeBuf.add symToken(typevar.symId, typevar.info)
         else:
-          raiseAssert("typevar should always be declared")
-          #invokeBuf.addSubtree typevar
+          # assume it was left as an identifier
+          invokeBuf.addSubtree typevar
         skip params
     endRead(c.dest)
     c.dest.add invokeBuf
@@ -4316,7 +4316,9 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
     # copy toplevel scope status for exported fields
     c.currentScope.kind = oldScopeKind
     isGeneric = true
+  
   let crucial = semTypePragmas(c, n, delayed.s.name, beforeExportMarker)
+
   if c.phase == SemcheckSignatures or
       (delayed.status in {OkNew, OkExistingFresh} and
         c.phase != SemcheckTopLevelSyms):
@@ -4363,7 +4365,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
         # capture typevars for instantiation of forward declared types to work
         var ctx = createUntypedContext(addr c, UntypedForwardGeneric)
         addParams(ctx, beforeGenerics)
-        semTemplBody ctx, n
+        semTemplBody ctx, n # body
       else:
         c.takeTree n # body
   if isGeneric:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4361,7 +4361,7 @@ proc semTypeSection(c: var SemContext; n: var Cursor) =
     if not isRefPtrObj: # body not already handled
       if isGeneric:
         # capture typevars for instantiation of forward declared types to work
-        var ctx = createUntypedContext(addr c, UntypedGeneric)
+        var ctx = createUntypedContext(addr c, UntypedForwardGeneric)
         addParams(ctx, beforeGenerics)
         semTemplBody ctx, n
       else:

--- a/src/nimony/semuntyped.nim
+++ b/src/nimony/semuntyped.nim
@@ -69,6 +69,7 @@ type
   UntypedMode* = enum
     UntypedTemplate
     UntypedGeneric
+    UntypedForwardGeneric
   UntypedCtx* = object
     c: ptr SemContext
     mode: UntypedMode
@@ -379,6 +380,10 @@ proc semTemplBody*(c: var UntypedCtx; n: var Cursor) =
         assert count == 1
         c.c.dest.shrink start
         c.c.dest.add symToken(firstSym, n.info)
+      elif c.mode == UntypedForwardGeneric:
+        # leave as ident if not typevar
+        c.c.dest.shrink start
+        c.c.dest.add n
       elif contains(c.toBind, firstSym):
         if count == 1:
           c.c.dest.shrink start

--- a/src/nimony/semuntyped.nim
+++ b/src/nimony/semuntyped.nim
@@ -343,7 +343,6 @@ proc semTemplTypeDecl(c: var UntypedCtx; n: var Cursor) =
     closeScope c
 
 proc semTemplLocal(c: var UntypedCtx; n: var Cursor; k: SymKind) =
-  let orig = n
   let local = asLocal(n)
   let declStart = c.c.dest.len
   takeToken c.c[], n

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -38,10 +38,10 @@
  (proc 5 :typeof.0.tge7jvqqk1
   (typeof) . 12
   (typevars 1
-   (typevar :T.3.tge7jvqqk1 . . . .)) 15
+   (typevar :T.6.tge7jvqqk1 . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.3.tge7jvqqk1 .)) 16
-  (typedesc 1 T.3.tge7jvqqk1) 35
+   (param :x.0 . . 3 T.6.tge7jvqqk1 .)) 16
+  (typedesc 1 T.6.tge7jvqqk1) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,14
  (type ~8 :string.0.tge7jvqqk1 x . . string.0.sysvq0asl) 4,16
@@ -73,9 +73,9 @@
      (i -1) +0 +2)) 1 +1 4 +2 7 +3)) 15,23
  (type ~13 :MyGeneric.0.tge7jvqqk1 . ~4
   (typevars 1
-   (typevar :T.4.tge7jvqqk1 . . . .)) . 2
+   (typevar :T.3.tge7jvqqk1 . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tge7jvqqk1 . . 3 T.4.tge7jvqqk1 .))) 2,27
+   (fld :x.0.tge7jvqqk1 . . 3 T.3.tge7jvqqk1 .))) 2,27
  (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.I8smrpu.tge7jvqqk1 .) 2,28
  (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.Iliphp3.tge7jvqqk1 .) 9,30
  (asgn ~3
@@ -122,15 +122,15 @@
       (i -1) ~2 +34 1 +56) 8 "xyz")))) 16,48
  (type ~14 :HSlice.0.tge7jvqqk1 x ~7
   (typevars 1
-   (typevar :T.5.tge7jvqqk1 . . . .) 4
+   (typevar :T.4.tge7jvqqk1 . . . .) 4
    (typevar :U.0.tge7jvqqk1 . . . .)) . 2
   (object . ~14,1
-   (fld :a.0.tge7jvqqk1 . . 3 T.5.tge7jvqqk1 .) ~14,2
+   (fld :a.0.tge7jvqqk1 . . 3 T.4.tge7jvqqk1 .) ~14,2
    (fld :b.0.tge7jvqqk1 . . 3 U.0.tge7jvqqk1 .))) 12,51
  (type ~10 :Slice.0.tge7jvqqk1 x ~4
   (typevars 1
-   (typevar :T.6.tge7jvqqk1 . . . .)) . 8
-  (at ~6 HSlice.0.tge7jvqqk1 1 T.6.tge7jvqqk1 4 T.6.tge7jvqqk1)) ,53
+   (typevar :T.5.tge7jvqqk1 . . . .)) . 8
+  (at ~6 HSlice.0.tge7jvqqk1 1 T.5.tge7jvqqk1 4 T.5.tge7jvqqk1)) ,53
  (proc 5 :\2E..0.tge7jvqqk1 x . 10
   (typevars 1
    (typevar :T.7.tge7jvqqk1 . . . .) 4

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -28,18 +28,18 @@
  (proc 5 :typeof.0.tte5tld8n
   (typeof) . 12
   (typevars 1
-   (typevar :T.2.tte5tld8n . . . .)) 15
+   (typevar :T.3.tte5tld8n . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.2.tte5tld8n .)) 16
-  (typedesc 1 T.2.tte5tld8n) 35
+   (param :x.0 . . 3 T.3.tte5tld8n .)) 16
+  (typedesc 1 T.3.tte5tld8n) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,12
  (type ~8 :string.0.tte5tld8n x . . string.0.sysvq0asl) 15,15
  (type ~13 :MyGeneric.0.tte5tld8n . ~4
   (typevars 1
-   (typevar :T.3.tte5tld8n . . . .)) . 2
+   (typevar :T.2.tte5tld8n . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tte5tld8n . . 3 T.3.tte5tld8n .))) 2,19
+   (fld :x.0.tte5tld8n . . 3 T.2.tte5tld8n .))) 2,19
  (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.Igj236q.tte5tld8n .) 2,20
  (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.Ibr3ivb1.tte5tld8n .) 9,22
  (asgn ~3

--- a/tests/nimony/sysbasics/trefobject.nif
+++ b/tests/nimony/sysbasics/trefobject.nif
@@ -27,7 +27,68 @@
     (ref 4
      (at Node.Obj.0.tre8amq6m 6,2 T.1.tre8amq6m)) .))) 4,11
  (gvar :node.0.tre8amq6m . . 8,~4
-  (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) 14,11
+  (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) 14,14
+ (type ~12 :Forward1.0.tre8amq6m . ~4
+  (typevars 1
+   (typevar :T.2.tre8amq6m . . . .)) . 2
+  (object . ~12,1
+   (fld :x.1.tre8amq6m . . 16,1
+    (ref 4
+     (at ForwardNode1.Obj.0.tre8amq6m ~4,~1 T.2.tre8amq6m)) .))) 18,16
+ (type ~16 :ForwardNode1.0.tre8amq6m . ~4
+  (typevars 1
+   (typevar :T.3.tre8amq6m . . . .)) . 2
+  (ref 4
+   (at ForwardNode1.Obj.0.tre8amq6m ~9 T.3.tre8amq6m))) 18,16
+ (type ~16 :ForwardNode1.Obj.0.tre8amq6m . ~4
+  (typevars 1
+   (typevar :T.4.tre8amq6m . . . .)) . 6
+  (object . ~20,1
+   (fld :val.1.tre8amq6m . . 5 T.4.tre8amq6m .) ~20,2
+   (fld :left.1.tre8amq6m . . 16,~2
+    (ref 4
+     (at ForwardNode1.Obj.0.tre8amq6m 6,2 T.4.tre8amq6m)) .) ~14,2
+   (fld :right.1.tre8amq6m . . 10,~2
+    (ref 4
+     (at ForwardNode1.Obj.0.tre8amq6m 6,2 T.4.tre8amq6m)) .))) 4,20
+ (gvar :forwardNode1.0.tre8amq6m . . 16,~4
+  (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m) .) 11,23
+ (type ~9 :Forward2.0.tre8amq6m . . . 2
+  (object . ~9,1
+   (fld :x.2.tre8amq6m . . 16,1
+    (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .))) 18,25
+ (type ~16 :ForwardNode2.0.tre8amq6m . ~4
+  (typevars 1
+   (typevar :T.5.tre8amq6m . . . .)) . 2
+  (ref 4
+   (at ForwardNode2.Obj.0.tre8amq6m ~9 T.5.tre8amq6m))) 18,25
+ (type ~16 :ForwardNode2.Obj.0.tre8amq6m . ~4
+  (typevars 1
+   (typevar :T.6.tre8amq6m . . . .)) . 6
+  (object . ~20,1
+   (fld :val.3.tre8amq6m . . 5 T.6.tre8amq6m .) ~20,2
+   (fld :left.3.tre8amq6m . . 16,~2
+    (ref 4
+     (at ForwardNode2.Obj.0.tre8amq6m 6,2 T.6.tre8amq6m)) .) ~14,2
+   (fld :right.3.tre8amq6m . . 10,~2
+    (ref 4
+     (at ForwardNode2.Obj.0.tre8amq6m 6,2 T.6.tre8amq6m)) .))) 4,29
+ (gvar :forwardNode2.0.tre8amq6m . . 16,~4
+  (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .) 19,24
+ (type :ForwardNode2.0.Ishmn651.tre8amq6m .
+  (at ForwardNode2.0.tre8amq6m 1
+   (i -1)) ~1,1 . 1,1
+  (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m)) 24,25
+ (type :ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m .
+  (at ForwardNode2.Obj.0.tre8amq6m ~4,~1
+   (i -1)) ~6 .
+  (object . ~20,1
+   (fld :val.2.tre8amq6m . . 16,~2
+    (i -1) .) ~20,2
+   (fld :left.2.tre8amq6m . . 16,~2
+    (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .) ~14,2
+   (fld :right.2.tre8amq6m . . 10,~2
+    (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .))) 14,11
  (type :Node.0.Isesnzm1.tre8amq6m .
   (at Node.0.tre8amq6m 1
    (i -1)) ~4,~4 . ~2,~4
@@ -41,4 +102,18 @@
    (fld :left.0.Iiz3k2p1.tre8amq6m . . 8,~2
     (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) ~6,2
    (fld :right.0.Iiz3k2p1.tre8amq6m . . 2,~2
-    (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .))))
+    (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .))) 30,20
+ (type :ForwardNode1.0.Iee6hkd1.tre8amq6m .
+  (at ForwardNode1.0.tre8amq6m 1
+   (i -1)) ~12,~4 . ~10,~4
+  (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m)) 24,16
+ (type :ForwardNode1.Obj.0.I93upex.tre8amq6m .
+  (at ForwardNode1.Obj.0.tre8amq6m 7,4
+   (i -1)) ~6 .
+  (object . ~20,1
+   (fld :val.1.I93upex.tre8amq6m . . 27,3
+    (i -1) .) ~20,2
+   (fld :left.1.I93upex.tre8amq6m . . 16,~2
+    (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m) .) ~14,2
+   (fld :right.1.I93upex.tre8amq6m . . 10,~2
+    (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m) .))))

--- a/tests/nimony/sysbasics/trefobject.nim
+++ b/tests/nimony/sysbasics/trefobject.nim
@@ -11,21 +11,20 @@ type
 
 var node: Node[int]
 
-when false: # need forwarded generic structural types to work
-  type
-    Forward1[T] = object
-      x: ForwardNode1[T]
-    ForwardNode1[T] = ref object
-      val: T
-      left, right: ForwardNode1[T]
+type
+  Forward1[T] = object
+    x: ForwardNode1[T]
+  ForwardNode1[T] = ref object
+    val: T
+    left, right: ForwardNode1[T]
 
-  var forwardNode1: ForwardNode1[int]
+var forwardNode1: ForwardNode1[int]
 
-  type
-    Forward2 = object
-      x: ForwardNode2[int]
-    ForwardNode2[T] = ref object
-      val: T
-      left, right: ForwardNode2[T]
+type
+  Forward2 = object
+    x: ForwardNode2[int]
+  ForwardNode2[T] = ref object
+    val: T
+    left, right: ForwardNode2[T]
 
-  var forwardNode2: ForwardNode2[int]
+var forwardNode2: ForwardNode2[int]


### PR DESCRIPTION
closes #645

The untyped mode in this case leaves everything except the generic params (given they were not shadowed) as identifiers, i.e. only the typevars are captured, since not every symbol in the module is processed yet.

