### PR TITLE
match instantiated template bodies to return types, required fixes

### DIFF
--- a/tests/nimony/calls/ttemplatecalltype1.nim
+++ b/tests/nimony/calls/ttemplatecalltype1.nim
@@ -1,0 +1,7 @@
+import std/syncio
+
+template foo[T](): T = 123
+
+let x = foo[float]()
+let y: float = x
+assert y == 123.0

--- a/tests/nimony/calls/ttemplatecalltype2.msgs
+++ b/tests/nimony/calls/ttemplatecalltype2.msgs
@@ -1,0 +1,2 @@
+tests/nimony/calls/ttemplatecalltype2.nim(3, 27) Trace: instantiation from here
+tests/nimony/calls/ttemplatecalltype2.nim(1, 24) Error: type mismatch: got: (f +64) but wanted: string.0.sysvq0asl

--- a/tests/nimony/calls/ttemplatecalltype2.nim
+++ b/tests/nimony/calls/ttemplatecalltype2.nim
@@ -1,0 +1,3 @@
+template foo[T](): T = 123
+
+let x: string = foo[float]()

--- a/tests/nimony/nosystem/tcstring.nif
+++ b/tests/nimony/nosystem/tcstring.nif
@@ -57,6 +57,6 @@
   (cstring) 17
   (suf "abc" "C")) 4,20
  (gvar :zz.0.tcsj45p9m . . 8,~2
-  (cstring)
-  (hconv 12,20,tests/nimony/nosystem/tcstring.nim
-   (cstring) 18,22,tests/nimony/nosystem/tcstring.nim "xzy")))
+  (cstring) 14
+  (hconv ~6,~2
+   (cstring) "xzy")))

--- a/tests/nimony/sysbasics/tconstarrlen.nif
+++ b/tests/nimony/sysbasics/tconstarrlen.nif
@@ -19,8 +19,8 @@
     (i -1) +0 +99)) .) ,7
  (if 3
   (elif 6
-   (eq 15,134,lib/std/system.nim
-    (i +64) 2,465,lib/std/system.nim
+   (eq
+    (i -1) 2,465,lib/std/system.nim
     (expr
      (expr ,~4
       (expr

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -266,7 +266,7 @@
        (hconv 17,19,lib/std/system/mimalloc.nim
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
-         (pointer) 13,17,lib/std/system/seqimpl.nim
+         (pointer)
          (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.0.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -398,7 +398,7 @@
          (hconv 17,16,lib/std/system/mimalloc.nim
           (pointer)
           (hconv 17,19,lib/std/system/mimalloc.nim
-           (pointer) 56,101,lib/std/system/seqimpl.nim
+           (pointer)
            (dot ~4
             (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0))) 12 memSize.3))) ,4
       (if 3
@@ -471,7 +471,7 @@
        (hconv 17,19,lib/std/system/mimalloc.nim
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
-         (pointer) 13,17,lib/std/system/seqimpl.nim
+         (pointer)
          (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.1.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl
@@ -603,7 +603,7 @@
          (hconv 17,16,lib/std/system/mimalloc.nim
           (pointer)
           (hconv 17,19,lib/std/system/mimalloc.nim
-           (pointer) 56,101,lib/std/system/seqimpl.nim
+           (pointer)
            (dot ~4
             (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0))) 12 memSize.4))) ,4
       (if 3
@@ -676,7 +676,7 @@
        (hconv 17,19,lib/std/system/mimalloc.nim
         (pointer)
         (hconv 17,19,lib/std/system/mimalloc.nim
-         (pointer) 13,17,lib/std/system/seqimpl.nim
+         (pointer)
          (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.2.temd2l7vy . .
   (at =wasMoved.2.sysvq0asl 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -808,7 +808,7 @@
          (hconv 17,16,lib/std/system/mimalloc.nim
           (pointer)
           (hconv 17,19,lib/std/system/mimalloc.nim
-           (pointer) 56,101,lib/std/system/seqimpl.nim
+           (pointer)
            (dot ~4
             (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0))) 12 memSize.5))) ,4
       (if 3
@@ -892,7 +892,7 @@
         (hconv 23,22,lib/std/system/mimalloc.nim
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
-          (pointer) 44,9,lib/std/system/seqimpl.nim
+          (pointer)
           (dot ~1 s.15 data.0.Ipe57hg.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
@@ -924,7 +924,7 @@
         (hconv 23,22,lib/std/system/mimalloc.nim
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
-          (pointer) 44,9,lib/std/system/seqimpl.nim
+          (pointer)
           (dot ~1 s.16 data.0.Iw9f2pq.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1
@@ -956,7 +956,7 @@
         (hconv 23,22,lib/std/system/mimalloc.nim
          (pointer)
          (hconv 17,19,lib/std/system/mimalloc.nim
-          (pointer) 44,9,lib/std/system/seqimpl.nim
+          (pointer)
           (dot ~1 s.17 data.0.Iq4ofkp1.temd2l7vy +0)))))) 40
      (else 6
       (expr +0)))) ~2,~1

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -348,8 +348,8 @@
     (expr
      (if 3
       (elif 7
-       (eq 17,111,lib/std/system.nim
-        (i +64) 2,465,lib/std/system.nim
+       (eq 7,33,lib/std/system.nim
+        (i -1) 2,465,lib/std/system.nim
         (expr
          (expr ,~4
           (expr


### PR DESCRIPTION
follows up #844

After the expanded template body is semchecked, it is matched to the return type first (`untyped` is special cased to not do anything as in `semProcBody` but maybe it can be handled generally in `commonType`), then matched to the expected type of the expression.

Sigmatch now skips `(expr)` etc when matching int and string literals. This is not done yet for empty collection literals since they manipulate the AST instead of just prepending to it but it's not hard to do.