### PR TITLE
Use '+' for numbers

### DIFF
--- a/src/nifc/typenav.nim
+++ b/src/nifc/typenav.nim
@@ -49,13 +49,13 @@ proc getTypeImpl(m: var Module; n: Cursor): Cursor =
   of UIntLit:
     result = createIntegralType(m, "(u -1)")
   of FloatLit:
-    result = createIntegralType(m, "(f 64)")
-  of StringLit: result = createIntegralType(m, "(aptr (c 8))")
-  of CharLit: result = createIntegralType(m, "(c 8)")
+    result = createIntegralType(m, "(f +64)")
+  of StringLit: result = createIntegralType(m, "(aptr (c +8))")
+  of CharLit: result = createIntegralType(m, "(c +8)")
   of ParLe:
     case n.exprKind
-    of SizeofC, AlignofC, OffsetofC: result = createIntegralType(m, "(i 8)")
-    of InfC, NegInfC, NanC: result = createIntegralType(m, "(f 64)")
+    of SizeofC, AlignofC, OffsetofC: result = createIntegralType(m, "(i +8)")
+    of InfC, NegInfC, NanC: result = createIntegralType(m, "(f +64)")
     of TrueC, FalseC, AndC, OrC, NotC, EqC, NeqC, LeC, LtC, ErrvC:
       result = createIntegralType(m, "(bool)")
     of CallC:

--- a/tests/nifc/app.c.nif
+++ b/tests/nifc/app.c.nif
@@ -2,8 +2,8 @@
 (stmts
   (proc :main.c . (i +32) . (stmts
 
-    (var :x.mangled . (f +32) 1.2)
-    (var :y.mangled . (f +64) 1.223)
-    (var :z.mangled . (f +64) 4.6)
+    (var :x.mangled . (f +32) +1.2)
+    (var :y.mangled . (f +64) +1.223)
+    (var :z.mangled . (f +64) +4.6)
     (ret +0)
   )))


### PR DESCRIPTION
Some numbers in the code don't use +, so they are treated as dot with line info between them. 
This even breaks getType logic