### PR TITLE
fixes #716; generates a file contains options

### DIFF
--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -321,6 +321,9 @@ proc generateFinalMakefile(c: DepContext; commandLineArgsNifc: string; passC, pa
   result = c.config.nifcachePath / c.rootNode.files[0].modname & ".final.makefile"
   writeFile result, s
 
+proc cachedConfigFile(config: NifConfig): string =
+  config.nifcachePath / "cachedconfigfile.txt"
+
 proc generateFrontendMakefile(c: DepContext; commandLineArgs: string): string =
   var s = makefileHeader
 
@@ -337,6 +340,7 @@ proc generateFrontendMakefile(c: DepContext; commandLineArgs: string): string =
       let idxFile = c.config.indexFile(f)
       if not seenDeps.containsOrIncl(idxFile):
         s.add "  " & mescape(idxFile)
+    s.add " " & c.config.cachedConfigFile()
     let args = commandLineArgs & (if v.isSystem: " --isSystem" else: "")
     s.add "\n\t" & mescape(c.nimsem) & " " & args & " m " & mescape(c.config.parsedFile(v.files[0])) & " " &
       mescape(c.config.semmedFile(v.files[0])) & " " & mescape(c.config.indexFile(v.files[0]))
@@ -354,6 +358,16 @@ proc generateFrontendMakefile(c: DepContext; commandLineArgs: string): string =
 
   result = c.config.nifcachePath / c.rootNode.files[0].modname & ".makefile"
   writeFile result, s
+
+proc generateCachedConfigFile(c: DepContext) =
+  let path = c.config.cachedConfigFile()
+  let configStr = c.config.getOptionsAsOneString() & " " & c.rootNode.files[0].nimFile
+  let needUpdate = if semos.fileExists(path) and not c.forceRebuild:
+                     configStr != readFile path
+                   else:
+                     true
+  if needUpdate:
+    writeFile path, configStr
 
 proc buildGraph*(config: sink NifConfig; project: string; forceRebuild, silentMake: bool;
     commandLineArgs, commandLineArgsNifc: string; moduleFlags: set[ModuleFlag]; cmd: Command;
@@ -374,6 +388,7 @@ proc buildGraph*(config: sink NifConfig; project: string; forceRebuild, silentMa
   c.nodes.add c.rootNode
   c.processedModules.incl p.modname
   parseDeps c, p, c.rootNode
+  generateCachedConfigFile c
   let makeFilename = generateFrontendMakefile(c, commandLineArgs)
   #echo "run with: make -f ", makeFilename
   when defined(windows):

--- a/src/nimony/nifconfig.nim
+++ b/src/nimony/nifconfig.nim
@@ -74,6 +74,15 @@ proc parseNifConfig*(configFile: string; result: var NifConfig) =
   finally:
     f.close()
 
+proc getOptionsAsOneString*(config: NifConfig): string =
+  ## Returns the concatenation of options that affects generated files.
+  result = "--cwd:" & config.currentPath
+
+  for i in config.defines:
+    result.add(" -d:" & i)
+
+  result.add " --bits:" & $config.bits
+
 when isMainModule:
   var conf = default(NifConfig)
   parseNifConfig "src/nifler/nifler.cfg.nif", conf


### PR DESCRIPTION
This PR generates a file with `NifConfig` in the cache directory.
When the command line option changed, content of the file is updated and `*.2.idx.nif` and `*.2.nif` files are updated.