### PR TITLE
allow any routine kind in concepts, fix concepts in other modules

### DIFF
--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -488,11 +488,18 @@ proc transformStmt(e: var EContext; c: var Cursor) =
     of FuncS, ProcS, ConverterS, MethodS:
       e.dest.add c
       inc c
-      for i in 0..<BodyPos:
+      takeTree(e, c) # name
+      takeTree(e, c) # exported
+      takeTree(e, c) # pattern
+      let isGeneric = c.substructureKind == TypevarsU
+      for i in 3..<BodyPos:
         takeTree(e, c)
       let oldTmpId = e.tmpId
       e.tmpId = 0
-      transformStmt(e, c)
+      if isGeneric:
+        takeTree(e, c)
+      else:
+        transformStmt(e, c)
       e.tmpId = oldTmpId
       takeParRi(e, c)
     of VarS, LetS, CursorS, ResultS:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -20,6 +20,7 @@ type
     kind*: SymKind
     sym*: SymId
     typ*: Cursor
+    fromConcept*: bool
 
   MatchErrorKind* = enum
     InvalidMatch

--- a/tests/nimony/concepts/tconceptiterator.nim
+++ b/tests/nimony/concepts/tconceptiterator.nim
@@ -1,0 +1,18 @@
+# issue #829
+
+iterator `..`*(a, b: int): int {.inline.} =
+  var i = a
+  while i <= b:
+    yield i
+    inc i
+
+type
+  Iterable* = concept
+    iterator `..`(a, b: Self): Self
+
+proc default2*[I: Iterable; T: HasDefault](x: typedesc[array[I, T]]): array[I, T] {.inline, noinit.} =
+  # Needs to call iterator `..`(a, b: I): I
+  for i in low(array[I, T]) .. high(array[I, T]):
+    result[i] = default(T)
+
+var x = default2(array[2, int])

--- a/tests/nimony/nosystem/tfib2.nif
+++ b/tests/nimony/nosystem/tfib2.nif
@@ -76,16 +76,16 @@
   (concept . .
    (typevar :Self.0.tfitjdpcx . . . .) ~8,1
    (stmts
-    (proc 5 :<=.0 . . . 9
+    (proc 5 :<=.2.tfitjdpcx . . . 9
      (params 1
       (param :a.0 . . 6 Self.0.tfitjdpcx .) 4
       (param :b.0 . . 3 Self.0.tfitjdpcx .)) 14
      (bool) . . .) ,1
-    (proc 5 :\2B.0 . . . 8
+    (proc 5 :\2B.2.tfitjdpcx . . . 8
      (params 1
       (param :x.6 . . 6 Self.0.tfitjdpcx .) 4
       (param :y.6 . . 3 Self.0.tfitjdpcx .)) 14 Self.0.tfitjdpcx . . .) ,2
-    (proc 5 :\2D.0 . . . 8
+    (proc 5 :\2D.2.tfitjdpcx . . . 8
      (params 1
       (param :x.7 . . 6 Self.0.tfitjdpcx .) 4
       (param :y.7 . . 3 Self.0.tfitjdpcx .)) 14 Self.0.tfitjdpcx . . .)))) ,22


### PR DESCRIPTION
fixes #829

Instead of `ConceptProcY` `FnCandidate` tracks if the routine came from a concept and uses the same routine kind as declared in the concept.

Also routine symbols of concepts in toplevel scope also declare their symbols as global so that their generic parameters can be loaded in sigmatch if they have any.

iterinliner also no longer transforms generic routines.