### PR TITLE
fix consecutive imports to the same module

### DIFF
--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -4,7 +4,7 @@
 # See the file "license.txt", included in this
 # distribution, for details about the copyright.
 
-import std / [syncio, os, tables, times, packedsets]
+import std / [syncio, os, tables, sequtils, times, packedsets]
 include nifprelude
 import nifindexes, symparser, reporters, builtintypes
 
@@ -54,18 +54,20 @@ proc loadInterface*(suffix: string; iface: var Iface;
                     converters: var Table[SymId, seq[SymId]];
                     marker: var PackedSet[StrId]; negateMarker: bool) =
   let m = load(suffix)
+  let alreadyLoaded = iface.len != 0
   for k, _ in m.index.public:
     var base = k
     extractBasename(base)
     let strId = pool.strings.getOrIncl(base)
     let symId = pool.syms.getOrIncl(k)
-    iface.mgetOrPut(strId, @[]).add symId
+    if not alreadyLoaded:
+      iface.mgetOrPut(strId, @[]).add symId
     let symMarked =
       if negateMarker: marker.missingOrExcl(strId)
       else: marker.containsOrIncl(strId)
     if not symMarked:
       # mark that this module contains the identifier `strId`:
-      importTab.mgetOrPut(strId, @[]).add(module)
+      importTab.mgetOrPut(strId, @[]).addUnique(module)
   for k, v in m.index.converters.items:
     var name = v
     extractBasename(name)
@@ -74,7 +76,7 @@ proc loadInterface*(suffix: string; iface: var Iface;
     if nameId in importTab and module in importTab[nameId]:
       let key = if k == ".": SymId(0) else: pool.syms.getOrIncl(k)
       let val = pool.syms.getOrIncl(v)
-      converters.mgetOrPut(key, @[]).add(val)
+      converters.mgetOrPut(key, @[]).addUnique(val)
 
 proc error*(msg: string; c: Cursor) {.noreturn.} =
   when defined(debug):

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -293,24 +293,27 @@ proc importSingleFile(c: var SemContext; f1: ImportedFilename; origin: string; m
     c.buildErr info, "file not found: " & f2
     return
   let suffix = moduleSuffix(f2, c.g.config.paths)
-  if not c.processedModules.containsOrIncl(suffix):
+  var moduleSym = SymId(0)
+  if not c.processedModules.contains(suffix):
     c.meta.importedFiles.add f2
     if c.canSelfExec and needsRecompile(f2, suffixToNif suffix):
       selfExec c, f2, (if mode.kind == ImportSystem: " --isSystem" else: "")
 
     let moduleName = pool.strings.getOrIncl(f1.name)
-    let moduleSym = identToSym(c, moduleName, ModuleY)
+    moduleSym = identToSym(c, moduleName, ModuleY)
+    c.processedModules[suffix] = moduleSym
     let s = Sym(kind: ModuleY, name: moduleSym, pos: ImportedPos)
     c.currentScope.addOverloadable(moduleName, s)
     var moduleDecl = createTokenBuf(2)
     moduleDecl.addParLe(ModuleY, info)
     moduleDecl.addParRi()
     publish moduleSym, moduleDecl
-    var module = ImportedModule()
-    var marker = mode.list
-    loadInterface suffix, module.iface, moduleSym, c.importTab, c.converters,
-      marker, negateMarker = mode.kind == FromImport
-    c.importedModules[moduleSym] = module
+  else:
+    moduleSym = c.processedModules[suffix]
+  let module = addr c.importedModules.mgetOrPut(moduleSym, ImportedModule())
+  var marker = mode.list
+  loadInterface suffix, module.iface, moduleSym, c.importTab, c.converters,
+    marker, negateMarker = mode.kind == FromImport
 
 proc cyclicImport(c: var SemContext; x: var Cursor) =
   c.buildErr x.info, "cyclic module imports are not implemented"

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -87,7 +87,7 @@ type
     instantiatedProcs*: Table[(SymId, string), SymId]
     thisModuleSuffix*: string
     moduleFlags*: set[ModuleFlag]
-    processedModules*: HashSet[string]
+    processedModules*: Table[string, SymId] # suffix to sym
     usedTypevars*: int
     phase*: SemPhase
     canSelfExec*: bool

--- a/tests/nimony/modules/tmultipleimport.nim
+++ b/tests/nimony/modules/tmultipleimport.nim
@@ -1,0 +1,5 @@
+from deps/mfieldvis import Foo
+import deps/mfieldvis
+
+var x: Foo
+var y: Generic[int]


### PR DESCRIPTION
Previously the first import of a module would be the only one considered. Now they are additive. The idea is that a module being imported and another module exporting symbols from it do not clash with each other but I'm not sure if this fix is needed for that. In any case silently doing nothing on a consecutive import is not good.