### PR TITLE
error for recursions in typed templates

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -785,7 +785,7 @@ proc semTemplateCall(c: var SemContext; it: var Item; fnId: SymId; beforeCall: i
   if res.status == LacksNothing:
     let args = cursorAt(c.dest, beforeCall + 2)
     let firstVarargMatch = cursorAt(c.dest, beforeCall + 2 + m.firstVarargPosition)
-    expandTemplate(c, expandedInto, res.decl, args, firstVarargMatch, addr m.inferred)
+    expandTemplate(c, expandedInto, res.decl, args, firstVarargMatch, addr m.inferred, c.dest[beforeCall].info)
     # We took 2 cursors, so we have to do the `endRead` twice too:
     endRead(c.dest)
     endRead(c.dest)

--- a/tests/nimony/templates/tinvalidrecursion.msgs
+++ b/tests/nimony/templates/tinvalidrecursion.msgs
@@ -1,0 +1,8 @@
+tests/nimony/templates/tinvalidrecursion.nim(2, 6) Trace: instantiation from here
+tests/nimony/templates/tinvalidrecursion.nim(2, 6) Error: cannot expand template from prototype; possibly a recursive template call
+tests/nimony/templates/tinvalidrecursion.nim(5, 7) Trace: instantiation from here
+tests/nimony/templates/tinvalidrecursion.nim(8, 7) Trace: instantiation from here
+tests/nimony/templates/tinvalidrecursion.nim(8, 7) Error: cannot expand template from prototype; possibly a recursive template call
+tests/nimony/templates/tinvalidrecursion.nim(5, 7) Trace: instantiation from here
+tests/nimony/templates/tinvalidrecursion.nim(8, 7) Trace: instantiation from here
+tests/nimony/templates/tinvalidrecursion.nim(8, 7) Error: cannot expand template from prototype; possibly a recursive template call

--- a/tests/nimony/templates/tinvalidrecursion.nim
+++ b/tests/nimony/templates/tinvalidrecursion.nim
@@ -1,0 +1,8 @@
+template foo(): int =
+  foo()
+
+template bar1(): int =
+  bar2()
+
+template bar2(): int =
+  bar1()


### PR DESCRIPTION
When typechecking the body of a template, if it calls itself, it will try to expand it based on the body of the prototype, which is `.`. Calling `semExpr` on this gives an "expression expected" error with no line info. So attempting to expand a template with body `.` now directly gives an error.

This is not to say that template recursions are always invalid but they should probably only be allowed in untyped contexts as they may add symbols to scope etc.