### PR TITLE
partially fixes 716; changing command line options changes module suffix

### DIFF
--- a/src/gear2/modnames.nim
+++ b/src/gear2/modnames.nim
@@ -49,7 +49,13 @@ proc uhashBase36*(s: string): string =
     result.add Base36[int(id mod 36'u32)]
     id = id div 36'u32
 
-proc moduleSuffix*(path: string; searchPaths: openArray[string]): string =
+proc moduleSuffix*(path: string; searchPaths: openArray[string]; additional: string): string =
+  # `additional` contains command line options that can affects generated nif or c files.
+  # When they are changed, new generated files have different module suffix and
+  # existing cached files are not used.
+  #
+  # `additional` must be empty when `path` is system module as
+  # `nimony/builtintypes.SystemModuleSuffix`.
   var f = relativePath(path, getCurrentDir(), '/')
   # Select the path that is shortest relative to the searchPath:
   for s in searchPaths:
@@ -57,7 +63,7 @@ proc moduleSuffix*(path: string; searchPaths: openArray[string]): string =
     if candidate.len < f.len:
       f = candidate
   let m = extractModulename(f)
-  var id = uhash(f)
+  var id = uhash(f & additional)
   result = newStringOfCap(10)
   for i in 0..<min(m.len, PrefixLen):
     result.add m[i]

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -47,7 +47,7 @@ proc writeVersion() = quit(Version & "\n", QuitSuccess)
 proc processSingleModule(nimFile: string; config: sink NifConfig; moduleFlags: set[ModuleFlag];
                          commandLineArgs: string; forceRebuild: bool) =
   let nifler = findTool("nifler")
-  let name = moduleSuffix(nimFile, config.paths)
+  let name = moduleSuffix(nimFile, config.paths, config.getOptionsAsOneString(IsMain in moduleFlags))
   let src = config.nifcachePath / name & ".1.nif"
   let dest = config.nifcachePath / name & ".2.nif"
   let toforceRebuild = if forceRebuild: " -f " else: ""
@@ -67,11 +67,7 @@ proc handleCmdLine() =
   var useEnv = true
   var doRun = false
   var moduleFlags: set[ModuleFlag] = {}
-  var config = NifConfig()
-  config.currentPath = getCurrentDir()
-  config.nifcachePath = "nimcache"
-  config.defines.incl "nimony"
-  config.bits = sizeof(int)*8
+  var config = initNifConfig()
   var commandLineArgs = ""
   var commandLineArgsNifc = ""
   var isChild = false

--- a/src/nimony/nimsem.nim
+++ b/src/nimony/nimsem.nim
@@ -56,11 +56,7 @@ proc handleCmdLine() =
   var forceRebuild = false
   var useEnv = true
   var moduleFlags: set[ModuleFlag] = {}
-  var config = NifConfig()
-  config.currentPath = getCurrentDir()
-  config.nifcachePath = "nimcache"
-  config.defines.incl "nimony"
-  config.bits = sizeof(int)*8
+  var config = initNifConfig()
   var commandLineArgs = ""
   for kind, key, val in getopt():
     case kind

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -263,7 +263,7 @@ proc semInclude(c: var SemContext; it: var Item) =
           break
 
       if not isRecursive:
-        var buf = parseFile(f2, c.g.config.paths, c.g.config.nifcachePath)
+        var buf = parseFile(f2, c.g.config)
         c.includeStack.add f2
         #c.m.includes.add f2
         var n = cursorAt(buf, 0)
@@ -292,7 +292,12 @@ proc importSingleFile(c: var SemContext; f1: ImportedFilename; origin: string; m
   if not fileExists(f2):
     c.buildErr info, "file not found: " & f2
     return
-  let suffix = moduleSuffix(f2, c.g.config.paths)
+  let suffix = moduleSuffix(f2,
+                            c.g.config.paths,
+                            if mode.kind == ImportSystem:
+                              ""
+                            else:
+                              c.g.config.getOptionsAsOneString(false))
   if not c.processedModules.containsOrIncl(suffix):
     c.meta.importedFiles.add f2
     if c.canSelfExec and needsRecompile(f2, suffixToNif suffix):

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -264,10 +264,10 @@ proc replaceSubs*(fmt, currentFile: string; config: NifConfig): string =
 
 # ------------------ include/import handling ------------------------
 
-proc parseFile*(nimFile: string; paths: openArray[string], nifcachePath: string): TokenBuf =
+proc parseFile*(nimFile: string; config: NifConfig): TokenBuf =
   let nifler = findTool("nifler")
-  let name = moduleSuffix(nimFile, paths)
-  let src = nifcachePath / name & ".1.nif"
+  let name = moduleSuffix(nimFile, config.paths, config.getOptionsAsOneString(false))
+  let src = config.nifcachePath / name & ".1.nif"
   exec quoteShell(nifler) & " --portablePaths --deps parse " & quoteShell(nimFile) & " " &
     quoteShell(src)
 

--- a/tests/nimony/arc/tmove_only.msgs
+++ b/tests/nimony/arc/tmove_only.msgs
@@ -1,1 +1,1 @@
-tests/nimony/arc/tmove_only.nim(18, 15) Error: '=dup' is not available for type <MyObj.0.tmoloqt6c1>
+tests/nimony/arc/tmove_only.nim(18, 15) Error: '=dup' is not available for type <MyObj.0.tmostiary>

--- a/tests/nimony/arc/tmove_only2.msgs
+++ b/tests/nimony/arc/tmove_only2.msgs
@@ -1,3 +1,3 @@
-tests/nimony/arc/tmove_only2.nim(19, 15) Error: '=dup' is not available for type <(array MyObj.0.tmozst6gl
+tests/nimony/arc/tmove_only2.nim(19, 15) Error: '=dup' is not available for type <(array MyObj.0.tmovtefsu
  (rangetype
   (i -1) +0 +1))>

--- a/tests/nimony/errmsgs/tcaseerrors.msgs
+++ b/tests/nimony/errmsgs/tcaseerrors.msgs
@@ -1,7 +1,7 @@
-tests/nimony/errmsgs/tcaseerrors.nim(5, 18) Error: cannot evaluate symbol at compile time: a.0.tcagl87gf1
+tests/nimony/errmsgs/tcaseerrors.nim(5, 18) Error: cannot evaluate symbol at compile time: a.0.tca355emu1
 tests/nimony/errmsgs/tcaseerrors.nim(6, 11) Error: value already handled
 tests/nimony/errmsgs/tcaseerrors.nim(12, 12) Error: overlapping values
-tests/nimony/errmsgs/tcaseerrors.nim(12, 19) Error: cannot evaluate symbol at compile time: b.0.tcagl87gf1
+tests/nimony/errmsgs/tcaseerrors.nim(12, 19) Error: cannot evaluate symbol at compile time: b.0.tca355emu1
 tests/nimony/errmsgs/tcaseerrors.nim(13, 4) Error: value already handled
-tests/nimony/errmsgs/tcaseerrors.nim(20, 32) Error: cannot evaluate symbol at compile time: c.0.tcagl87gf1
+tests/nimony/errmsgs/tcaseerrors.nim(20, 32) Error: cannot evaluate symbol at compile time: c.0.tca355emu1
 tests/nimony/errmsgs/tcaseerrors.nim(21, 25) Error: value already handled

--- a/tests/nimony/errmsgs/tcommontype.msgs
+++ b/tests/nimony/errmsgs/tcommontype.msgs
@@ -1,3 +1,3 @@
 tests/nimony/errmsgs/tcommontype.nim(6, 26) Error: type mismatch: got: (ptr
  (i -1)) but wanted: (ptr
- (uarray T.1.tcoq7zxn71))
+ (uarray T.1.tcorv2wsn1))

--- a/tests/nimony/errmsgs/tobjconstr.msgs
+++ b/tests/nimony/errmsgs/tobjconstr.msgs
@@ -1,2 +1,2 @@
-tests/nimony/errmsgs/tobjconstr.nim(4, 13) Error: undeclared field: 'undeclaredField' for type Foo.0.tobfnj5681
+tests/nimony/errmsgs/tobjconstr.nim(4, 13) Error: undeclared field: 'undeclaredField' for type Foo.0.tob8jgnv6
 tests/nimony/errmsgs/tobjconstr.nim(4, 33) Error: expected key/value pair in object constructor

--- a/tests/nimony/errmsgs/tunderspecifiedgeneric.msgs
+++ b/tests/nimony/errmsgs/tunderspecifiedgeneric.msgs
@@ -1,1 +1,1 @@
-tests/nimony/errmsgs/tunderspecifiedgeneric.nim(3, 4) Error: could not infer type for T.0.tunsd0i13
+tests/nimony/errmsgs/tunderspecifiedgeneric.nim(3, 4) Error: could not infer type for T.0.tuncsvb5x1

--- a/tests/nimony/generics/texplicitprocinst.nif
+++ b/tests/nimony/generics/texplicitprocinst.nif
@@ -1,37 +1,37 @@
 (.nif24)
 0,1,tests/nimony/generics/texplicitprocinst.nim(stmts
- (proc 5 :foo.0.texhjoap . . 8
+ (proc 5 :foo.0.tex05sevi . . 8
   (typevars 1
-   (typevar :T.0.texhjoap . . . .)) 11
+   (typevar :T.0.tex05sevi . . . .)) 11
   (params 1
-   (param :x.0 . . 3 T.0.texhjoap .)) . . . 20
+   (param :x.0 . . 3 T.0.tex05sevi .)) . . . 20
   (stmts
    (discard .))) ,1
- (proc 5 :foo.1.texhjoap . . 8
+ (proc 5 :foo.1.tex05sevi . . 8
   (typevars 1
-   (typevar :T.1.texhjoap . . . .) 4
-   (typevar :U.0.texhjoap . . . .)) 14
+   (typevar :T.1.tex05sevi . . . .) 4
+   (typevar :U.0.tex05sevi . . . .)) 14
   (params 1
-   (param :x.1 . . 3 T.1.texhjoap .) 7
-   (param :y.0 . . 3 U.0.texhjoap .)) . . . 29
+   (param :x.1 . . 3 T.1.tex05sevi .) 7
+   (param :y.0 . . 3 U.0.tex05sevi .)) . . . 29
   (stmts
    (discard .))) ,3
- (discard 8 foo.2.texhjoap) ,4
- (discard 8 foo.3.texhjoap) 8,5
- (call ~8 foo.2.texhjoap 1 +123) 16,6
- (call ~16 foo.3.texhjoap 1 +123 6 "abc") ,10
+ (discard 8 foo.2.tex05sevi) ,4
+ (discard 8 foo.3.tex05sevi) 8,5
+ (call ~8 foo.2.tex05sevi 1 +123) 16,6
+ (call ~16 foo.3.tex05sevi 1 +123 6 "abc") ,10
  (discard 28
-  (call ~20 importedGeneric.0.texhjoap 1 +123)) 8,3
- (proc :foo.2.texhjoap . ~8,~3 .
-  (at foo.0.texhjoap 4
+  (call ~20 importedGeneric.0.tex05sevi 1 +123)) 8,3
+ (proc :foo.2.tex05sevi . ~8,~3 .
+  (at foo.0.tex05sevi 4
    (i -1)) 3,~3
   (params 1
    (param :x.5 . . ,3
     (i -1) .)) ~8,~3 . ~8,~3 . ~8,~3 . 12,~3
   (stmts
    (discard .))) 8,4
- (proc :foo.3.texhjoap . ~8,~3 .
-  (at foo.1.texhjoap 4
+ (proc :foo.3.tex05sevi . ~8,~3 .
+  (at foo.1.tex05sevi 4
    (i -1) 9 string.0.sysvq0asl) 6,~3
   (params 1
    (param :x.6 . . ~3,3
@@ -39,8 +39,8 @@
    (param :y.2 . . ~4,3 string.0.sysvq0asl .)) ~8,~3 . ~8,~3 . ~8,~3 . 21,~3
   (stmts
    (discard .))) 28,10
- (proc :importedGeneric.0.texhjoap . 0,1,tests/nimony/generics/deps/mgenericproc.nim .
-  (at importedGeneric.0.mgesx53wa1 ~4
+ (proc :importedGeneric.0.tex05sevi . 0,1,tests/nimony/generics/deps/mgenericproc.nim .
+  (at importedGeneric.0.mgel4w424 ~4
    (i -1)) 24,1,tests/nimony/generics/deps/mgenericproc.nim
   (params 1
    (param :x.7 . . 24,11,tests/nimony/generics/texplicitprocinst.nim

--- a/tests/nimony/generics/ttuplecache.nif
+++ b/tests/nimony/generics/ttuplecache.nif
@@ -1,49 +1,49 @@
 (.nif24)
 0,3,tests/nimony/generics/ttuplecache.nim(stmts 9,1
- (type ~7 :Foo.0.ttuv4zf4c1 . ~4
+ (type ~7 :Foo.0.ttu4jtydr1 . ~4
   (typevars 1
-   (typevar :T.0.ttuv4zf4c1 . . . .)) . 2
+   (typevar :T.0.ttu4jtydr1 . . . .)) . 2
   (object . ~7,1
-   (fld :data.0.ttuv4zf4c1 . . 6 T.0.ttuv4zf4c1 .))) ,5
- (proc 5 :initFooInt.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.0.Iw8bgj.ttuv4zf4c1 . . 2,1
+   (fld :data.0.ttu4jtydr1 . . 6 T.0.ttu4jtydr1 .))) ,5
+ (proc 5 :initFooInt.0.ttu4jtydr1 . . . 15
+  (params) 7 Foo.0.I8pgvwy1.ttu4jtydr1 . . 2,1
   (stmts 8
-   (result :result.0 . . ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 .) 8
+   (result :result.0 . . ~3,~1 Foo.0.I8pgvwy1.ttu4jtydr1 .) 8
    (asgn result.0
     (expr
-     (oconstr ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 5
-      (kv ~5 data.0.Iw8bgj.ttuv4zf4c1 2 +0)))) ~2,~1
+     (oconstr ~3,~1 Foo.0.I8pgvwy1.ttu4jtydr1 5
+      (kv ~5 data.0.I8pgvwy1.ttu4jtydr1 2 +0)))) ~2,~1
    (ret result.0))) ,8
- (proc 5 :initFooTup.0.ttuv4zf4c1 . . . 15
-  (params) 7 Foo.0.Ildbpdf1.ttuv4zf4c1 . . 2,2
+ (proc 5 :initFooTup.0.ttu4jtydr1 . . . 15
+  (params) 7 Foo.0.Ieo8a041.ttu4jtydr1 . . 2,2
   (stmts 15
-   (result :result.1 . . ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 .) 15
+   (result :result.1 . . ~10,~2 Foo.0.Ieo8a041.ttu4jtydr1 .) 15
    (asgn result.1
     (expr
-     (oconstr ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 5
-      (kv ~5 data.0.Ildbpdf1.ttuv4zf4c1 2
+     (oconstr ~10,~2 Foo.0.Ieo8a041.ttu4jtydr1 5
+      (kv ~5 data.0.Ieo8a041.ttu4jtydr1 2
        (tupconstr ~16,~2
         (tuple 1
          (i -1) 6
          (i -1)) 1 +0 4 +0))))) ~2,~2
    (ret result.1))) ,12
- (proc 5 :initFooGeneric.0.ttuv4zf4c1 . . 19
+ (proc 5 :initFooGeneric.0.ttu4jtydr1 . . 19
   (typevars 1
-   (typevar :T.1.ttuv4zf4c1 . . . .)) 22
+   (typevar :T.1.ttu4jtydr1 . . . .)) 22
   (params 1
-   (param :x.0 . . 3 T.1.ttuv4zf4c1 .)) 11
-  (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) . . 2,1
+   (param :x.0 . . 3 T.1.ttu4jtydr1 .)) 11
+  (at ~3 Foo.0.ttu4jtydr1 1 T.1.ttu4jtydr1) . . 2,1
   (stmts 6
    (result :result.2 . . 3,~1
-    (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) .) 6
+    (at ~3 Foo.0.ttu4jtydr1 1 T.1.ttu4jtydr1) .) 6
    (asgn result.2
     (expr
      (oconstr 3,~1
-      (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
+      (at ~3 Foo.0.ttu4jtydr1 1 T.1.ttu4jtydr1) 5
       (kv ~5 data 2 x.0)))) ~2,~1
    (ret result.2))) 4,15
- (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.Iv5bnz4.ttuv4zf4c1 18
-  (call ~14 initFooGeneric.1.ttuv4zf4c1 1
+ (glet :x.0.ttu4jtydr1 . . 7,~3 Foo.0.I5hv486.ttu4jtydr1 18
+  (call ~14 initFooGeneric.1.ttu4jtydr1 1
    (tupconstr 2
     (tuple
      (kv ~1 a
@@ -51,15 +51,15 @@
      (kv ~1 b string.0.sysvq0asl)) 2
     (kv ~1 a 2 +1) 8
     (kv ~1 b 2 "abc")))) 4,16
- (glet :x1.0.ttuv4zf4c1 . . 4,~11
+ (glet :x1.0.ttu4jtydr1 . . 4,~11
   (i -1) 16
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.0.Iv5bnz4.ttuv4zf4c1 +0) +0)) 4,17
- (glet :x2.0.ttuv4zf4c1 . . 4 string.0.sysvq0asl 19
+   (dot ~1 x.0.ttu4jtydr1 data.0.I5hv486.ttu4jtydr1 +0) +0)) 4,17
+ (glet :x2.0.ttu4jtydr1 . . 4 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 x.0.ttuv4zf4c1 data.0.Iv5bnz4.ttuv4zf4c1 +0) +1)) 4,19
- (glet :y.0.ttuv4zf4c1 . . 7,~7 Foo.0.Iarhs7y1.ttuv4zf4c1 18
-  (call ~14 initFooGeneric.2.ttuv4zf4c1 1
+   (dot ~1 x.0.ttu4jtydr1 data.0.I5hv486.ttu4jtydr1 +0) +1)) 4,19
+ (glet :y.0.ttu4jtydr1 . . 7,~7 Foo.0.I1dtihf1.ttu4jtydr1 18
+  (call ~14 initFooGeneric.2.ttu4jtydr1 1
    (tupconstr 2
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
@@ -67,15 +67,15 @@
       (i -1))) 2
     (kv ~1 x 2 "def") 12
     (kv ~1 y 2 +2)))) 4,20
- (glet :y1.0.ttuv4zf4c1 . . 4,~3 string.0.sysvq0asl 19
+ (glet :y1.0.ttu4jtydr1 . . 4,~3 string.0.sysvq0asl 19
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.0.Iarhs7y1.ttuv4zf4c1 +0) +0)) 4,21
- (glet :y2.0.ttuv4zf4c1 . . 4,~16
+   (dot ~1 y.0.ttu4jtydr1 data.0.I1dtihf1.ttu4jtydr1 +0) +0)) 4,21
+ (glet :y2.0.ttu4jtydr1 . . 4,~16
   (i -1) 16
   (tupat ~5
-   (dot ~1 y.0.ttuv4zf4c1 data.0.Iarhs7y1.ttuv4zf4c1 +0) +1)) 22,15
- (proc :initFooGeneric.1.ttuv4zf4c1 . ~22,~3 .
-  (at initFooGeneric.0.ttuv4zf4c1 3
+   (dot ~1 y.0.ttu4jtydr1 data.0.I1dtihf1.ttu4jtydr1 +0) +1)) 22,15
+ (proc :initFooGeneric.1.ttu4jtydr1 . ~22,~3 .
+  (at initFooGeneric.0.ttu4jtydr1 3
    (tuple
     (kv ~1 a
      (i -1)) 6
@@ -85,16 +85,16 @@
     (tuple
      (kv ~1 a
       (i -1)) 6
-     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.Iv5bnz4.ttuv4zf4c1 ~22,~3 . ~22,~3 . ~20,~2
+     (kv ~1 b string.0.sysvq0asl)) .)) ~11,~3 Foo.0.I5hv486.ttu4jtydr1 ~22,~3 . ~22,~3 . ~20,~2
   (stmts 6
-   (result :result.3 . . 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 .) 6
+   (result :result.3 . . 3,~1 Foo.0.I5hv486.ttu4jtydr1 .) 6
    (asgn result.3
     (expr
-     (oconstr 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 5
-      (kv ~5 data.0.Iv5bnz4.ttuv4zf4c1 2 x.3)))) ~2,~1
+     (oconstr 3,~1 Foo.0.I5hv486.ttu4jtydr1 5
+      (kv ~5 data.0.I5hv486.ttu4jtydr1 2 x.3)))) ~2,~1
    (ret result.3))) 22,19
- (proc :initFooGeneric.2.ttuv4zf4c1 . ~22,~7 .
-  (at initFooGeneric.0.ttuv4zf4c1 3
+ (proc :initFooGeneric.2.ttu4jtydr1 . ~22,~7 .
+  (at initFooGeneric.0.ttu4jtydr1 3
    (tuple
     (kv ~1 x string.0.sysvq0asl) 10
     (kv ~1 y
@@ -104,50 +104,50 @@
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y
-      (i -1))) .)) ~11,~7 Foo.0.Iarhs7y1.ttuv4zf4c1 ~22,~7 . ~22,~7 . ~20,~6
+      (i -1))) .)) ~11,~7 Foo.0.I1dtihf1.ttu4jtydr1 ~22,~7 . ~22,~7 . ~20,~6
   (stmts 6
-   (result :result.4 . . 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 .) 6
+   (result :result.4 . . 3,~1 Foo.0.I1dtihf1.ttu4jtydr1 .) 6
    (asgn result.4
     (expr
-     (oconstr 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 5
-      (kv ~5 data.0.Iarhs7y1.ttuv4zf4c1 2 x.4)))) ~2,~1
+     (oconstr 3,~1 Foo.0.I1dtihf1.ttu4jtydr1 5
+      (kv ~5 data.0.I1dtihf1.ttu4jtydr1 2 x.4)))) ~2,~1
    (ret result.4))) 7,5
- (type :Foo.0.Iw8bgj.ttuv4zf4c1 .
-  (at Foo.0.ttuv4zf4c1 1
+ (type :Foo.0.I8pgvwy1.ttu4jtydr1 .
+  (at Foo.0.ttu4jtydr1 1
    (i -1)) 2,~4 . 4,~4
   (object . ~7,1
-   (fld :data.0.Iw8bgj.ttuv4zf4c1 . . 4,3
+   (fld :data.0.I8pgvwy1.ttu4jtydr1 . . 4,3
     (i -1) .))) 7,8
- (type :Foo.0.Ildbpdf1.ttuv4zf4c1 .
-  (at Foo.0.ttuv4zf4c1 1
+ (type :Foo.0.Ieo8a041.ttu4jtydr1 .
+  (at Foo.0.ttu4jtydr1 1
    (tuple 1
     (i -1) 6
     (i -1))) 2,~7 . 4,~7
   (object . ~7,1
-   (fld :data.0.Ildbpdf1.ttuv4zf4c1 . . 4,6
+   (fld :data.0.Ieo8a041.ttu4jtydr1 . . 4,6
     (tuple 1
      (i -1) 6
      (i -1)) .))) 11,12
- (type :Foo.0.Iv5bnz4.ttuv4zf4c1 .
-  (at Foo.0.ttuv4zf4c1 14,3
+ (type :Foo.0.I5hv486.ttu4jtydr1 .
+  (at Foo.0.ttu4jtydr1 14,3
    (tuple
     (kv ~1 a
      (i -1)) 6
     (kv ~1 b string.0.sysvq0asl))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.0.Iv5bnz4.ttuv4zf4c1 . . 21,13
+   (fld :data.0.I5hv486.ttu4jtydr1 . . 21,13
     (tuple
      (kv ~1 a
       (i -1)) 6
      (kv ~1 b string.0.sysvq0asl)) .))) 11,12
- (type :Foo.0.Iarhs7y1.ttuv4zf4c1 .
-  (at Foo.0.ttuv4zf4c1 14,7
+ (type :Foo.0.I1dtihf1.ttu4jtydr1 .
+  (at Foo.0.ttu4jtydr1 14,7
    (tuple
     (kv ~1 x string.0.sysvq0asl) 10
     (kv ~1 y
      (i -1)))) ~2,~11 . ,~11
   (object . ~7,1
-   (fld :data.0.Iarhs7y1.ttuv4zf4c1 . . 21,17
+   (fld :data.0.I1dtihf1.ttu4jtydr1 . . 21,17
     (tuple
      (kv ~1 x string.0.sysvq0asl) 10
      (kv ~1 y

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,2 +1,2 @@
 tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
-[2] expected: (i -1) but got: Foo.0.Iy40vk81.twrt5xaak
+[2] expected: (i -1) but got: Foo.0.Itk1gpi.twrupn78u1

--- a/tests/nimony/lookups/tambtype.msgs
+++ b/tests/nimony/lookups/tambtype.msgs
@@ -1,2 +1,2 @@
 tests/nimony/lookups/tambtype.nim(3, 8) Error: ambiguous identifier
-tests/nimony/lookups/tambtype.nim(3, 14) Error: type mismatch: got: (i -1) but wanted: (ochoice Foo.0.mamdoporf Foo.0.mamiajb2h)
+tests/nimony/lookups/tambtype.nim(3, 14) Error: type mismatch: got: (i -1) but wanted: (ochoice Foo.0.mamzpuf22 Foo.0.mamlmtudh1)

--- a/tests/nimony/modules/tfieldviserr.msgs
+++ b/tests/nimony/modules/tfieldviserr.msgs
@@ -1,4 +1,4 @@
-tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfil3x52c
-tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.Iect8g8.tfis16ujj
-tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.Iect8g8.tfis16ujj
+tests/nimony/modules/tfieldviserr.nim(3, 15) Error: undeclared field: 'private' for type Foo.0.mfivekjyu1
+tests/nimony/modules/tfieldviserr.nim(4, 12) Error: undeclared field: 'private' for type Foo.0.mfivekjyu1
+tests/nimony/modules/tfieldviserr.nim(6, 28) Error: undeclared field: 'private' for type Generic.0.Iqg8s6g1.tfiy8lqx21
+tests/nimony/modules/tfieldviserr.nim(7, 16) Error: undeclared field: 'private' for type Generic.0.Iqg8s6g1.tfiy8lqx21

--- a/tests/nimony/nosystem/t2.nif
+++ b/tests/nimony/nosystem/t2.nif
@@ -1,30 +1,30 @@
 (.nif24)
 0,2,tests/nimony/nosystem/t2.nim(stmts 2,1
- (type :int.0.t2er4ggt1
+ (type :int.0.t2oplpoj
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,3
- (type :float.0.t2er4ggt1
+ (type :float.0.t2oplpoj
   (f +64) . 7
   (pragmas 2
    (magic 7 Float)) .) 2,4
- (type :typedesc.0.t2er4ggt1
+ (type :typedesc.0.t2oplpoj
   (typedesc) 9
   (typevars 1
-   (typevar :T.0.t2er4ggt1 . . . .)) 13
+   (typevar :T.0.t2oplpoj . . . .)) 13
   (pragmas 2
    (magic 7 TypeDesc)) .) ,6
- (proc 5 :typeof.0.t2er4ggt1
+ (proc 5 :typeof.0.t2oplpoj
   (typeof) . 12
   (typevars 1
-   (typevar :T.1.t2er4ggt1 . . . .)) 15
+   (typevar :T.1.t2oplpoj . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.1.t2er4ggt1 .)) 16
-  (typedesc 1 T.1.t2er4ggt1) 35
+   (param :x.0 . . 3 T.1.t2oplpoj .)) 16
+  (typedesc 1 T.1.t2oplpoj) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,9
- (type ~8 :string.0.t2er4ggt1 x . . string.0.sysvq0asl) ,12
- (proc 5 :\2B.0.t2er4ggt1
+ (type ~8 :string.0.t2oplpoj x . . string.0.sysvq0asl) ,12
+ (proc 5 :\2B.0.t2oplpoj
   (add -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -34,7 +34,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,14
- (proc 5 :foo.0.t2er4ggt1 . . . 8
+ (proc 5 :foo.0.t2oplpoj . . . 8
   (params 1
    (param :x.2 . . 3
     (i -1) .) 9
@@ -47,7 +47,7 @@
    (asgn ~7 result.0 2 +4) 2,2
    (asgn ~2 x.4 2 "34") ~2,~1
    (ret result.0))) ,19
- (proc 5 :overloaded.0.t2er4ggt1 . . . 15
+ (proc 5 :overloaded.0.t2oplpoj . . . 15
   (params) . . . 2,1
   (stmts 4
    (let :someInt.0 . . 7,~8
@@ -55,10 +55,10 @@
     (add
      (i -1) 1 +23 5 +90)) ,1
    (discard 11
-    (call ~3 foo.0.t2er4ggt1 3
+    (call ~3 foo.0.t2oplpoj 3
      (add
       (i -1) ~2 +34 1 +56) 8 "xyz")))) ,23
- (proc 5 :exprReturn.0.t2er4ggt1 . . . 15
+ (proc 5 :exprReturn.0.t2oplpoj . . . 15
   (params 1
    (param :x.3 . . 3
     (i -1) .)) 10

--- a/tests/nimony/nosystem/tbinarytree.nif
+++ b/tests/nimony/nosystem/tbinarytree.nif
@@ -1,60 +1,60 @@
 (.nif24)
 0,1,tests/nimony/nosystem/tbinarytree.nim(stmts 5
- (type :int.0.tbimvo1d9
+ (type :int.0.tbitsvlox
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 10,3
- (type ~8 :NodeObj.0.tbimvo1d9 . . . 2
+ (type ~8 :NodeObj.0.tbitsvlox . . . 2
   (object . ~8,1
-   (fld :data.0.tbimvo1d9 . . 6
+   (fld :data.0.tbitsvlox . . 6
     (i -1) .) ~8,2
-   (fld :left.0.tbimvo1d9 . . 5,1
-    (ref 4 NodeObj.0.tbimvo1d9) .) ~2,2
-   (fld :right.0.tbimvo1d9 . . ~1,1
-    (ref 4 NodeObj.0.tbimvo1d9) .))) 7,6
- (type ~5 :Node.0.tbimvo1d9 . . . 2
-  (ref 4 NodeObj.0.tbimvo1d9)) 4,8
- (gvar :x.0.tbimvo1d9 . . 5,~2
-  (ref 4 NodeObj.0.tbimvo1d9) 8
+   (fld :left.0.tbitsvlox . . 5,1
+    (ref 4 NodeObj.0.tbitsvlox) .) ~2,2
+   (fld :right.0.tbitsvlox . . ~1,1
+    (ref 4 NodeObj.0.tbitsvlox) .))) 7,6
+ (type ~5 :Node.0.tbitsvlox . . . 2
+  (ref 4 NodeObj.0.tbitsvlox)) 4,8
+ (gvar :x.0.tbitsvlox . . 5,~2
+  (ref 4 NodeObj.0.tbitsvlox) 8
   (newobj ~3,~2
-   (ref 4 NodeObj.0.tbimvo1d9) 5
-   (kv ~5 data.0.tbimvo1d9 2 +123) 16
-   (kv ~16 left.0.tbimvo1d9 2
+   (ref 4 NodeObj.0.tbitsvlox) 5
+   (kv ~5 data.0.tbitsvlox 2 +123) 16
+   (kv ~16 left.0.tbitsvlox 2
     (nil)) 28
-   (kv ~28 right.0.tbimvo1d9 2
+   (kv ~28 right.0.tbitsvlox 2
     (nil)))) 7,9
  (asgn ~6
-  (ddot ~1 x.0.tbimvo1d9 data.0.tbimvo1d9 +0) 2 +456) 7,10
+  (ddot ~1 x.0.tbitsvlox data.0.tbitsvlox +0) 2 +456) 7,10
  (asgn ~6
-  (ddot ~1 x.0.tbimvo1d9 left.0.tbimvo1d9 +0) 6
+  (ddot ~1 x.0.tbitsvlox left.0.tbitsvlox +0) 6
   (newobj ~4,~4
-   (ref 4 NodeObj.0.tbimvo1d9) 5
-   (kv ~5 data.0.tbimvo1d9 2 +123) 16
-   (kv ~16 left.0.tbimvo1d9 2
+   (ref 4 NodeObj.0.tbitsvlox) 5
+   (kv ~5 data.0.tbitsvlox 2 +123) 16
+   (kv ~16 left.0.tbitsvlox 2
     (nil)) 28
-   (kv ~28 right.0.tbimvo1d9 2
+   (kv ~28 right.0.tbitsvlox 2
     (nil)))) 8,11
  (asgn ~7
-  (ddot ~1 x.0.tbimvo1d9 right.0.tbimvo1d9 +0) 2
+  (ddot ~1 x.0.tbitsvlox right.0.tbitsvlox +0) 2
   (nil)) 13,12
  (asgn ~7
   (ddot ~5
-   (ddot ~1 x.0.tbimvo1d9 left.0.tbimvo1d9 +0) right.0.tbimvo1d9 +0) 2
+   (ddot ~1 x.0.tbitsvlox left.0.tbitsvlox +0) right.0.tbitsvlox +0) 2
   (nil)) 4,13
- (gvar :y.0.tbimvo1d9 . . 5,~7
-  (ref 4 NodeObj.0.tbimvo1d9) 8
+ (gvar :y.0.tbitsvlox . . 5,~7
+  (ref 4 NodeObj.0.tbitsvlox) 8
   (newobj ~3,~7
-   (ref 4 NodeObj.0.tbimvo1d9) 5
-   (kv ~5 data.0.tbimvo1d9 2 +987) 16
-   (kv ~16 left.0.tbimvo1d9 2
+   (ref 4 NodeObj.0.tbitsvlox) 5
+   (kv ~5 data.0.tbitsvlox 2 +987) 16
+   (kv ~16 left.0.tbitsvlox 2
     (nil)) 28
-   (kv ~28 right.0.tbimvo1d9 2
+   (kv ~28 right.0.tbitsvlox 2
     (nil)))) 12,14
  (asgn ~6
   (ddot ~5
-   (ddot ~1 x.0.tbimvo1d9 left.0.tbimvo1d9 +0) left.0.tbimvo1d9 +0) 15
+   (ddot ~1 x.0.tbitsvlox left.0.tbitsvlox +0) left.0.tbitsvlox +0) 15
   (newobj ~18,~8
-   (ref 4 NodeObj.0.tbimvo1d9) 5
-   (kv ~5 data.0.tbimvo1d9 2 -123) 17
-   (kv ~17 left.0.tbimvo1d9 2 y.0.tbimvo1d9) 27
-   (kv ~27 right.0.tbimvo1d9 2 y.0.tbimvo1d9))))
+   (ref 4 NodeObj.0.tbitsvlox) 5
+   (kv ~5 data.0.tbitsvlox 2 -123) 17
+   (kv ~17 left.0.tbitsvlox 2 y.0.tbitsvlox) 27
+   (kv ~27 right.0.tbitsvlox 2 y.0.tbitsvlox))))

--- a/tests/nimony/nosystem/tbool.nif
+++ b/tests/nimony/nosystem/tbool.nif
@@ -1,20 +1,20 @@
 (.nif24)
 0,1,tests/nimony/nosystem/tbool.nim(stmts 26
- (type ~21 :bool.0.tbokvwxm9
+ (type ~21 :bool.0.tbo17jbuq1
   (bool) . ~16
   (pragmas 2
    (magic 7 Bool)) 2
   (enum
    (u +8) ~18,1
-   (efld ~8 :false.0.tbokvwxm9
+   (efld ~8 :false.0.tbo17jbuq1
     (false) .
     (bool)
     (tup +0 "false")) ~8,1
-   (efld ~7 :true.0.tbokvwxm9
+   (efld ~7 :true.0.tbo17jbuq1
     (true) .
     (bool)
     (tup +1 "true")))) 5
- (proc :dollar`.bool.0.tbokvwxm9 x . .
+ (proc :dollar`.bool.0.tbo17jbuq1 x . .
   (params
    (param :e.0 . .
     (bool) .)) string.0.sysvq0asl . .
@@ -32,6 +32,6 @@
      (stmts
       (ret "true"))))
    (ret result.0))) 4,3
- (glet :x.0.tbokvwxm9 . . 1,~3
+ (glet :x.0.tbo17jbuq1 . . 1,~3
   (bool) 10
   (true)))

--- a/tests/nimony/nosystem/tcstring.nif
+++ b/tests/nimony/nosystem/tcstring.nif
@@ -1,22 +1,22 @@
 (.nif24)
 0,2,tests/nimony/nosystem/tcstring.nim(stmts 2,1
- (type :int.0.tcsj45p9m
+ (type :int.0.tcsaaosui1
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,2
- (type :bool.0.tcsj45p9m
+ (type :bool.0.tcsaaosui1
   (bool) . 6
   (pragmas 2
    (magic 7 Bool)) .) 2,4
- (type :cstring.0.tcsj45p9m
+ (type :cstring.0.tcsaaosui1
   (cstring) . 9
   (pragmas 2
    (magic 7 Cstring)) .) 2,5
- (type :pointer.0.tcsj45p9m
+ (type :pointer.0.tcsaaosui1
   (pointer) . 9
   (pragmas 2
    (magic 7 Pointer)) .) ,8
- (proc 5 :\2B.0.tcsj45p9m
+ (proc 5 :\2B.0.tcsaaosui1
   (add -3) . . 9
   (params 1
    (param :x.0 . . 6
@@ -26,7 +26,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,9
- (proc 5 :\2D.0.tcsj45p9m
+ (proc 5 :\2D.0.tcsaaosui1
   (sub -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -36,7 +36,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,11
- (proc 5 :<=.0.tcsj45p9m
+ (proc 5 :<=.0.tcsaaosui1
   (le -3) . . 10
   (params 1
    (param :x.2 . . 6
@@ -46,19 +46,19 @@
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) 4,13
- (gvar :x.0.tcsj45p9m . . 12,~5
+ (gvar :x.0.tcsaaosui1 . . 12,~5
   (i -1) 4
   (cast 5
    (i -1) 10 +55)) 4,15
- (gvar :y.0.tcsj45p9m . . 3
+ (gvar :y.0.tcsaaosui1 . . 3
   (pointer) 13
   (nil)) 2,18
- (const :myconst.0.tcsj45p9m . . 10
+ (const :myconst.0.tcsaaosui1 . . 10
   (cstring) 17
   (conv ~7
    (cstring)
    (suf "abc" "R"))) 4,20
- (gvar :zz.0.tcsj45p9m . . 4
+ (gvar :zz.0.tcsaaosui1 . . 4
   (cstring)
   (hconv 8,22,tests/nimony/nosystem/tcstring.nim
    (cstring) 18,22,tests/nimony/nosystem/tcstring.nim "xzy")))

--- a/tests/nimony/nosystem/tdefinedarg.nif
+++ b/tests/nimony/nosystem/tdefinedarg.nif
@@ -1,22 +1,22 @@
 (.nif24)
 0,1,tests/nimony/nosystem/tdefinedarg.nim(stmts 5
- (type :untyped.0.tdej0g1hh1
+ (type :untyped.0.tdeoeo7gr1
   (untyped) . 9
   (pragmas 2
    (magic 7 Expr)) .) ,2
- (proc 5 :defined.0.tdej0g1hh1
+ (proc 5 :defined.0.tdeoeo7gr1
   (defined) . . 12
   (params 1
    (param :x.0 . . 3
     (untyped) .)) . 25
   (pragmas 2
    (magic 7 Defined)) . .) 4,4
- (glet :x.0.tdej0g1hh1 . .
+ (glet :x.0.tdeoeo7gr1 . .
   (bool) 12
   (false)) 4,5
- (glet :y.0.tdej0g1hh1 . .
+ (glet :y.0.tdeoeo7gr1 . .
   (bool) 12
   (true)) 4,6
- (glet :z.0.tdej0g1hh1 . .
+ (glet :z.0.tdeoeo7gr1 . .
   (bool) 15
   (false)))

--- a/tests/nimony/nosystem/tdistinct.nif
+++ b/tests/nimony/nosystem/tdistinct.nif
@@ -1,38 +1,38 @@
 (.nif24)
 0,2,tests/nimony/nosystem/tdistinct.nim(stmts 2,1
- (type :int.0.tdiuhv8dm
+ (type :int.0.tdi05qu67
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,2
- (type :bool.0.tdiuhv8dm
+ (type :bool.0.tdi05qu67
   (bool) . 6
   (pragmas 2
    (magic 7 Bool)) .) 2,3
- (type :char.0.tdiuhv8dm
+ (type :char.0.tdi05qu67
   (c +8) . 6
   (pragmas 2
    (magic 7 Char)) .) 2,5
- (type :int8.0.tdiuhv8dm
+ (type :int8.0.tdi05qu67
   (i +8) . 6
   (pragmas 2
    (magic 7 Int8)) .) 2,6
- (type :typedesc.0.tdiuhv8dm
+ (type :typedesc.0.tdi05qu67
   (typedesc) 9
   (typevars 1
-   (typevar :T.0.tdiuhv8dm . . . .)) 13
+   (typevar :T.0.tdi05qu67 . . . .)) 13
   (pragmas 2
    (magic 7 TypeDesc)) .) ,8
- (proc 5 :typeof.0.tdiuhv8dm
+ (proc 5 :typeof.0.tdi05qu67
   (typeof) . 12
   (typevars 1
-   (typevar :T.1.tdiuhv8dm . . . .)) 15
+   (typevar :T.1.tdi05qu67 . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.1.tdiuhv8dm .)) 16
-  (typedesc 1 T.1.tdiuhv8dm) 35
+   (param :x.0 . . 3 T.1.tdi05qu67 .)) 16
+  (typedesc 1 T.1.tdi05qu67) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,11
- (type ~8 :string.0.tdiuhv8dm x . . string.0.sysvq0asl) ,13
- (proc 5 :\2B.0.tdiuhv8dm
+ (type ~8 :string.0.tdi05qu67 x . . string.0.sysvq0asl) ,13
+ (proc 5 :\2B.0.tdi05qu67
   (add -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -42,7 +42,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,14
- (proc 5 :\2D.0.tdiuhv8dm
+ (proc 5 :\2D.0.tdi05qu67
   (sub -3) . . 9
   (params 1
    (param :x.2 . . 6
@@ -52,7 +52,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,16
- (proc 5 :<=.0.tdiuhv8dm
+ (proc 5 :<=.0.tdi05qu67
   (le -3) . . 10
   (params 1
    (param :x.3 . . 6
@@ -62,28 +62,28 @@
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) 9,20
- (type ~7 :VarId.0.tdiuhv8dm x . . 2
+ (type ~7 :VarId.0.tdi05qu67 x . . 2
   (distinct 9
    (i -1))) ,22
- (proc 5 :\2B.1.tdiuhv8dm x . . 9
+ (proc 5 :\2B.1.tdi05qu67 x . . 9
   (params 1
-   (param :x.4 . . 6 VarId.0.tdiuhv8dm .) 4
-   (param :y.3 . . 3 VarId.0.tdiuhv8dm .)) 15 VarId.0.tdiuhv8dm 30
+   (param :x.4 . . 6 VarId.0.tdi05qu67 .) 4
+   (param :y.3 . . 3 VarId.0.tdi05qu67 .)) 15 VarId.0.tdi05qu67 30
   (pragmas 2
    (borrow)) . 9
   (stmts
    (ret
-    (dconv 6 VarId.0.tdiuhv8dm
+    (dconv 6 VarId.0.tdi05qu67
      (add 7,~9
       (i -1)
       (dconv 11,~2
        (i -1) x.4)
       (dconv 11,~2
        (i -1) y.3)))))) 4,29
- (gvar :x.0.tdiuhv8dm . . 3 VarId.0.tdiuhv8dm .) 2,31
- (asgn ~2 x.0.tdiuhv8dm 4
-  (infix \2B.1.tdiuhv8dm ~2 x.0.tdiuhv8dm 2 x.0.tdiuhv8dm)) 4,33
- (glet :y.0.tdiuhv8dm . . 4
+ (gvar :x.0.tdi05qu67 . . 3 VarId.0.tdi05qu67 .) 2,31
+ (asgn ~2 x.0.tdi05qu67 4
+  (infix \2B.1.tdi05qu67 ~2 x.0.tdi05qu67 2 x.0.tdi05qu67)) 4,33
+ (glet :y.0.tdi05qu67 . . 4
   (i +8) 8
   (conv ~4
-   (i +8) 1 x.0.tdiuhv8dm)))
+   (i +8) 1 x.0.tdi05qu67)))

--- a/tests/nimony/nosystem/tenumsizes.nif
+++ b/tests/nimony/nosystem/tenumsizes.nif
@@ -1,104 +1,104 @@
 (.nif24)
 0,3,tests/nimony/nosystem/tenumsizes.nim(stmts 7
- (type ~2 :A.0.tene657oj . . . 2
+ (type ~2 :A.0.tenyojnr01 . . . 2
   (enum
    (u +8) ~7,1
-   (efld :a0.0.tene657oj . . A.0.tene657oj
+   (efld :a0.0.tenyojnr01 . . A.0.tenyojnr01
     (tup +0 "a0")) ~3,1
-   (efld :a1.0.tene657oj . . A.0.tene657oj
+   (efld :a1.0.tenyojnr01 . . A.0.tenyojnr01
     (tup +1 "a1")) 1,1
-   (efld :a2.0.tene657oj . . A.0.tene657oj
+   (efld :a2.0.tenyojnr01 . . A.0.tenyojnr01
     (tup +2 "a2")) 5,1
-   (efld :a3.0.tene657oj . . A.0.tene657oj
+   (efld :a3.0.tenyojnr01 . . A.0.tenyojnr01
     (tup +3 "a3")))) 5
- (proc :dollar`.A.0.tene657oj x . .
+ (proc :dollar`.A.0.tenyojnr01 x . .
   (params
-   (param :e.0 . . A.0.tene657oj .)) string.0.sysvq0asl . .
+   (param :e.0 . . A.0.tenyojnr01 .)) string.0.sysvq0asl . .
   (stmts 4
    (result :result.0 . . string.0.sysvq0asl .) 4
    (case e.0 ~7,1
     (of
-     (ranges a0.0.tene657oj)
+     (ranges a0.0.tenyojnr01)
      (stmts
       (ret "a0"))) ~3,1
     (of
-     (ranges a1.0.tene657oj)
+     (ranges a1.0.tenyojnr01)
      (stmts
       (ret "a1"))) 1,1
     (of
-     (ranges a2.0.tene657oj)
+     (ranges a2.0.tenyojnr01)
      (stmts
       (ret "a2"))) 5,1
     (of
-     (ranges a3.0.tene657oj)
+     (ranges a3.0.tenyojnr01)
      (stmts
       (ret "a3"))))
    (ret result.0))) 7,2
- (type ~2 :B.0.tene657oj . . . 2
+ (type ~2 :B.0.tenyojnr01 . . . 2
   (onum
    (i +32) ~2,1
-   (efld ~5 :b0.0.tene657oj . . B.0.tene657oj
+   (efld ~5 :b0.0.tenyojnr01 . . B.0.tenyojnr01
     (tup -1 "b0")) 2,1
-   (efld :b1.0.tene657oj . . B.0.tene657oj
+   (efld :b1.0.tenyojnr01 . . B.0.tenyojnr01
     (tup +0 "b1")) 6,1
-   (efld :b2.0.tene657oj . . B.0.tene657oj
+   (efld :b2.0.tenyojnr01 . . B.0.tenyojnr01
     (tup +1 "b2")) 15,1
-   (efld ~5 :b3.0.tene657oj . . B.0.tene657oj
+   (efld ~5 :b3.0.tenyojnr01 . . B.0.tenyojnr01
     (tup +5 "b3")))) 5,2
- (proc :dollar`.B.0.tene657oj x . .
+ (proc :dollar`.B.0.tenyojnr01 x . .
   (params
-   (param :e.1 . . B.0.tene657oj .)) string.0.sysvq0asl . .
+   (param :e.1 . . B.0.tenyojnr01 .)) string.0.sysvq0asl . .
   (stmts 4
    (result :result.1 . . string.0.sysvq0asl .) 4
    (case e.1 ~2,1
     (of
-     (ranges ~5 b0.0.tene657oj)
+     (ranges ~5 b0.0.tenyojnr01)
      (stmts
       (ret "b0"))) 2,1
     (of
-     (ranges b1.0.tene657oj)
+     (ranges b1.0.tenyojnr01)
      (stmts
       (ret "b1"))) 6,1
     (of
-     (ranges b2.0.tene657oj)
+     (ranges b2.0.tenyojnr01)
      (stmts
       (ret "b2"))) 15,1
     (of
-     (ranges ~5 b3.0.tene657oj)
+     (ranges ~5 b3.0.tenyojnr01)
      (stmts
       (ret "b3"))))
    (ret result.1))) 7,4
- (type ~2 :C.0.tene657oj . . . 2
+ (type ~2 :C.0.tenyojnr01 . . . 2
   (onum
    (u +16) ~7,1
-   (efld :c0.0.tene657oj . . C.0.tene657oj
+   (efld :c0.0.tenyojnr01 . . C.0.tenyojnr01
     (tup +0 "c0")) ~3,1
-   (efld :c1.0.tene657oj . . C.0.tene657oj
+   (efld :c1.0.tenyojnr01 . . C.0.tenyojnr01
     (tup +1 "c1")) 6,1
-   (efld ~5 :c2.0.tene657oj . . C.0.tene657oj
+   (efld ~5 :c2.0.tenyojnr01 . . C.0.tenyojnr01
     (tup +30000 "c2")) 14,1
-   (efld :c3.0.tene657oj . . C.0.tene657oj
+   (efld :c3.0.tenyojnr01 . . C.0.tenyojnr01
     (tup +30001 "c3")))) 5,4
- (proc :dollar`.C.0.tene657oj x . .
+ (proc :dollar`.C.0.tenyojnr01 x . .
   (params
-   (param :e.2 . . C.0.tene657oj .)) string.0.sysvq0asl . .
+   (param :e.2 . . C.0.tenyojnr01 .)) string.0.sysvq0asl . .
   (stmts 4
    (result :result.2 . . string.0.sysvq0asl .) 4
    (case e.2 ~7,1
     (of
-     (ranges c0.0.tene657oj)
+     (ranges c0.0.tenyojnr01)
      (stmts
       (ret "c0"))) ~3,1
     (of
-     (ranges c1.0.tene657oj)
+     (ranges c1.0.tenyojnr01)
      (stmts
       (ret "c1"))) 6,1
     (of
-     (ranges ~5 c2.0.tene657oj)
+     (ranges ~5 c2.0.tenyojnr01)
      (stmts
       (ret "c2"))) 14,1
     (of
-     (ranges c3.0.tene657oj)
+     (ranges c3.0.tenyojnr01)
      (stmts
       (ret "c3"))))
    (ret result.2))))

--- a/tests/nimony/nosystem/tfib2.nif
+++ b/tests/nimony/nosystem/tfib2.nif
@@ -1,18 +1,18 @@
 (.nif24)
 0,2,tests/nimony/nosystem/tfib2.nim(stmts 2,1
- (type :int.0.tfitjdpcx
+ (type :int.0.tfiajbpjs1
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,2
- (type :bool.0.tfitjdpcx
+ (type :bool.0.tfiajbpjs1
   (bool) . 6
   (pragmas 2
    (magic 7 Bool)) .) 2,3
- (type :float.0.tfitjdpcx
+ (type :float.0.tfiajbpjs1
   (f +64) . 7
   (pragmas 2
    (magic 7 Float)) .) ,5
- (proc 5 :\2B.0.tfitjdpcx
+ (proc 5 :\2B.0.tfiajbpjs1
   (add -3) . . 9
   (params 1
    (param :x.0 . . 6
@@ -22,7 +22,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,6
- (proc 5 :\2D.0.tfitjdpcx
+ (proc 5 :\2D.0.tfiajbpjs1
   (sub -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -32,7 +32,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,8
- (proc 5 :<=.0.tfitjdpcx
+ (proc 5 :<=.0.tfiajbpjs1
   (le -3) . . 10
   (params 1
    (param :x.2 . . 6
@@ -42,7 +42,7 @@
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) ,10
- (proc 5 :\2B.1.tfitjdpcx
+ (proc 5 :\2B.1.tfiajbpjs1
   (add -3) . . 9
   (params 1
    (param :x.3 . . 6
@@ -52,7 +52,7 @@
   (f +64) 30
   (pragmas 2
    (magic 7 "AddF64")) . .) ,11
- (proc 5 :\2D.1.tfitjdpcx
+ (proc 5 :\2D.1.tfiajbpjs1
   (sub -3) . . 9
   (params 1
    (param :x.4 . . 6
@@ -62,7 +62,7 @@
   (f +64) 30
   (pragmas 2
    (magic 7 "SubF64")) . .) ,13
- (proc 5 :<=.1.tfitjdpcx
+ (proc 5 :<=.1.tfiajbpjs1
   (le -3) . . 10
   (params 1
    (param :x.5 . . 6
@@ -72,30 +72,30 @@
   (bool) 30
   (pragmas 2
    (magic 7 "LeF64")) . .) 10,17
- (type ~8 :Fibable.0.tfitjdpcx . . . 2
+ (type ~8 :Fibable.0.tfiajbpjs1 . . . 2
   (concept . .
-   (typevar :Self.0.tfitjdpcx . . . .) ~8,1
+   (typevar :Self.0.tfiajbpjs1 . . . .) ~8,1
    (stmts
     (proc 5 :<=.0 . . . 9
      (params 1
-      (param :a.0 . . 6 Self.0.tfitjdpcx .) 4
-      (param :b.0 . . 3 Self.0.tfitjdpcx .)) 14
+      (param :a.0 . . 6 Self.0.tfiajbpjs1 .) 4
+      (param :b.0 . . 3 Self.0.tfiajbpjs1 .)) 14
      (bool) . . .) ,1
     (proc 5 :\2B.0 . . . 8
      (params 1
-      (param :x.6 . . 6 Self.0.tfitjdpcx .) 4
-      (param :y.6 . . 3 Self.0.tfitjdpcx .)) 14 Self.0.tfitjdpcx . . .) ,2
+      (param :x.6 . . 6 Self.0.tfiajbpjs1 .) 4
+      (param :y.6 . . 3 Self.0.tfiajbpjs1 .)) 14 Self.0.tfiajbpjs1 . . .) ,2
     (proc 5 :\2D.0 . . . 8
      (params 1
-      (param :x.7 . . 6 Self.0.tfitjdpcx .) 4
-      (param :y.7 . . 3 Self.0.tfitjdpcx .)) 14 Self.0.tfitjdpcx . . .)))) ,22
- (proc 5 :fib.0.tfitjdpcx . . 8
+      (param :x.7 . . 6 Self.0.tfiajbpjs1 .) 4
+      (param :y.7 . . 3 Self.0.tfiajbpjs1 .)) 14 Self.0.tfiajbpjs1 . . .)))) ,22
+ (proc 5 :fib.0.tfiajbpjs1 . . 8
   (typevars 1
-   (typevar :T.0.tfitjdpcx . . 3 Fibable.0.tfitjdpcx .)) 20
+   (typevar :T.0.tfiajbpjs1 . . 3 Fibable.0.tfiajbpjs1 .)) 20
   (params 1
-   (param :a.1 . . 3 T.0.tfitjdpcx .)) 8 T.0.tfitjdpcx . . 2,1
+   (param :a.1 . . 3 T.0.tfiajbpjs1 .)) 8 T.0.tfiajbpjs1 . . 2,1
   (stmts
-   (result :result.0 . . 22,~1 T.0.tfitjdpcx .)
+   (result :result.0 . . 22,~1 T.0.tfiajbpjs1 .)
    (if 3
     (elif 2
      (infix <= ~2 a.1 3 +2) ~1,1
@@ -105,17 +105,17 @@
      (stmts 7
       (asgn ~7 result.0 11
        (infix \2B ~6
-        (call ~3 fib.0.tfitjdpcx 2
+        (call ~3 fib.0.tfiajbpjs1 2
          (infix \2D ~1 a.1 1 +1)) 5
-        (call ~3 fib.0.tfitjdpcx 2
+        (call ~3 fib.0.tfiajbpjs1 2
          (infix \2D ~1 a.1 1 +2))))))) ~2,~1
    (ret result.0))) ,28
  (discard 11
-  (call ~3 fib.1.tfitjdpcx 1 +8)) ,29
+  (call ~3 fib.1.tfiajbpjs1 1 +8)) ,29
  (discard 16
-  (call ~8 fib.1.tfitjdpcx 1 +8)) 11,28
- (proc :fib.1.tfitjdpcx . ~11,~6 .
-  (at fib.0.tfitjdpcx
+  (call ~8 fib.1.tfiajbpjs1 1 +8)) 11,28
+ (proc :fib.1.tfiajbpjs1 . ~11,~6 .
+  (at fib.0.tfiajbpjs1
    (i -1)) 9,~6
   (params 1
    (param :a.3 . .
@@ -135,10 +135,10 @@
       (asgn ~7 result.1 11
        (add ~6,~21
         (i -1) ~6
-        (call ~3 fib.1.tfitjdpcx 2
+        (call ~3 fib.1.tfiajbpjs1 2
          (sub
           (i -1) ~1 a.3 1 +1)) 5
-        (call ~3 fib.1.tfitjdpcx 2
+        (call ~3 fib.1.tfiajbpjs1 2
          (sub
           (i -1) ~1 a.3 1 +2))))))) ~2,~1
    (ret result.1))))

--- a/tests/nimony/nosystem/tforloop.nif
+++ b/tests/nimony/nosystem/tforloop.nif
@@ -1,14 +1,14 @@
 (.nif24)
 0,2,tests/nimony/nosystem/tforloop.nim(stmts 2,1
- (type :int.0.tfov349y21
+ (type :int.0.tfogxvrp1
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,2
- (type :bool.0.tfov349y21
+ (type :bool.0.tfogxvrp1
   (bool) . 6
   (pragmas 2
    (magic 7 Bool)) .) ,4
- (proc 5 :\2B.0.tfov349y21
+ (proc 5 :\2B.0.tfogxvrp1
   (add -3) . . 9
   (params 1
    (param :x.0 . . 6
@@ -18,7 +18,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,5
- (proc 5 :\2D.0.tfov349y21
+ (proc 5 :\2D.0.tfogxvrp1
   (sub -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -28,7 +28,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,7
- (proc 5 :<=.0.tfov349y21
+ (proc 5 :<=.0.tfogxvrp1
   (le -3) . . 10
   (params 1
    (param :x.2 . . 6
@@ -38,7 +38,7 @@
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) ,9
- (iterator 9 :countup.0.tfov349y21 . . . 16
+ (iterator 9 :countup.0.tfogxvrp1 . . . 16
   (params 1
    (param :a.0 . . 6
     (i -1) .) 4
@@ -57,7 +57,7 @@
       (add 13,~4
        (i -1) ~2 x.3 2 +1)))))) 4,15
  (for 20
-  (call ~7 countup.0.tfov349y21 1 +0 4 +44)
+  (call ~7 countup.0.tfogxvrp1 1 +0 4 +44)
   (unpackflat
    (let :mycounter.0 . . 9,~6
     (i -1) .)) ~2,1

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -1,88 +1,88 @@
 (.nif24)
 0,2,tests/nimony/nosystem/tgeneric_obj.nim(stmts 2,1
- (type :int.0.tge7jvqqk1
+ (type :int.0.tge244bit
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,3
- (type :float.0.tge7jvqqk1
+ (type :float.0.tge244bit
   (f +64) . 7
   (pragmas 2
    (magic 7 Float)) .) 2,4
- (type :char.0.tge7jvqqk1
+ (type :char.0.tge244bit
   (c +8) . 6
   (pragmas 2
    (magic 7 Char)) .) 2,5
- (type :uint8.0.tge7jvqqk1
+ (type :uint8.0.tge244bit
   (u +8) . 7
   (pragmas 2
    (magic 7 UInt8)) .) 2,7
- (type :set.0.tge7jvqqk1
+ (type :set.0.tge244bit
   (set) 4
   (typevars 1
-   (typevar :T.0.tge7jvqqk1 . . . .)) 8
+   (typevar :T.0.tge244bit . . . .)) 8
   (pragmas 2
    (magic 7 Set)) .) 2,8
- (type :array.0.tge7jvqqk1
+ (type :array.0.tge244bit
   (array) 7
   (typevars 1
-   (typevar :Index.0.tge7jvqqk1 . . . .) 8
-   (typevar :T.1.tge7jvqqk1 . . . .)) 18
+   (typevar :Index.0.tge244bit . . . .) 8
+   (typevar :T.1.tge244bit . . . .)) 18
   (pragmas 2
    (magic 7 Array)) .) 2,9
- (type :typedesc.0.tge7jvqqk1
+ (type :typedesc.0.tge244bit
   (typedesc) 9
   (typevars 1
-   (typevar :T.2.tge7jvqqk1 . . . .)) 13
+   (typevar :T.2.tge244bit . . . .)) 13
   (pragmas 2
    (magic 7 TypeDesc)) .) ,11
- (proc 5 :typeof.0.tge7jvqqk1
+ (proc 5 :typeof.0.tge244bit
   (typeof) . 12
   (typevars 1
-   (typevar :T.6.tge7jvqqk1 . . . .)) 15
+   (typevar :T.6.tge244bit . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.6.tge7jvqqk1 .)) 16
-  (typedesc 1 T.6.tge7jvqqk1) 35
+   (param :x.0 . . 3 T.6.tge244bit .)) 16
+  (typedesc 1 T.6.tge244bit) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,14
- (type ~8 :string.0.tge7jvqqk1 x . . string.0.sysvq0asl) 4,16
- (gvar :myset.0.tge7jvqqk1 . . 10
+ (type ~8 :string.0.tge244bit x . . string.0.sysvq0asl) 4,16
+ (gvar :myset.0.tge244bit . . 10
   (set 1
    (u +8)) .) 4,17
- (gvar :myarr.0.tge7jvqqk1 . . 12
+ (gvar :myarr.0.tge244bit . . 12
   (array 4
    (i -1)
    (rangetype
     (i -1) +0 +2)) .) 4,18
- (glet :u8.0.tge7jvqqk1 . .
+ (glet :u8.0.tge244bit . .
   (u +8) 5
   (suf +3u "u8")) 6,19
- (asgn ~6 myset.0.tge7jvqqk1 2
+ (asgn ~6 myset.0.tge244bit 2
   (setconstr 6,~3
    (set 1
     (u +8)) 1
-   (suf +1u "u8") 7 u8.0.tge7jvqqk1 11
+   (suf +1u "u8") 7 u8.0.tge244bit 11
    (suf +5u "u8") 17
    (range
     (suf +7u "u8") 6
     (suf +9u "u8")))) 6,20
- (asgn ~6 myarr.0.tge7jvqqk1 2
+ (asgn ~6 myarr.0.tge244bit 2
   (aconstr 8,~3
    (array 4
     (i -1)
     (rangetype
      (i -1) +0 +2)) 1 +1 4 +2 7 +3)) 15,23
- (type ~13 :MyGeneric.0.tge7jvqqk1 . ~4
+ (type ~13 :MyGeneric.0.tge244bit . ~4
   (typevars 1
-   (typevar :T.3.tge7jvqqk1 . . . .)) . 2
+   (typevar :T.3.tge244bit . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tge7jvqqk1 . . 3 T.3.tge7jvqqk1 .))) 2,27
- (gvar :myglob.0.tge7jvqqk1 . . 17 MyGeneric.0.I8smrpu.tge7jvqqk1 .) 2,28
- (gvar :other.0.tge7jvqqk1 . . 16 MyGeneric.0.Iliphp3.tge7jvqqk1 .) 9,30
+   (fld :x.0.tge244bit . . 3 T.3.tge244bit .))) 2,27
+ (gvar :myglob.0.tge244bit . . 17 MyGeneric.0.Ix1o1r81.tge244bit .) 2,28
+ (gvar :other.0.tge244bit . . 16 MyGeneric.0.Ip4d2b9.tge244bit .) 9,30
  (asgn ~3
-  (dot ~6 myglob.0.tge7jvqqk1 x.0.I8smrpu.tge7jvqqk1 +0) 2 +56) 8,31
+  (dot ~6 myglob.0.tge244bit x.0.Ix1o1r81.tge244bit +0) 2 +56) 8,31
  (asgn ~3
-  (dot ~5 other.0.tge7jvqqk1 x.0.Iliphp3.tge7jvqqk1 +0) 2 +79.0) ,33
- (proc 5 :\2B.0.tge7jvqqk1
+  (dot ~5 other.0.tge244bit x.0.Ip4d2b9.tge244bit +0) 2 +79.0) ,33
+ (proc 5 :\2B.0.tge244bit
   (add -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -92,11 +92,11 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,35
- (template 9 :foobar.0.tge7jvqqk1 . . . 15
+ (template 9 :foobar.0.tge244bit . . . 15
   (params) . . . 2,1
   (stmts
    (break .))) ,38
- (proc 5 :foo.0.tge7jvqqk1 . . . 8
+ (proc 5 :foo.0.tge244bit . . . 8
   (params 1
    (param :x.2 . . 3
     (i -1) .) 9
@@ -109,7 +109,7 @@
    (asgn ~7 result.0 2 +4) 2,2
    (asgn ~2 x.5 2 "34") ~2,~1
    (ret result.0))) ,43
- (proc 5 :overloaded.0.tge7jvqqk1 . . . 15
+ (proc 5 :overloaded.0.tge244bit . . . 15
   (params) . . . 2,1
   (stmts 4
    (let :someInt.0 . . 7,~11
@@ -117,45 +117,45 @@
     (add
      (i -1) 1 +23 5 +90)) ,1
    (discard 11
-    (call ~3 foo.0.tge7jvqqk1 3
+    (call ~3 foo.0.tge244bit 3
      (add
       (i -1) ~2 +34 1 +56) 8 "xyz")))) 16,48
- (type ~14 :HSlice.0.tge7jvqqk1 x ~7
+ (type ~14 :HSlice.0.tge244bit x ~7
   (typevars 1
-   (typevar :T.4.tge7jvqqk1 . . . .) 4
-   (typevar :U.0.tge7jvqqk1 . . . .)) . 2
+   (typevar :T.4.tge244bit . . . .) 4
+   (typevar :U.0.tge244bit . . . .)) . 2
   (object . ~14,1
-   (fld :a.0.tge7jvqqk1 . . 3 T.4.tge7jvqqk1 .) ~14,2
-   (fld :b.0.tge7jvqqk1 . . 3 U.0.tge7jvqqk1 .))) 12,51
- (type ~10 :Slice.0.tge7jvqqk1 x ~4
+   (fld :a.0.tge244bit . . 3 T.4.tge244bit .) ~14,2
+   (fld :b.0.tge244bit . . 3 U.0.tge244bit .))) 12,51
+ (type ~10 :Slice.0.tge244bit x ~4
   (typevars 1
-   (typevar :T.5.tge7jvqqk1 . . . .)) . 8
-  (at ~6 HSlice.0.tge7jvqqk1 1 T.5.tge7jvqqk1 4 T.5.tge7jvqqk1)) ,53
- (proc 5 :\2E..0.tge7jvqqk1 x . 10
+   (typevar :T.5.tge244bit . . . .)) . 8
+  (at ~6 HSlice.0.tge244bit 1 T.5.tge244bit 4 T.5.tge244bit)) ,53
+ (proc 5 :\2E..0.tge244bit x . 10
   (typevars 1
-   (typevar :T.7.tge7jvqqk1 . . . .) 4
-   (typevar :U.1.tge7jvqqk1 . . . .)) 16
+   (typevar :T.7.tge244bit . . . .) 4
+   (typevar :U.1.tge244bit . . . .)) 16
   (params 1
-   (param :a.0 . . 3 T.7.tge7jvqqk1 .) 7
-   (param :b.0 . . 3 U.1.tge7jvqqk1 .)) 20
-  (at ~6 HSlice.0.tge7jvqqk1 1 T.7.tge7jvqqk1 4 U.1.tge7jvqqk1) . . 45
+   (param :a.0 . . 3 T.7.tge244bit .) 7
+   (param :b.0 . . 3 U.1.tge244bit .)) 20
+  (at ~6 HSlice.0.tge244bit 1 T.7.tge244bit 4 U.1.tge244bit) . . 45
   (stmts
    (result :result.1 . . ~25
-    (at ~6 HSlice.0.tge7jvqqk1 1 T.7.tge7jvqqk1 4 U.1.tge7jvqqk1) .)
+    (at ~6 HSlice.0.tge244bit 1 T.7.tge244bit 4 U.1.tge244bit) .)
    (discard .) ~45
    (ret result.1))) 4,56
- (gvar :myarr2.0.tge7jvqqk1 . . 12,~39
+ (gvar :myarr2.0.tge244bit . . 12,~39
   (array 4
    (i -1)
    (rangetype
-    (i -1) +0 +2)) 27 myarr.0.tge7jvqqk1) 7,57
- (asgn ~7 myarr2.0.tge7jvqqk1 2
+    (i -1) +0 +2)) 27 myarr.0.tge244bit) 7,57
+ (asgn ~7 myarr2.0.tge244bit 2
   (aconstr 7,~40
    (array 4
     (i -1)
     (rangetype
      (i -1) +0 +2)) 1 +4 4 +5 7 +6)) 4,59
- (gvar :m3.0.tge7jvqqk1 . . 9
+ (gvar :m3.0.tge244bit . . 9
   (array 4
    (i -1)
    (rangetype
@@ -165,44 +165,44 @@
     (i -1)
     (rangetype
      (i -1) +0 +3)) 1 +1 4 +2 7 +3 10 +45)) 4,60
- (gvar :x3.0.tge7jvqqk1 . . 9
+ (gvar :x3.0.tge244bit . . 9
   (array 7
    (i -1)
    (rangetype
-    (i -1) 1 +4 4 +7)) 23 m3.0.tge7jvqqk1) 3,61
- (asgn ~3 x3.0.tge7jvqqk1 2
+    (i -1) 1 +4 4 +7)) 23 m3.0.tge244bit) 3,61
+ (asgn ~3 x3.0.tge244bit 2
   (aconstr 8,~2
    (array 4
     (i -1)
     (rangetype
      (i -1) +0 +3)) 1 +2 4 +3 7 +4 10 +5)) ,63
- (proc 5 :foo.1.tge7jvqqk1 . . 8
+ (proc 5 :foo.1.tge244bit . . 8
   (typevars 1
-   (typevar :I.0.tge7jvqqk1 . . . .) 4
-   (typevar :T.8.tge7jvqqk1 . . . .)) 14
+   (typevar :I.0.tge244bit . . . .) 4
+   (typevar :T.8.tge244bit . . . .)) 14
   (params 1
    (param :x.3 . . 8
-    (array 4 T.8.tge7jvqqk1 1 I.0.tge7jvqqk1) .)) . . . 33
+    (array 4 T.8.tge244bit 1 I.0.tge244bit) .)) . . . 33
   (stmts
    (discard .))) 3,64
- (call ~3 foo.2.tge7jvqqk1 1 myarr2.0.tge7jvqqk1) ,66
- (proc 5 :identity.0.tge7jvqqk1 . . 13
+ (call ~3 foo.2.tge244bit 1 myarr2.0.tge244bit) ,66
+ (proc 5 :identity.0.tge244bit . . 13
   (typevars 1
-   (typevar :I.1.tge7jvqqk1 . . . .) 4
-   (typevar :T.9.tge7jvqqk1 . . . .)) 19
+   (typevar :I.1.tge244bit . . . .) 4
+   (typevar :T.9.tge244bit . . . .)) 19
   (params 1
    (param :x.4 . . 8
-    (array 4 T.9.tge7jvqqk1 1 I.1.tge7jvqqk1) .)) 23
-  (array 4 T.9.tge7jvqqk1 1 I.1.tge7jvqqk1) . . 2,1
+    (array 4 T.9.tge244bit 1 I.1.tge244bit) .)) 23
+  (array 4 T.9.tge244bit 1 I.1.tge244bit) . . 2,1
   (stmts 7
    (result :result.2 . . 19,~1
-    (array 4 T.9.tge7jvqqk1 1 I.1.tge7jvqqk1) .) 7
+    (array 4 T.9.tge244bit 1 I.1.tge244bit) .) 7
    (asgn ~7 result.2 2 x.4) ~2,~1
    (ret result.2))) 7,68
- (asgn ~7 myarr2.0.tge7jvqqk1 10
-  (call ~8 identity.1.tge7jvqqk1 1 myarr2.0.tge7jvqqk1)) 3,64
- (proc :foo.2.tge7jvqqk1 . ~3,~1 .
-  (at foo.1.tge7jvqqk1 13,~47
+ (asgn ~7 myarr2.0.tge244bit 10
+  (call ~8 identity.1.tge244bit 1 myarr2.0.tge244bit)) 3,64
+ (proc :foo.2.tge244bit . ~3,~1 .
+  (at foo.1.tge244bit 13,~47
    (rangetype
     (i -1) +0 +2) 17,~47
    (i -1)) 11,~1
@@ -214,8 +214,8 @@
       (i -1) +0 +2)) .)) ~3,~1 . ~3,~1 . ~3,~1 . 30,~1
   (stmts
    (discard .))) 17,68
- (proc :identity.1.tge7jvqqk1 . ~17,~2 .
-  (at identity.0.tge7jvqqk1 ~1,~51
+ (proc :identity.1.tge244bit . ~17,~2 .
+  (at identity.0.tge244bit ~1,~51
    (rangetype
     (i -1) +0 +2) 3,~51
    (i -1)) 2,~2
@@ -237,15 +237,15 @@
       (i -1) +0 +2)) .) 7
    (asgn ~7 result.3 2 x.9) ~2,~1
    (ret result.3))) 19,27
- (type :MyGeneric.0.I8smrpu.tge7jvqqk1 .
-  (at MyGeneric.0.tge7jvqqk1 1
+ (type :MyGeneric.0.Ix1o1r81.tge244bit .
+  (at MyGeneric.0.tge244bit 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.0.I8smrpu.tge7jvqqk1 . . 16,3
+   (fld :x.0.Ix1o1r81.tge244bit . . 16,3
     (i -1) .))) 18,28
- (type :MyGeneric.0.Iliphp3.tge7jvqqk1 .
-  (at MyGeneric.0.tge7jvqqk1 1
+ (type :MyGeneric.0.Ip4d2b9.tge244bit .
+  (at MyGeneric.0.tge244bit 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.0.Iliphp3.tge7jvqqk1 . . 15,4
+   (fld :x.0.Ip4d2b9.tge244bit . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/tgenericbinarytree.nif
+++ b/tests/nimony/nosystem/tgenericbinarytree.nif
@@ -1,128 +1,128 @@
 (.nif24)
 0,1,tests/nimony/nosystem/tgenericbinarytree.nim(stmts 5
- (type :int.0.tge70unlm
+ (type :int.0.tgexqxvrf
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 10,3
- (type ~8 :Node.0.tge70unlm . ~4
+ (type ~8 :Node.0.tgexqxvrf . ~4
   (typevars 1
-   (typevar :T.0.tge70unlm . . . .)) . 2
+   (typevar :T.0.tgexqxvrf . . . .)) . 2
   (ref 11
-   (at ~7 NodeObj.0.tge70unlm 1 T.0.tge70unlm))) 13,4
- (type ~11 :NodeObj.0.tge70unlm . ~4
+   (at ~7 NodeObj.0.tgexqxvrf 1 T.0.tgexqxvrf))) 13,4
+ (type ~11 :NodeObj.0.tgexqxvrf . ~4
   (typevars 1
-   (typevar :T.1.tge70unlm . . . .)) . 2
+   (typevar :T.1.tgexqxvrf . . . .)) . 2
   (object . ~11,1
-   (fld :data.0.tge70unlm . . 6 T.1.tge70unlm .) ~11,2
-   (fld :left.0.tge70unlm . . 8,~3
+   (fld :data.0.tgexqxvrf . . 6 T.1.tgexqxvrf .) ~11,2
+   (fld :left.0.tgexqxvrf . . 8,~3
     (ref 11
-     (at ~7 NodeObj.0.tge70unlm ~1,3 T.1.tge70unlm)) .) ~5,2
-   (fld :right.0.tge70unlm . . 2,~3
+     (at ~7 NodeObj.0.tgexqxvrf ~1,3 T.1.tgexqxvrf)) .) ~5,2
+   (fld :right.0.tgexqxvrf . . 2,~3
     (ref 11
-     (at ~7 NodeObj.0.tge70unlm ~1,3 T.1.tge70unlm)) .))) 4,8
- (gvar :x.0.tge70unlm . . 8,~5
-  (ref 11 NodeObj.0.Itet59r.tge70unlm) 13
+     (at ~7 NodeObj.0.tgexqxvrf ~1,3 T.1.tgexqxvrf)) .))) 4,8
+ (gvar :x.0.tgexqxvrf . . 8,~5
+  (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 13
   (newobj ~5,~5
-   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.Itet59r.tge70unlm 2 +123) 16
-   (kv ~16 left.0.Itet59r.tge70unlm 2
+   (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 5
+   (kv ~5 data.0.Ib3t77t1.tgexqxvrf 2 +123) 16
+   (kv ~16 left.0.Ib3t77t1.tgexqxvrf 2
     (nil)) 28
-   (kv ~28 right.0.Itet59r.tge70unlm 2
+   (kv ~28 right.0.Ib3t77t1.tgexqxvrf 2
     (nil)))) 7,9
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm data.0.Itet59r.tge70unlm +0) 2 +456) 7,10
+  (ddot ~1 x.0.tgexqxvrf data.0.Ib3t77t1.tgexqxvrf +0) 2 +456) 7,10
  (asgn ~6
-  (ddot ~1 x.0.tge70unlm left.0.Itet59r.tge70unlm +0) 11
+  (ddot ~1 x.0.tgexqxvrf left.0.Ib3t77t1.tgexqxvrf +0) 11
   (newobj ~6,~7
-   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.Itet59r.tge70unlm 2 +123) 16
-   (kv ~16 left.0.Itet59r.tge70unlm 2
+   (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 5
+   (kv ~5 data.0.Ib3t77t1.tgexqxvrf 2 +123) 16
+   (kv ~16 left.0.Ib3t77t1.tgexqxvrf 2
     (nil)) 28
-   (kv ~28 right.0.Itet59r.tge70unlm 2
+   (kv ~28 right.0.Ib3t77t1.tgexqxvrf 2
     (nil)))) 8,11
  (asgn ~7
-  (ddot ~1 x.0.tge70unlm right.0.Itet59r.tge70unlm +0) 2
+  (ddot ~1 x.0.tgexqxvrf right.0.Ib3t77t1.tgexqxvrf +0) 2
   (nil)) 13,12
  (asgn ~7
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.0.Itet59r.tge70unlm +0) right.0.Itet59r.tge70unlm +0) 2
+   (ddot ~1 x.0.tgexqxvrf left.0.Ib3t77t1.tgexqxvrf +0) right.0.Ib3t77t1.tgexqxvrf +0) 2
   (nil)) 4,13
- (gvar :y.0.tge70unlm . . 8,~10
-  (ref 11 NodeObj.0.Itet59r.tge70unlm) 13
+ (gvar :y.0.tgexqxvrf . . 8,~10
+  (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 13
   (newobj ~5,~10
-   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.Itet59r.tge70unlm 2 +987) 16
-   (kv ~16 left.0.Itet59r.tge70unlm 2
+   (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 5
+   (kv ~5 data.0.Ib3t77t1.tgexqxvrf 2 +987) 16
+   (kv ~16 left.0.Ib3t77t1.tgexqxvrf 2
     (nil)) 28
-   (kv ~28 right.0.Itet59r.tge70unlm 2
+   (kv ~28 right.0.Ib3t77t1.tgexqxvrf 2
     (nil)))) 12,14
  (asgn ~6
   (ddot ~5
-   (ddot ~1 x.0.tge70unlm left.0.Itet59r.tge70unlm +0) left.0.Itet59r.tge70unlm +0) 11
+   (ddot ~1 x.0.tgexqxvrf left.0.Ib3t77t1.tgexqxvrf +0) left.0.Ib3t77t1.tgexqxvrf +0) 11
   (newobj ~11,~11
-   (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
-   (kv ~5 data.0.Itet59r.tge70unlm 2 -123) 17
-   (kv ~17 left.0.Itet59r.tge70unlm 2 y.0.tge70unlm) 27
-   (kv ~27 right.0.Itet59r.tge70unlm 2 y.0.tge70unlm))) ,16
- (proc 5 :foo.0.tge70unlm . . 8
+   (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 5
+   (kv ~5 data.0.Ib3t77t1.tgexqxvrf 2 -123) 17
+   (kv ~17 left.0.Ib3t77t1.tgexqxvrf 2 y.0.tgexqxvrf) 27
+   (kv ~27 right.0.Ib3t77t1.tgexqxvrf 2 y.0.tgexqxvrf))) ,16
+ (proc 5 :foo.0.tgexqxvrf . . 8
   (typevars 1
-   (typevar :T.2.tge70unlm . . . .)) 11
+   (typevar :T.2.tgexqxvrf . . . .)) 11
   (params 1
-   (param :data.0 . . 6 T.2.tge70unlm .)) 12,~13
+   (param :data.0 . . 6 T.2.tgexqxvrf .)) 12,~13
   (ref 11
-   (at ~7 NodeObj.0.tge70unlm ~7,13 T.2.tge70unlm)) . . 2,1
+   (at ~7 NodeObj.0.tgexqxvrf ~7,13 T.2.tgexqxvrf)) . . 2,1
   (stmts 7
    (result :result.0 . . 3,~14
     (ref 11
-     (at ~7 NodeObj.0.tge70unlm ~7,13 T.2.tge70unlm)) .) 7
+     (at ~7 NodeObj.0.tgexqxvrf ~7,13 T.2.tgexqxvrf)) .) 7
    (asgn ~7 result.0 9
     (newobj ~6,~14
      (ref 11
-      (at ~7 NodeObj.0.tge70unlm ~7,13 T.2.tge70unlm)) 5
+      (at ~7 NodeObj.0.tgexqxvrf ~7,13 T.2.tgexqxvrf)) 5
      (kv ~5 data 2 data.0) 17
      (kv ~17 left 2
       (nil)) 29
      (kv ~29 right 2
       (nil)))) 12,1
    (asgn ~6
-    (ddot ~6 result.0 data.0.tge70unlm +0) 2 data.0) ~2,~1
+    (ddot ~6 result.0 data.0.tgexqxvrf +0) 2 data.0) ~2,~1
    (ret result.0))) 4,19
- (glet :a.0.tge70unlm . . 8,~16
-  (ref 11 NodeObj.0.Itet59r.tge70unlm) 7
-  (call ~3 foo.1.tge70unlm 1 +123)) 2,20
- (asgn ~2 x.0.tge70unlm 2 a.0.tge70unlm) 11,19
- (proc :foo.1.tge70unlm . ~11,~3 .
-  (at foo.0.tge70unlm
+ (glet :a.0.tgexqxvrf . . 8,~16
+  (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 7
+  (call ~3 foo.1.tgexqxvrf 1 +123)) 2,20
+ (asgn ~2 x.0.tgexqxvrf 2 a.0.tgexqxvrf) 11,19
+ (proc :foo.1.tgexqxvrf . ~11,~3 .
+  (at foo.0.tgexqxvrf
    (i -1)) ,~3
   (params 1
    (param :data.2 . .
     (i -1) .)) 1,~16
-  (ref 11 NodeObj.0.Itet59r.tge70unlm) ~11,~3 . ~11,~3 . ~9,~2
+  (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) ~11,~3 . ~11,~3 . ~9,~2
   (stmts 7
    (result :result.1 . . 3,~14
-    (ref 11 NodeObj.0.Itet59r.tge70unlm) .) 7
+    (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) .) 7
    (asgn ~7 result.1 9
     (newobj ~6,~14
-     (ref 11 NodeObj.0.Itet59r.tge70unlm) 5
-     (kv ~5 data.0.Itet59r.tge70unlm 2 data.2) 17
-     (kv ~17 left.0.Itet59r.tge70unlm 2
+     (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) 5
+     (kv ~5 data.0.Ib3t77t1.tgexqxvrf 2 data.2) 17
+     (kv ~17 left.0.Ib3t77t1.tgexqxvrf 2
       (nil)) 29
-     (kv ~29 right.0.Itet59r.tge70unlm 2
+     (kv ~29 right.0.Ib3t77t1.tgexqxvrf 2
       (nil)))) 12,1
    (asgn ~6
-    (ddot ~6 result.1 data.0.Itet59r.tge70unlm +0) 2 data.2) ~2,~1
+    (ddot ~6 result.1 data.0.Ib3t77t1.tgexqxvrf +0) 2 data.2) ~2,~1
    (ret result.1))) 12,8
- (type :Node.0.Ikmiisb.tge70unlm .
-  (at Node.0.tge70unlm 1
+ (type :Node.0.I26wl13.tgexqxvrf .
+  (at Node.0.tgexqxvrf 1
    (i -1)) ~2,~5 . ,~5
-  (ref 11 NodeObj.0.Itet59r.tge70unlm)) 23,3
- (type :NodeObj.0.Itet59r.tge70unlm .
-  (at NodeObj.0.tge70unlm ~10,5
+  (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf)) 23,3
+ (type :NodeObj.0.Ib3t77t1.tgexqxvrf .
+  (at NodeObj.0.tgexqxvrf ~10,5
    (i -1)) ~10,1 . ~8,1
   (object . ~11,1
-   (fld :data.0.Itet59r.tge70unlm . . 9,3
+   (fld :data.0.Ib3t77t1.tgexqxvrf . . 9,3
     (i -1) .) ~11,2
-   (fld :left.0.Itet59r.tge70unlm . . 8,~3
-    (ref 11 NodeObj.0.Itet59r.tge70unlm) .) ~5,2
-   (fld :right.0.Itet59r.tge70unlm . . 2,~3
-    (ref 11 NodeObj.0.Itet59r.tge70unlm) .))))
+   (fld :left.0.Ib3t77t1.tgexqxvrf . . 8,~3
+    (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) .) ~5,2
+   (fld :right.0.Ib3t77t1.tgexqxvrf . . 2,~3
+    (ref 11 NodeObj.0.Ib3t77t1.tgexqxvrf) .))))

--- a/tests/nimony/nosystem/tholeyenum.msgs
+++ b/tests/nimony/nosystem/tholeyenum.msgs
@@ -1,1 +1,1 @@
-tests/nimony/nosystem/tholeyenum.nim(15, 14) Error: invalid array index type: HoleyEnum.0.thobkwvgz
+tests/nimony/nosystem/tholeyenum.nim(15, 14) Error: invalid array index type: HoleyEnum.0.thov9p3ju

--- a/tests/nimony/nosystem/timportfromexcept.nif
+++ b/tests/nimony/nosystem/timportfromexcept.nif
@@ -1,6 +1,6 @@
 (.nif24)
 0,1,tests/nimony/nosystem/timportfromexcept.nim(stmts 4,4
- (glet :allImported.0.timhjtr28 . . 14
+ (glet :allImported.0.timu9vi34 . . 14
   (array 11,2,tests/nimony/nosystem/deps/modexcept.nim
    (i -1)
    (rangetype
@@ -9,8 +9,8 @@
    (array 11,2,tests/nimony/nosystem/deps/modexcept.nim
     (i -1)
     (rangetype
-     (i -1) +0 +2)) 1 exceptB.0.modvx9hpf 10 fromA.0.modepjal 17 fromC.0.modepjal)) 4,5
- (glet :exceptDeclared.0.timhjtr28 . . 17
+     (i -1) +0 +2)) 1 exceptB.0.mod2zzixa 10 fromA.0.modf6zvn81 17 fromC.0.modf6zvn81)) 4,5
+ (glet :exceptDeclared.0.timu9vi34 . . 17
   (array
    (bool)
    (rangetype
@@ -23,7 +23,7 @@
    (false) 29
    (true) 48
    (false))) 4,6
- (glet :fromDeclared.0.timhjtr28 . . 17,~1
+ (glet :fromDeclared.0.timu9vi34 . . 17,~1
   (array
    (bool)
    (rangetype

--- a/tests/nimony/nosystem/tresemtype.nif
+++ b/tests/nimony/nosystem/tresemtype.nif
@@ -1,48 +1,48 @@
 (.nif24)
 0,3,tests/nimony/nosystem/tresemtype.nim(stmts
- (proc 5 :foo.0.treckpe1i1 . . 8
+ (proc 5 :foo.0.trepbt94u1 . . 8
   (typevars 1
-   (typevar :T.0.treckpe1i1 . . . .)) 11
+   (typevar :T.0.trepbt94u1 . . . .)) 11
   (params 1
-   (param :x.0 . . 3 T.0.treckpe1i1 .)) . . . 2,1
+   (param :x.0 . . 3 T.0.trepbt94u1 .)) . . . 2,1
   (stmts 9
    (type ~4 :Foo.0 . . . 2
     (object . ~9,1
-     (fld :val.0.treckpe1i1 . . 5 T.0.treckpe1i1 .))) 4,2
+     (fld :val.0.trepbt94u1 . . 5 T.0.trepbt94u1 .))) 4,2
    (var :obj.0 . . 6 Foo.0 9
     (oconstr ~3 Foo.0 4
-     (kv ~4 val.0.treckpe1i1 2 x.0))))) 3,5
- (call ~3 foo.1.treckpe1i1 1 +123) 3,6
- (call ~3 foo.2.treckpe1i1 1 "abc") ,8
- (template 9 :fooTempl.0.treckpe1i1 . . 17
+     (kv ~4 val.0.trepbt94u1 2 x.0))))) 3,5
+ (call ~3 foo.1.trepbt94u1 1 +123) 3,6
+ (call ~3 foo.2.trepbt94u1 1 "abc") ,8
+ (template 9 :fooTempl.0.trepbt94u1 . . 17
   (typevars 1
-   (typevar :T.1.treckpe1i1 . . . .)) 20
+   (typevar :T.1.trepbt94u1 . . . .)) 20
   (params 1
-   (param :x.1 . . 3 T.1.treckpe1i1 .)) . . . 2,1
+   (param :x.1 . . 3 T.1.trepbt94u1 .)) . . . 2,1
   (stmts 9
    (type ~4 :Foo.1 . . . 2
     (object . ~9,1
-     (fld :val.1.treckpe1i1 . . 5 T.1.treckpe1i1 .))) 4,2
+     (fld :val.1.trepbt94u1 . . 5 T.1.trepbt94u1 .))) 4,2
    (var :obj.1 . . 6 Foo.1 9
     (oconstr ~3 Foo.1 4
-     (kv ~4 val.1.treckpe1i1 2 x.1))))) 2,9
+     (kv ~4 val.1.trepbt94u1 2 x.1))))) 2,9
  (stmts 9
   (type ~4 :Foo.2 . . . 2
    (object . ~9,1
-    (fld :val.2.treckpe1i1 . .
+    (fld :val.2.trepbt94u1 . .
      (i -1) .))) 4,2
   (gvar :obj.2 . . 6 Foo.2 9
    (oconstr ~3 Foo.2 4
-    (kv ~4 val.2.treckpe1i1 ~10,2 +123)))) 2,9
+    (kv ~4 val.2.trepbt94u1 ~10,2 +123)))) 2,9
  (stmts 9
   (type ~4 :Foo.3 . . . 2
    (object . ~9,1
-    (fld :val.3.treckpe1i1 . . string.0.sysvq0asl .))) 4,2
+    (fld :val.3.trepbt94u1 . . string.0.sysvq0asl .))) 4,2
   (gvar :obj.3 . . 6 Foo.3 9
    (oconstr ~3 Foo.3 4
-    (kv ~4 val.3.treckpe1i1 ~10,3 "abc")))) 3,5
- (proc :foo.1.treckpe1i1 . ~3,~5 .
-  (at foo.0.treckpe1i1
+    (kv ~4 val.3.trepbt94u1 ~10,3 "abc")))) 3,5
+ (proc :foo.1.trepbt94u1 . ~3,~5 .
+  (at foo.0.trepbt94u1
    (i -1)) 8,~5
   (params 1
    (param :x.4 . .
@@ -50,19 +50,19 @@
   (stmts 9
    (type ~4 :Foo.4 . . . 2
     (object . ~9,1
-     (fld :val.4.treckpe1i1 . .
+     (fld :val.4.trepbt94u1 . .
       (i -1) .))) 4,2
    (var :obj.4 . . 6 Foo.4 9
     (oconstr ~3 Foo.4 4
-     (kv ~4 val.4.treckpe1i1 2 x.4))))) 3,6
- (proc :foo.2.treckpe1i1 . ~3,~6 .
-  (at foo.0.treckpe1i1 string.0.sysvq0asl) 8,~6
+     (kv ~4 val.4.trepbt94u1 2 x.4))))) 3,6
+ (proc :foo.2.trepbt94u1 . ~3,~6 .
+  (at foo.0.trepbt94u1 string.0.sysvq0asl) 8,~6
   (params 1
    (param :x.5 . . string.0.sysvq0asl .)) ~3,~6 . ~3,~6 . ~3,~6 . ~1,~5
   (stmts 9
    (type ~4 :Foo.5 . . . 2
     (object . ~9,1
-     (fld :val.5.treckpe1i1 . . string.0.sysvq0asl .))) 4,2
+     (fld :val.5.trepbt94u1 . . string.0.sysvq0asl .))) 4,2
    (var :obj.5 . . 6 Foo.5 9
     (oconstr ~3 Foo.5 4
-     (kv ~4 val.5.treckpe1i1 2 x.5))))))
+     (kv ~4 val.5.trepbt94u1 2 x.5))))))

--- a/tests/nimony/nosystem/tsetter.nif
+++ b/tests/nimony/nosystem/tsetter.nif
@@ -1,27 +1,27 @@
 (.nif24)
 0,1,tests/nimony/nosystem/tsetter.nim(stmts 5
- (type :int.0.tseyic8ua1
+ (type :int.0.tsea4ic221
   (i -1) . 4
   (pragmas 2
    (magic 7 Int)) .) 9,2
- (type ~4 :Foo.0.tseyic8ua1 . . . 2
+ (type ~4 :Foo.0.tsea4ic221 . . . 2
   (object .)) ,4
- (proc 5 :bar=.0.tseyic8ua1 . . . 11
+ (proc 5 :bar=.0.tsea4ic221 . . . 11
   (params 1
-   (param :x.0 . . 3 Foo.0.tseyic8ua1 .) 9
+   (param :x.0 . . 3 Foo.0.tsea4ic221 .) 9
    (param :y.0 . . 3
     (i -1) .)) . . . 30
   (stmts
    (discard .))) ,5
- (proc 5 :\5B\5D=.0.tseyic8ua1 . . . 10
+ (proc 5 :\5B\5D=.0.tsea4ic221 . . . 10
   (params 1
-   (param :x.1 . . 3 Foo.0.tseyic8ua1 .) 9
+   (param :x.1 . . 3 Foo.0.tsea4ic221 .) 9
    (param :y.1 . . 3
     (i -1) .) 17
    (param :z.0 . . 3
     (i -1) .)) . . . 37
   (stmts
    (discard .))) 4,7
- (gvar :foo.0.tseyic8ua1 . . 5 Foo.0.tseyic8ua1 .) ,8
- (call bar=.0.tseyic8ua1 foo.0.tseyic8ua1 10 +123) ,9
- (call \5B\5D=.0.tseyic8ua1 foo.0.tseyic8ua1 4 +123 11 +456))
+ (gvar :foo.0.tsea4ic221 . . 5 Foo.0.tsea4ic221 .) ,8
+ (call bar=.0.tsea4ic221 foo.0.tsea4ic221 10 +123) ,9
+ (call \5B\5D=.0.tsea4ic221 foo.0.tsea4ic221 4 +123 11 +456))

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -1,52 +1,52 @@
 (.nif24)
 0,2,tests/nimony/nosystem/ttemplate.nim(stmts 2,1
- (type :int.0.tte5tld8n
+ (type :int.0.tterqlp661
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,3
- (type :float.0.tte5tld8n
+ (type :float.0.tterqlp661
   (f +64) . 7
   (pragmas 2
    (magic 7 Float)) .) 2,4
- (type :char.0.tte5tld8n
+ (type :char.0.tterqlp661
   (c +8) . 6
   (pragmas 2
    (magic 7 Char)) .) 2,6
- (type :array.0.tte5tld8n
+ (type :array.0.tterqlp661
   (array) 7
   (typevars 1
-   (typevar :Index.0.tte5tld8n . . . .) 8
-   (typevar :T.0.tte5tld8n . . . .)) 18
+   (typevar :Index.0.tterqlp661 . . . .) 8
+   (typevar :T.0.tterqlp661 . . . .)) 18
   (pragmas 2
    (magic 7 Array)) .) 2,7
- (type :typedesc.0.tte5tld8n
+ (type :typedesc.0.tterqlp661
   (typedesc) 9
   (typevars 1
-   (typevar :T.1.tte5tld8n . . . .)) 13
+   (typevar :T.1.tterqlp661 . . . .)) 13
   (pragmas 2
    (magic 7 TypeDesc)) .) ,9
- (proc 5 :typeof.0.tte5tld8n
+ (proc 5 :typeof.0.tterqlp661
   (typeof) . 12
   (typevars 1
-   (typevar :T.3.tte5tld8n . . . .)) 15
+   (typevar :T.3.tterqlp661 . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.3.tte5tld8n .)) 16
-  (typedesc 1 T.3.tte5tld8n) 35
+   (param :x.0 . . 3 T.3.tterqlp661 .)) 16
+  (typedesc 1 T.3.tterqlp661) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,12
- (type ~8 :string.0.tte5tld8n x . . string.0.sysvq0asl) 15,15
- (type ~13 :MyGeneric.0.tte5tld8n . ~4
+ (type ~8 :string.0.tterqlp661 x . . string.0.sysvq0asl) 15,15
+ (type ~13 :MyGeneric.0.tterqlp661 . ~4
   (typevars 1
-   (typevar :T.2.tte5tld8n . . . .)) . 2
+   (typevar :T.2.tterqlp661 . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tte5tld8n . . 3 T.2.tte5tld8n .))) 2,19
- (gvar :myglob.0.tte5tld8n . . 17 MyGeneric.0.Igj236q.tte5tld8n .) 2,20
- (gvar :other.0.tte5tld8n . . 16 MyGeneric.0.Ibr3ivb1.tte5tld8n .) 9,22
+   (fld :x.0.tterqlp661 . . 3 T.2.tterqlp661 .))) 2,19
+ (gvar :myglob.0.tterqlp661 . . 17 MyGeneric.0.Iw0gq351.tterqlp661 .) 2,20
+ (gvar :other.0.tterqlp661 . . 16 MyGeneric.0.If0jtig.tterqlp661 .) 9,22
  (asgn ~3
-  (dot ~6 myglob.0.tte5tld8n x.0.Igj236q.tte5tld8n +0) 2 +56) 8,23
+  (dot ~6 myglob.0.tterqlp661 x.0.Iw0gq351.tterqlp661 +0) 2 +56) 8,23
  (asgn ~3
-  (dot ~5 other.0.tte5tld8n x.0.Ibr3ivb1.tte5tld8n +0) 2 +79.0) ,25
- (proc 5 :\2B.0.tte5tld8n
+  (dot ~5 other.0.tterqlp661 x.0.If0jtig.tterqlp661 +0) 2 +79.0) ,25
+ (proc 5 :\2B.0.tterqlp661
   (add -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -56,7 +56,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,27
- (template 9 :plus.0.tte5tld8n . . . 13
+ (template 9 :plus.0.tterqlp661 . . . 13
   (params 1
    (param :x.2 . . 6
     (i -1) .) 4
@@ -67,7 +67,7 @@
    (expr
     (add ~14
      (i -1) ~2 x.2 2 y.1)))) ,29
- (proc 5 :foo.0.tte5tld8n . . . 8
+ (proc 5 :foo.0.tterqlp661 . . . 8
   (params 1
    (param :x.3 . . 3
     (i -1) .) 9
@@ -88,7 +88,7 @@
           (i -1) ~10,4 +2 ~7,4 +89))))))) 2,2
    (asgn ~2 x.5 2 "34") ~2,~1
    (ret result.0))) ,34
- (proc 5 :overloaded.0.tte5tld8n . . . 15
+ (proc 5 :overloaded.0.tterqlp661 . . . 15
   (params) . . . 2,1
   (stmts 4
    (let :someInt.0 . . 7,~10
@@ -96,38 +96,38 @@
     (add
      (i -1) 1 +23 5 +90)) ,1
    (discard 11
-    (call ~3 foo.0.tte5tld8n 3
+    (call ~3 foo.0.tterqlp661 3
      (add
       (i -1) ~2 +34 1 +56) 8 "xyz")))) 5,38
- (type :uint.0.tte5tld8n
+ (type :uint.0.tterqlp661
   (u -1) . 6
   (pragmas 2
    (magic 7 UInt)) .) ,40
- (template 9 :conv.0.tte5tld8n . . 13
+ (template 9 :conv.0.tterqlp661 . . 13
   (typevars 1
-   (typevar :T.4.tte5tld8n . . . .)) 16
+   (typevar :T.4.tterqlp661 . . . .)) 16
   (params 1
    (param :x.4 . . 3
-    (i -1) .)) 10 T.4.tte5tld8n . . 30
+    (i -1) .)) 10 T.4.tterqlp661 . . 30
   (stmts 1
    (expr
-    (conv ~1 T.4.tte5tld8n 1 x.4)))) 4,42
- (glet :val.0.tte5tld8n . .
+    (conv ~1 T.4.tterqlp661 1 x.4)))) 4,42
+ (glet :val.0.tterqlp661 . .
   (i -1) 6 +123) ,43
  (discard 30,~3
   (expr 1
    (expr
     (conv ~18,3
-     (u -1) ~12,3 val.0.tte5tld8n)))) 19,19
- (type :MyGeneric.0.Igj236q.tte5tld8n .
-  (at MyGeneric.0.tte5tld8n 1
+     (u -1) ~12,3 val.0.tterqlp661)))) 19,19
+ (type :MyGeneric.0.Iw0gq351.tterqlp661 .
+  (at MyGeneric.0.tterqlp661 1
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.0.Igj236q.tte5tld8n . . 16,3
+   (fld :x.0.Iw0gq351.tterqlp661 . . 16,3
     (i -1) .))) 18,20
- (type :MyGeneric.0.Ibr3ivb1.tte5tld8n .
-  (at MyGeneric.0.tte5tld8n 1
+ (type :MyGeneric.0.If0jtig.tterqlp661 .
+  (at MyGeneric.0.tterqlp661 1
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.0.Ibr3ivb1.tte5tld8n . . 15,4
+   (fld :x.0.If0jtig.tterqlp661 . . 15,4
     (f +64) .))))

--- a/tests/nimony/nosystem/tvarargs.nif
+++ b/tests/nimony/nosystem/tvarargs.nif
@@ -1,34 +1,34 @@
 (.nif24)
 0,2,tests/nimony/nosystem/tvarargs.nim(stmts 2,1
- (type :int.0.tvah6culb
+ (type :int.0.tvaykbv321
   (i -1) . 5
   (pragmas 2
    (magic 7 Int)) .) 2,2
- (type :bool.0.tvah6culb
+ (type :bool.0.tvaykbv321
   (bool) . 6
   (pragmas 2
    (magic 7 Bool)) .) 2,3
- (type :char.0.tvah6culb
+ (type :char.0.tvaykbv321
   (c +8) . 6
   (pragmas 2
    (magic 7 Char)) .) 2,4
- (type :typedesc.0.tvah6culb
+ (type :typedesc.0.tvaykbv321
   (typedesc) 9
   (typevars 1
-   (typevar :T.0.tvah6culb . . . .)) 13
+   (typevar :T.0.tvaykbv321 . . . .)) 13
   (pragmas 2
    (magic 7 TypeDesc)) .) ,6
- (proc 5 :typeof.0.tvah6culb
+ (proc 5 :typeof.0.tvaykbv321
   (typeof) . 12
   (typevars 1
-   (typevar :T.1.tvah6culb . . . .)) 15
+   (typevar :T.1.tvaykbv321 . . . .)) 15
   (params 1
-   (param :x.0 . . 3 T.1.tvah6culb .)) 16
-  (typedesc 1 T.1.tvah6culb) 35
+   (param :x.0 . . 3 T.1.tvaykbv321 .)) 16
+  (typedesc 1 T.1.tvaykbv321) 35
   (pragmas 2
    (magic 7 TypeOf)) . .) 10,9
- (type ~8 :string.0.tvah6culb x . . string.0.sysvq0asl) ,11
- (proc 5 :\2B.0.tvah6culb
+ (type ~8 :string.0.tvaykbv321 x . . string.0.sysvq0asl) ,11
+ (proc 5 :\2B.0.tvaykbv321
   (add -3) . . 9
   (params 1
    (param :x.1 . . 6
@@ -38,7 +38,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "AddI")) . .) ,12
- (proc 5 :\2D.0.tvah6culb
+ (proc 5 :\2D.0.tvaykbv321
   (sub -3) . . 9
   (params 1
    (param :x.2 . . 6
@@ -48,7 +48,7 @@
   (i -1) 26
   (pragmas 2
    (magic 7 "SubI")) . .) ,14
- (proc 5 :<=.0.tvah6culb
+ (proc 5 :<=.0.tvaykbv321
   (le -3) . . 10
   (params 1
    (param :x.3 . . 6
@@ -58,37 +58,37 @@
   (bool) 28
   (pragmas 2
    (magic 7 "LeI")) . .) 8,17
- (type ~6 :File.0.tvah6culb x . . 2
+ (type ~6 :File.0.tvaykbv321 x . . 2
   (object .)) 4,19
- (gvar :stdout.0.tvah6culb . . 8 File.0.tvah6culb .) ,21
- (proc 5 :write.0.tvah6culb . . . 10
+ (gvar :stdout.0.tvaykbv321 . . 8 File.0.tvaykbv321 .) ,21
+ (proc 5 :write.0.tvaykbv321 . . . 10
   (params 1
    (param :f.0 . . 3
-    (mut 4 File.0.tvah6culb) .) 14
+    (mut 4 File.0.tvaykbv321) .) 14
    (param :c.0 . . 3
     (c +8) .)) . . . 35
   (stmts
    (discard .))) ,22
- (proc 5 :write.1.tvah6culb . . . 10
+ (proc 5 :write.1.tvaykbv321 . . . 10
   (params 1
    (param :f.1 . . 3
-    (mut 4 File.0.tvah6culb) .) 14
+    (mut 4 File.0.tvaykbv321) .) 14
    (param :s.0 . . string.0.sysvq0asl .)) . . . 37
   (stmts
    (discard .))) ,24
- (cmd write.0.tvah6culb 6
-  (haddr stdout.0.tvah6culb) 14 '\0A') 2,27
- (type :untyped.0.tvah6culb
+ (cmd write.0.tvaykbv321 6
+  (haddr stdout.0.tvaykbv321) 14 '\0A') 2,27
+ (type :untyped.0.tvaykbv321
   (untyped) . 9
   (pragmas 2
    (magic 7 Expr)) .) ,29
- (iterator 9 :unpack.0.tvah6culb
+ (iterator 9 :unpack.0.tvaykbv321
   (unpack) . . 15
   (params) 4
   (untyped) 27
   (pragmas 2
    (magic 7 Unpack)) . .) ,31
- (template 9 :echo.0.tvah6culb x . . 14
+ (template 9 :echo.0.tvaykbv321 x . . 14
   (params 5
    (param :vanon.0 . .
     (varargs) .)) . 17
@@ -102,36 +102,36 @@
       (untyped) .)) ~2,1
     (expr
      (cmd
-      (ochoice write.0.tvah6culb write.1.tvah6culb) 6 stdout.0.tvah6culb 14 x.4))) ,2
-   (cmd write.0.tvah6culb 6 stdout.0.tvah6culb 14 '\0A'))) 4,36
- (gvar :someVar.0.tvah6culb . . string.0.sysvq0asl 10 "") 2,32
+      (ochoice write.0.tvaykbv321 write.1.tvaykbv321) 6 stdout.0.tvaykbv321 14 x.4))) ,2
+   (cmd write.0.tvaykbv321 6 stdout.0.tvaykbv321 14 '\0A'))) 4,36
+ (gvar :someVar.0.tvaykbv321 . . string.0.sysvq0asl 10 "") 2,32
  (stmts 2,1
   (stmts
-   (cmd write.1.tvah6culb 6
-    (haddr stdout.0.tvah6culb) 1,5 "a")) 2,1
+   (cmd write.1.tvaykbv321 6
+    (haddr stdout.0.tvaykbv321) 1,5 "a")) 2,1
   (stmts
-   (cmd write.1.tvah6culb 6
-    (haddr stdout.0.tvah6culb) 6,5 someVar.0.tvah6culb)) 2,1
+   (cmd write.1.tvaykbv321 6
+    (haddr stdout.0.tvaykbv321) 6,5 someVar.0.tvaykbv321)) 2,1
   (stmts
-   (cmd write.1.tvah6culb 6
-    (haddr stdout.0.tvah6culb) 15,5 "b")) ,2
-  (cmd write.0.tvah6culb 6
-   (haddr stdout.0.tvah6culb) 14 '\0A')) 2,32
+   (cmd write.1.tvaykbv321 6
+    (haddr stdout.0.tvaykbv321) 15,5 "b")) ,2
+  (cmd write.0.tvaykbv321 6
+   (haddr stdout.0.tvaykbv321) 14 '\0A')) 2,32
  (stmts 2,1
   (stmts
-   (cmd write.1.tvah6culb 6
-    (haddr stdout.0.tvah6culb) 1,7 "xzy")) 2,1
+   (cmd write.1.tvaykbv321 6
+    (haddr stdout.0.tvaykbv321) 1,7 "xzy")) 2,1
   (stmts
-   (cmd write.0.tvah6culb 6
-    (haddr stdout.0.tvah6culb) 8,7 'c')) ,2
-  (cmd write.0.tvah6culb 6
-   (haddr stdout.0.tvah6culb) 14 '\0A')) 2,32
+   (cmd write.0.tvaykbv321 6
+    (haddr stdout.0.tvaykbv321) 8,7 'c')) ,2
+  (cmd write.0.tvaykbv321 6
+   (haddr stdout.0.tvaykbv321) 14 '\0A')) 2,32
  (stmts ,2
-  (cmd write.0.tvah6culb 6
-   (haddr stdout.0.tvah6culb) 14 '\0A')) 2,32
+  (cmd write.0.tvaykbv321 6
+   (haddr stdout.0.tvaykbv321) 14 '\0A')) 2,32
  (stmts 2,1
   (stmts
-   (cmd write.1.tvah6culb 6
-    (haddr stdout.0.tvah6culb) 1,11 someVar.0.tvah6culb)) ,2
-  (cmd write.0.tvah6culb 6
-   (haddr stdout.0.tvah6culb) 14 '\0A')))
+   (cmd write.1.tvaykbv321 6
+    (haddr stdout.0.tvaykbv321) 1,11 someVar.0.tvaykbv321)) ,2
+  (cmd write.0.tvaykbv321 6
+   (haddr stdout.0.tvaykbv321) 14 '\0A')))

--- a/tests/nimony/nosystem/twhen.nif
+++ b/tests/nimony/nosystem/twhen.nif
@@ -8,7 +8,7 @@
   (discard 8 "good")) 2,20
  (stmts
   (discard 8 "good")) ,28
- (proc 5 :not.0.twho7opw81
+ (proc 5 :not.0.twhoeq1fy1
   (not) . . 11
   (params 1
    (param :x.0 . . 3

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -1,11 +1,11 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tbasics.nim(stmts 8,1
- (type ~6 :Array.0.tbawx6nu81 . . . 7
+ (type ~6 :Array.0.tbayqq7xr1 . . . 7
   (array 4
    (i -1)
    (rangetype
     (i -1) +0 +4))) 4,3
- (gvar :s.0.tbawx6nu81 . . 4
+ (gvar :s.0.tbayqq7xr1 . . 4
   (array
    (i -1)
    (rangetype
@@ -15,12 +15,12 @@
     (i -1)
     (rangetype
      (i -1) +0 +2)) 1 +1 4 +2 7 +3)) 4,4
- (gvar :s2.0.tbawx6nu81 . . 11,~3
+ (gvar :s2.0.tbayqq7xr1 . . 11,~3
   (array 4
    (i -1)
    (rangetype
     (i -1) +0 +4)) .) 4,5
- (gvar :s3.0.tbawx6nu81 . . 11,~4
+ (gvar :s3.0.tbayqq7xr1 . . 11,~4
   (array 4
    (i -1)
    (rangetype
@@ -30,7 +30,7 @@
     (i -1)
     (rangetype
      (i -1) +0 +4)) 1 +1 4 +2 7 +3 10 +4 13 +5)) ,7
- (proc 5 :foo.0.tbawx6nu81 . . . 9
+ (proc 5 :foo.0.tbayqq7xr1 . . . 9
   (params) . . . 2,1
   (stmts 4
    (var :x.2 . . 2,~5
@@ -53,8 +53,8 @@
       (i -1)
       (rangetype
        (i -1) +0 +3)) 1 +5 4 +6 7 +7 10 +8)))) 3,11
- (call ~3 foo.0.tbawx6nu81) ,13
- (proc 5 :foo2.0.tbawx6nu81 . . . 9
+ (call ~3 foo.0.tbayqq7xr1) ,13
+ (proc 5 :foo2.0.tbayqq7xr1 . . . 9
   (params 1
    (param :m.0 . . 3
     (i -1) .)) . . . 2,1
@@ -101,8 +101,8 @@
       (tuple 1,~3
        (i -1)
        (i -1))) 1 y.0 4 s.0 7 m1.0)))) 4,20
- (call ~4 foo2.0.tbawx6nu81 1 +12) ,22
- (proc 5 :foo3.0.tbawx6nu81 . . . 9
+ (call ~4 foo2.0.tbayqq7xr1 1 +12) ,22
+ (proc 5 :foo3.0.tbayqq7xr1 . . . 9
   (params 1
    (param :x.0 . . 3
     (pointer) .)) . . . 2,1
@@ -126,52 +126,52 @@
     (ptr 4
      (i -1)) 9
     (addr s.1)) 4,2
-   (call ~4 foo3.0.tbawx6nu81 1
+   (call ~4 foo3.0.tbayqq7xr1 1
     (hconv 6,~8
      (pointer) m.3)) 4,3
    (let :m2.0 . . 7,~9
     (pointer) 5
     (cast 5
      (pointer) 14 m.3)) 4,4
-   (call ~4 foo3.0.tbawx6nu81 1 m2.0))) 10,35
- (type ~8 :Foo1314.0.tbawx6nu81 . . . 2
+   (call ~4 foo3.0.tbayqq7xr1 1 m2.0))) 10,35
+ (type ~8 :Foo1314.0.tbayqq7xr1 . . . 2
   (object . ~8,1
-   (fld :a.0.tbawx6nu81 . . 15
+   (fld :a.0.tbayqq7xr1 . . 15
     (i -1) .) ~5,1
-   (fld :b.0.tbawx6nu81 . . 12
+   (fld :b.0.tbayqq7xr1 . . 12
     (i -1) .) ~2,1
-   (fld :c.0.tbawx6nu81 . . 9
+   (fld :c.0.tbayqq7xr1 . . 9
     (i -1) .) 1,1
-   (fld :d.0.tbawx6nu81 . . 6
+   (fld :d.0.tbayqq7xr1 . . 6
     (i -1) .) 4,1
-   (fld :e.0.tbawx6nu81 . . 3
+   (fld :e.0.tbayqq7xr1 . . 3
     (i -1) .))) ,39
- (proc 5 :foo1314.0.tbawx6nu81 . . . 12
+ (proc 5 :foo1314.0.tbayqq7xr1 . . . 12
   (params 1
-   (param :x.1 . . 3 Foo1314.0.tbawx6nu81 .)) . . . 2,1
+   (param :x.1 . . 3 Foo1314.0.tbayqq7xr1 .)) . . . 2,1
   (stmts 4
    (let :s.2 . . 13,~4
     (i -1) 5
-    (dot ~1 x.1 a.0.tbawx6nu81 +0)))) 4,42
- (gvar :a.1.tbawx6nu81 . . 12,~3 Foo1314.0.tbawx6nu81 11
-  (oconstr 1,~3 Foo1314.0.tbawx6nu81
-   (kv a.0.tbawx6nu81 43,412,lib/std/system.nim
+    (dot ~1 x.1 a.0.tbayqq7xr1 +0)))) 4,42
+ (gvar :a.1.tbayqq7xr1 . . 12,~3 Foo1314.0.tbayqq7xr1 11
+  (oconstr 1,~3 Foo1314.0.tbayqq7xr1
+   (kv a.0.tbayqq7xr1 43,412,lib/std/system.nim
     (expr
      (expr +0)))
-   (kv b.0.tbawx6nu81 43,412,lib/std/system.nim
+   (kv b.0.tbayqq7xr1 43,412,lib/std/system.nim
     (expr
      (expr +0)))
-   (kv c.0.tbawx6nu81 43,412,lib/std/system.nim
+   (kv c.0.tbayqq7xr1 43,412,lib/std/system.nim
     (expr
      (expr +0)))
-   (kv d.0.tbawx6nu81 43,412,lib/std/system.nim
+   (kv d.0.tbayqq7xr1 43,412,lib/std/system.nim
     (expr
      (expr +0)))
-   (kv e.0.tbawx6nu81 43,412,lib/std/system.nim
+   (kv e.0.tbayqq7xr1 43,412,lib/std/system.nim
     (expr
      (expr +0))))) 7,43
- (call ~7 foo1314.0.tbawx6nu81 1 a.1.tbawx6nu81) ,45
- (proc 5 :foo2233.0.tbawx6nu81 . . . 12
+ (call ~7 foo1314.0.tbayqq7xr1 1 a.1.tbayqq7xr1) ,45
+ (proc 5 :foo2233.0.tbayqq7xr1 . . . 12
   (params) . 15
   (pragmas 2
    (nimcall)) . 2,1
@@ -186,8 +186,8 @@
      (params) . 3
      (pragmas 2
       (nimcall)) . .) .))) 7,51
- (call ~7 foo2233.0.tbawx6nu81) ,53
- (proc 5 :basictuple.0.tbawx6nu81 . . . 15
+ (call ~7 foo2233.0.tbayqq7xr1) ,53
+ (proc 5 :basictuple.0.tbayqq7xr1 . . . 15
   (params) . . . 2,1
   (stmts 4
    (var :t.0 . . 3
@@ -221,4 +221,4 @@
     (tupat t.0 2 +0)) ,5
    (discard 8
     (tupat t.0 2 +1)))) 10,61
- (call ~10 basictuple.0.tbawx6nu81))
+ (call ~10 basictuple.0.tbayqq7xr1))

--- a/tests/nimony/sysbasics/tconstarrlen.nif
+++ b/tests/nimony/sysbasics/tconstarrlen.nif
@@ -1,18 +1,18 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tconstarrlen.nim(stmts 6
- (const :Len.0.tcoacwdbr . .
+ (const :Len.0.tcoc38ok51 . .
   (i -1) 6 +100) 4,1
- (gvar :a.0.tcoacwdbr . . 8
+ (gvar :a.0.tcoc38ok51 . . 8
   (array 6
    (i -1)
    (rangetype
     (i -1) +0 +99)) .) 11,4
- (type ~9 :FooArray.0.tcoacwdbr . . . 7
+ (type ~9 :FooArray.0.tcoc38ok51 . . . 7
   (array 6
    (i -1)
    (rangetype
     (i -1) +0 +99))) 4,6
- (gvar :b.0.tcoacwdbr . . 14,~2
+ (gvar :b.0.tcoc38ok51 . . 14,~2
   (array 6
    (i -1)
    (rangetype
@@ -36,6 +36,6 @@
           (conv ~12,~48
            (i -1) ~13
            (conv
-            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))))) 3 Len.0.tcoacwdbr) ~1,1
+            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))))) 3 Len.0.tcoc38ok51) ~1,1
    (stmts
     (discard .)))))

--- a/tests/nimony/sysbasics/tdefaultparams.nif
+++ b/tests/nimony/sysbasics/tdefaultparams.nif
@@ -1,6 +1,6 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tdefaultparams.nim(stmts
- (proc 5 :foo1.0.tdebp8hax . . . 9
+ (proc 5 :foo1.0.tdeht49b71 . . . 9
   (params 1
    (param :x.0 . . 3
     (i -1) .) 9
@@ -9,7 +9,7 @@
   (stmts 4
    (let :m.0 . . 7,~1
     (i -1) 4 x.0))) ,3
- (proc 5 :foo2.0.tdebp8hax . . . 9
+ (proc 5 :foo2.0.tdeht49b71 . . . 9
   (params 1
    (param :x.1 . . 3,~3
     (i -1) 4 +3) 8
@@ -20,7 +20,7 @@
     (i -1) 4 x.1) 4,1
    (let :j.0 . . 7,~5
     (i -1) 4 y.1))) ,7
- (proc 5 :foo3.0.tdebp8hax . . . 9
+ (proc 5 :foo3.0.tdeht49b71 . . . 9
   (params 1
    (param :x.2 . . 3
     (i -1) .) 9
@@ -30,7 +30,7 @@
     (i -1) 9 +23)) . . . 2,1
   (stmts
    (discard .))) ,10
- (proc 5 :foo4.0.tdebp8hax . . . 9
+ (proc 5 :foo4.0.tdeht49b71 . . . 9
   (params 1
    (param :x.3 . . 3
     (i -1) .) 9
@@ -42,49 +42,49 @@
     (f +64) 11 +1.2)) . . . 2,1
   (stmts
    (discard .))) ,13
- (proc 5 :foo5.0.tdebp8hax . . 9
+ (proc 5 :foo5.0.tdeht49b71 . . 9
   (typevars 1
-   (typevar :T.0.tdebp8hax . . . .)) 12
+   (typevar :T.0.tdeht49b71 . . . .)) 12
   (params 1
-   (param :x.4 . . 3 T.0.tdebp8hax .) 7
+   (param :x.4 . . 3 T.0.tdeht49b71 .) 7
    (param :y.4 . . ~6,~13
     (i -1) 9 +7)) . . . 2,1
   (stmts
    (discard .))) ,16
- (proc 5 :foo6.0.tdebp8hax . . 9
+ (proc 5 :foo6.0.tdeht49b71 . . 9
   (typevars 1
-   (typevar :T.1.tdebp8hax . . . .)) 12
+   (typevar :T.1.tdeht49b71 . . . .)) 12
   (params 1
-   (param :x.5 . . 3 T.1.tdebp8hax 7 +3) 11
+   (param :x.5 . . 3 T.1.tdeht49b71 7 +3) 11
    (param :y.5 . . ~10,~16
     (i -1) 9 +7)) . . . 2,1
   (stmts
    (discard .))) ,19
- (proc 5 :foo.0.tdebp8hax . . 8
+ (proc 5 :foo.0.tdeht49b71 . . 8
   (typevars 1
-   (typevar :T.2.tdebp8hax . . . .)) 11
+   (typevar :T.2.tdeht49b71 . . . .)) 11
   (params 1
-   (param :x.6 . . 3 T.2.tdebp8hax .) 7
-   (param :y.6 . . ~3 T.2.tdebp8hax 8
-    (conv ~1 T.2.tdebp8hax 1 +7))) . . . 2,1
+   (param :x.6 . . 3 T.2.tdeht49b71 .) 7
+   (param :y.6 . . ~3 T.2.tdeht49b71 8
+    (conv ~1 T.2.tdeht49b71 1 +7))) . . . 2,1
   (stmts 4
-   (let :s.1 . . 9,~1 T.2.tdebp8hax 4 x.6) 4,1
-   (let :j.1 . . 9,~2 T.2.tdebp8hax 4 y.6))) 3,23
- (call ~3 foo.1.tdebp8hax 1 +3 23,~4
+   (let :s.1 . . 9,~1 T.2.tdeht49b71 4 x.6) 4,1
+   (let :j.1 . . 9,~2 T.2.tdeht49b71 4 y.6))) 3,23
+ (call ~3 foo.1.tdeht49b71 1 +3 23,~4
   (conv
    (i -1) 1 +7)) 4,24
- (call ~4 foo2.0.tdebp8hax 10,~21 +3 17,~21 +7) 4,25
- (call ~4 foo2.0.tdebp8hax 1 +1 17,~22 +7) 4,26
- (call ~4 foo3.0.tdebp8hax 1 +1 4 +2.3 33,~19 +23) 4,27
- (call ~4 foo4.0.tdebp8hax 1 +1 4 +234.34 33,~17 +23 48,~17 +1.2) 4,29
- (call ~4 foo2.0.tdebp8hax 1 +2 4 +3) 4,31
- (call ~4 foo1.0.tdebp8hax 1 +34 25,~31 +1.2) 4,33
- (call ~4 foo5.1.tdebp8hax 1 +1.3 24,~20 +7) 4,34
- (call ~4 foo6.1.tdebp8hax 1 +4 28,~18 +7) 9,35
- (call ~9 foo6.1.tdebp8hax 11,~19 +3 23,~19 +7) 4,36
- (call ~4 foo6.1.tdebp8hax 16,~20 +3 28,~20 +7) 3,23
- (proc :foo.1.tdebp8hax . ~3,~4 .
-  (at foo.0.tdebp8hax
+ (call ~4 foo2.0.tdeht49b71 10,~21 +3 17,~21 +7) 4,25
+ (call ~4 foo2.0.tdeht49b71 1 +1 17,~22 +7) 4,26
+ (call ~4 foo3.0.tdeht49b71 1 +1 4 +2.3 33,~19 +23) 4,27
+ (call ~4 foo4.0.tdeht49b71 1 +1 4 +234.34 33,~17 +23 48,~17 +1.2) 4,29
+ (call ~4 foo2.0.tdeht49b71 1 +2 4 +3) 4,31
+ (call ~4 foo1.0.tdeht49b71 1 +34 25,~31 +1.2) 4,33
+ (call ~4 foo5.1.tdeht49b71 1 +1.3 24,~20 +7) 4,34
+ (call ~4 foo6.1.tdeht49b71 1 +4 28,~18 +7) 9,35
+ (call ~9 foo6.1.tdeht49b71 11,~19 +3 23,~19 +7) 4,36
+ (call ~4 foo6.1.tdeht49b71 16,~20 +3 28,~20 +7) 3,23
+ (proc :foo.1.tdeht49b71 . ~3,~4 .
+  (at foo.0.tdeht49b71
    (i -1)) 8,~4
   (params 1
    (param :x.10 . .
@@ -98,8 +98,8 @@
     (i -1) 4 x.10) 4,1
    (let :j.2 . . 7,~21
     (i -1) 4 y.10))) 4,33
- (proc :foo5.1.tdebp8hax . ~4,~20 .
-  (at foo5.0.tdebp8hax
+ (proc :foo5.1.tdeht49b71 . ~4,~20 .
+  (at foo5.0.tdeht49b71
    (f +64)) 8,~20
   (params 1
    (param :x.11 . .
@@ -108,8 +108,8 @@
     (i -1) 9 +7)) ~4,~20 . ~4,~20 . ~4,~20 . ~2,~19
   (stmts
    (discard .))) 4,34
- (proc :foo6.1.tdebp8hax . ~4,~18 .
-  (at foo6.0.tdebp8hax
+ (proc :foo6.1.tdeht49b71 . ~4,~18 .
+  (at foo6.0.tdeht49b71
    (i -1)) 8,~18
   (params 1
    (param :x.12 . . ,~16

--- a/tests/nimony/sysbasics/tderefs.msgs
+++ b/tests/nimony/sysbasics/tderefs.msgs
@@ -1,1 +1,1 @@
-tests/nimony/sysbasics/tderefs.nim(2, 1) Error: cannot mutate expression x.0.tdex3tcd51
+tests/nimony/sysbasics/tderefs.nim(2, 1) Error: cannot mutate expression x.0.tdeok03je1

--- a/tests/nimony/sysbasics/tderefs1.msgs
+++ b/tests/nimony/sysbasics/tderefs1.msgs
@@ -1,1 +1,1 @@
-tests/nimony/sysbasics/tderefs1.nim(7, 8) Error: cannot pass (call foo.0.tder01ckv) to var/out T parameter
+tests/nimony/sysbasics/tderefs1.nim(7, 8) Error: cannot pass (call foo.0.tded6boh6) to var/out T parameter

--- a/tests/nimony/sysbasics/tderefs2.nif
+++ b/tests/nimony/sysbasics/tderefs2.nif
@@ -1,6 +1,6 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tderefs2.nim(stmts
- (proc 5 :g.0.tdexr7cz81 . . . 6
+ (proc 5 :g.0.tderhveqa . . . 6
   (params 1
    (param :x.0 . . 3
     (mut 4
@@ -13,7 +13,7 @@
      (i -1)) .) 7
    (asgn ~7 result.0 2 x.0) ~2,~1
    (ret result.0))) ,3
- (proc 5 :foo.0.tdexr7cz81 . . . 9
+ (proc 5 :foo.0.tderhveqa . . . 9
   (params) . . . 2,1
   (stmts 4
    (var :s.0 . .
@@ -21,10 +21,10 @@
    (let :x.8 . . 12,~5
     (i -1) 5
     (hderef
-     (call ~1 g.0.tdexr7cz81 1
+     (call ~1 g.0.tderhveqa 1
       (haddr s.0)))))) 3,7
- (call ~3 foo.0.tdexr7cz81) ,10
- (proc 5 :g1.0.tdexr7cz81 . . . 7
+ (call ~3 foo.0.tderhveqa) ,10
+ (proc 5 :g1.0.tderhveqa . . . 7
   (params 1
    (param :x.1 . . 3
     (mut 4
@@ -37,7 +37,7 @@
      (i -1)) .) 7
    (asgn ~7 result.1 2 x.1) ~2,~1
    (ret result.1))) ,13
- (proc 5 :g2.0.tdexr7cz81 . . . 7
+ (proc 5 :g2.0.tderhveqa . . . 7
   (params 1
    (param :x.2 . . 3
     (mut 4
@@ -50,7 +50,7 @@
      (i -1)) .) 7
    (asgn ~7 result.2 2 x.2) ~2,~1
    (ret result.2))) ,16
- (proc 5 :foo1.0.tdexr7cz81 . . . 9
+ (proc 5 :foo1.0.tderhveqa . . . 9
   (params 1
    (param :x.3 . . 3
     (i -1) .)) . . . 2,1
@@ -60,21 +60,21 @@
    (var :s.1 . . 12,~8
     (i -1) 6
     (hderef
-     (call ~2 g1.0.tdexr7cz81 1
+     (call ~2 g1.0.tderhveqa 1
       (haddr x.9)))) 4,2
    (let :y.0 . . 12,~6
     (i -1) 6
     (hderef
-     (call ~2 g2.0.tdexr7cz81 1
+     (call ~2 g2.0.tderhveqa 1
       (haddr s.1)))) 4,3
    (let :n.0 . . 12,~7
     (i -1) 6
     (hderef
-     (call ~2 g2.0.tdexr7cz81 3
-      (call ~2 g1.0.tdexr7cz81 1
+     (call ~2 g2.0.tderhveqa 3
+      (call ~2 g1.0.tderhveqa 1
        (haddr x.9))))))) 4,22
- (call ~4 foo1.0.tdexr7cz81 1 +12) ,24
- (proc 5 :g21.0.tdexr7cz81 . . . 8
+ (call ~4 foo1.0.tderhveqa 1 +12) ,24
+ (proc 5 :g21.0.tderhveqa . . . 8
   (params 1
    (param :x.4 . . 3
     (mut 4
@@ -90,29 +90,29 @@
    (asgn ~7 result.3 2
     (hderef x.4)) ~2,~1
    (ret result.3))) ,29
- (proc 5 :g31.0.tdexr7cz81 . . 8
+ (proc 5 :g31.0.tderhveqa . . 8
   (typevars 1
-   (typevar :T.0.tdexr7cz81 . . . .)) 11
+   (typevar :T.0.tderhveqa . . . .)) 11
   (params 1
    (param :x.5 . . 3
-    (mut 4 T.0.tdexr7cz81) .)) 12 T.0.tdexr7cz81 . . 2,1
+    (mut 4 T.0.tderhveqa) .)) 12 T.0.tderhveqa . . 2,1
   (stmts 7
-   (result :result.4 . . 3,~1 T.0.tdexr7cz81 .) 7
+   (result :result.4 . . 3,~1 T.0.tderhveqa .) 7
    (asgn ~7 result.4 2 x.5) ~2,~1
    (ret result.4))) ,32
- (proc 5 :g41.0.tdexr7cz81 . . 8
+ (proc 5 :g41.0.tderhveqa . . 8
   (typevars 1
-   (typevar :T.1.tdexr7cz81 . . . .)) 11
+   (typevar :T.1.tderhveqa . . . .)) 11
   (params 1
    (param :x.6 . . 3
-    (mut 4 T.1.tdexr7cz81) .)) 12
-  (mut 4 T.1.tdexr7cz81) . . 2,1
+    (mut 4 T.1.tderhveqa) .)) 12
+  (mut 4 T.1.tderhveqa) . . 2,1
   (stmts 7
    (result :result.5 . . 6,~1
-    (mut 4 T.1.tdexr7cz81) .) 7
+    (mut 4 T.1.tderhveqa) .) 7
    (asgn ~7 result.5 2 x.6) ~2,~1
    (ret result.5))) ,35
- (proc 5 :foo11.0.tdexr7cz81 . . . 10
+ (proc 5 :foo11.0.tderhveqa . . . 10
   (params 1
    (param :x.7 . . 3
     (i -1) .)) . . . 2,1
@@ -121,20 +121,20 @@
     (i -1) 4 x.7) 4,1
    (let :s1.0 . . 8,~13
     (i -1) 8
-    (call ~3 g21.0.tdexr7cz81 1
+    (call ~3 g21.0.tderhveqa 1
      (haddr x.10))) 4,2
    (var :s2.0 . . 7,~22
     (i -1) 8
-    (call ~3 g31.1.tdexr7cz81 1
+    (call ~3 g31.1.tderhveqa 1
      (haddr x.10))) 4,3
    (var :s3.0 . . 8,~39
     (i -1) 8
     (hderef
-     (call ~3 g41.1.tdexr7cz81 1
+     (call ~3 g41.1.tderhveqa 1
       (haddr s2.0)))))) 5,41
- (call ~5 foo11.0.tdexr7cz81 1 +12) 14,38
- (proc :g31.1.tdexr7cz81 . ~14,~9 .
-  (at g31.0.tdexr7cz81 ,~3
+ (call ~5 foo11.0.tderhveqa 1 +12) 14,38
+ (proc :g31.1.tderhveqa . ~14,~9 .
+  (at g31.0.tderhveqa ,~3
    (i -1)) ~3,~9
   (params 1
    (param :x.13 . . 3
@@ -147,8 +147,8 @@
    (asgn ~7 result.6 2
     (hderef x.13)) ~2,~1
    (ret result.6))) 14,39
- (proc :g41.1.tdexr7cz81 . ~14,~7 .
-  (at g41.0.tdexr7cz81 ~1,~23
+ (proc :g41.1.tderhveqa . ~14,~7 .
+  (at g41.0.tderhveqa ~1,~23
    (i -1)) ~3,~7
   (params 1
    (param :x.14 . . 3

--- a/tests/nimony/sysbasics/tdollar.nif
+++ b/tests/nimony/sysbasics/tdollar.nif
@@ -1,35 +1,35 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tdollar.nim(stmts 9,1
- (type ~7 :Color1.0.tdoqc0e0v . . . 2
+ (type ~7 :Color1.0.tdom5db6r . . . 2
   (enum
    (u +8) ~7,1
-   (efld :Red1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v
+   (efld :Red1.0.tdom5db6r . . Color1.0.tdom5db6r
     (tup +0 "Red1")) ~1,1
-   (efld :Blue1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v
+   (efld :Blue1.0.tdom5db6r . . Color1.0.tdom5db6r
     (tup +1 "Blue1")) 6,1
-   (efld :Green1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v
+   (efld :Green1.0.tdom5db6r . . Color1.0.tdom5db6r
     (tup +2 "Green1")))) 2,1
- (proc :dollar`.Color1.0.tdoqc0e0v x . .
+ (proc :dollar`.Color1.0.tdom5db6r x . .
   (params
-   (param :e.0 . . Color1.0.tdoqc0e0v .)) string.0.sysvq0asl . .
+   (param :e.0 . . Color1.0.tdom5db6r .)) string.0.sysvq0asl . .
   (stmts 9
    (result :result.0 . . string.0.sysvq0asl .) 9
    (case e.0 ~7,1
     (of
-     (ranges Red1.0.tdoqc0e0v)
+     (ranges Red1.0.tdom5db6r)
      (stmts
       (ret "Red1"))) ~1,1
     (of
-     (ranges Blue1.0.tdoqc0e0v)
+     (ranges Blue1.0.tdom5db6r)
      (stmts
       (ret "Blue1"))) 6,1
     (of
-     (ranges Green1.0.tdoqc0e0v)
+     (ranges Green1.0.tdom5db6r)
      (stmts
       (ret "Green1"))))
    (ret result.0))) ,5
- (proc 5 :fooColor.0.tdoqc0e0v . . . 14
+ (proc 5 :fooColor.0.tdom5db6r . . . 14
   (params) . . . 2,1
   (stmts 4
    (let :m.0 . . string.0.sysvq0asl 4
-    (call dollar`.Color1.0.tdoqc0e0v 1 Blue1.0.tdoqc0e0v)))))
+    (call dollar`.Color1.0.tdom5db6r 1 Blue1.0.tdom5db6r)))))

--- a/tests/nimony/sysbasics/temits.nif
+++ b/tests/nimony/sysbasics/temits.nif
@@ -1,10 +1,10 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/temits.nim(stmts 2
  (emit 6 "int s = 12;") ,2
- (proc 5 :foo.0.temqwhg6j . . . 9
+ (proc 5 :foo.0.temvrtddt1 . . . 9
   (params) . . . 2,1
   (stmts 4
    (var :s.0 . .
     (i -1) 4 +12) 2,1
    (emit 7 s.0 10 " = " 17 +3 20 ";"))) 3,6
- (call ~3 foo.0.temqwhg6j))
+ (call ~3 foo.0.temvrtddt1))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -1,51 +1,51 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/temptyseq.nim(stmts
- (proc 5 :foo.0.temd2l7vy . . . 8
+ (proc 5 :foo.0.temcyppv11 . . . 8
   (params 1
-   (param :x.0 . . 6 seq.0.Ipe57hg.temd2l7vy .)) . . . 24
+   (param :x.0 . . 6 seq.0.Ipe57hg.temcyppv11 .)) . . . 24
   (stmts
    (discard .))) 3,2
- (call ~3 foo.0.temd2l7vy 43,147,lib/std/system/seqimpl.nim
+ (call ~3 foo.0.temcyppv11 43,147,lib/std/system/seqimpl.nim
   (expr 15
    (expr
-    (call ~15 newSeqUninit.0.temd2l7vy 1 +0)))) ,4
- (proc 5 :bar.0.temd2l7vy . . 8
+    (call ~15 newSeqUninit.0.temcyppv11 1 +0)))) ,4
+ (proc 5 :bar.0.temcyppv11 . . 8
   (typevars 1
-   (typevar :T.0.temd2l7vy . . . .)) 11
+   (typevar :T.0.temcyppv11 . . . .)) 11
   (params 1
-   (param :x.1 . . 3 T.0.temd2l7vy .) 7
+   (param :x.1 . . 3 T.0.temcyppv11 .) 7
    (param :y.0 . . 6
-    (at ~3 seq.0.sysvq0asl 1 T.0.temd2l7vy) .)) . . . 31
+    (at ~3 seq.0.sysvq0asl 1 T.0.temcyppv11) .)) . . . 31
   (stmts
    (discard .))) 3,6
- (call ~3 bar.1.temd2l7vy 1 +1.23 43,147,lib/std/system/seqimpl.nim
+ (call ~3 bar.1.temcyppv11 1 +1.23 43,147,lib/std/system/seqimpl.nim
   (expr 15
    (expr
-    (call ~15 newSeqUninit.1.temd2l7vy 1 +0)))) 4,8
- (gvar :s.0.temd2l7vy . . 6 seq.0.Iq4ofkp1.temd2l7vy 43,147,lib/std/system/seqimpl.nim
+    (call ~15 newSeqUninit.1.temcyppv11 1 +0)))) 4,8
+ (gvar :s.0.temcyppv11 . . 6 seq.0.Iq4ofkp1.temcyppv11 43,147,lib/std/system/seqimpl.nim
   (expr 15
    (expr
-    (call ~15 newSeqUninit.2.temd2l7vy 1 +0)))) 58,147,lib/std/system/seqimpl.nim
- (proc :newSeqUninit.0.temd2l7vy . ~58,~92 .
+    (call ~15 newSeqUninit.2.temcyppv11 1 +0)))) 58,147,lib/std/system/seqimpl.nim
+ (proc :newSeqUninit.0.temcyppv11 . ~58,~92 .
   (at newSeqUninit.0.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) ~37,~92
   (params 1
    (param :size.3 . . 6
-    (i -1) .)) ~42,~92 seq.0.Ipe57hg.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.Ipe57hg.temcyppv11 ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.0 . . 14,~1 seq.0.Ipe57hg.temd2l7vy .)
+   (result :result.0 . . 14,~1 seq.0.Ipe57hg.temcyppv11 .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.3 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temd2l7vy 4
-        (kv ~4 len.6.Ipe57hg.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.Ipe57hg.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temcyppv11 4
+        (kv ~4 len.6.Ipe57hg.temcyppv11 2 size.3) 16
+        (kv ~16 data.0.Ipe57hg.temcyppv11 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -56,9 +56,9 @@
         (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
          (i -1)))) 7,1
       (asgn ~7 result.0 8
-       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temd2l7vy 4
-        (kv ~4 len.6.Ipe57hg.temd2l7vy 2 size.3) 16
-        (kv ~16 data.0.Ipe57hg.temd2l7vy 2
+       (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temcyppv11 4
+        (kv ~4 len.6.Ipe57hg.temcyppv11 2 size.3) 16
+        (kv ~16 data.0.Ipe57hg.temcyppv11 2
          (cast 5
           (ptr 18
            (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -72,36 +72,36 @@
            (ptr 18
             (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
              (i -1))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.0 data.0.Ipe57hg.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.0 data.0.Ipe57hg.temcyppv11 +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.0 len.6.Ipe57hg.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.0 len.6.Ipe57hg.temcyppv11 +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.0))))))) ~2,~1
    (ret result.0))) 58,147,lib/std/system/seqimpl.nim
- (proc :newSeqUninit.1.temd2l7vy . ~58,~92 .
+ (proc :newSeqUninit.1.temcyppv11 . ~58,~92 .
   (at newSeqUninit.0.sysvq0asl
    (f +64)) ~37,~92
   (params 1
    (param :size.4 . . 6
-    (i -1) .)) ~42,~92 seq.0.Iw9f2pq.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.Iw9f2pq.temcyppv11 ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.1 . . 14,~1 seq.0.Iw9f2pq.temd2l7vy .)
+   (result :result.1 . . 14,~1 seq.0.Iw9f2pq.temcyppv11 .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.4 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.1 8
-       (oconstr ~3,~2 seq.0.Iw9f2pq.temd2l7vy 4
-        (kv ~4 len.6.Iw9f2pq.temd2l7vy 2 size.4) 16
-        (kv ~16 data.0.Iw9f2pq.temd2l7vy 2
+       (oconstr ~3,~2 seq.0.Iw9f2pq.temcyppv11 4
+        (kv ~4 len.6.Iw9f2pq.temcyppv11 2 size.4) 16
+        (kv ~16 data.0.Iw9f2pq.temcyppv11 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -112,9 +112,9 @@
         (sizeof
          (f +64)))) 7,1
       (asgn ~7 result.1 8
-       (oconstr ~3,~5 seq.0.Iw9f2pq.temd2l7vy 4
-        (kv ~4 len.6.Iw9f2pq.temd2l7vy 2 size.4) 16
-        (kv ~16 data.0.Iw9f2pq.temd2l7vy 2
+       (oconstr ~3,~5 seq.0.Iw9f2pq.temcyppv11 4
+        (kv ~4 len.6.Iw9f2pq.temcyppv11 2 size.4) 16
+        (kv ~16 data.0.Iw9f2pq.temcyppv11 2
          (cast 5
           (ptr 18
            (uarray
@@ -128,45 +128,45 @@
            (ptr 18
             (uarray
              (f +64))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.1 data.0.Iw9f2pq.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.1 data.0.Iw9f2pq.temcyppv11 +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.1 len.6.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.1 len.6.Iw9f2pq.temcyppv11 +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.1))))))) ~2,~1
    (ret result.1))) 3,6
- (proc :bar.1.temd2l7vy . ~3,~2 .
-  (at bar.0.temd2l7vy
+ (proc :bar.1.temcyppv11 . ~3,~2 .
+  (at bar.0.temcyppv11
    (f +64)) 8,~2
   (params 1
    (param :x.3 . .
     (f +64) .) 7
-   (param :y.2 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
+   (param :y.2 . . 6 seq.0.Iw9f2pq.temcyppv11 .)) ~3,~2 . ~3,~2 . ~3,~2 . 28,~2
   (stmts
    (discard .))) 58,147,lib/std/system/seqimpl.nim
- (proc :newSeqUninit.2.temd2l7vy . ~58,~92 .
+ (proc :newSeqUninit.2.temcyppv11 . ~58,~92 .
   (at newSeqUninit.0.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) ~37,~92
   (params 1
    (param :size.5 . . 6
-    (i -1) .)) ~42,~92 seq.0.Iq4ofkp1.temd2l7vy ~17,~92
+    (i -1) .)) ~42,~92 seq.0.Iq4ofkp1.temcyppv11 ~17,~92
   (pragmas 2
    (nodestroy) 13
    (inline)) ~58,~92 . ~56,~91
   (stmts
-   (result :result.2 . . 14,~1 seq.0.Iq4ofkp1.temd2l7vy .)
+   (result :result.2 . . 14,~1 seq.0.Iq4ofkp1.temcyppv11 .)
    (if 3
     (elif 5
      (eq 18,~1
       (i -1) ~5 size.5 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temd2l7vy 4
-        (kv ~4 len.6.Iq4ofkp1.temd2l7vy 2 size.5) 16
-        (kv ~16 data.0.Iq4ofkp1.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temcyppv11 4
+        (kv ~4 len.6.Iq4ofkp1.temcyppv11 2 size.5) 16
+        (kv ~16 data.0.Iq4ofkp1.temcyppv11 2
          (nil)))))) ,2
     (else 2,1
      (stmts 4
@@ -177,9 +177,9 @@
         (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
          (u +8)))) 7,1
       (asgn ~7 result.2 8
-       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temd2l7vy 4
-        (kv ~4 len.6.Iq4ofkp1.temd2l7vy 2 size.5) 16
-        (kv ~16 data.0.Iq4ofkp1.temd2l7vy 2
+       (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temcyppv11 4
+        (kv ~4 len.6.Iq4ofkp1.temcyppv11 2 size.5) 16
+        (kv ~16 data.0.Iq4ofkp1.temcyppv11 2
          (cast 5
           (ptr 18
            (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -193,63 +193,63 @@
            (ptr 18
             (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
              (u +8))) 13,61,lib/std/system/seqimpl.nim
-           (dot ~6 result.2 data.0.Iq4ofkp1.temd2l7vy +0) 22,61,lib/std/system/seqimpl.nim
+           (dot ~6 result.2 data.0.Iq4ofkp1.temcyppv11 +0) 22,61,lib/std/system/seqimpl.nim
            (nil)))) ~1,1
         (stmts
          (discard 8 "leave uninitialized"))) ,2
        (else 2,1
         (stmts 11
          (asgn ~5
-          (dot ~6 result.2 len.6.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
+          (dot ~6 result.2 len.6.Iq4ofkp1.temcyppv11 +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.2))))))) ~2,~1
    (ret result.2))) 15
- (type :seq.0.Ipe57hg.temd2l7vy .
+ (type :seq.0.Ipe57hg.temcyppv11 .
   (at seq.0.sysvq0asl 1
    (i -1)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.6.Ipe57hg.temd2l7vy . . 5
+   (fld :len.6.Ipe57hg.temcyppv11 . . 5
     (i -1) .) ~8,2
-   (fld :data.0.Ipe57hg.temd2l7vy . . 6
+   (fld :data.0.Ipe57hg.temcyppv11 . . 6
     (ptr 18
      (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
       (i -1))) .))) 16,55,lib/std/system/seqimpl.nim
- (type :seq.0.Iw9f2pq.temd2l7vy .
+ (type :seq.0.Iw9f2pq.temcyppv11 .
   (at seq.0.sysvq0asl
    (f +64)) ~6,~51 . ~4,~51
   (object . ~8,1
-   (fld :len.6.Iw9f2pq.temd2l7vy . . 5
+   (fld :len.6.Iw9f2pq.temcyppv11 . . 5
     (i -1) .) ~8,2
-   (fld :data.0.Iw9f2pq.temd2l7vy . . 6
+   (fld :data.0.Iw9f2pq.temcyppv11 . . 6
     (ptr 18
      (uarray
       (f +64))) .))) 10,8
- (type :seq.0.Iq4ofkp1.temd2l7vy .
+ (type :seq.0.Iq4ofkp1.temcyppv11 .
   (at seq.0.sysvq0asl 1
    (u +8)) 10,4,lib/std/system/seqimpl.nim . 12,4,lib/std/system/seqimpl.nim
   (object . ~8,1
-   (fld :len.6.Iq4ofkp1.temd2l7vy . . 5
+   (fld :len.6.Iq4ofkp1.temcyppv11 . . 5
     (i -1) .) ~8,2
-   (fld :data.0.Iq4ofkp1.temd2l7vy . . 6
+   (fld :data.0.Iq4ofkp1.temcyppv11 . . 6
     (ptr 18
      (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
       (u +8))) .))) 0,11,lib/std/system/seqimpl.nim
- (proc :=destroy.0.temd2l7vy . .
+ (proc :=destroy.0.temcyppv11 . .
   (at =destroy.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 19
   (params 1
-   (param :s.6 . . 6 seq.0.Ipe57hg.temd2l7vy .)) . . . 2,1
+   (param :s.6 . . 6 seq.0.Ipe57hg.temcyppv11 .)) . . . 2,1
   (stmts 4
    (var :i.0 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.0 3
-     (dot ~1 s.6 len.6.Ipe57hg.temd2l7vy +0)) 2,1
+     (dot ~1 s.6 len.6.Ipe57hg.temcyppv11 +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0) 6 i.0)) ,1
-     (cmd inc.0.temd2l7vy 4
+       (dot ~1 s.6 data.0.Ipe57hg.temcyppv11 +0) 6 i.0)) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.0)))) ,4
    (if 3
     (elif 2,399,lib/std/system.nim
@@ -259,7 +259,7 @@
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
           (i -1))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.6 data.0.Ipe57hg.temcyppv11 +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -267,58 +267,58 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
- (proc :=wasMoved.0.temd2l7vy . .
+         (dot ~1 s.6 data.0.Ipe57hg.temcyppv11 +0))))))))) 0,19,lib/std/system/seqimpl.nim
+ (proc :=wasMoved.0.temcyppv11 . .
   (at =wasMoved.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 20
   (params 1
    (param :s.7 . . 3
-    (mut 7 seq.0.Ipe57hg.temd2l7vy) .)) . 36
+    (mut 7 seq.0.Ipe57hg.temcyppv11) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.7) len.6.Ipe57hg.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.7) len.6.Ipe57hg.temcyppv11 +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.7) data.0.Ipe57hg.temd2l7vy +0) 2
+     (hderef s.7) data.0.Ipe57hg.temcyppv11 +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
- (proc :=dup.0.temd2l7vy . .
+ (proc :=dup.0.temcyppv11 . .
   (at =dup.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 15
   (params 1
-   (param :a.3 . . 6 seq.0.Ipe57hg.temd2l7vy .)) 16 seq.0.Ipe57hg.temd2l7vy 35
+   (param :a.3 . . 6 seq.0.Ipe57hg.temcyppv11 .)) 16 seq.0.Ipe57hg.temcyppv11 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.3 . . 13,~1 seq.0.Ipe57hg.temd2l7vy .) 7
+   (result :result.3 . . 13,~1 seq.0.Ipe57hg.temcyppv11 .) 7
    (asgn ~7 result.3 17
-    (call ~15 newSeqUninit.0.temd2l7vy 2
-     (dot ~1 a.3 len.6.Ipe57hg.temd2l7vy +0))) 4,1
+    (call ~15 newSeqUninit.0.temcyppv11 2
+     (dot ~1 a.3 len.6.Ipe57hg.temcyppv11 +0))) 4,1
    (var :i.1 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.1 3
-     (dot ~1 a.3 len.6.Ipe57hg.temd2l7vy +0)) 2,1
+     (dot ~1 a.3 len.6.Ipe57hg.temcyppv11 +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.3 data.0.Ipe57hg.temd2l7vy +0) 6 i.1) 8
+       (dot ~6 result.3 data.0.Ipe57hg.temcyppv11 +0) 6 i.1) 8
       (dup 2
        (pat
-        (dot ~1 a.3 data.0.Ipe57hg.temd2l7vy +0) 6 i.1))) ,1
-     (cmd inc.0.temd2l7vy 4
+        (dot ~1 a.3 data.0.Ipe57hg.temcyppv11 +0) 6 i.1))) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.1)))) ~2,~1
    (ret result.3))) 0,93,lib/std/system/seqimpl.nim
- (proc :=copy.0.temd2l7vy . .
+ (proc :=copy.0.temcyppv11 . .
   (at =copy.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 16
   (params 1
    (param :dest.3 . . 6
-    (mut 7 seq.0.Ipe57hg.temd2l7vy) .) 19
-   (param :src.3 . . 8 seq.0.Ipe57hg.temd2l7vy .)) . 48
+    (mut 7 seq.0.Ipe57hg.temcyppv11) .) 19
+   (param :src.3 . . 8 seq.0.Ipe57hg.temcyppv11 .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -329,41 +329,41 @@
        (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1))) ~6
       (dot ~4
-       (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 6
-      (dot ~3 src.3 data.0.Ipe57hg.temd2l7vy +0)) 23
+       (hderef dest.3) data.0.Ipe57hg.temcyppv11 +0) 6
+      (dot ~3 src.3 data.0.Ipe57hg.temcyppv11 +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0) 6
+      (dot ~3 src.3 len.6.Ipe57hg.temcyppv11 +0) 6
       (dot ~4
-       (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0)) ~1,1
+       (hderef dest.3) len.6.Ipe57hg.temcyppv11 +0)) ~1,1
      (stmts 4
       (var :i.2 . . 1,~91
        (i -1) 7
-       (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0)) ,1
+       (dot ~3 src.3 len.6.Ipe57hg.temcyppv11 +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.2 6
         (dot ~4
-         (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0)) 2,1
+         (hderef dest.3) len.6.Ipe57hg.temcyppv11 +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 6 i.2)) ,1
-        (cmd inc.0.temd2l7vy 4
+           (hderef dest.3) data.0.Ipe57hg.temcyppv11 +0) 6 i.2)) ,1
+        (cmd inc.0.temcyppv11 4
          (haddr i.2)))))) 5,5
     (elif 16
      (lt 7,33,lib/std/system.nim
       (i -1) ~12
-      (call 1 capInBytes.0.temd2l7vy ~4
+      (call 1 capInBytes.0.temcyppv11 ~4
        (hderef dest.3)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0) 8
+       (dot ~3 src.3 len.6.Ipe57hg.temcyppv11 +0) 8
        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1)))) ~3,1
      (stmts 4
@@ -371,7 +371,7 @@
        (i -1) 25
        (div 7,33,lib/std/system.nim
         (i -1) ~12
-        (call 1 capInBytes.0.temd2l7vy ~4
+        (call 1 capInBytes.0.temcyppv11 ~4
          (hderef dest.3)) 10
         (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
          (i -1)))) 4,1
@@ -380,7 +380,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.0 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0) 2 oldCap.0))) 4,2
+         (dot ~3 src.3 len.6.Ipe57hg.temcyppv11 +0) 2 oldCap.0))) 4,2
       (let :memSize.3 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -389,7 +389,7 @@
          (i -1)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 2
+        (hderef dest.3) data.0.Ipe57hg.temcyppv11 +0) 2
        (cast 5
         (ptr 18
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -400,7 +400,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0))) 12 memSize.3))) ,4
+            (hderef dest.3) data.0.Ipe57hg.temcyppv11 +0))) 12 memSize.3))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -408,53 +408,53 @@
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) ~6
          (dot ~4
-          (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 3
+          (hderef dest.3) data.0.Ipe57hg.temcyppv11 +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.3) len.6.Ipe57hg.temcyppv11 +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.3) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0) 5
-    (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0)) 4,16
+     (hderef dest.3) len.6.Ipe57hg.temcyppv11 +0) 5
+    (dot ~3 src.3 len.6.Ipe57hg.temcyppv11 +0)) 4,16
    (var :i.3 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.3 6
      (dot ~4
-      (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0)) 2,1
+      (hderef dest.3) len.6.Ipe57hg.temcyppv11 +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.3) data.0.Ipe57hg.temcyppv11 +0) 14,112,lib/std/system/seqimpl.nim i.3) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.3 data.0.Ipe57hg.temd2l7vy +0) 6 i.3)))) ,1
-     (cmd inc.0.temd2l7vy 4
+         (dot ~3 src.3 data.0.Ipe57hg.temcyppv11 +0) 6 i.3)))) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.3)))))) 0,11,lib/std/system/seqimpl.nim
- (proc :=destroy.1.temd2l7vy . .
+ (proc :=destroy.1.temcyppv11 . .
   (at =destroy.2.sysvq0asl
    (f +64)) 19
   (params 1
-   (param :s.9 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) . . . 2,1
+   (param :s.9 . . 6 seq.0.Iw9f2pq.temcyppv11 .)) . . . 2,1
   (stmts 4
    (var :i.4 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.4 3
-     (dot ~1 s.9 len.6.Iw9f2pq.temd2l7vy +0)) 2,1
+     (dot ~1 s.9 len.6.Iw9f2pq.temcyppv11 +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0) 6 i.4)) ,1
-     (cmd inc.0.temd2l7vy 4
+       (dot ~1 s.9 data.0.Iw9f2pq.temcyppv11 +0) 6 i.4)) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.4)))) ,4
    (if 3
     (elif 2,399,lib/std/system.nim
@@ -464,7 +464,7 @@
         (ptr 18
          (uarray
           (f +64))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.9 data.0.Iw9f2pq.temcyppv11 +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -472,58 +472,58 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
- (proc :=wasMoved.1.temd2l7vy . .
+         (dot ~1 s.9 data.0.Iw9f2pq.temcyppv11 +0))))))))) 0,19,lib/std/system/seqimpl.nim
+ (proc :=wasMoved.1.temcyppv11 . .
   (at =wasMoved.2.sysvq0asl
    (f +64)) 20
   (params 1
    (param :s.10 . . 3
-    (mut 7 seq.0.Iw9f2pq.temd2l7vy) .)) . 36
+    (mut 7 seq.0.Iw9f2pq.temcyppv11) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.10) len.6.Iw9f2pq.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.10) len.6.Iw9f2pq.temcyppv11 +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.10) data.0.Iw9f2pq.temd2l7vy +0) 2
+     (hderef s.10) data.0.Iw9f2pq.temcyppv11 +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
- (proc :=dup.1.temd2l7vy . .
+ (proc :=dup.1.temcyppv11 . .
   (at =dup.2.sysvq0asl
    (f +64)) 15
   (params 1
-   (param :a.4 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) 16 seq.0.Iw9f2pq.temd2l7vy 35
+   (param :a.4 . . 6 seq.0.Iw9f2pq.temcyppv11 .)) 16 seq.0.Iw9f2pq.temcyppv11 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.4 . . 13,~1 seq.0.Iw9f2pq.temd2l7vy .) 7
+   (result :result.4 . . 13,~1 seq.0.Iw9f2pq.temcyppv11 .) 7
    (asgn ~7 result.4 17
-    (call ~15 newSeqUninit.1.temd2l7vy 2
-     (dot ~1 a.4 len.6.Iw9f2pq.temd2l7vy +0))) 4,1
+    (call ~15 newSeqUninit.1.temcyppv11 2
+     (dot ~1 a.4 len.6.Iw9f2pq.temcyppv11 +0))) 4,1
    (var :i.5 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.5 3
-     (dot ~1 a.4 len.6.Iw9f2pq.temd2l7vy +0)) 2,1
+     (dot ~1 a.4 len.6.Iw9f2pq.temcyppv11 +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.4 data.0.Iw9f2pq.temd2l7vy +0) 6 i.5) 8
+       (dot ~6 result.4 data.0.Iw9f2pq.temcyppv11 +0) 6 i.5) 8
       (dup 2
        (pat
-        (dot ~1 a.4 data.0.Iw9f2pq.temd2l7vy +0) 6 i.5))) ,1
-     (cmd inc.0.temd2l7vy 4
+        (dot ~1 a.4 data.0.Iw9f2pq.temcyppv11 +0) 6 i.5))) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.5)))) ~2,~1
    (ret result.4))) 0,93,lib/std/system/seqimpl.nim
- (proc :=copy.1.temd2l7vy . .
+ (proc :=copy.1.temcyppv11 . .
   (at =copy.2.sysvq0asl
    (f +64)) 16
   (params 1
    (param :dest.4 . . 6
-    (mut 7 seq.0.Iw9f2pq.temd2l7vy) .) 19
-   (param :src.4 . . 8 seq.0.Iw9f2pq.temd2l7vy .)) . 48
+    (mut 7 seq.0.Iw9f2pq.temcyppv11) .) 19
+   (param :src.4 . . 8 seq.0.Iw9f2pq.temcyppv11 .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -534,41 +534,41 @@
        (uarray
         (f +64))) ~6
       (dot ~4
-       (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 6
-      (dot ~3 src.4 data.0.Iw9f2pq.temd2l7vy +0)) 23
+       (hderef dest.4) data.0.Iw9f2pq.temcyppv11 +0) 6
+      (dot ~3 src.4 data.0.Iw9f2pq.temcyppv11 +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0) 6
+      (dot ~3 src.4 len.6.Iw9f2pq.temcyppv11 +0) 6
       (dot ~4
-       (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0)) ~1,1
+       (hderef dest.4) len.6.Iw9f2pq.temcyppv11 +0)) ~1,1
      (stmts 4
       (var :i.6 . . 1,~91
        (i -1) 7
-       (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0)) ,1
+       (dot ~3 src.4 len.6.Iw9f2pq.temcyppv11 +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.6 6
         (dot ~4
-         (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0)) 2,1
+         (hderef dest.4) len.6.Iw9f2pq.temcyppv11 +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 6 i.6)) ,1
-        (cmd inc.0.temd2l7vy 4
+           (hderef dest.4) data.0.Iw9f2pq.temcyppv11 +0) 6 i.6)) ,1
+        (cmd inc.0.temcyppv11 4
          (haddr i.6)))))) 5,5
     (elif 16
      (lt 7,33,lib/std/system.nim
       (i -1) ~12
-      (call 1 capInBytes.1.temd2l7vy ~4
+      (call 1 capInBytes.1.temcyppv11 ~4
        (hderef dest.4)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0) 8
+       (dot ~3 src.4 len.6.Iw9f2pq.temcyppv11 +0) 8
        (sizeof
         (f +64)))) ~3,1
      (stmts 4
@@ -576,7 +576,7 @@
        (i -1) 25
        (div 7,33,lib/std/system.nim
         (i -1) ~12
-        (call 1 capInBytes.1.temd2l7vy ~4
+        (call 1 capInBytes.1.temcyppv11 ~4
          (hderef dest.4)) 10
         (sizeof
          (f +64)))) 4,1
@@ -585,7 +585,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.1 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0) 2 oldCap.1))) 4,2
+         (dot ~3 src.4 len.6.Iw9f2pq.temcyppv11 +0) 2 oldCap.1))) 4,2
       (let :memSize.4 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -594,7 +594,7 @@
          (f +64)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 2
+        (hderef dest.4) data.0.Iw9f2pq.temcyppv11 +0) 2
        (cast 5
         (ptr 18
          (uarray
@@ -605,7 +605,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0))) 12 memSize.4))) ,4
+            (hderef dest.4) data.0.Iw9f2pq.temcyppv11 +0))) 12 memSize.4))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -613,53 +613,53 @@
           (uarray
            (f +64))) ~6
          (dot ~4
-          (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 3
+          (hderef dest.4) data.0.Iw9f2pq.temcyppv11 +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.4) len.6.Iw9f2pq.temcyppv11 +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.4) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0) 5
-    (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0)) 4,16
+     (hderef dest.4) len.6.Iw9f2pq.temcyppv11 +0) 5
+    (dot ~3 src.4 len.6.Iw9f2pq.temcyppv11 +0)) 4,16
    (var :i.7 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.7 6
      (dot ~4
-      (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0)) 2,1
+      (hderef dest.4) len.6.Iw9f2pq.temcyppv11 +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.4) data.0.Iw9f2pq.temcyppv11 +0) 14,112,lib/std/system/seqimpl.nim i.7) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.4 data.0.Iw9f2pq.temd2l7vy +0) 6 i.7)))) ,1
-     (cmd inc.0.temd2l7vy 4
+         (dot ~3 src.4 data.0.Iw9f2pq.temcyppv11 +0) 6 i.7)))) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.7)))))) 0,11,lib/std/system/seqimpl.nim
- (proc :=destroy.2.temd2l7vy . .
+ (proc :=destroy.2.temcyppv11 . .
   (at =destroy.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 19
   (params 1
-   (param :s.12 . . 6 seq.0.Iq4ofkp1.temd2l7vy .)) . . . 2,1
+   (param :s.12 . . 6 seq.0.Iq4ofkp1.temcyppv11 .)) . . . 2,1
   (stmts 4
    (var :i.8 . . 3,~7
     (i -1) 4 +0) ,1
    (while 8
     (lt
      (i -1) ~2 i.8 3
-     (dot ~1 s.12 len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
+     (dot ~1 s.12 len.6.Iq4ofkp1.temcyppv11 +0)) 2,1
     (stmts 10
      (destroy 2
       (pat
-       (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.8)) ,1
-     (cmd inc.0.temd2l7vy 4
+       (dot ~1 s.12 data.0.Iq4ofkp1.temcyppv11 +0) 6 i.8)) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.8)))) ,4
    (if 3
     (elif 2,399,lib/std/system.nim
@@ -669,7 +669,7 @@
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
           (u +8))) 6,16,lib/std/system/seqimpl.nim
-        (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0) 15,16,lib/std/system/seqimpl.nim
+        (dot ~1 s.12 data.0.Iq4ofkp1.temcyppv11 +0) 15,16,lib/std/system/seqimpl.nim
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
@@ -677,58 +677,58 @@
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
          (pointer) 13,17,lib/std/system/seqimpl.nim
-         (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
- (proc :=wasMoved.2.temd2l7vy . .
+         (dot ~1 s.12 data.0.Iq4ofkp1.temcyppv11 +0))))))))) 0,19,lib/std/system/seqimpl.nim
+ (proc :=wasMoved.2.temcyppv11 . .
   (at =wasMoved.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 20
   (params 1
    (param :s.13 . . 3
-    (mut 7 seq.0.Iq4ofkp1.temd2l7vy) .)) . 36
+    (mut 7 seq.0.Iq4ofkp1.temcyppv11) .)) . 36
   (pragmas 2
    (inline)) . 2,1
   (stmts 6
    (asgn ~5
     (dot ~1
-     (hderef s.13) len.6.Iq4ofkp1.temd2l7vy +0) 2 +0) 7,1
+     (hderef s.13) len.6.Iq4ofkp1.temcyppv11 +0) 2 +0) 7,1
    (asgn ~6
     (dot ~1
-     (hderef s.13) data.0.Iq4ofkp1.temd2l7vy +0) 2
+     (hderef s.13) data.0.Iq4ofkp1.temcyppv11 +0) 2
     (nil)))) 0,69,lib/std/system/seqimpl.nim
- (proc :=dup.2.temd2l7vy . .
+ (proc :=dup.2.temcyppv11 . .
   (at =dup.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 15
   (params 1
-   (param :a.5 . . 6 seq.0.Iq4ofkp1.temd2l7vy .)) 16 seq.0.Iq4ofkp1.temd2l7vy 35
+   (param :a.5 . . 6 seq.0.Iq4ofkp1.temcyppv11 .)) 16 seq.0.Iq4ofkp1.temcyppv11 35
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts 7
-   (result :result.5 . . 13,~1 seq.0.Iq4ofkp1.temd2l7vy .) 7
+   (result :result.5 . . 13,~1 seq.0.Iq4ofkp1.temcyppv11 .) 7
    (asgn ~7 result.5 17
-    (call ~15 newSeqUninit.2.temd2l7vy 2
-     (dot ~1 a.5 len.6.Iq4ofkp1.temd2l7vy +0))) 4,1
+    (call ~15 newSeqUninit.2.temcyppv11 2
+     (dot ~1 a.5 len.6.Iq4ofkp1.temcyppv11 +0))) 4,1
    (var :i.9 . . 3,~66
     (i -1) 4 +0) ,2
    (while 8
     (lt
      (i -1) ~2 i.9 3
-     (dot ~1 a.5 len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
+     (dot ~1 a.5 len.6.Iq4ofkp1.temcyppv11 +0)) 2,1
     (stmts 17
      (asgn ~10
       (pat
-       (dot ~6 result.5 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.9) 8
+       (dot ~6 result.5 data.0.Iq4ofkp1.temcyppv11 +0) 6 i.9) 8
       (dup 2
        (pat
-        (dot ~1 a.5 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.9))) ,1
-     (cmd inc.0.temd2l7vy 4
+        (dot ~1 a.5 data.0.Iq4ofkp1.temcyppv11 +0) 6 i.9))) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.9)))) ~2,~1
    (ret result.5))) 0,93,lib/std/system/seqimpl.nim
- (proc :=copy.2.temd2l7vy . .
+ (proc :=copy.2.temcyppv11 . .
   (at =copy.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 16
   (params 1
    (param :dest.5 . . 6
-    (mut 7 seq.0.Iq4ofkp1.temd2l7vy) .) 19
-   (param :src.5 . . 8 seq.0.Iq4ofkp1.temd2l7vy .)) . 48
+    (mut 7 seq.0.Iq4ofkp1.temcyppv11) .) 19
+   (param :src.5 . . 8 seq.0.Iq4ofkp1.temcyppv11 .)) . 48
   (pragmas 2
    (nodestroy)) . 2,1
   (stmts
@@ -739,41 +739,41 @@
        (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8))) ~6
       (dot ~4
-       (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 6
-      (dot ~3 src.5 data.0.Iq4ofkp1.temd2l7vy +0)) 23
+       (hderef dest.5) data.0.Iq4ofkp1.temcyppv11 +0) 6
+      (dot ~3 src.5 data.0.Iq4ofkp1.temcyppv11 +0)) 23
      (stmts
       (ret .)))) ,1
    (if 3
     (elif 8
      (lt 7,33,lib/std/system.nim
       (i -1) ~5
-      (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0) 6
+      (dot ~3 src.5 len.6.Iq4ofkp1.temcyppv11 +0) 6
       (dot ~4
-       (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0)) ~1,1
+       (hderef dest.5) len.6.Iq4ofkp1.temcyppv11 +0)) ~1,1
      (stmts 4
       (var :i.10 . . 1,~91
        (i -1) 7
-       (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0)) ,1
+       (dot ~3 src.5 len.6.Iq4ofkp1.temcyppv11 +0)) ,1
       (while 8
        (lt 7,33,lib/std/system.nim
         (i -1) ~2 i.10 6
         (dot ~4
-         (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
+         (hderef dest.5) len.6.Iq4ofkp1.temcyppv11 +0)) 2,1
        (stmts 10
         (destroy 5
          (pat
           (dot ~4
-           (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 6 i.10)) ,1
-        (cmd inc.0.temd2l7vy 4
+           (hderef dest.5) data.0.Iq4ofkp1.temcyppv11 +0) 6 i.10)) ,1
+        (cmd inc.0.temcyppv11 4
          (haddr i.10)))))) 5,5
     (elif 16
      (lt 7,33,lib/std/system.nim
       (i -1) ~12
-      (call 1 capInBytes.2.temd2l7vy ~4
+      (call 1 capInBytes.2.temcyppv11 ~4
        (hderef dest.5)) 10
       (mul 7,33,lib/std/system.nim
        (i -1) ~5
-       (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0) 8
+       (dot ~3 src.5 len.6.Iq4ofkp1.temcyppv11 +0) 8
        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8)))) ~3,1
      (stmts 4
@@ -781,7 +781,7 @@
        (i -1) 25
        (div 7,33,lib/std/system.nim
         (i -1) ~12
-        (call 1 capInBytes.2.temd2l7vy ~4
+        (call 1 capInBytes.2.temcyppv11 ~4
          (hderef dest.5)) 10
         (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
          (u +8)))) 4,1
@@ -790,7 +790,7 @@
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.2 17
         (sub 7,33,lib/std/system.nim
          (i -1) ~5
-         (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0) 2 oldCap.2))) 4,2
+         (dot ~3 src.5 len.6.Iq4ofkp1.temcyppv11 +0) 2 oldCap.2))) 4,2
       (let :memSize.5 . . 1,~98
        (i -1) 17
        (mul 5,~27
@@ -799,7 +799,7 @@
          (u +8)))) 10,3
       (asgn ~6
        (dot ~4
-        (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 2
+        (hderef dest.5) data.0.Iq4ofkp1.temcyppv11 +0) 2
        (cast 5
         (ptr 18
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -810,7 +810,7 @@
           (hconv 17,19,lib/std/system/mimalloc.nim
            (pointer) 56,104,lib/std/system/seqimpl.nim
            (dot ~4
-            (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0))) 12 memSize.5))) ,4
+            (hderef dest.5) data.0.Iq4ofkp1.temcyppv11 +0))) 12 memSize.5))) ,4
       (if 3
        (elif 10
         (eq ~7,~99
@@ -818,37 +818,37 @@
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) ~6
          (dot ~4
-          (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 3
+          (hderef dest.5) data.0.Iq4ofkp1.temcyppv11 +0) 3
          (nil)) ~1,1
         (stmts 9
          (asgn ~5
           (dot ~4
-           (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0) 2 +0) ,1
+           (hderef dest.5) len.6.Iq4ofkp1.temcyppv11 +0) 2 +0) ,1
          (cmd oomHandler.0.sysvq0asl 11 memSize.5) ,2
          (ret .))))))) 9,15
    (asgn ~5
     (dot ~4
-     (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0) 5
-    (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0)) 4,16
+     (hderef dest.5) len.6.Iq4ofkp1.temcyppv11 +0) 5
+    (dot ~3 src.5 len.6.Iq4ofkp1.temcyppv11 +0)) 4,16
    (var :i.11 . . 3,~105
     (i -1) 4 +0) ,17
    (while 8
     (lt
      (i -1) ~2 i.11 6
      (dot ~4
-      (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
+      (hderef dest.5) len.6.Iq4ofkp1.temcyppv11 +0)) 2,1
     (stmts 2,98,lib/std/system.nim
      (stmts 7
       (asgn ~6
        (pat 8,112,lib/std/system/seqimpl.nim
         (dot ~4
-         (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
+         (hderef dest.5) data.0.Iq4ofkp1.temcyppv11 +0) 14,112,lib/std/system/seqimpl.nim i.11) 25,112,lib/std/system/seqimpl.nim
        (dup 4
         (pat
-         (dot ~3 src.5 data.0.Iq4ofkp1.temd2l7vy +0) 6 i.11)))) ,1
-     (cmd inc.0.temd2l7vy 4
+         (dot ~3 src.5 data.0.Iq4ofkp1.temcyppv11 +0) 6 i.11)))) ,1
+     (cmd inc.0.temcyppv11 4
       (haddr i.11)))))) 4,15,lib/std/system/seqimpl.nim
- (proc :inc.0.temd2l7vy . 0,276,lib/std/system.nim .
+ (proc :inc.0.temcyppv11 . 0,276,lib/std/system.nim .
   (at inc.1.sysvq0asl 5,~10
    (i -1)) 21,276,lib/std/system.nim
   (params 1
@@ -865,11 +865,11 @@
      (hderef x.5) 3
      (conv 9,5,lib/std/system/seqimpl.nim
       (i -1) 1 +1))))) 11,100,lib/std/system/seqimpl.nim
- (proc :capInBytes.0.temd2l7vy . ~11,~92 .
+ (proc :capInBytes.0.temcyppv11 . ~11,~92 .
   (at capInBytes.0.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) 7,~92
   (params 1
-   (param :s.15 . . 6 seq.0.Ipe57hg.temd2l7vy .)) 2,~92
+   (param :s.15 . . 6 seq.0.Ipe57hg.temcyppv11 .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -885,7 +885,7 @@
          (ptr 18
           (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
            (i -1))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.15 data.0.Ipe57hg.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.15 data.0.Ipe57hg.temcyppv11 +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -893,15 +893,15 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.15 data.0.Ipe57hg.temd2l7vy +0)))))) 40
+          (dot ~1 s.15 data.0.Ipe57hg.temcyppv11 +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.6))) 11,100,lib/std/system/seqimpl.nim
- (proc :capInBytes.1.temd2l7vy . ~11,~92 .
+ (proc :capInBytes.1.temcyppv11 . ~11,~92 .
   (at capInBytes.0.sysvq0asl
    (f +64)) 7,~92
   (params 1
-   (param :s.16 . . 6 seq.0.Iw9f2pq.temd2l7vy .)) 2,~92
+   (param :s.16 . . 6 seq.0.Iw9f2pq.temcyppv11 .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -917,7 +917,7 @@
          (ptr 18
           (uarray
            (f +64))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.16 data.0.Iw9f2pq.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.16 data.0.Iw9f2pq.temcyppv11 +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -925,15 +925,15 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.16 data.0.Iw9f2pq.temd2l7vy +0)))))) 40
+          (dot ~1 s.16 data.0.Iw9f2pq.temcyppv11 +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.7))) 11,100,lib/std/system/seqimpl.nim
- (proc :capInBytes.2.temd2l7vy . ~11,~92 .
+ (proc :capInBytes.2.temcyppv11 . ~11,~92 .
   (at capInBytes.0.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
    (u +8)) 7,~92
   (params 1
-   (param :s.17 . . 6 seq.0.Iq4ofkp1.temd2l7vy .)) 2,~92
+   (param :s.17 . . 6 seq.0.Iq4ofkp1.temcyppv11 .)) 2,~92
   (i -1) 24,~92
   (pragmas 2
    (inline)) ~11,~92 . ~9,~91
@@ -949,7 +949,7 @@
          (ptr 18
           (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
            (u +8))) 15,9,lib/std/system/seqimpl.nim
-         (dot ~1 s.17 data.0.Iq4ofkp1.temd2l7vy +0) 24,9,lib/std/system/seqimpl.nim
+         (dot ~1 s.17 data.0.Iq4ofkp1.temcyppv11 +0) 24,9,lib/std/system/seqimpl.nim
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
@@ -957,7 +957,7 @@
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
           (pointer) 44,9,lib/std/system/seqimpl.nim
-          (dot ~1 s.17 data.0.Iq4ofkp1.temd2l7vy +0)))))) 40
+          (dot ~1 s.17 data.0.Iq4ofkp1.temcyppv11 +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
    (ret result.8))))

--- a/tests/nimony/sysbasics/tforloops.nif
+++ b/tests/nimony/sysbasics/tforloops.nif
@@ -1,8 +1,8 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tforloops.nim(stmts 4
- (gvar :globalX.0.tfo6zftzj1 . .
+ (gvar :globalX.0.tfovc75a41 . .
   (i -1) 10 +12) ,2
- (iterator 9 :foo.0.tfo6zftzj1 . . . 12
+ (iterator 9 :foo.0.tfovc75a41 . . . 12
   (params 1
    (param :x.0 . . 3
     (i -1) .)) 10
@@ -27,7 +27,7 @@
      (tupconstr ~2,~2
       (tuple 1
        (i -1) 6
-       (i -1)) 1 +12 5 globalX.0.tfo6zftzj1))) ,1
+       (i -1)) 1 +12 5 globalX.0.tfovc75a41))) ,1
    (yld 6
     (arrat ff.0 3 +0)) ,2
    (yld 6
@@ -42,7 +42,7 @@
      (tuple 1
       (i -1) 6
       (i -1)) 1 +22 5 +4)))) ,10
- (iterator 9 :foo1.0.tfo6zftzj1 . . . 13
+ (iterator 9 :foo1.0.tfovc75a41 . . . 13
   (params 1
    (param :x.1 . . 3
     (i -1) .)) 10
@@ -51,7 +51,7 @@
    (yld 6 +1) ,1
    (yld 6 x.1))) 4,14
  (for 9
-  (call ~4 foo1.0.tfo6zftzj1 1 +2)
+  (call ~4 foo1.0.tfovc75a41 1 +2)
   (unpackflat
    (let :m.0 . . 6,~4
     (i -1) .)) ~2,1
@@ -59,7 +59,7 @@
    (let :n.0 . . 4,~5
     (i -1) 4 m.0))) 4,18
  (for 11
-  (call ~3 foo.0.tfo6zftzj1 1 +2)
+  (call ~3 foo.0.tfovc75a41 1 +2)
   (unpackflat
    (let :i.0 . . 7,~16
     (i -1) .)
@@ -73,7 +73,7 @@
    (let :n.1 . . 5,~19
     (i -1) 4 s.0))) 4,23
  (for 11
-  (call ~3 foo.0.tfo6zftzj1 1 +2)
+  (call ~3 foo.0.tfovc75a41 1 +2)
   (unpackflat
    (let :i.1 . . 7,~21
     (i -1) .)
@@ -84,11 +84,11 @@
     (i -1) 4 i.1) 4,1
    (let :m.2 . . 10,~23
     (i -1) 4 j.1))) ,27
- (proc 5 :bar.0.tfo6zftzj1 . . . 8
+ (proc 5 :bar.0.tfovc75a41 . . . 8
   (params) . . . 2,1
   (stmts 4
    (for 11
-    (call ~3 foo.0.tfo6zftzj1 1 +2)
+    (call ~3 foo.0.tfovc75a41 1 +2)
     (unpackflat
      (let :i.2 . . 5,~26
       (i -1) .)
@@ -100,7 +100,7 @@
      (let :m.3 . . 8,~28
       (i -1) 4 j.2))) 4,4
    (for 13
-    (call ~3 foo.0.tfo6zftzj1 1 +2)
+    (call ~3 foo.0.tfovc75a41 1 +2)
     (unpacktup
      (let 1 :i.3 . . 5,~30
       (i -1) .)
@@ -111,4 +111,4 @@
       (i -1) 4 i.3) 4,1
      (let :m.4 . . 8,~32
       (i -1) 4 j.3))))) 3,36
- (call ~3 bar.0.tfo6zftzj1))
+ (call ~3 bar.0.tfovc75a41))

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -1,6 +1,6 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tforloops1.nim(stmts ,2
- (iterator 9 :powers.0.tfo6yv57p . . . 15
+ (iterator 9 :powers.0.tfoeikd3t1 . . . 15
   (params 1
    (param :n.0 . . 3
     (i -1) .)) 10
@@ -24,7 +24,7 @@
      (asgn ~2 i.0 4
       (add
        (i -1) ~2 i.0 2 +1)))))) ,10
- (proc 5 :printf.0.tfo6yv57p . . . 11
+ (proc 5 :printf.0.tfoeikd3t1 . . . 11
   (params 1
    (param :format.0 . . 8
     (cstring) .) 39
@@ -36,17 +36,17 @@
    (header 8 "<stdio.h>") 51
    (nodecl)) . .) 4,13
  (for 11
-  (call ~6 powers.0.tfo6yv57p 1 +5)
+  (call ~6 powers.0.tfoeikd3t1 1 +5)
   (unpackflat
    (let :i.1 . . 6,~11
     (i -1) .)) ~2,1
   (stmts 4
    (let :m.0 . . 4,~12
     (i -1) 4 i.1) 6,2
-   (call ~6 printf.0.tfo6yv57p 1
+   (call ~6 printf.0.tfoeikd3t1 1
     (hconv 11,~6
      (cstring) "Hello, world\3A %ld\0A") 24 m.0))) ,18
- (iterator 9 :countup.0.tfo6yv57p . . . 16
+ (iterator 9 :countup.0.tfoeikd3t1 . . . 16
   (params 1
    (param :a.0 . . 6
     (i -1) .) 4
@@ -61,17 +61,17 @@
      (i -1) ~2 i.2 3 b.0) 2,1
     (stmts
      (yld 6 i.2) ,1
-     (cmd inc.0.tfo6yv57p 4
+     (cmd inc.0.tfoeikd3t1 4
       (haddr i.2)))))) 4,24
  (for 12
-  (call ~7 countup.0.tfo6yv57p 1 +1 4 +5)
+  (call ~7 countup.0.tfoeikd3t1 1 +1 4 +5)
   (unpackflat
    (let :x.1 . . 9,~6
     (i -1) .)) ~2,1
   (stmts 4
    (let :m.1 . . 7,~7
     (i -1) 4 x.1) 6,1
-   (call ~6 printf.0.tfo6yv57p 1
+   (call ~6 printf.0.tfoeikd3t1 1
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
@@ -86,10 +86,10 @@
       (i -1) ~2 x.1 2 +3) ~3,1
      (stmts
       (continue .)))) 6,6
-   (call ~6 printf.0.tfo6yv57p 1
+   (call ~6 printf.0.tfoeikd3t1 1
     (hconv 11,~21
      (cstring) "countup end\3A %ld\0A") 23 m.1))) ,33
- (iterator 9 :countup2.0.tfo6yv57p . . . 17
+ (iterator 9 :countup2.0.tfoeikd3t1 . . . 17
   (params 1
    (param :n.1 . . 3
     (i -1) .)) 10
@@ -102,16 +102,16 @@
      (i -1) ~2 i.3 3 n.1) 2,1
     (stmts
      (yld 6 i.3) ,1
-     (cmd inc.0.tfo6yv57p 4
+     (cmd inc.0.tfoeikd3t1 4
       (haddr i.3)))))) ,39
- (iterator 9 :powers2.0.tfo6yv57p . . . 16
+ (iterator 9 :powers2.0.tfoeikd3t1 . . . 16
   (params 1
    (param :n.2 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts 4
    (for 13
-    (call ~8 countup2.0.tfo6yv57p 1 n.2)
+    (call ~8 countup2.0.tfoeikd3t1 1 n.2)
     (unpackflat
      (let :i.4 . . 4,~7
       (i -1) .)) ~2,1
@@ -126,47 +126,47 @@
        (mul ~1,~10
         (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,45
  (for 12
-  (call ~7 powers2.0.tfo6yv57p 1 +6)
+  (call ~7 powers2.0.tfoeikd3t1 1 +6)
   (unpackflat
    (let :i.5 . . 6,~6
     (i -1) .)) ~2,1
   (stmts 6
-   (call ~6 printf.0.tfo6yv57p 1
+   (call ~6 printf.0.tfoeikd3t1 1
     (hconv 11,~36
      (cstring) "Hello, world\3A %ld\0A") 24 i.5))) ,48
- (iterator 9 :countup3.0.tfo6yv57p . . . 17
+ (iterator 9 :countup3.0.tfoeikd3t1 . . . 17
   (params 1
    (param :a.1 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts
    (yld 6 +3))) ,51
- (iterator 9 :powers3.0.tfo6yv57p . . . 16
+ (iterator 9 :powers3.0.tfoeikd3t1 . . . 16
   (params 1
    (param :b.1 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts 4
    (for 13
-    (call ~8 countup3.0.tfo6yv57p 1 b.1)
+    (call ~8 countup3.0.tfoeikd3t1 1 b.1)
     (unpackflat
      (let :j.0 . . 4,~4
       (i -1) .)) ~2,1
     (stmts
      (yld 6 j.0))))) 4,55
  (for 12
-  (call ~7 powers3.0.tfo6yv57p 1 +5)
+  (call ~7 powers3.0.tfoeikd3t1 1 +5)
   (unpackflat
    (let :m.2 . . 6,~4
     (i -1) .)) ~2,1
   (stmts 4
    (for 13
-    (call ~8 countup3.0.tfo6yv57p 1 +4)
+    (call ~8 countup3.0.tfoeikd3t1 1 +4)
     (unpackflat
      (let :n.3 . . 4,~8
       (i -1) .)) ~2,1
     (stmts 6
-     (call ~6 printf.0.tfo6yv57p 1
+     (call ~6 printf.0.tfoeikd3t1 1
       (hconv 9,~47
        (cstring) "Hello, world\3A %ld\0A") 25
       (add ~25,~6
@@ -182,39 +182,39 @@
     (stmts
      (discard 8 i.6))) ,2
    (break .))) ,65
- (iterator 9 :countup4.0.tfo6yv57p . . . 17
+ (iterator 9 :countup4.0.tfoeikd3t1 . . . 17
   (params 1
    (param :a.2 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts
    (yld 6 a.2))) ,68
- (iterator 9 :powers4.0.tfo6yv57p . . . 16
+ (iterator 9 :powers4.0.tfoeikd3t1 . . . 16
   (params 1
    (param :a.3 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts 4
    (for 13
-    (call ~8 countup4.0.tfo6yv57p 1 a.3)
+    (call ~8 countup4.0.tfoeikd3t1 1 a.3)
     (unpackflat
      (let :j.1 . . 4,~4
       (i -1) .)) ~2,1
     (stmts
      (yld 6 j.1))))) 4,72
  (for 12
-  (call ~7 powers4.0.tfo6yv57p 1 +5)
+  (call ~7 powers4.0.tfoeikd3t1 1 +5)
   (unpackflat
    (let :i.7 . . 6,~4
     (i -1) .)) ~2,1
   (stmts 4
    (for 13
-    (call ~8 countup4.0.tfo6yv57p 1 +4)
+    (call ~8 countup4.0.tfoeikd3t1 1 +4)
     (unpackflat
      (let :j.2 . . 4,~8
       (i -1) .)) ~2,1
     (stmts 6
-     (call ~6 printf.0.tfo6yv57p 1
+     (call ~6 printf.0.tfoeikd3t1 1
       (hconv 9,~64
        (cstring) "Hello, world\3A %ld\0A") 25
       (add ~25,~6
@@ -238,20 +238,20 @@
        (stmts 2,104,lib/std/syncio.nim
         (stmts 2,1
          (stmts
-          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,81,tests/nimony/sysbasics/tforloops1.nim "left the loop!")) ,2
-         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+          (cmd write.0.synx4sfio1 6 stdout.0.synx4sfio1 11,81,tests/nimony/sysbasics/tforloops1.nim "left the loop!")) ,2
+         (cmd write.5.synx4sfio1 6 stdout.0.synx4sfio1 14 '\0A')) ,1
         (break .)))) 2,104,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/sysbasics/tforloops1.nim "A i ")) 2,1
+       (cmd write.0.synx4sfio1 6 stdout.0.synx4sfio1 9,83,tests/nimony/sysbasics/tforloops1.nim "A i ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/sysbasics/tforloops1.nim i.8)) 2,1
+       (cmd write.2.synx4sfio1 6 stdout.0.synx4sfio1 17,83,tests/nimony/sysbasics/tforloops1.nim i.8)) 2,1
       (stmts
-       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 20,83,tests/nimony/sysbasics/tforloops1.nim " j ")) 2,1
+       (cmd write.0.synx4sfio1 6 stdout.0.synx4sfio1 20,83,tests/nimony/sysbasics/tforloops1.nim " j ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/sysbasics/tforloops1.nim j.3)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
- (proc :inc.0.tfo6yv57p . 0,276,lib/std/system.nim .
+       (cmd write.2.synx4sfio1 6 stdout.0.synx4sfio1 27,83,tests/nimony/sysbasics/tforloops1.nim j.3)) ,2
+      (cmd write.5.synx4sfio1 6 stdout.0.synx4sfio1 14 '\0A')))))) 4,22
+ (proc :inc.0.tfoeikd3t1 . 0,276,lib/std/system.nim .
   (at inc.1.sysvq0asl 19,~4
    (i -1)) 21,276,lib/std/system.nim
   (params 1

--- a/tests/nimony/sysbasics/thooks.nif
+++ b/tests/nimony/sysbasics/thooks.nif
@@ -1,227 +1,227 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/thooks.nim(stmts 15,1
- (type ~13 :MyObjectBase.0.tho8gh7q4 . . . 2
+ (type ~13 :MyObjectBase.0.thowpkw321 . . . 2
   (object . ~13,1
-   (fld :x.0.tho8gh7q4 . . 6
+   (fld :x.0.thowpkw321 . . 6
     (i -1) .) ~10,1
-   (fld :y.0.tho8gh7q4 . . 3
+   (fld :y.0.thowpkw321 . . 3
     (i -1) .))) 17,4
- (type ~15 :MyObject.0.tho8gh7q4 . ~7
+ (type ~15 :MyObject.0.thowpkw321 . ~7
   (typevars 1
-   (typevar :T.0.tho8gh7q4 . . . .) 4
-   (typevar :Y.0.tho8gh7q4 . . . .)) . 2
+   (typevar :T.0.thowpkw321 . . . .) 4
+   (typevar :Y.0.thowpkw321 . . . .)) . 2
   (object . ~15,1
-   (fld :x.1.tho8gh7q4 . . 6
+   (fld :x.1.thowpkw321 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.tho8gh7q4 . . 3
+   (fld :y.1.thowpkw321 . . 3
     (i -1) .))) ,7
- (proc 5 :=trace.0.tho8gh7q4 . . . 13
+ (proc 5 :=trace.0.thowpkw321 . . . 13
   (params 1
    (param :x.0 . . 3
-    (mut 4 MyObjectBase.0.tho8gh7q4) .) 22
+    (mut 4 MyObjectBase.0.thowpkw321) .) 22
    (param :p.0 . . 3
     (pointer) .)) . . . 2,1
   (stmts
    (discard .))) ,10
- (proc 5 :=wasMoved.0.tho8gh7q4 . . . 16
+ (proc 5 :=wasMoved.0.thowpkw321 . . . 16
   (params 1
    (param :x.1 . . 3
-    (mut 4 MyObjectBase.0.tho8gh7q4) .)) . . . 2,1
+    (mut 4 MyObjectBase.0.thowpkw321) .)) . . . 2,1
   (stmts
    (discard .))) ,13
- (proc 5 :=copy.0.tho8gh7q4 . . . 12
+ (proc 5 :=copy.0.thowpkw321 . . . 12
   (params 1
    (param :x.2 . . 3
-    (mut 4 MyObjectBase.0.tho8gh7q4) .) 22
-   (param :y.0 . . 3 MyObjectBase.0.tho8gh7q4 .)) . . . 2,1
+    (mut 4 MyObjectBase.0.thowpkw321) .) 22
+   (param :y.0 . . 3 MyObjectBase.0.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))) ,16
- (proc 5 :=sink.0.tho8gh7q4 . . . 12
+ (proc 5 :=sink.0.thowpkw321 . . . 12
   (params 1
    (param :x.3 . . 3
-    (mut 4 MyObjectBase.0.tho8gh7q4) .) 22
-   (param :y.1 . . 3 MyObjectBase.0.tho8gh7q4 .)) . . . 2,1
+    (mut 4 MyObjectBase.0.thowpkw321) .) 22
+   (param :y.1 . . 3 MyObjectBase.0.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))) ,19
- (proc 5 :=destroy.0.tho8gh7q4 . . . 15
+ (proc 5 :=destroy.0.thowpkw321 . . . 15
   (params 1
-   (param :x.4 . . 3 MyObjectBase.0.tho8gh7q4 .)) . . . 2,1
+   (param :x.4 . . 3 MyObjectBase.0.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))) ,22
- (proc 5 :=wasMoved.1.tho8gh7q4 . . 16
+ (proc 5 :=wasMoved.1.thowpkw321 . . 16
   (typevars 1
-   (typevar :T.1.tho8gh7q4 . . . .) 4
-   (typevar :Y.1.tho8gh7q4 . . . .)) 22
+   (typevar :T.1.thowpkw321 . . . .) 4
+   (typevar :Y.1.thowpkw321 . . . .)) 22
   (params 1
    (param :x.5 . . 3
     (mut 12
-     (at ~8 MyObject.0.tho8gh7q4 1 T.1.tho8gh7q4 4 Y.1.tho8gh7q4)) .)) . . . 2,1
+     (at ~8 MyObject.0.thowpkw321 1 T.1.thowpkw321 4 Y.1.thowpkw321)) .)) . . . 2,1
   (stmts 4
    (let :x.10 . .
     (i -1) 4 +12) 4,1
    (let :y.4 . .
     (i -1) 4 +4))) ,26
- (proc 5 :=copy.1.tho8gh7q4 . . 12
+ (proc 5 :=copy.1.thowpkw321 . . 12
   (typevars 1
-   (typevar :T.2.tho8gh7q4 . . . .) 4
-   (typevar :Y.2.tho8gh7q4 . . . .)) 18
+   (typevar :T.2.thowpkw321 . . . .) 4
+   (typevar :Y.2.thowpkw321 . . . .)) 18
   (params 1
    (param :x.6 . . 3
     (mut 12
-     (at ~8 MyObject.0.tho8gh7q4 1 T.2.tho8gh7q4 4 Y.2.tho8gh7q4)) .) 24
+     (at ~8 MyObject.0.thowpkw321 1 T.2.thowpkw321 4 Y.2.thowpkw321)) .) 24
    (param :y.2 . . 11
-    (at ~8 MyObject.0.tho8gh7q4 1 T.2.tho8gh7q4 4 Y.2.tho8gh7q4) .)) . . . 2,1
+    (at ~8 MyObject.0.thowpkw321 1 T.2.thowpkw321 4 Y.2.thowpkw321) .)) . . . 2,1
   (stmts
    (discard .))) ,29
- (proc 5 :=sink.1.tho8gh7q4 . . 12
+ (proc 5 :=sink.1.thowpkw321 . . 12
   (typevars 1
-   (typevar :T.3.tho8gh7q4 . . . .) 4
-   (typevar :Y.3.tho8gh7q4 . . . .)) 18
+   (typevar :T.3.thowpkw321 . . . .) 4
+   (typevar :Y.3.thowpkw321 . . . .)) 18
   (params 1
    (param :x.7 . . 3
     (mut 12
-     (at ~8 MyObject.0.tho8gh7q4 1 T.3.tho8gh7q4 4 Y.3.tho8gh7q4)) .) 24
+     (at ~8 MyObject.0.thowpkw321 1 T.3.thowpkw321 4 Y.3.thowpkw321)) .) 24
    (param :y.3 . . 11
-    (at ~8 MyObject.0.tho8gh7q4 1 T.3.tho8gh7q4 4 Y.3.tho8gh7q4) .)) . . . 2,1
+    (at ~8 MyObject.0.thowpkw321 1 T.3.thowpkw321 4 Y.3.thowpkw321) .)) . . . 2,1
   (stmts
    (discard .))) ,32
- (proc 5 :=destroy.1.tho8gh7q4 . . 15
+ (proc 5 :=destroy.1.thowpkw321 . . 15
   (typevars 1
-   (typevar :T.4.tho8gh7q4 . . . .) 4
-   (typevar :Y.4.tho8gh7q4 . . . .)) 21
+   (typevar :T.4.thowpkw321 . . . .) 4
+   (typevar :Y.4.thowpkw321 . . . .)) 21
   (params 1
    (param :x.8 . . 11
-    (at ~8 MyObject.0.tho8gh7q4 1 T.4.tho8gh7q4 4 Y.4.tho8gh7q4) .)) . . . 2,1
+    (at ~8 MyObject.0.thowpkw321 1 T.4.thowpkw321 4 Y.4.thowpkw321) .)) . . . 2,1
   (stmts 4
    (let :x.11 . .
     (i -1) 4 +12))) ,35
- (proc 5 :foo.0.tho8gh7q4 . . . 9
+ (proc 5 :foo.0.thowpkw321 . . . 9
   (params) . . . 2,1
   (stmts 4
-   (var :obj.0 . . 13 MyObject.0.I76zger.tho8gh7q4 .) 4,2
-   (var :obj2.0 . . 14 MyObject.0.I3kvyeb.tho8gh7q4 .) 10,4
+   (var :obj.0 . . 13 MyObject.0.Isgzwlo.thowpkw321 .) 4,2
+   (var :obj2.0 . . 14 MyObject.0.Ip7o2y8.thowpkw321 .) 10,4
    (destroy 1 obj.0) 4,6
-   (var :objbase.0 . . 9 MyObjectBase.0.tho8gh7q4 .) 4,7
-   (var :objbase2.0 . . 10 MyObjectBase.0.tho8gh7q4 .) 10,8
-   (call 1 =destroy.0.tho8gh7q4 1 objbase2.0) 10,9
-   (call 1 =destroy.0.tho8gh7q4 1 objbase.0))) 3,47
- (call ~3 foo.0.tho8gh7q4) ,49
- (proc 5 :=checkHook.0.tho8gh7q4 . . 17
+   (var :objbase.0 . . 9 MyObjectBase.0.thowpkw321 .) 4,7
+   (var :objbase2.0 . . 10 MyObjectBase.0.thowpkw321 .) 10,8
+   (call 1 =destroy.0.thowpkw321 1 objbase2.0) 10,9
+   (call 1 =destroy.0.thowpkw321 1 objbase.0))) 3,47
+ (call ~3 foo.0.thowpkw321) ,49
+ (proc 5 :=checkHook.0.thowpkw321 . . 17
   (typevars 1
-   (typevar :T.5.tho8gh7q4 . . . .) 4
-   (typevar :Y.5.tho8gh7q4 . . . .)) 23
+   (typevar :T.5.thowpkw321 . . . .) 4
+   (typevar :Y.5.thowpkw321 . . . .)) 23
   (params 1
    (param :x.9 . . 12
-    (at ~8 MyObject.0.tho8gh7q4 1 T.5.tho8gh7q4 4 Y.5.tho8gh7q4) .)) . . . 2,1
+    (at ~8 MyObject.0.thowpkw321 1 T.5.thowpkw321 4 Y.5.thowpkw321) .)) . . . 2,1
   (stmts
    (discard .))) 4,52
- (gvar :obj.0.tho8gh7q4 . . 13 MyObject.0.I76zger.tho8gh7q4 .) 12,53
- (call 1 =checkHook.1.tho8gh7q4 1 obj.0.tho8gh7q4) 12,53
- (proc :=checkHook.1.tho8gh7q4 . ~12,~4 .
-  (at =checkHook.0.tho8gh7q4 8,~17
+ (gvar :obj.0.thowpkw321 . . 13 MyObject.0.Isgzwlo.thowpkw321 .) 12,53
+ (call 1 =checkHook.1.thowpkw321 1 obj.0.thowpkw321) 12,53
+ (proc :=checkHook.1.thowpkw321 . ~12,~4 .
+  (at =checkHook.0.thowpkw321 8,~17
    (i -1) 13,~17
    (f +64)) 11,~4
   (params 1
-   (param :x.13 . . 12 MyObject.0.I76zger.tho8gh7q4 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
+   (param :x.13 . . 12 MyObject.0.Isgzwlo.thowpkw321 .)) ~12,~4 . ~12,~4 . ~12,~4 . ~10,~3
   (stmts
    (discard .))) 19,36
- (type :MyObject.0.I76zger.tho8gh7q4 .
-  (at MyObject.0.tho8gh7q4 1
+ (type :MyObject.0.Isgzwlo.thowpkw321 .
+  (at MyObject.0.thowpkw321 1
    (i -1) 6
    (f +64)) ~2,~32 . ,~32
   (object . ~15,1
-   (fld :x.1.I76zger.tho8gh7q4 . . 6
+   (fld :x.1.Isgzwlo.thowpkw321 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.I76zger.tho8gh7q4 . . 3
+   (fld :y.1.Isgzwlo.thowpkw321 . . 3
     (i -1) .))) 20,38
- (type :MyObject.0.I3kvyeb.tho8gh7q4 .
-  (at MyObject.0.tho8gh7q4 1
+ (type :MyObject.0.Ip7o2y8.thowpkw321 .
+  (at MyObject.0.thowpkw321 1
    (f +64) 8
    (i -1)) ~3,~34 . ~1,~34
   (object . ~15,1
-   (fld :x.1.I3kvyeb.tho8gh7q4 . . 6
+   (fld :x.1.Ip7o2y8.thowpkw321 . . 6
     (i -1) .) ~12,1
-   (fld :y.1.I3kvyeb.tho8gh7q4 . . 3
+   (fld :y.1.Ip7o2y8.thowpkw321 . . 3
     (i -1) .))) ,32
- (proc :=destroy.2.tho8gh7q4 . .
-  (at =destroy.1.tho8gh7q4 20,4
+ (proc :=destroy.2.thowpkw321 . .
+  (at =destroy.1.thowpkw321 20,4
    (i -1) 25,4
    (f +64)) 21
   (params 1
-   (param :x.22 . . 11 MyObject.0.I76zger.tho8gh7q4 .)) . . . 2,1
+   (param :x.22 . . 11 MyObject.0.Isgzwlo.thowpkw321 .)) . . . 2,1
   (stmts 4
    (let :x.23 . . 4,~31
     (i -1) 4 +12))) ,22
- (proc :=wasMoved.2.tho8gh7q4 . .
-  (at =wasMoved.1.tho8gh7q4 20,14
+ (proc :=wasMoved.2.thowpkw321 . .
+  (at =wasMoved.1.thowpkw321 20,14
    (i -1) 25,14
    (f +64)) 22
   (params 1
    (param :x.24 . . 3
-    (mut 12 MyObject.0.I76zger.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.Isgzwlo.thowpkw321) .)) . . . 2,1
   (stmts 4
    (let :x.25 . . 4,~21
     (i -1) 4 +12) 4,1
    (let :y.9 . . 4,~22
     (i -1) 4 +4))) ,26
- (proc :=copy.2.tho8gh7q4 . .
-  (at =copy.1.tho8gh7q4 20,10
+ (proc :=copy.2.thowpkw321 . .
+  (at =copy.1.thowpkw321 20,10
    (i -1) 25,10
    (f +64)) 18
   (params 1
    (param :x.26 . . 3
-    (mut 12 MyObject.0.I76zger.tho8gh7q4) .) 24
-   (param :y.10 . . 11 MyObject.0.I76zger.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.Isgzwlo.thowpkw321) .) 24
+   (param :y.10 . . 11 MyObject.0.Isgzwlo.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))) ,29
- (proc :=sink.2.tho8gh7q4 . .
-  (at =sink.1.tho8gh7q4 20,7
+ (proc :=sink.2.thowpkw321 . .
+  (at =sink.1.thowpkw321 20,7
    (i -1) 25,7
    (f +64)) 18
   (params 1
    (param :x.27 . . 3
-    (mut 12 MyObject.0.I76zger.tho8gh7q4) .) 24
-   (param :y.11 . . 11 MyObject.0.I76zger.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.Isgzwlo.thowpkw321) .) 24
+   (param :y.11 . . 11 MyObject.0.Isgzwlo.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))) ,32
- (proc :=destroy.3.tho8gh7q4 . .
-  (at =destroy.1.tho8gh7q4 21,6
+ (proc :=destroy.3.thowpkw321 . .
+  (at =destroy.1.thowpkw321 21,6
    (f +64) 28,6
    (i -1)) 21
   (params 1
-   (param :x.28 . . 11 MyObject.0.I3kvyeb.tho8gh7q4 .)) . . . 2,1
+   (param :x.28 . . 11 MyObject.0.Ip7o2y8.thowpkw321 .)) . . . 2,1
   (stmts 4
    (let :x.29 . . 4,~31
     (i -1) 4 +12))) ,22
- (proc :=wasMoved.3.tho8gh7q4 . .
-  (at =wasMoved.1.tho8gh7q4 21,16
+ (proc :=wasMoved.3.thowpkw321 . .
+  (at =wasMoved.1.thowpkw321 21,16
    (f +64) 28,16
    (i -1)) 22
   (params 1
    (param :x.30 . . 3
-    (mut 12 MyObject.0.I3kvyeb.tho8gh7q4) .)) . . . 2,1
+    (mut 12 MyObject.0.Ip7o2y8.thowpkw321) .)) . . . 2,1
   (stmts 4
    (let :x.31 . . 4,~21
     (i -1) 4 +12) 4,1
    (let :y.12 . . 4,~22
     (i -1) 4 +4))) ,26
- (proc :=copy.3.tho8gh7q4 . .
-  (at =copy.1.tho8gh7q4 21,12
+ (proc :=copy.3.thowpkw321 . .
+  (at =copy.1.thowpkw321 21,12
    (f +64) 28,12
    (i -1)) 18
   (params 1
    (param :x.32 . . 3
-    (mut 12 MyObject.0.I3kvyeb.tho8gh7q4) .) 24
-   (param :y.13 . . 11 MyObject.0.I3kvyeb.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.Ip7o2y8.thowpkw321) .) 24
+   (param :y.13 . . 11 MyObject.0.Ip7o2y8.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))) ,29
- (proc :=sink.3.tho8gh7q4 . .
-  (at =sink.1.tho8gh7q4 21,9
+ (proc :=sink.3.thowpkw321 . .
+  (at =sink.1.thowpkw321 21,9
    (f +64) 28,9
    (i -1)) 18
   (params 1
    (param :x.33 . . 3
-    (mut 12 MyObject.0.I3kvyeb.tho8gh7q4) .) 24
-   (param :y.14 . . 11 MyObject.0.I3kvyeb.tho8gh7q4 .)) . . . 2,1
+    (mut 12 MyObject.0.Ip7o2y8.thowpkw321) .) 24
+   (param :y.14 . . 11 MyObject.0.Ip7o2y8.thowpkw321 .)) . . . 2,1
   (stmts
    (discard .))))

--- a/tests/nimony/sysbasics/tintlitmatch.nif
+++ b/tests/nimony/sysbasics/tintlitmatch.nif
@@ -1,48 +1,48 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tintlitmatch.nim(stmts
- (proc 5 :foo.0.tin4pj0od1 . . . 8
+ (proc 5 :foo.0.tinprju1p1 . . . 8
   (params 1
    (param :x.0 . . 3
     (i +16) .)) . . . 21
   (stmts
    (discard .))) ,1
- (proc 5 :bar.0.tin4pj0od1 . . . 8
+ (proc 5 :bar.0.tinprju1p1 . . . 8
   (params 1
    (param :x.1 . . 3
     (f +64) .)) . . . 21
   (stmts
    (discard .))) 3,2
- (call ~3 foo.0.tin4pj0od1 1
+ (call ~3 foo.0.tinprju1p1 1
   (hconv 8,~2
    (i +16) +123)) 3,3
- (call ~3 bar.0.tin4pj0od1 1
+ (call ~3 bar.0.tinprju1p1 1
   (hconv 8,~2
    (f +64) +123)) ,4
- (proc 5 :baz.0.tin4pj0od1 . . . 8
+ (proc 5 :baz.0.tinprju1p1 . . . 8
   (params 1
    (param :x.2 . . 3
     (i +16) .)) . . . 21
   (stmts
    (discard .))) ,5
- (proc 5 :baz.1.tin4pj0od1 . . . 8
+ (proc 5 :baz.1.tinprju1p1 . . . 8
   (params 1
    (param :x.3 . . 3
     (i -1) .)) . . . 19
   (stmts
    (discard .))) 3,6
- (call ~3 baz.1.tin4pj0od1 1 +123) 4,9
- (gvar :x.0.tin4pj0od1 . . 3
+ (call ~3 baz.1.tinprju1p1 1 +123) 4,9
+ (gvar :x.0.tinprju1p1 . . 3
   (i +32) .) 4,10
- (gvar :y.0.tin4pj0od1 . . 3
+ (gvar :y.0.tinprju1p1 . . 3
   (i -1) .) ,13
  (discard 10
   (eq ~3,~4
    (i +32) ~2
    (hconv 17,334,lib/std/system.nim
-    (i +64) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
+    (i +64) x.0.tinprju1p1) 3 y.0.tinprju1p1)) ,14
  (discard 10
   (eq ~3,~4
-   (i -1) ~2 y.0.tin4pj0od1 6
+   (i -1) ~2 y.0.tinprju1p1 6
    (hconv 17,334,lib/std/system.nim
     (i +64)
     (conv 1
@@ -53,7 +53,7 @@
    (hconv 17,334,lib/std/system.nim
     (i +64)
     (conv 6,~1
-     (i +32) ~3 +123)) 3 y.0.tin4pj0od1)) ,16
+     (i +32) ~3 +123)) 3 y.0.tinprju1p1)) ,16
  (discard 16
   (eq ~4
    (i -1) ~5
@@ -84,6 +84,6 @@
     (i +32) ~3 +123))) ,22
  (discard 10
   (eq ~3,~13
-   (i +32) ~2 x.0.tin4pj0od1 3
+   (i +32) ~2 x.0.tinprju1p1 3
    (hconv 17,333,lib/std/system.nim
     (i +32) +123))))

--- a/tests/nimony/sysbasics/trefobject.nif
+++ b/tests/nimony/sysbasics/trefobject.nif
@@ -1,119 +1,119 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/trefobject.nim(stmts 9
- (type ~4 :Foo.0.tre8amq6m . . . 2
-  (ref 4 Foo.Obj.0.tre8amq6m)) 9
- (type ~4 :Foo.Obj.0.tre8amq6m . . . 6
+ (type ~4 :Foo.0.tregrbip11 . . . 2
+  (ref 4 Foo.Obj.0.tregrbip11)) 9
+ (type ~4 :Foo.Obj.0.tregrbip11 . . . 6
   (object . ~13,1
-   (fld :x.0.tre8amq6m . . 3
+   (fld :x.0.tregrbip11 . . 3
     (i -1) .) ~13,2
-   (fld :parent.0.tre8amq6m . . 9,~2
-    (ref 4 Foo.Obj.0.tre8amq6m) .))) 4,4
- (gvar :foo.0.tre8amq6m . . 7,~4
-  (ref 4 Foo.Obj.0.tre8amq6m) .) 10,7
- (type ~8 :Node.0.tre8amq6m . ~4
+   (fld :parent.0.tregrbip11 . . 9,~2
+    (ref 4 Foo.Obj.0.tregrbip11) .))) 4,4
+ (gvar :foo.0.tregrbip11 . . 7,~4
+  (ref 4 Foo.Obj.0.tregrbip11) .) 10,7
+ (type ~8 :Node.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.0.tre8amq6m . . . .)) . 2
+   (typevar :T.0.tregrbip11 . . . .)) . 2
   (ref 4
-   (at Node.Obj.0.tre8amq6m ~9 T.0.tre8amq6m))) 10,7
- (type ~8 :Node.Obj.0.tre8amq6m . ~4
+   (at Node.Obj.0.tregrbip11 ~9 T.0.tregrbip11))) 10,7
+ (type ~8 :Node.Obj.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.1.tre8amq6m . . . .)) . 6
+   (typevar :T.1.tregrbip11 . . . .)) . 6
   (object . ~12,1
-   (fld :val.0.tre8amq6m . . 5 T.1.tre8amq6m .) ~12,2
-   (fld :left.0.tre8amq6m . . 8,~2
+   (fld :val.0.tregrbip11 . . 5 T.1.tregrbip11 .) ~12,2
+   (fld :left.0.tregrbip11 . . 8,~2
     (ref 4
-     (at Node.Obj.0.tre8amq6m 6,2 T.1.tre8amq6m)) .) ~6,2
-   (fld :right.0.tre8amq6m . . 2,~2
+     (at Node.Obj.0.tregrbip11 6,2 T.1.tregrbip11)) .) ~6,2
+   (fld :right.0.tregrbip11 . . 2,~2
     (ref 4
-     (at Node.Obj.0.tre8amq6m 6,2 T.1.tre8amq6m)) .))) 4,11
- (gvar :node.0.tre8amq6m . . 8,~4
-  (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) 14,14
- (type ~12 :Forward1.0.tre8amq6m . ~4
+     (at Node.Obj.0.tregrbip11 6,2 T.1.tregrbip11)) .))) 4,11
+ (gvar :node.0.tregrbip11 . . 8,~4
+  (ref 4 Node.Obj.0.Ir2xlws.tregrbip11) .) 14,14
+ (type ~12 :Forward1.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.2.tre8amq6m . . . .)) . 2
+   (typevar :T.2.tregrbip11 . . . .)) . 2
   (object . ~12,1
-   (fld :x.1.tre8amq6m . . 16,1
+   (fld :x.1.tregrbip11 . . 16,1
     (ref 4
-     (at ForwardNode1.Obj.0.tre8amq6m ~4,~1 T.2.tre8amq6m)) .))) 18,16
- (type ~16 :ForwardNode1.0.tre8amq6m . ~4
+     (at ForwardNode1.Obj.0.tregrbip11 ~4,~1 T.2.tregrbip11)) .))) 18,16
+ (type ~16 :ForwardNode1.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.3.tre8amq6m . . . .)) . 2
+   (typevar :T.3.tregrbip11 . . . .)) . 2
   (ref 4
-   (at ForwardNode1.Obj.0.tre8amq6m ~9 T.3.tre8amq6m))) 18,16
- (type ~16 :ForwardNode1.Obj.0.tre8amq6m . ~4
+   (at ForwardNode1.Obj.0.tregrbip11 ~9 T.3.tregrbip11))) 18,16
+ (type ~16 :ForwardNode1.Obj.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.4.tre8amq6m . . . .)) . 6
+   (typevar :T.4.tregrbip11 . . . .)) . 6
   (object . ~20,1
-   (fld :val.1.tre8amq6m . . 5 T.4.tre8amq6m .) ~20,2
-   (fld :left.1.tre8amq6m . . 16,~2
+   (fld :val.1.tregrbip11 . . 5 T.4.tregrbip11 .) ~20,2
+   (fld :left.1.tregrbip11 . . 16,~2
     (ref 4
-     (at ForwardNode1.Obj.0.tre8amq6m 6,2 T.4.tre8amq6m)) .) ~14,2
-   (fld :right.1.tre8amq6m . . 10,~2
+     (at ForwardNode1.Obj.0.tregrbip11 6,2 T.4.tregrbip11)) .) ~14,2
+   (fld :right.1.tregrbip11 . . 10,~2
     (ref 4
-     (at ForwardNode1.Obj.0.tre8amq6m 6,2 T.4.tre8amq6m)) .))) 4,20
- (gvar :forwardNode1.0.tre8amq6m . . 16,~4
-  (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m) .) 11,23
- (type ~9 :Forward2.0.tre8amq6m . . . 2
+     (at ForwardNode1.Obj.0.tregrbip11 6,2 T.4.tregrbip11)) .))) 4,20
+ (gvar :forwardNode1.0.tregrbip11 . . 16,~4
+  (ref 4 ForwardNode1.Obj.0.Isi4prb.tregrbip11) .) 11,23
+ (type ~9 :Forward2.0.tregrbip11 . . . 2
   (object . ~9,1
-   (fld :x.2.tre8amq6m . . 16,1
-    (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .))) 18,25
- (type ~16 :ForwardNode2.0.tre8amq6m . ~4
+   (fld :x.2.tregrbip11 . . 16,1
+    (ref 4 ForwardNode2.Obj.0.Iz2wdw3.tregrbip11) .))) 18,25
+ (type ~16 :ForwardNode2.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.5.tre8amq6m . . . .)) . 2
+   (typevar :T.5.tregrbip11 . . . .)) . 2
   (ref 4
-   (at ForwardNode2.Obj.0.tre8amq6m ~9 T.5.tre8amq6m))) 18,25
- (type ~16 :ForwardNode2.Obj.0.tre8amq6m . ~4
+   (at ForwardNode2.Obj.0.tregrbip11 ~9 T.5.tregrbip11))) 18,25
+ (type ~16 :ForwardNode2.Obj.0.tregrbip11 . ~4
   (typevars 1
-   (typevar :T.6.tre8amq6m . . . .)) . 6
+   (typevar :T.6.tregrbip11 . . . .)) . 6
   (object . ~20,1
-   (fld :val.3.tre8amq6m . . 5 T.6.tre8amq6m .) ~20,2
-   (fld :left.3.tre8amq6m . . 16,~2
+   (fld :val.3.tregrbip11 . . 5 T.6.tregrbip11 .) ~20,2
+   (fld :left.3.tregrbip11 . . 16,~2
     (ref 4
-     (at ForwardNode2.Obj.0.tre8amq6m 6,2 T.6.tre8amq6m)) .) ~14,2
-   (fld :right.3.tre8amq6m . . 10,~2
+     (at ForwardNode2.Obj.0.tregrbip11 6,2 T.6.tregrbip11)) .) ~14,2
+   (fld :right.3.tregrbip11 . . 10,~2
     (ref 4
-     (at ForwardNode2.Obj.0.tre8amq6m 6,2 T.6.tre8amq6m)) .))) 4,29
- (gvar :forwardNode2.0.tre8amq6m . . 16,~4
-  (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .) 19,24
- (type :ForwardNode2.0.Ishmn651.tre8amq6m .
-  (at ForwardNode2.0.tre8amq6m 1
+     (at ForwardNode2.Obj.0.tregrbip11 6,2 T.6.tregrbip11)) .))) 4,29
+ (gvar :forwardNode2.0.tregrbip11 . . 16,~4
+  (ref 4 ForwardNode2.Obj.0.Iz2wdw3.tregrbip11) .) 19,24
+ (type :ForwardNode2.0.Inrrgt41.tregrbip11 .
+  (at ForwardNode2.0.tregrbip11 1
    (i -1)) ~1,1 . 1,1
-  (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m)) 24,25
- (type :ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m .
-  (at ForwardNode2.Obj.0.tre8amq6m ~4,~1
+  (ref 4 ForwardNode2.Obj.0.Iz2wdw3.tregrbip11)) 24,25
+ (type :ForwardNode2.Obj.0.Iz2wdw3.tregrbip11 .
+  (at ForwardNode2.Obj.0.tregrbip11 ~4,~1
    (i -1)) ~6 .
   (object . ~20,1
-   (fld :val.2.tre8amq6m . . 16,~2
+   (fld :val.2.tregrbip11 . . 16,~2
     (i -1) .) ~20,2
-   (fld :left.2.tre8amq6m . . 16,~2
-    (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .) ~14,2
-   (fld :right.2.tre8amq6m . . 10,~2
-    (ref 4 ForwardNode2.Obj.0.Ikl0rjv.tre8amq6m) .))) 14,11
- (type :Node.0.Isesnzm1.tre8amq6m .
-  (at Node.0.tre8amq6m 1
+   (fld :left.2.tregrbip11 . . 16,~2
+    (ref 4 ForwardNode2.Obj.0.Iz2wdw3.tregrbip11) .) ~14,2
+   (fld :right.2.tregrbip11 . . 10,~2
+    (ref 4 ForwardNode2.Obj.0.Iz2wdw3.tregrbip11) .))) 14,11
+ (type :Node.0.Ib92ikk1.tregrbip11 .
+  (at Node.0.tregrbip11 1
    (i -1)) ~4,~4 . ~2,~4
-  (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m)) 16,7
- (type :Node.Obj.0.Iiz3k2p1.tre8amq6m .
-  (at Node.Obj.0.tre8amq6m ~1,4
+  (ref 4 Node.Obj.0.Ir2xlws.tregrbip11)) 16,7
+ (type :Node.Obj.0.Ir2xlws.tregrbip11 .
+  (at Node.Obj.0.tregrbip11 ~1,4
    (i -1)) ~6 .
   (object . ~12,1
-   (fld :val.0.Iiz3k2p1.tre8amq6m . . 11,3
+   (fld :val.0.Ir2xlws.tregrbip11 . . 11,3
     (i -1) .) ~12,2
-   (fld :left.0.Iiz3k2p1.tre8amq6m . . 8,~2
-    (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .) ~6,2
-   (fld :right.0.Iiz3k2p1.tre8amq6m . . 2,~2
-    (ref 4 Node.Obj.0.Iiz3k2p1.tre8amq6m) .))) 30,20
- (type :ForwardNode1.0.Iee6hkd1.tre8amq6m .
-  (at ForwardNode1.0.tre8amq6m 1
+   (fld :left.0.Ir2xlws.tregrbip11 . . 8,~2
+    (ref 4 Node.Obj.0.Ir2xlws.tregrbip11) .) ~6,2
+   (fld :right.0.Ir2xlws.tregrbip11 . . 2,~2
+    (ref 4 Node.Obj.0.Ir2xlws.tregrbip11) .))) 30,20
+ (type :ForwardNode1.0.Irtywr8.tregrbip11 .
+  (at ForwardNode1.0.tregrbip11 1
    (i -1)) ~12,~4 . ~10,~4
-  (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m)) 24,16
- (type :ForwardNode1.Obj.0.I93upex.tre8amq6m .
-  (at ForwardNode1.Obj.0.tre8amq6m 7,4
+  (ref 4 ForwardNode1.Obj.0.Isi4prb.tregrbip11)) 24,16
+ (type :ForwardNode1.Obj.0.Isi4prb.tregrbip11 .
+  (at ForwardNode1.Obj.0.tregrbip11 7,4
    (i -1)) ~6 .
   (object . ~20,1
-   (fld :val.1.I93upex.tre8amq6m . . 27,3
+   (fld :val.1.Isi4prb.tregrbip11 . . 27,3
     (i -1) .) ~20,2
-   (fld :left.1.I93upex.tre8amq6m . . 16,~2
-    (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m) .) ~14,2
-   (fld :right.1.I93upex.tre8amq6m . . 10,~2
-    (ref 4 ForwardNode1.Obj.0.I93upex.tre8amq6m) .))))
+   (fld :left.1.Isi4prb.tregrbip11 . . 16,~2
+    (ref 4 ForwardNode1.Obj.0.Isi4prb.tregrbip11) .) ~14,2
+   (fld :right.1.Isi4prb.tregrbip11 . . 10,~2
+    (ref 4 ForwardNode1.Obj.0.Isi4prb.tregrbip11) .))))

--- a/tests/nimony/sysbasics/tresultnoinit.nif
+++ b/tests/nimony/sysbasics/tresultnoinit.nif
@@ -1,6 +1,6 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tresultnoinit.nim(stmts
- (proc 5 :foo.0.tremd49gb1 . . . 8
+ (proc 5 :foo.0.trebvpy7f1 . . . 8
   (params) 4
   (i -1) 16
   (pragmas 2

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -1,116 +1,116 @@
 (.nif24)
 0,1,tests/nimony/sysbasics/tsets.nim(stmts 9
- (type ~4 :Foo.0.tsefy5wha . . . 2
+ (type ~4 :Foo.0.tse6d56m4 . . . 2
   (enum
    (u +8) ~9,1
-   (efld :A.0.tsefy5wha . . Foo.0.tsefy5wha
+   (efld :A.0.tse6d56m4 . . Foo.0.tse6d56m4
     (tup +0 "A")) ~6,1
-   (efld :B.0.tsefy5wha . . Foo.0.tsefy5wha
+   (efld :B.0.tse6d56m4 . . Foo.0.tse6d56m4
     (tup +1 "B")) ~3,1
-   (efld :C.0.tsefy5wha . . Foo.0.tsefy5wha
+   (efld :C.0.tse6d56m4 . . Foo.0.tse6d56m4
     (tup +2 "C")) ,1
-   (efld :D.0.tsefy5wha . . Foo.0.tsefy5wha
+   (efld :D.0.tse6d56m4 . . Foo.0.tse6d56m4
     (tup +3 "D")) 3,1
-   (efld :E.0.tsefy5wha . . Foo.0.tsefy5wha
+   (efld :E.0.tse6d56m4 . . Foo.0.tse6d56m4
     (tup +4 "E")) 6,1
-   (efld :F.0.tsefy5wha . . Foo.0.tsefy5wha
+   (efld :F.0.tse6d56m4 . . Foo.0.tse6d56m4
     (tup +5 "F")))) 5
- (proc :dollar`.Foo.0.tsefy5wha x . .
+ (proc :dollar`.Foo.0.tse6d56m4 x . .
   (params
-   (param :e.0 . . Foo.0.tsefy5wha .)) string.0.sysvq0asl . .
+   (param :e.0 . . Foo.0.tse6d56m4 .)) string.0.sysvq0asl . .
   (stmts 6
    (result :result.0 . . string.0.sysvq0asl .) 6
    (case e.0 ~9,1
     (of
-     (ranges A.0.tsefy5wha)
+     (ranges A.0.tse6d56m4)
      (stmts
       (ret "A"))) ~6,1
     (of
-     (ranges B.0.tsefy5wha)
+     (ranges B.0.tse6d56m4)
      (stmts
       (ret "B"))) ~3,1
     (of
-     (ranges C.0.tsefy5wha)
+     (ranges C.0.tse6d56m4)
      (stmts
       (ret "C"))) ,1
     (of
-     (ranges D.0.tsefy5wha)
+     (ranges D.0.tse6d56m4)
      (stmts
       (ret "D"))) 3,1
     (of
-     (ranges E.0.tsefy5wha)
+     (ranges E.0.tse6d56m4)
      (stmts
       (ret "E"))) 6,1
     (of
-     (ranges F.0.tsefy5wha)
+     (ranges F.0.tse6d56m4)
      (stmts
       (ret "F"))))
    (ret result.0))) 4,3
- (gvar :s.0.tsefy5wha . . 10
-  (set 1 Foo.0.tsefy5wha) .) 7,3
- (gvar :s1.0.tsefy5wha . . 7
-  (set 1 Foo.0.tsefy5wha) .) 2,4
- (asgn ~2 s.0.tsefy5wha 2
+ (gvar :s.0.tse6d56m4 . . 10
+  (set 1 Foo.0.tse6d56m4) .) 7,3
+ (gvar :s1.0.tse6d56m4 . . 7
+  (set 1 Foo.0.tse6d56m4) .) 2,4
+ (asgn ~2 s.0.tse6d56m4 2
   (setconstr 10,~1
-   (set 1 Foo.0.tsefy5wha) 1
-   (range A.0.tsefy5wha 3 D.0.tsefy5wha))) 3,5
- (asgn ~3 s1.0.tsefy5wha 2
+   (set 1 Foo.0.tse6d56m4) 1
+   (range A.0.tse6d56m4 3 D.0.tse6d56m4))) 3,5
+ (asgn ~3 s1.0.tse6d56m4 2
   (setconstr 9,~2
-   (set 1 Foo.0.tsefy5wha) 1
-   (range A.0.tsefy5wha 3 C.0.tsefy5wha))) ,6
+   (set 1 Foo.0.tse6d56m4) 1
+   (range A.0.tse6d56m4 3 C.0.tse6d56m4))) ,6
  (discard 11
   (ltset 3,~3
-   (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,7
- (glet :y.0.tsefy5wha . . 10,~4
-  (set 1 Foo.0.tsefy5wha) 7
+   (set 1 Foo.0.tse6d56m4) ~3 s1.0.tse6d56m4 2 s.0.tse6d56m4)) 4,7
+ (glet :y.0.tse6d56m4 . . 10,~4
+  (set 1 Foo.0.tse6d56m4) 7
   (mulset 3,~4
-   (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,8
- (glet :z.0.tsefy5wha . . 10,~5
-  (set 1 Foo.0.tsefy5wha) 14 y.0.tsefy5wha) ,9
+   (set 1 Foo.0.tse6d56m4) ~3 s1.0.tse6d56m4 2 s.0.tse6d56m4)) 4,8
+ (glet :z.0.tse6d56m4 . . 10,~5
+  (set 1 Foo.0.tse6d56m4) 14 y.0.tse6d56m4) ,9
  (discard 10
   (eqset 4,~6
-   (set 1 Foo.0.tsefy5wha) ~2 y.0.tsefy5wha 3
+   (set 1 Foo.0.tse6d56m4) ~2 y.0.tse6d56m4 3
    (setconstr 1,~6
-    (set 1 Foo.0.tsefy5wha) 1
-    (range A.0.tsefy5wha 3 C.0.tsefy5wha)))) ,10
+    (set 1 Foo.0.tse6d56m4) 1
+    (range A.0.tse6d56m4 3 C.0.tse6d56m4)))) ,10
  (discard 10
   (eqset 4,~7
-   (set 1 Foo.0.tsefy5wha) ~2 z.0.tsefy5wha 3
+   (set 1 Foo.0.tse6d56m4) ~2 z.0.tse6d56m4 3
    (setconstr 1,~7
-    (set 1 Foo.0.tsefy5wha) 1
-    (range A.0.tsefy5wha 3 C.0.tsefy5wha)))) ,11
+    (set 1 Foo.0.tse6d56m4) 1
+    (range A.0.tse6d56m4 3 C.0.tse6d56m4)))) ,11
  (discard 15
   (eqset ~1,~8
-   (set 1 Foo.0.tsefy5wha) ~5
+   (set 1 Foo.0.tse6d56m4) ~5
    (minusset 4,~8
-    (set 1 Foo.0.tsefy5wha) ~2 s.0.tsefy5wha 2 s1.0.tsefy5wha) 3
+    (set 1 Foo.0.tse6d56m4) ~2 s.0.tse6d56m4 2 s1.0.tse6d56m4) 3
    (setconstr ~4,~8
-    (set 1 Foo.0.tsefy5wha) 1 D.0.tsefy5wha))) ,12
+    (set 1 Foo.0.tse6d56m4) 1 D.0.tse6d56m4))) ,12
  (discard 11
   (leset 3,~9
-   (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 3 s.0.tsefy5wha)) 4,13
- (glet :val.0.tsefy5wha . . 7,~12 Foo.0.tsefy5wha 6 D.0.tsefy5wha) 3,14
- (asgn ~3 s1.0.tsefy5wha 2
+   (set 1 Foo.0.tse6d56m4) ~3 s1.0.tse6d56m4 3 s.0.tse6d56m4)) 4,13
+ (glet :val.0.tse6d56m4 . . 7,~12 Foo.0.tse6d56m4 6 D.0.tse6d56m4) 3,14
+ (asgn ~3 s1.0.tse6d56m4 2
   (setconstr 9,~11
-   (set 1 Foo.0.tsefy5wha) 1
-   (range A.0.tsefy5wha 3 B.0.tsefy5wha) 7 val.0.tsefy5wha 12 F.0.tsefy5wha)) ,16
- (template 9 :resem.0.tsefy5wha . . . 14
+   (set 1 Foo.0.tse6d56m4) 1
+   (range A.0.tse6d56m4 3 B.0.tse6d56m4) 7 val.0.tse6d56m4 12 F.0.tse6d56m4)) ,16
+ (template 9 :resem.0.tse6d56m4 . . . 14
   (params) . . . 2,1
   (stmts 2
-   (asgn ~2 s.0.tsefy5wha 2
+   (asgn ~2 s.0.tse6d56m4 2
     (setconstr 8,~14
-     (set 1 Foo.0.tsefy5wha) 1 A.0.tsefy5wha 4
-     (range C.0.tsefy5wha 3 E.0.tsefy5wha) 10 F.0.tsefy5wha)) 3,1
-   (asgn ~3 s1.0.tsefy5wha 2
+     (set 1 Foo.0.tse6d56m4) 1 A.0.tse6d56m4 4
+     (range C.0.tse6d56m4 3 E.0.tse6d56m4) 10 F.0.tse6d56m4)) 3,1
+   (asgn ~3 s1.0.tse6d56m4 2
     (setconstr 7,~15
-     (set 1 Foo.0.tsefy5wha) 1
-     (range A.0.tsefy5wha 3 B.0.tsefy5wha) 7 val.0.tsefy5wha 12 F.0.tsefy5wha)))) 2,17
+     (set 1 Foo.0.tse6d56m4) 1
+     (range A.0.tse6d56m4 3 B.0.tse6d56m4) 7 val.0.tse6d56m4 12 F.0.tse6d56m4)))) 2,17
  (stmts 2
-  (asgn ~2 s.0.tsefy5wha 2
+  (asgn ~2 s.0.tse6d56m4 2
    (setconstr 8,~14
-    (set 1 Foo.0.tsefy5wha) 1 A.0.tsefy5wha 4
-    (range C.0.tsefy5wha 3 E.0.tsefy5wha) 10 F.0.tsefy5wha)) 3,1
-  (asgn ~3 s1.0.tsefy5wha 2
+    (set 1 Foo.0.tse6d56m4) 1 A.0.tse6d56m4 4
+    (range C.0.tse6d56m4 3 E.0.tse6d56m4) 10 F.0.tse6d56m4)) 3,1
+  (asgn ~3 s1.0.tse6d56m4 2
    (setconstr 7,~15
-    (set 1 Foo.0.tsefy5wha) 1
-    (range A.0.tsefy5wha 3 B.0.tsefy5wha) 7 val.0.tsefy5wha 12 F.0.tsefy5wha))))
+    (set 1 Foo.0.tse6d56m4) 1
+    (range A.0.tse6d56m4 3 B.0.tse6d56m4) 7 val.0.tse6d56m4 12 F.0.tse6d56m4))))


### PR DESCRIPTION
When command line options that can affects generated nif or c files are changed, new generated files have different module suffix and existing cached files are ignored.
But module suffix of the system module are not changed because it must be constant equals to `nimony/builtintypes.SystemModuleSuffix`.

This PR doesn't support changing `--passC` and `--passL` options.
I will create separate PR to support these options.