### PR TITLE
fixes #873; set constructor in proc in block statement causes error 

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -663,9 +663,11 @@ proc traverseProcBody(c: var EContext; n: var Cursor) =
 
 template moveToTopLevel(c: var EContext; mode: TraverseMode; body: typed) =
   if mode == TraverseAll:
-    swap c.dest, c.pending
+    var temp = createTokenBuf()
+    swap c.dest, temp
     body
-    swap c.dest, c.pending
+    swap c.dest, temp
+    c.pending.add temp
   else:
     body
 

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -304,4 +304,13 @@
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 31,32 "")) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-       (cmd quit.0.syn1lfpjv 5 +1))))))))
+       (cmd quit.0.syn1lfpjv 5 +1))))))) ,37
+ (block . 2,1
+  (stmts
+   (proc 5 :test.0 . . . 9
+    (params) . . . 2,1
+    (stmts
+     (discard 8
+      (setconstr 2,~12
+       (set 1
+        (c +8)) 1 'a')))))))

--- a/tests/nimony/sysbasics/tsets.nim
+++ b/tests/nimony/sysbasics/tsets.nim
@@ -34,3 +34,7 @@ block:
   assert card(sss) == 26
   sss.incl('u')
   assert card(sss) == 26
+
+block:
+  proc test() =
+    discard {'a'}


### PR DESCRIPTION
fixes #873

adds a temp for `c.pending` because of nested scopes

