### PR TITLE
syncio: use `pointer` type for `writeBuffer`

### DIFF
--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -25,13 +25,11 @@ var
   stdout* {.importc: "stdout", header: "<stdio.h>".}: File
   stderr* {.importc: "stderr", header: "<stdio.h>".}: File
 
-proc c_fwrite(buf: ptr UncheckedArray[char]; size, n: uint; f: File): uint {.
-  importc: "fwrite", header: "<stdio.h>".}
-proc c_fwrite(buf: ptr UncheckedArray[uint8]; size, n: uint; f: File): uint {.
-  importc: "fwrite", header: "<stdio.h>".}
 proc c_fputc(c: int32; f: File): int32 {.
   importc: "fputc", header: "<stdio.h>".}
-proc c_fread(buf: ptr UncheckedArray[uint8]; size, n: uint; f: File): uint {.
+proc c_fwrite(buf: pointer; size, n: uint; f: File): uint {.
+  importc: "fwrite", header: "<stdio.h>".}
+proc c_fread(buf: pointer; size, n: uint; f: File): uint {.
   importc: "fread", header: "<stdio.h>".}
 
 proc fprintf(f: File; fmt: cstring) {.varargs, importc: "fprintf", header: "<stdio.h>".}
@@ -64,10 +62,10 @@ proc close*(f: File) = discard fclose(f)
 
 proc fopen(filename, mode: cstring): File {.importc: "fopen", header: "<stdio.h>".}
 
-proc writeBuffer*(f: File; buffer: ptr UncheckedArray[uint8]; size: int): int =
+proc writeBuffer*(f: File; buffer: pointer; size: int): int =
   result = cast[int](c_fwrite(buffer, 1'u, cast[uint](size), f))
 
-proc readBuffer*(f: File; buffer: ptr UncheckedArray[uint8]; size: int): int =
+proc readBuffer*(f: File; buffer: pointer; size: int): int =
   result = cast[int](c_fread(buffer, 1'u, cast[uint](size), f))
 
 proc c_ferror(f: File): int32 {.
@@ -75,7 +73,7 @@ proc c_ferror(f: File): int32 {.
 
 proc failed*(f: File): bool {.inline.} = c_ferror(f) != 0
 
-proc c_setvbuf(f: File; buffer: ptr UncheckedArray[uint8]; mode: int32; size: uint): int32 {.
+proc c_setvbuf(f: File; buffer: pointer; mode: int32; size: uint): int32 {.
   importc: "setvbuf", header: "<stdio.h>".}
 
 var IOFBF {.importc: "_IOFBF", header: "<stdio.h>".}: int32

--- a/tests/nimony/stdlib/tsyncio.nim
+++ b/tests/nimony/stdlib/tsyncio.nim
@@ -56,4 +56,17 @@ echo 'a'
 echo "xyz", 111'u, true, 'b'
 echo 0.0, " ", 1.0
 
+type
+  DummyObject0 = object
+    o, b, j, n: char
+  DummyObject1 = object
+    a, b, c, n: char
+
+let obj0 = DummyObject0(o: 'o', b: 'b', j: 'j', n: '\n')
+let obj1 = DummyObject1(a: 'a', b: 'b', c: 'c', n: '\n')
+let n0 = stdout.writeBuffer(addr obj0, sizeof DummyObject0)
+let n1 = stdout.writeBuffer(addr obj1, sizeof DummyObject1)
+
+assert n0 == sizeof DummyObject0
+assert n1 == sizeof DummyObject1
 assert true

--- a/tests/nimony/stdlib/tsyncio.output
+++ b/tests/nimony/stdlib/tsyncio.output
@@ -26,3 +26,5 @@ abc123
 a
 xyz111trueb
 0 1
+obj
+abc

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -225,7 +225,7 @@
  (proc 5 :classify1.0.tbawx6nu81 . . . 14
   (params 1
    (param :s.0 . . 3 string.0.sysvq0asl .)) . . . 2,1
-  (stmts 2,104,lib/std/syncio.nim
+  (stmts 2,102,lib/std/syncio.nim
    (stmts 2,1
     (stmts
      (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 7,75,tests/nimony/sysbasics/tbasics.nim s.0)) ,2
@@ -236,7 +236,7 @@
    (proc 5 :classify.0 . . . 13
     (params 1
      (param :s.4 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,104,lib/std/syncio.nim
+    (stmts 2,102,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,82,tests/nimony/sysbasics/tbasics.nim s.4)) ,2
@@ -247,7 +247,7 @@
      (proc 5 :classify2.0 . . . 14
       (params 1
        (param :s.5 . . 3 string.0.sysvq0asl .)) . . . 2,1
-      (stmts 2,104,lib/std/syncio.nim
+      (stmts 2,102,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,87,tests/nimony/sysbasics/tbasics.nim s.5)) ,2
@@ -258,7 +258,7 @@
    (proc 5 :classify2.1 . . . 14
     (params 1
      (param :s.6 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,104,lib/std/syncio.nim
+    (stmts 2,102,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,93,tests/nimony/sysbasics/tbasics.nim s.6)) ,2
@@ -269,7 +269,7 @@
    (proc 5 :classify.1 . . . 13
     (params 1
      (param :s.7 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,104,lib/std/syncio.nim
+    (stmts 2,102,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,99,tests/nimony/sysbasics/tbasics.nim s.7)) ,2
@@ -282,7 +282,7 @@
      (proc 5 :classify.2 . . . 13
       (params 1
        (param :s.8 . . 3 string.0.sysvq0asl .)) . . . 2,1
-      (stmts 2,104,lib/std/syncio.nim
+      (stmts 2,102,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,106,tests/nimony/sysbasics/tbasics.nim s.8)) ,2
@@ -294,7 +294,7 @@
    (proc 5 :classify.3 . . . 13
     (params 1
      (param :s.9 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,104,lib/std/syncio.nim
+    (stmts 2,102,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,112,tests/nimony/sysbasics/tbasics.nim s.9)) ,2

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -235,12 +235,12 @@
       (elif 2
        (eq 10,~77
         (i -1) ~2 j.3 3 +2) ~1,1
-       (stmts 2,104,lib/std/syncio.nim
+       (stmts 2,102,lib/std/syncio.nim
         (stmts 2,1
          (stmts
           (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,81,tests/nimony/sysbasics/tforloops1.nim "left the loop!")) ,2
          (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-        (break .)))) 2,104,lib/std/syncio.nim
+        (break .)))) 2,102,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/sysbasics/tforloops1.nim "A i ")) 2,1
@@ -279,7 +279,7 @@
         (stmts 4
          (asgn ~4 sum.0 6
           (add 1,~88
-           (i -1) ~4 sum.0 2 a.5)))) 2,104,lib/std/syncio.nim
+           (i -1) ~4 sum.0 2 a.5)))) 2,102,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/sysbasics/tforloops1.nim sum.0)) ,2
@@ -304,7 +304,7 @@
      (let :i.10 . . 19,38,lib/std/system/openarrays.nim
       (mut
        (i -1)) .)) ~2,1
-    (stmts 2,104,lib/std/syncio.nim
+    (stmts 2,102,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,97,tests/nimony/sysbasics/tforloops1.nim

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -57,7 +57,7 @@
  (asgn ~3 s1.0.tsefy5wha 2
   (setconstr 9,~2
    (set 1 Foo.0.tsefy5wha) 1
-   (range A.0.tsefy5wha 3 C.0.tsefy5wha))) 2,138,lib/std/syncio.nim
+   (range A.0.tsefy5wha 3 C.0.tsefy5wha))) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -77,7 +77,7 @@
   (mulset 3,~4
    (set 1 Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) 4,10
  (glet :z.0.tsefy5wha . . 10,~5
-  (set 1 Foo.0.tsefy5wha) 14 y.0.tsefy5wha) 2,138,lib/std/syncio.nim
+  (set 1 Foo.0.tsefy5wha) 14 y.0.tsefy5wha) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -94,7 +94,7 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 31,32 "")) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-     (cmd quit.0.syn1lfpjv 5 +1))))) 2,138,lib/std/syncio.nim
+     (cmd quit.0.syn1lfpjv 5 +1))))) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -111,7 +111,7 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 31,32 "")) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-     (cmd quit.0.syn1lfpjv 5 +1))))) 2,138,lib/std/syncio.nim
+     (cmd quit.0.syn1lfpjv 5 +1))))) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -129,7 +129,7 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 31,32 "")) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-     (cmd quit.0.syn1lfpjv 5 +1))))) 2,138,lib/std/syncio.nim
+     (cmd quit.0.syn1lfpjv 5 +1))))) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -143,7 +143,7 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 31,32 "")) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-     (cmd quit.0.syn1lfpjv 5 +1))))) 2,138,lib/std/syncio.nim
+     (cmd quit.0.syn1lfpjv 5 +1))))) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -159,7 +159,7 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 31,32 "")) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-     (cmd quit.0.syn1lfpjv 5 +1))))) 2,138,lib/std/syncio.nim
+     (cmd quit.0.syn1lfpjv 5 +1))))) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -180,7 +180,7 @@
  (asgn ~3 s1.0.tsefy5wha 2
   (setconstr 9,~13
    (set 1 Foo.0.tsefy5wha) 1
-   (range A.0.tsefy5wha 3 B.0.tsefy5wha) 7 val.0.tsefy5wha 12 F.0.tsefy5wha)) 2,138,lib/std/syncio.nim
+   (range A.0.tsefy5wha 3 B.0.tsefy5wha) 7 val.0.tsefy5wha 12 F.0.tsefy5wha)) 2,136,lib/std/syncio.nim
  (stmts
   (if 3
    (elif
@@ -225,7 +225,7 @@
    (asgn ~4 sss.0 2
     (setconstr 6,~1
      (set 1
-      (c +8)))) 2,138,lib/std/syncio.nim
+      (c +8)))) 2,136,lib/std/syncio.nim
    (stmts
     (if 3
      (elif
@@ -247,7 +247,7 @@
     (setconstr 6,~3
      (set 1
       (c +8)) 1
-     (range 'a' 7 'z') 13 '_')) 2,138,lib/std/syncio.nim
+     (range 'a' 7 'z') 13 '_')) 2,136,lib/std/syncio.nim
    (stmts
     (if 3
      (elif
@@ -267,7 +267,7 @@
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,5
    (excl 4,~5
     (set 1
-     (c +8)) ~8 sss.0 1 'm') 2,138,lib/std/syncio.nim
+     (c +8)) ~8 sss.0 1 'm') 2,136,lib/std/syncio.nim
    (stmts
     (if 3
      (elif
@@ -287,7 +287,7 @@
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,7
    (incl 4,~7
     (set 1
-     (c +8)) ~8 sss.0 1 'u') 2,138,lib/std/syncio.nim
+     (c +8)) ~8 sss.0 1 'u') 2,136,lib/std/syncio.nim
    (stmts
     (if 3
      (elif


### PR DESCRIPTION
- change `writeBuffer` argument type to `pointer` to make it generic like `copyMem` and compat with nim 2.x
- add a test for `writeBuffer` (also it's another test for pointer and sizeof)