### PR TITLE
don't generate (expr) for routine expression returns

### DIFF
--- a/tests/nimony/generics/ttuplecache.nif
+++ b/tests/nimony/generics/ttuplecache.nif
@@ -10,22 +10,20 @@
   (stmts 8
    (result :result.0 . . ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 .) 8
    (asgn result.0
-    (expr
-     (oconstr ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 5
-      (kv ~5 data.0.Iw8bgj.ttuv4zf4c1 2 +0)))) ~2,~1
+    (oconstr ~3,~1 Foo.0.Iw8bgj.ttuv4zf4c1 5
+     (kv ~5 data.0.Iw8bgj.ttuv4zf4c1 2 +0))) ~2,~1
    (ret result.0))) ,8
  (proc 5 :initFooTup.0.ttuv4zf4c1 . . . 15
   (params) 7 Foo.0.Ildbpdf1.ttuv4zf4c1 . . 2,2
   (stmts 15
    (result :result.1 . . ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 .) 15
    (asgn result.1
-    (expr
-     (oconstr ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 5
-      (kv ~5 data.0.Ildbpdf1.ttuv4zf4c1 2
-       (tupconstr ~16,~2
-        (tuple 1
-         (i -1) 6
-         (i -1)) 1 +0 4 +0))))) ~2,~2
+    (oconstr ~10,~2 Foo.0.Ildbpdf1.ttuv4zf4c1 5
+     (kv ~5 data.0.Ildbpdf1.ttuv4zf4c1 2
+      (tupconstr ~16,~2
+       (tuple 1
+        (i -1) 6
+        (i -1)) 1 +0 4 +0)))) ~2,~2
    (ret result.1))) ,12
  (proc 5 :initFooGeneric.0.ttuv4zf4c1 . . 19
   (typevars 1
@@ -37,10 +35,9 @@
    (result :result.2 . . 3,~1
     (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) .) 6
    (asgn result.2
-    (expr
-     (oconstr 3,~1
-      (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
-      (kv ~5 data 2 x.0)))) ~2,~1
+    (oconstr 3,~1
+     (at ~3 Foo.0.ttuv4zf4c1 1 T.1.ttuv4zf4c1) 5
+     (kv ~5 data 2 x.0))) ~2,~1
    (ret result.2))) 4,15
  (glet :x.0.ttuv4zf4c1 . . 7,~3 Foo.0.Iv5bnz4.ttuv4zf4c1 18
   (call ~14 initFooGeneric.1.ttuv4zf4c1 1
@@ -89,9 +86,8 @@
   (stmts 6
    (result :result.3 . . 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 .) 6
    (asgn result.3
-    (expr
-     (oconstr 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 5
-      (kv ~5 data.0.Iv5bnz4.ttuv4zf4c1 2 x.3)))) ~2,~1
+    (oconstr 3,~1 Foo.0.Iv5bnz4.ttuv4zf4c1 5
+     (kv ~5 data.0.Iv5bnz4.ttuv4zf4c1 2 x.3))) ~2,~1
    (ret result.3))) 22,19
  (proc :initFooGeneric.2.ttuv4zf4c1 . ~22,~7 .
   (at initFooGeneric.0.ttuv4zf4c1 3
@@ -108,9 +104,8 @@
   (stmts 6
    (result :result.4 . . 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 .) 6
    (asgn result.4
-    (expr
-     (oconstr 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 5
-      (kv ~5 data.0.Iarhs7y1.ttuv4zf4c1 2 x.4)))) ~2,~1
+    (oconstr 3,~1 Foo.0.Iarhs7y1.ttuv4zf4c1 5
+     (kv ~5 data.0.Iarhs7y1.ttuv4zf4c1 2 x.4))) ~2,~1
    (ret result.4))) 7,5
  (type :Foo.0.Iw8bgj.ttuv4zf4c1 .
   (at Foo.0.ttuv4zf4c1 1

--- a/tests/nimony/nosystem/t2.nif
+++ b/tests/nimony/nosystem/t2.nif
@@ -66,6 +66,5 @@
   (stmts
    (result :result.1 . . ~15,~11
     (i -1) .)
-   (asgn result.1
-    (expr x.3)) ~31
+   (asgn result.1 x.3) ~31
    (ret result.1))))

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -64,9 +64,8 @@
     (i -1) .)) 13
   (i -1) . . 32
   (stmts 2
-   (expr
-    (add ~14
-     (i -1) ~2 x.2 2 y.1)))) ,29
+   (add ~14
+    (i -1) ~2 x.2 2 y.1))) ,29
  (proc 5 :foo.0.tte5tld8n . . . 8
   (params 1
    (param :x.3 . . 3
@@ -79,13 +78,11 @@
    (var :x.5 . . string.0.sysvq0asl 4 "abc") 7,1
    (asgn ~7 result.0 23,~4
     (expr 2
-     (expr
-      (add ~14
-       (i -1) ~18,4 +4 ~2
-       (expr 2
-        (expr
-         (add ~14
-          (i -1) ~10,4 +2 ~7,4 +89))))))) 2,2
+     (add ~14
+      (i -1) ~18,4 +4 ~2
+      (expr 2
+       (add ~14
+        (i -1) ~10,4 +2 ~7,4 +89))))) 2,2
    (asgn ~2 x.5 2 "34") ~2,~1
    (ret result.0))) ,34
  (proc 5 :overloaded.0.tte5tld8n . . . 15
@@ -110,15 +107,13 @@
    (param :x.4 . . 3
     (i -1) .)) 10 T.4.tte5tld8n . . 30
   (stmts 1
-   (expr
-    (conv ~1 T.4.tte5tld8n 1 x.4)))) 4,42
+   (conv ~1 T.4.tte5tld8n 1 x.4))) 4,42
  (glet :val.0.tte5tld8n . .
   (i -1) 6 +123) ,43
  (discard 30,~3
   (expr 1
-   (expr
-    (conv ~18,3
-     (u -1) ~12,3 val.0.tte5tld8n)))) 19,19
+   (conv ~18,3
+    (u -1) ~12,3 val.0.tte5tld8n))) 19,19
  (type :MyGeneric.0.Igj236q.tte5tld8n .
   (at MyGeneric.0.tte5tld8n 1
    (i -1)) ~4,~4 . ~2,~4

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -156,20 +156,15 @@
  (gvar :a.1.tbawx6nu81 . . 12,~3 Foo1314.0.tbawx6nu81 11
   (oconstr 1,~3 Foo1314.0.tbawx6nu81
    (kv a.0.tbawx6nu81 43,6,lib/std/system/defaults.nim
-    (expr
-     (expr +0)))
+    (expr +0))
    (kv b.0.tbawx6nu81 43,6,lib/std/system/defaults.nim
-    (expr
-     (expr +0)))
+    (expr +0))
    (kv c.0.tbawx6nu81 43,6,lib/std/system/defaults.nim
-    (expr
-     (expr +0)))
+    (expr +0))
    (kv d.0.tbawx6nu81 43,6,lib/std/system/defaults.nim
-    (expr
-     (expr +0)))
+    (expr +0))
    (kv e.0.tbawx6nu81 43,6,lib/std/system/defaults.nim
-    (expr
-     (expr +0))))) 7,43
+    (expr +0)))) 7,43
  (call ~7 foo1314.0.tbawx6nu81 1 a.1.tbawx6nu81) ,45
  (proc 5 :foo2233.0.tbawx6nu81 . . . 12
   (params) . 15

--- a/tests/nimony/sysbasics/tconstarrlen.nif
+++ b/tests/nimony/sysbasics/tconstarrlen.nif
@@ -21,21 +21,19 @@
   (elif 6
    (eq
     (i -1) 2,65,lib/std/system.nim
-    (expr
-     (expr ,~4
-      (expr
-       (expr 45,2
-        (add 15,50,lib/std/system/arithmetics.nim
-         (i +64) ~23
-         (sub 30,6,lib/std/system/defaults.nim
-          (i -1) ~5
-          (conv 30,6,lib/std/system/defaults.nim
-           (i -1) ~13
-           (conv
-            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +99)) 18
-          (conv 30,6,lib/std/system/defaults.nim
-           (i -1) ~13
-           (conv
-            (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))))) 3 Len.0.tcoacwdbr) ~1,1
+    (expr ,~4
+     (expr 45,2
+      (add 15,50,lib/std/system/arithmetics.nim
+       (i +64) ~23
+       (sub 30,6,lib/std/system/defaults.nim
+        (i -1) ~5
+        (conv 30,6,lib/std/system/defaults.nim
+         (i -1) ~13
+         (conv
+          (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +99)) 18
+        (conv 30,6,lib/std/system/defaults.nim
+         (i -1) ~13
+         (conv
+          (i -1) 12,2,tests/nimony/sysbasics/tconstarrlen.nim +0))) 2 +1))) 3 Len.0.tcoacwdbr) ~1,1
    (stmts
     (discard .)))))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -7,8 +7,7 @@
    (discard .))) 3,2
  (call ~3 foo.0.temd2l7vy 43,144,lib/std/system/seqimpl.nim
   (expr 15
-   (expr
-    (call ~15 newSeqUninit.0.temd2l7vy 1 +0)))) ,4
+   (call ~15 newSeqUninit.0.temd2l7vy 1 +0))) ,4
  (proc 5 :bar.0.temd2l7vy . . 8
   (typevars 1
    (typevar :T.0.temd2l7vy . . . .)) 11
@@ -20,12 +19,10 @@
    (discard .))) 3,6
  (call ~3 bar.1.temd2l7vy 1 +1.23 43,144,lib/std/system/seqimpl.nim
   (expr 15
-   (expr
-    (call ~15 newSeqUninit.1.temd2l7vy 1 +0)))) 4,8
+   (call ~15 newSeqUninit.1.temd2l7vy 1 +0))) 4,8
  (gvar :s.0.temd2l7vy . . 6 seq.0.Iq4ofkp1.temd2l7vy 43,144,lib/std/system/seqimpl.nim
   (expr 15
-   (expr
-    (call ~15 newSeqUninit.2.temd2l7vy 1 +0)))) 58,144,lib/std/system/seqimpl.nim
+   (call ~15 newSeqUninit.2.temd2l7vy 1 +0))) 58,144,lib/std/system/seqimpl.nim
  (proc :newSeqUninit.0.temd2l7vy . ~58,~92 .
   (at newSeqUninit.0.sysvq0asl 16,1,tests/nimony/sysbasics/temptyseq.nim
    (i -1)) ~37,~92

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -366,58 +366,53 @@
   (stmts
    (result :result.0 . . 35,~1 openArray.0.Inff8aa1.tfo6yv57p .)
    (asgn result.0
-    (expr
-     (if 3
-      (elif 7
-       (eq 7,31,lib/std/system/basic_types.nim
-        (i -1) 2,65,lib/std/system.nim
-        (expr
+    (if 3
+     (elif 7
+      (eq 7,31,lib/std/system/basic_types.nim
+       (i -1) 2,65,lib/std/system.nim
+       (expr ,~4
+        (expr 45,2
+         (add 15,50,lib/std/system/arithmetics.nim
+          (i +64) ~23
+          (sub 30,6,lib/std/system/defaults.nim
+           (i -1) ~5
+           (conv 30,6,lib/std/system/defaults.nim
+            (i -1) ~13
+            (conv
+             (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +5)) 18
+           (conv 30,6,lib/std/system/defaults.nim
+            (i -1) ~13
+            (conv
+             (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +0))) 2 +1))) 3 +0) ~1,1
+      (expr 12
+       (oconstr 21,~2 openArray.0.Inff8aa1.tfo6yv57p 2
+        (kv ~2 a.1.Inff8aa1.tfo6yv57p 2
+         (nil)) 12
+        (kv ~12 len.4.Inff8aa1.tfo6yv57p 2 +0)))) ,2
+     (else 2,1
+      (expr 12
+       (oconstr 21,~4 openArray.0.Inff8aa1.tfo6yv57p 2
+        (kv ~2 a.1.Inff8aa1.tfo6yv57p 2
+         (cast 5
+          (ptr 18
+           (uarray
+            (i -1))) 32
+          (addr 1 x.4))) 45
+        (kv ~45 len.4.Inff8aa1.tfo6yv57p 2,65,lib/std/system.nim
          (expr ,~4
-          (expr
-           (expr 45,2
-            (add 15,50,lib/std/system/arithmetics.nim
-             (i +64) ~23
-             (sub 30,6,lib/std/system/defaults.nim
-              (i -1) ~5
-              (conv 30,6,lib/std/system/defaults.nim
-               (i -1) ~13
-               (conv
-                (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +5)) 18
-              (conv 30,6,lib/std/system/defaults.nim
-               (i -1) ~13
-               (conv
-                (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +0))) 2 +1))))) 3 +0) ~1,1
-       (expr 12
-        (oconstr 21,~2 openArray.0.Inff8aa1.tfo6yv57p 2
-         (kv ~2 a.1.Inff8aa1.tfo6yv57p 2
-          (nil)) 12
-         (kv ~12 len.4.Inff8aa1.tfo6yv57p 2 +0)))) ,2
-      (else 2,1
-       (expr 12
-        (oconstr 21,~4 openArray.0.Inff8aa1.tfo6yv57p 2
-         (kv ~2 a.1.Inff8aa1.tfo6yv57p 2
-          (cast 5
-           (ptr 18
-            (uarray
-             (i -1))) 32
-           (addr 1 x.4))) 45
-         (kv ~45 len.4.Inff8aa1.tfo6yv57p 2,65,lib/std/system.nim
-          (expr
-           (expr ,~4
-            (expr
-             (expr 45,2
-              (add 15,50,lib/std/system/arithmetics.nim
-               (i +64) ~23
-               (sub 30,6,lib/std/system/defaults.nim
-                (i -1) ~5
-                (conv 30,6,lib/std/system/defaults.nim
-                 (i -1) ~13
-                 (conv
-                  (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +5)) 18
-                (conv 30,6,lib/std/system/defaults.nim
-                 (i -1) ~13
-                 (conv
-                  (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +0))) 2 +1)))))))))))) ~2,~1
+          (expr 45,2
+           (add 15,50,lib/std/system/arithmetics.nim
+            (i +64) ~23
+            (sub 30,6,lib/std/system/defaults.nim
+             (i -1) ~5
+             (conv 30,6,lib/std/system/defaults.nim
+              (i -1) ~13
+              (conv
+               (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +5)) 18
+             (conv 30,6,lib/std/system/defaults.nim
+              (i -1) ~13
+              (conv
+               (i -1) 14,95,tests/nimony/sysbasics/tforloops1.nim +0))) 2 +1))))))))) ~2,~1
    (ret result.0))) 16,95
  (iterator :items.0.tfo6yv57p . 0,38,lib/std/system/openarrays.nim .
   (at items.0.sysvq0asl
@@ -450,8 +445,7 @@
    (result :result.1 . . 7,31,lib/std/system/basic_types.nim
     (i -1) .) 1
    (asgn result.1
-    (expr
-     (dot ~1 a.10 len.4.Inff8aa1.tfo6yv57p +0))) ~48
+    (dot ~1 a.10 len.4.Inff8aa1.tfo6yv57p +0)) ~48
    (ret result.1))) 10,41,lib/std/system/openarrays.nim
  (proc :\5B\5D.0.tfo6yv57p . ~10,~33 .
   (at \5B\5D.7.sysvq0asl
@@ -476,11 +470,10 @@
    (result :result.2 . . ~71
     (mut
      (i -1)) .) 3
-   (asgn result.2
-    (expr ~2
-     (haddr
-      (pat
-       (dot ~1 x.6 a.1.Inff8aa1.tfo6yv57p +0) 3 idx.1)))) ~97
+   (asgn result.2 ~2
+    (haddr
+     (pat
+      (dot ~1 x.6 a.1.Inff8aa1.tfo6yv57p +0) 3 idx.1))) ~97
    (ret result.2))) 37,13,lib/std/system/openarrays.nim
  (type :openArray.0.Inff8aa1.tfo6yv57p .
   (at openArray.0.sysvq0asl


### PR DESCRIPTION
This removes half of the `(expr (expr ...))` generated by template calls. The other (expr) is because the `(stmts)` part of template body is directly used when instantiating templates and semchecks to `(expr)`.