### PR TITLE
enable seq openarray converter, test default, fix `(typekind)` for invocations

### DIFF
--- a/lib/std/system/seqimpl.nim
+++ b/lib/std/system/seqimpl.nim
@@ -143,10 +143,8 @@ proc `@`*[I, T](a: array[I, T]): seq[T] {.nodestroy.} =
 # special cased in compiler as "@.1.<system suffix>" for empty seq type inference:
 template `@`*[T](a: array[0, T]): seq[T] = newSeqUninit[T](0)
 
-when false:
-  # XXX needs openArray implementation
-  converter toOpenArray*[T](x: seq[T]): openArray[T] {.inline.} =
-    toOpenArray(x.data, len(x))
+converter toOpenArray*[T](x: seq[T]): openArray[T] {.inline.} =
+  toOpenArray(x.data, len(x))
 
 proc del*[T](s: var seq[T]; idx: int) {.nodestroy.} =
   let L = s.len

--- a/lib/std/system/seqimpl.nim
+++ b/lib/std/system/seqimpl.nim
@@ -144,7 +144,7 @@ proc `@`*[I, T](a: array[I, T]): seq[T] {.nodestroy.} =
 template `@`*[T](a: array[0, T]): seq[T] = newSeqUninit[T](0)
 
 converter toOpenArray*[T](x: seq[T]): openArray[T] {.inline.} =
-  toOpenArray(x.data, len(x))
+  openArray[T](data: x.data, len: len(x))
 
 proc del*[T](s: var seq[T]; idx: int) {.nodestroy.} =
   let L = s.len

--- a/lib/std/system/seqimpl.nim
+++ b/lib/std/system/seqimpl.nim
@@ -144,7 +144,7 @@ proc `@`*[I, T](a: array[I, T]): seq[T] {.nodestroy.} =
 template `@`*[T](a: array[0, T]): seq[T] = newSeqUninit[T](0)
 
 converter toOpenArray*[T](x: seq[T]): openArray[T] {.inline.} =
-  openArray[T](data: x.data, len: len(x))
+  openArray[T](a: x.data, len: len(x))
 
 proc del*[T](s: var seq[T]; idx: int) {.nodestroy.} =
   let L = s.len

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -244,8 +244,10 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
     skip f
   of TypeKindT:
     var aTag = a
-    if a.kind == Symbol:
-      aTag = typeImpl(a.symId)
+    if aTag.typeKind == InvokeT:
+      inc aTag
+    if aTag.kind == Symbol:
+      aTag = typeImpl(aTag.symId)
     if aTag.typeKind == TypeKindT:
       inc aTag
     inc f

--- a/tests/nimony/sysbasics/tseqs.nim
+++ b/tests/nimony/sysbasics/tseqs.nim
@@ -2,7 +2,7 @@ import std/syncio
 
 proc main() =
   let x = newSeq[int](3)
-  var s = newSeqUninit[int](0) # XXX `default(seq[int])` doesn't work due to lack of generic disambiguation
+  var s = default(seq[int])
   s.add(123)
   s.add(456)
   #s.add(newSeq[int](3)) # not defined yet


### PR DESCRIPTION
`toOpenArray` call is changed to an object constructor to `openArray` since there is no overload of `toOpenArray` that takes a `ptr UncheckedArray` and a length parameter. In the original system the `toOpenArray` overload does not take a length, instead it takes a first index and a last index, so I didn't add an overload named as such here. Could still add a `toOpenArrayLen` overload that could be exported.

For generic disambiguation to work between `default(seq[T])` and `default(T: object)`, `T: object` did not match `seq[T]` because the `(typekind)` typeclass did not skip invocation types to their base type, this is now fixed