### PR TITLE
fixes strings forgot to update the newLen

### DIFF
--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -134,6 +134,8 @@ proc growImpl(s: var string; newLen: int) =
     else:
       oomHandler newCap
       s.i = EmptyI
+  else:
+    s.i = (newLen shl LenShift) or (s.i and IsAllocatedBit)
 
 proc makeAllocated(s: var string; newLen: int) =
   let len = s.len

--- a/tests/nimony/sysbasics/tstrings.nim
+++ b/tests/nimony/sysbasics/tstrings.nim
@@ -1,4 +1,12 @@
+import std/syncio
+
 proc main() =
   discard "abc" == "abc"
 
 main()
+
+var mytext = ""
+for i in 0..<10:
+  mytext.add "a"
+
+assert mytext.len == 10


### PR DESCRIPTION
`newLen` could be smaller or equal than `cap`, but the other branch is empty. It needs to update the length