### PR TITLE
fixes #823

### DIFF
--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -4,6 +4,7 @@ include nifprelude
 import std / [assertions, tables]
 
 import ".." / nimony / [nimony_model, programs, decls]
+import duplifier
 
 
 proc hasContinueStmt(c: Cursor): bool =
@@ -330,7 +331,7 @@ proc inlineIterator(e: var EContext; forStmt: ForStmt) =
       let symId = name.symId
 
       let newName = pool.syms.getOrIncl(pool.syms[symId] & ".lf." & $e.instId)
-      createDecl(e, newName, typ, iter, name.info, "cursor")
+      createDecl(e, newName, typ, iter, name.info, if constructsValue(iter): "var" else: "cursor")
       relationsMap[symId] = newName
 
       skip params

--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -330,7 +330,7 @@ proc inlineIterator(e: var EContext; forStmt: ForStmt) =
       let symId = name.symId
 
       let newName = pool.syms.getOrIncl(pool.syms[symId] & ".lf." & $e.instId)
-      createDecl(e, newName, typ, iter, name.info, "var")
+      createDecl(e, newName, typ, iter, name.info, "cursor")
       relationsMap[symId] = newName
 
       skip params


### PR DESCRIPTION
Values passed to the iterator can be modified by referencing it with cursor.
But probably it should use cursor only when it is safe to use it.
It should use cursor only when the argument is lvalue?