### PR TITLE
implement annotating constant types, fix cstring literals

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1078,10 +1078,11 @@ proc traverseExpr(c: var EContext; n: var Cursor) =
       let arg = suf
       skip suf
       assert suf.kind == StringLit
-      if arg.kind == StringLit and pool.strings[suf.litId] in ["R", "T"]:
+      if arg.kind == StringLit and pool.strings[suf.litId] == "C":
         # cstring conversion
         inc n
-        traverseExpr c, n # adds string lit directly
+        c.dest.add n # add string lit directly
+        inc n
         inc n # suf
         skipParRi c, n
       else:

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1078,11 +1078,15 @@ proc traverseExpr(c: var EContext; n: var Cursor) =
       let arg = suf
       skip suf
       assert suf.kind == StringLit
-      if arg.kind == StringLit and pool.strings[suf.litId] == "C":
-        # cstring conversion
+      if arg.kind == StringLit:
+        # no suffix for string literal in nifc
         inc n
-        c.dest.add n # add string lit directly
-        inc n
+        if pool.strings[suf.litId] == "C":
+          # cstring literal, add string lit directly:
+          c.dest.add n
+          inc n
+        else:
+          traverseExpr c, n
         inc n # suf
         skipParRi c, n
       else:

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -13,7 +13,6 @@ include nifprelude
 import symparser
 import typekeys
 import ".." / nimony / [nimony_model, programs, typenav, expreval, xints, decls, builtintypes, sizeof, typeprops]
-from ".." / nimony / sigmatch import isSomeStringType, isStringType
 import hexer_context, pipeline
 import  ".." / lib / stringtrees
 

--- a/src/nimony/builtintypes.nim
+++ b/src/nimony/builtintypes.nim
@@ -5,6 +5,7 @@
 # distribution, for details about the copyright.
 
 include nifprelude
+import nimony_model
 
 type
   BuiltinTypes* = object
@@ -112,3 +113,10 @@ proc createBuiltinTypes*(): BuiltinTypes =
   result.float64Type = result.mem.cursorAt(48)
   result.emptyTupleType = result.mem.cursorAt(51)
   result.untypedType = result.mem.cursorAt(53)
+
+proc isStringType*(a: Cursor): bool {.inline.} =
+  result = a.kind == Symbol and a.symId == pool.syms.getOrIncl(StringName)
+  #a.typeKind == StringT: StringT now unused!
+
+proc isSomeStringType*(a: Cursor): bool {.inline.} =
+  result = a.typeKind == CstringT or isStringType(a)

--- a/src/nimony/builtintypes.nim
+++ b/src/nimony/builtintypes.nim
@@ -17,6 +17,7 @@ type
     float32Type*, float64Type*: Cursor
     emptyTupleType*: Cursor
     untypedType*: Cursor
+    cstringType*: Cursor
 
 proc tagToken(tag: string; info: PackedLineInfo = NoLineInfo): PackedToken {.inline.} =
   parLeToken(pool.tags.getOrIncl(tag), info)
@@ -90,6 +91,9 @@ proc createBuiltinTypes*(): BuiltinTypes =
   result.mem.add tagToken"untyped" # 53
   result.mem.addParRi() # 54
 
+  result.mem.add tagToken"cstring" # 55
+  result.mem.addParRi() # 56
+
   result.mem.freeze()
 
   result.autoType = result.mem.cursorAt(0)
@@ -113,6 +117,7 @@ proc createBuiltinTypes*(): BuiltinTypes =
   result.float64Type = result.mem.cursorAt(48)
   result.emptyTupleType = result.mem.cursorAt(51)
   result.untypedType = result.mem.cursorAt(53)
+  result.cstringType = result.mem.cursorAt(55)
 
 proc isStringType*(a: Cursor): bool {.inline.} =
   result = a.kind == Symbol and a.symId == pool.syms.getOrIncl(StringName)

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -355,12 +355,12 @@ proc annotateConstantType*(buf: var TokenBuf; typ, n: Cursor) =
         buf.addParRi()
     else: err = true
   of StringLit:
-    if isStringType(typ):
+    if not cursorIsNil(symType) and isStringType(symType):
       buf.add n
     elif typ.typeKind == CstringT:
       buf.add parLeToken(SufX, n.info)
       buf.add n
-      buf.add strToken(pool.strings.getOrIncl("R"), n.info)
+      buf.add strToken(pool.strings.getOrIncl("C"), n.info)
       buf.addParRi()
     else: err = true
   of Symbol:

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -101,7 +101,7 @@ proc eval*(c: var EvalContext; n: var Cursor): Cursor =
     inc n
   of ParLe:
     case n.exprKind
-    of TrueX, FalseX:
+    of TrueX, FalseX, NanX, InfX, NeginfX:
       result = n
       skip n
     of AndX:
@@ -153,7 +153,7 @@ proc eval*(c: var EvalContext; n: var Cursor): Cursor =
       inc n
       result = n
       skipToEnd n
-    of ConvX:
+    of ConvX, HconvX:
       let nOrig = n
       inc n
       let typ = n
@@ -328,7 +328,7 @@ proc annotateConstantType*(buf: var TokenBuf; typ, n: Cursor) =
     if typ.typeKind == FloatT:
       inc typ
       let bits = typebits(typ.load)
-      if bits < 0:
+      if bits < 0 or bits == 64:
         buf.add n
       else:
         buf.add parLeToken(SufX, n.info)

--- a/src/nimony/renderer.nim
+++ b/src/nimony/renderer.nim
@@ -54,3 +54,6 @@ proc asNimCode*(n: Cursor): string =
   else:
     # Fallback to the NIF representation as it is much better than nothing:
     result = toString(n, false)
+
+proc typeToString*(n: Cursor): string =
+  result = asNimCode(n)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2981,7 +2981,8 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
       # no explicit type given:
       inc n # 3
       var it = Item(n: n, typ: c.types.autoType)
-      if kind == ConstY:
+      if false and kind == ConstY:
+        # XXX enable
         withNewScope c:
           semConstExpr c, it # 4
       else:
@@ -2996,7 +2997,8 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
         takeToken c, n
       else:
         var it = Item(n: n, typ: typ)
-        if kind == ConstY:
+        if false and kind == ConstY:
+          # XXX enable
           withNewScope c:
             semConstExpr c, it # 4
         else:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4489,6 +4489,7 @@ proc semSuf(c: var SemContext, it: var Item) =
   of "f32": it.typ = c.types.float32Type
   of "f64": it.typ = c.types.float64Type
   of "R", "T": it.typ = c.types.stringType
+  of "C": it.typ = c.types.cstringType
   else:
     c.buildErr it.n.info, "unknown suffix: " & pool.strings[it.n.litId]
   takeToken c, it.n # suffix

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -599,13 +599,13 @@ proc semConstIntExpr(c: var SemContext; n: var Cursor) =
 proc semConstExpr(c: var SemContext; it: var Item) =
   let start = c.dest.len
   semExpr c, it
+  # XXX future note: consider when the expression depends on a generic param
   var e = cursorAt(c.dest, start)
   var valueBuf = evalExpr(c, e)
   endRead(c.dest)
-  # XXX evaluated value is untyped so adding it to c.dest is wrong,
-  # maybe should construct typed AST from evaluated value
   c.dest.shrink start
-  c.dest.add valueBuf
+  var value = beginRead(valueBuf)
+  annotateConstantType c.dest, it.typ, value
 
 proc semStmtsExprImpl(c: var SemContext; it: var Item) =
   while it.n.kind != ParRi:
@@ -2978,8 +2978,7 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
       # no explicit type given:
       inc n # 3
       var it = Item(n: n, typ: c.types.autoType)
-      if false and kind == ConstY:
-        # XXX output from expreval is not typed so cannot be used yet
+      if kind == ConstY:
         withNewScope c:
           semConstExpr c, it # 4
       else:
@@ -2994,8 +2993,7 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
         takeToken c, n
       else:
         var it = Item(n: n, typ: typ)
-        if false and kind == ConstY:
-          # XXX output from expreval is not typed so cannot be used yet
+        if kind == ConstY:
           withNewScope c:
             semConstExpr c, it # 4
         else:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -598,7 +598,10 @@ proc semConstIntExpr(c: var SemContext; n: var Cursor) =
 
 proc semConstExpr(c: var SemContext; it: var Item) =
   let start = c.dest.len
+  var phase = SemcheckBodies
+  swap c.phase, phase
   semExpr c, it
+  swap c.phase, phase
   # XXX future note: consider when the expression depends on a generic param
   var e = cursorAt(c.dest, start)
   var valueBuf = evalExpr(c, e)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -70,9 +70,6 @@ proc concat(a: varargs[string]): string =
   result = a[0]
   for i in 1..high(a): result.add a[i]
 
-proc typeToString*(n: Cursor): string =
-  result = asNimCode(n)
-
 proc error(m: var Match; k: MatchErrorKind; expected, got: Cursor) =
   if m.err: return # first error is the important one
   m.err = true
@@ -670,13 +667,6 @@ proc matchArrayType(m: var Match; f: var Cursor; a: var Cursor) =
       m.error InvalidMatch, f, a
   else:
     m.error InvalidMatch, f, a
-
-proc isStringType*(a: Cursor): bool {.inline.} =
-  result = a.kind == Symbol and a.symId == pool.syms.getOrIncl(StringName)
-  #a.typeKind == StringT: StringT now unused!
-
-proc isSomeStringType*(a: Cursor): bool {.inline.} =
-  result = a.typeKind == CstringT or isStringType(a)
 
 proc isSomeSeqType*(a: Cursor, elemType: var Cursor): bool =
   # check that `a` is either an instantiation of seq or an invocation to it

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -374,6 +374,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor; flags: set[GetTypeFlag]): Cursor =
       of "f32": result = c.builtins.float32Type
       of "f64": result = c.builtins.float64Type
       of "R", "T": result = c.builtins.stringType
+      of "C": result = c.builtins.cstringType
       else: result = c.builtins.autoType
 
   assert result.kind != ParRi, "ParRi for expression: " & toString(n, false)

--- a/tests/nimony/stdlib/ttables.nim
+++ b/tests/nimony/stdlib/ttables.nim
@@ -23,7 +23,7 @@ block:
   assert t.getOrDefault(456) == 654
   assert t[456] == 654
 
-  let HC123 = (1 shl 31) + 123  # Hash collision to '123'
+  const HC123 = (1 shl 31) + 123  # Hash collision to '123'
   assert not t.contains(HC123)
   assert t.getOrDefault(HC123) == 0
 

--- a/tests/nimony/stdlib/ttables.nim
+++ b/tests/nimony/stdlib/ttables.nim
@@ -23,7 +23,7 @@ block:
   assert t.getOrDefault(456) == 654
   assert t[456] == 654
 
-  const HC123 = (1 shl 31) + 123  # Hash collision to '123'
+  let HC123 = (1 shl 31) + 123  # Hash collision to '123'
   assert not t.contains(HC123)
   assert t.getOrDefault(HC123) == 0
 


### PR DESCRIPTION
`semConstExpr` now fits the evaluated constant value to an expression matching the type of the constant. Though `semConstExpr` is only used for the values of `const` declarations which is still disabled and can be enabled in another PR after this one (it requires some test changes).

A new suffix `"C"` is added for cstring literals, previously `"R"` was used for cstring literals in expreval which is wrong, it is used for raw string literals.