### PR TITLE
semcheck`sizeof` and adds a template overload for `sizeof`

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -41,8 +41,10 @@ proc `$`*[T: enum](x: T): string {.magic: "EnumToStr", noSideEffect.}
 
 proc addr*[T](x: T): ptr T {.magic: "Addr", noSideEffect.}
 
-proc sizeof*[T](x: T): int {.magic: "SizeOf", noSideEffect.}
-proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}
+proc sizeof*[T](x: typedesc[T]): int {.magic: "SizeOf", noSideEffect.}
+
+template sizeof*[T](_: T): int =
+  sizeof(T)
 
 proc `=destroy`*[T](x: T) {.magic: "Destroy", noSideEffect.}
 proc `=dup`*[T](x: T): T {.magic: "Dup", noSideEffect.}

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -750,7 +750,7 @@ proc addFn(c: var SemContext; fn: FnCandidate; fnOrig: Cursor; args: openArray[I
         if n.kind == ParLe:
           if n.exprKind in {DefinedX, DeclaredX, CompilesX, TypeofX,
               LowX, HighX, AddrX, EnumToStrX, DefaultObjX, DefaultTupX,
-              ArrAtX, DerefX, TupatX}:
+              ArrAtX, DerefX, TupatX, SizeofX}:
             # magic needs semchecking after overloading
             result = MagicCallNeedsSemcheck
           else:
@@ -5555,10 +5555,10 @@ proc semAddr(c: var SemContext; it: var Item) =
 proc semSizeof(c: var SemContext; it: var Item) =
   let beforeExpr = c.dest.len
   let expected = it.typ
-  # We don't really have any kind of restrictions on the argument here
-  # and it was semchecked already in overload resolution, so it is fine
-  # to just copy it:
-  takeTree c, it.n
+  c.takeToken(it.n)
+  # handle types
+  semLocalTypeImpl c, it.n, InLocalDecl
+  c.takeParRi(it.n)
   it.typ = c.types.intType
   commonType c, it, beforeExpr, expected
 

--- a/tests/contracts/tbasics.msgs
+++ b/tests/contracts/tbasics.msgs
@@ -1,4 +1,3 @@
 OK v1 <= 0 + 9
 OK 0 <= v1 + -1
 OK (could indeed not prove) v1 <= 0 + 6
-

--- a/tests/nimony/stdlib/tsyncio.nim
+++ b/tests/nimony/stdlib/tsyncio.nim
@@ -70,3 +70,6 @@ let n1 = stdout.writeBuffer(addr obj1, sizeof DummyObject1)
 assert n0 == sizeof DummyObject0
 assert n1 == sizeof DummyObject1
 assert true
+
+type MyTuple = tuple[a, b, c: char]
+assert sizeof(MyTuple) == 3 # MyTuple not declared in c generated code

--- a/tests/nimony/stdlib/tsyncio.nim
+++ b/tests/nimony/stdlib/tsyncio.nim
@@ -73,3 +73,10 @@ assert true
 
 type MyTuple = tuple[a, b, c: char]
 assert sizeof(MyTuple) == 3 # MyTuple not declared in c generated code
+
+type
+  MyObject = object
+    a, b, c, d: int
+
+let my = default(MyObject)
+assert sizeof(my) == 32

--- a/tests/nimony/sysbasics/tconstarrlen.nif
+++ b/tests/nimony/sysbasics/tconstarrlen.nif
@@ -20,7 +20,7 @@
  (if 3
   (elif 6
    (eq
-    (i -1) 2,65,lib/std/system.nim
+    (i -1) 2,67,lib/std/system.nim
     (expr ,~4
      (expr 45,2
       (add 15,50,lib/std/system/arithmetics.nim

--- a/tests/nimony/sysbasics/tforloops1.nif
+++ b/tests/nimony/sysbasics/tforloops1.nif
@@ -369,7 +369,7 @@
     (if 3
      (elif 7
       (eq 7,31,lib/std/system/basic_types.nim
-       (i -1) 2,65,lib/std/system.nim
+       (i -1) 2,67,lib/std/system.nim
        (expr ,~4
         (expr 45,2
          (add 15,50,lib/std/system/arithmetics.nim
@@ -398,7 +398,7 @@
            (uarray
             (i -1))) 32
           (addr 1 x.4))) 45
-        (kv ~45 len.4.Inff8aa1.tfo6yv57p 2,65,lib/std/system.nim
+        (kv ~45 len.4.Inff8aa1.tfo6yv57p 2,67,lib/std/system.nim
          (expr ,~4
           (expr 45,2
            (add 15,50,lib/std/system/arithmetics.nim


### PR DESCRIPTION
fixes #878
fixes  #879

```nim
proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}
```
Without the typevar `T`, it seems to have some bugs on overloading