### PR TITLE
skip modifier in semBoolExpr

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -526,9 +526,10 @@ proc semBoolExpr(c: var SemContext; n: var Cursor) =
   let start = c.dest.len
   var it = Item(n: n, typ: c.types.autoType)
   semExpr c, it
-  if classifyType(c, it.typ) != BoolT:
+  let t = skipModifier(it.typ)
+  if classifyType(c, t) != BoolT:
     c.dest.shrink start
-    buildErr c, n.info, "expected `bool` but got: " & typeToString(it.typ)
+    buildErr c, n.info, "expected `bool` but got: " & typeToString(t)
   n = it.n
 
 proc semConstBoolExpr(c: var SemContext; n: var Cursor) =

--- a/tests/nimony/sysbasics/tlentboolif.nim
+++ b/tests/nimony/sysbasics/tlentboolif.nim
@@ -1,0 +1,15 @@
+# issue #853
+
+proc foo(x: seq[bool]): lent bool =
+  x[0]
+
+var s = @[false]
+if foo(s): discard
+
+iterator foo2(x: seq[bool]): lent bool =
+  yield x[0]
+
+var s2 = @[false]
+for i in foo2(s2):
+  if i:
+    discard


### PR DESCRIPTION
fixes #853

I must have missed it since `semConstBoolExpr` below already skips modifier