### PR TITLE
adapt original int64 etc matching rules

### DIFF
--- a/lib/std/hashes.nim
+++ b/lib/std/hashes.nim
@@ -24,8 +24,7 @@ when not defined(nimony):
     result = !$result
 
 proc hash*(u: uint): Hash {.inline.} = u
-when not defined(nimony):
-  proc hash*(x: int): Hash {.inline.} = cast[Hash](x)
+proc hash*(x: int): Hash {.inline.} = cast[Hash](x)
 
 proc hash*(x: int64): Hash {.inline.} = cast[Hash](x)
 proc hash*(x: int32): Hash {.inline.} = cast[Hash](int x)

--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -47,6 +47,20 @@ proc write*(f: File; x: int64) =
 proc write*(f: File; x: uint64) =
   fprintf(f, cstring"%llu", x)
 
+proc write*(f: File; x: int32) =
+  fprintf(f, cstring"%ld", x)
+
+proc write*(f: File; x: uint32) =
+  fprintf(f, cstring"%lu", x)
+
+proc write*(f: File; x: int) {.inline.} =
+  # XXX originally uses `when sizeof` check
+  write(f, int64(x))
+
+proc write*(f: File; x: uint) {.inline.} =
+  # XXX originally uses `when sizeof` check
+  write(f, uint64(x))
+
 proc write*[T: enum](f: File; x: T) =
   write f, $x
 

--- a/lib/std/system/arithmetics.nim
+++ b/lib/std/system/arithmetics.nim
@@ -80,20 +80,20 @@ proc `mod`*(x, y: int64): int64 {.magic: "ModI", noSideEffect.}
 type
   SomeInteger = int # for now just an alias
 
-proc `shr`*(x: int, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
+proc `shr`*(x: int, y: SomeInteger): int {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int8, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int16, y: SomeInteger): int16 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int32, y: SomeInteger): int32 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int64, y: SomeInteger): int64 {.magic: "AshrI", noSideEffect.}
 
 
-proc `shl`*(x: int, y: SomeInteger): int8 {.magic: "ShlI", noSideEffect.}
+proc `shl`*(x: int, y: SomeInteger): int {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int8, y: SomeInteger): int8 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int16, y: SomeInteger): int16 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int32, y: SomeInteger): int32 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int64, y: SomeInteger): int64 {.magic: "ShlI", noSideEffect.}
 
-proc ashr*(x: int, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
+proc ashr*(x: int, y: SomeInteger): int {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int8, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int16, y: SomeInteger): int16 {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int32, y: SomeInteger): int32 {.magic: "AshrI", noSideEffect.}

--- a/lib/std/system/arithmetics.nim
+++ b/lib/std/system/arithmetics.nim
@@ -21,46 +21,57 @@ proc dec*[T: Ordinal](x: var T) {.inline.} =
 # built-in operators
 
 # integer calculations:
+template `+`*(x: int): int = x
+  ## Unary `+` operator for an integer. Has no effect.
 template `+`*(x: int8): int8 = x
 template `+`*(x: int16): int16 = x
 template `+`*(x: int32): int32 = x
 template `+`*(x: int64): int64 = x
-  ## Unary `+` operator for an integer. Has no effect.
 
+proc `-`*(x: int): int {.magic: "UnaryMinusI", noSideEffect.}
+  ## Unary `-` operator for an integer. Negates `x`.
 proc `-`*(x: int8): int8 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int16): int16 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int32): int32 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int64): int64 {.magic: "UnaryMinusI", noSideEffect.}
-  ## Unary `-` operator for an integer. Negates `x`.
 
+proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect.}
+  ## Computes the `bitwise complement` of the integer `x`.
 proc `not`*(x: int8): int8 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: int16): int16 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: int32): int32 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: int64): int64 {.magic: "BitnotI", noSideEffect.}
 
+proc `+`*(x, y: int): int {.magic: "AddI", noSideEffect.}
+  ## Binary `+` operator for an integer.
 proc `+`*(x, y: int8): int8 {.magic: "AddI", noSideEffect.}
 proc `+`*(x, y: int16): int16 {.magic: "AddI", noSideEffect.}
 proc `+`*(x, y: int32): int32 {.magic: "AddI", noSideEffect.}
 proc `+`*(x, y: int64): int64 {.magic: "AddI", noSideEffect.}
-  ## Binary `+` operator for an integer.
 
+proc `-`*(x, y: int): int {.magic: "SubI", noSideEffect.}
+  ## Binary `-` operator for an integer.
 proc `-`*(x, y: int8): int8 {.magic: "SubI", noSideEffect.}
 proc `-`*(x, y: int16): int16 {.magic: "SubI", noSideEffect.}
 proc `-`*(x, y: int32): int32 {.magic: "SubI", noSideEffect.}
 proc `-`*(x, y: int64): int64 {.magic: "SubI", noSideEffect.}
-  ## Binary `-` operator for an integer.
 
+proc `*`*(x, y: int): int {.magic: "MulI", noSideEffect.}
+  ## Binary `*` operator for an integer.
 proc `*`*(x, y: int8): int8 {.magic: "MulI", noSideEffect.}
 proc `*`*(x, y: int16): int16 {.magic: "MulI", noSideEffect.}
 proc `*`*(x, y: int32): int32 {.magic: "MulI", noSideEffect.}
 proc `*`*(x, y: int64): int64 {.magic: "MulI", noSideEffect.}
-  ## Binary `*` operator for an integer.
 
+proc `div`*(x, y: int): int {.magic: "DivI", noSideEffect.}
+  ## Computes the integer division.
 proc `div`*(x, y: int8): int8 {.magic: "DivI", noSideEffect.}
 proc `div`*(x, y: int16): int16 {.magic: "DivI", noSideEffect.}
 proc `div`*(x, y: int32): int32 {.magic: "DivI", noSideEffect.}
 proc `div`*(x, y: int64): int64 {.magic: "DivI", noSideEffect.}
 
+proc `mod`*(x, y: int): int {.magic: "ModI", noSideEffect.}
+  ## Computes the integer modulo operation (remainder).
 proc `mod`*(x, y: int8): int8 {.magic: "ModI", noSideEffect.}
 proc `mod`*(x, y: int16): int16 {.magic: "ModI", noSideEffect.}
 proc `mod`*(x, y: int32): int32 {.magic: "ModI", noSideEffect.}
@@ -69,92 +80,119 @@ proc `mod`*(x, y: int64): int64 {.magic: "ModI", noSideEffect.}
 type
   SomeInteger = int # for now just an alias
 
+proc `shr`*(x: int, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int8, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int16, y: SomeInteger): int16 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int32, y: SomeInteger): int32 {.magic: "AshrI", noSideEffect.}
 proc `shr`*(x: int64, y: SomeInteger): int64 {.magic: "AshrI", noSideEffect.}
 
 
+proc `shl`*(x: int, y: SomeInteger): int8 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int8, y: SomeInteger): int8 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int16, y: SomeInteger): int16 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int32, y: SomeInteger): int32 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: int64, y: SomeInteger): int64 {.magic: "ShlI", noSideEffect.}
 
+proc ashr*(x: int, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int8, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int16, y: SomeInteger): int16 {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int32, y: SomeInteger): int32 {.magic: "AshrI", noSideEffect.}
 proc ashr*(x: int64, y: SomeInteger): int64 {.magic: "AshrI", noSideEffect.}
 
+proc `and`*(x, y: int): int {.magic: "BitandI", noSideEffect.}
+  ## Computes the `bitwise and` of numbers `x` and `y`.
 proc `and`*(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: int32): int32 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: int64): int64 {.magic: "BitandI", noSideEffect.}
-  ## Computes the `bitwise and` of numbers `x` and `y`.
 
+proc `or`*(x, y: int): int {.magic: "BitorI", noSideEffect.}
+  ## Computes the `bitwise or` of numbers `x` and `y`.
 proc `or`*(x, y: int8): int8 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
-  ## Computes the `bitwise or` of numbers `x` and `y`.
 
+proc `xor`*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
+  ## Computes the `bitwise xor` of numbers `x` and `y`.
 proc `xor`*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
-  ## Computes the `bitwise xor` of numbers `x` and `y`.
 
 # unsigned integer operations:
-
+proc `not`*(x: uint): uint {.magic: "BitnotI", noSideEffect.}
+  ## Computes the `bitwise complement` of the integer `x`.
 proc `not`*(x: uint8): uint8 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: uint16): uint16 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: uint32): uint32 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: uint64): uint64 {.magic: "BitnotI", noSideEffect.}
 
+proc `shr`*(x: uint, y: SomeInteger): uint {.magic: "ShrI", noSideEffect.}
+  ## Computes the `shift right` operation of `x` and `y`.
 proc `shr`*(x: uint8, y: SomeInteger): uint8 {.magic: "ShrI", noSideEffect.}
 proc `shr`*(x: uint16, y: SomeInteger): uint16 {.magic: "ShrI", noSideEffect.}
 proc `shr`*(x: uint32, y: SomeInteger): uint32 {.magic: "ShrI", noSideEffect.}
 proc `shr`*(x: uint64, y: SomeInteger): uint64 {.magic: "ShrI", noSideEffect.}
 
+proc `shl`*(x: uint, y: SomeInteger): uint {.magic: "ShlI", noSideEffect.}
+  ## Computes the `shift left` operation of `x` and `y`.
 proc `shl`*(x: uint8, y: SomeInteger): uint8 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: uint16, y: SomeInteger): uint16 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: uint32, y: SomeInteger): uint32 {.magic: "ShlI", noSideEffect.}
 proc `shl`*(x: uint64, y: SomeInteger): uint64 {.magic: "ShlI", noSideEffect.}
 
+proc `and`*(x, y: uint): uint {.magic: "BitandI", noSideEffect.}
+  ## Computes the `bitwise and` of numbers `x` and `y`.
 proc `and`*(x, y: uint8): uint8 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: uint16): uint16 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: uint32): uint32 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: uint64): uint64 {.magic: "BitandI", noSideEffect.}
 
+proc `or`*(x, y: uint): uint {.magic: "BitorI", noSideEffect.}
+  ## Computes the `bitwise or` of numbers `x` and `y`.
 proc `or`*(x, y: uint8): uint8 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: uint16): uint16 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: uint32): uint32 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: uint64): uint64 {.magic: "BitorI", noSideEffect.}
 
+proc `xor`*(x, y: uint): uint {.magic: "BitxorI", noSideEffect.}
+  ## Computes the `bitwise xor` of numbers `x` and `y`.
 proc `xor`*(x, y: uint8): uint8 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: uint16): uint16 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: uint32): uint32 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: uint64): uint64 {.magic: "BitxorI", noSideEffect.}
 
+proc `+`*(x, y: uint): uint {.magic: "AddU", noSideEffect.}
+  ## Binary `+` operator for unsigned integers.
 proc `+`*(x, y: uint8): uint8 {.magic: "AddU", noSideEffect.}
 proc `+`*(x, y: uint16): uint16 {.magic: "AddU", noSideEffect.}
 proc `+`*(x, y: uint32): uint32 {.magic: "AddU", noSideEffect.}
 proc `+`*(x, y: uint64): uint64 {.magic: "AddU", noSideEffect.}
 
+proc `-`*(x, y: uint): uint {.magic: "SubU", noSideEffect.}
+  ## Binary `-` operator for unsigned integers.
 proc `-`*(x, y: uint8): uint8 {.magic: "SubU", noSideEffect.}
 proc `-`*(x, y: uint16): uint16 {.magic: "SubU", noSideEffect.}
 proc `-`*(x, y: uint32): uint32 {.magic: "SubU", noSideEffect.}
 proc `-`*(x, y: uint64): uint64 {.magic: "SubU", noSideEffect.}
 
+proc `*`*(x, y: uint): uint {.magic: "MulU", noSideEffect.}
+  ## Binary `*` operator for unsigned integers.
 proc `*`*(x, y: uint8): uint8 {.magic: "MulU", noSideEffect.}
 proc `*`*(x, y: uint16): uint16 {.magic: "MulU", noSideEffect.}
 proc `*`*(x, y: uint32): uint32 {.magic: "MulU", noSideEffect.}
 proc `*`*(x, y: uint64): uint64 {.magic: "MulU", noSideEffect.}
 
+proc `div`*(x, y: uint): uint {.magic: "DivU", noSideEffect.}
+  ## Computes the integer division for unsigned integers.
 proc `div`*(x, y: uint8): uint8 {.magic: "DivU", noSideEffect.}
 proc `div`*(x, y: uint16): uint16 {.magic: "DivU", noSideEffect.}
 proc `div`*(x, y: uint32): uint32 {.magic: "DivU", noSideEffect.}
 proc `div`*(x, y: uint64): uint64 {.magic: "DivU", noSideEffect.}
 
+proc `mod`*(x, y: uint): uint {.magic: "ModU", noSideEffect.}
+  ## Computes the integer modulo operation (remainder) for unsigned integers.
 proc `mod`*(x, y: uint8): uint8 {.magic: "ModU", noSideEffect.}
 proc `mod`*(x, y: uint16): uint16 {.magic: "ModU", noSideEffect.}
 proc `mod`*(x, y: uint32): uint32 {.magic: "ModU", noSideEffect.}

--- a/lib/std/system/comparisons.nim
+++ b/lib/std/system/comparisons.nim
@@ -55,31 +55,43 @@ proc `<`*[T](x, y: set[T]): bool {.magic: "LtSet", noSideEffect.}
   ## A strict or proper subset `x` has all of its members in `y` but `y` has
   ## more elements than `y`.
 
+proc `==`*(x, y: int): bool {.magic: "EqI", noSideEffect.}
+  ## Compares two integers for equality.
 proc `==`*(x, y: int8): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: int16): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: int32): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: int64): bool {.magic: "EqI", noSideEffect.}
 
+proc `<=`*(x, y: int): bool {.magic: "LeI", noSideEffect.}
+  ## Returns true if `x` is less than or equal to `y`.
 proc `<=`*(x, y: int8): bool {.magic: "LeI", noSideEffect.}
 proc `<=`*(x, y: int16): bool {.magic: "LeI", noSideEffect.}
 proc `<=`*(x, y: int32): bool {.magic: "LeI", noSideEffect.}
 proc `<=`*(x, y: int64): bool {.magic: "LeI", noSideEffect.}
 
+proc `<`*(x, y: int): bool {.magic: "LtI", noSideEffect.}
+  ## Returns true if `x` is less than `y`.
 proc `<`*(x, y: int8): bool {.magic: "LtI", noSideEffect.}
 proc `<`*(x, y: int16): bool {.magic: "LtI", noSideEffect.}
 proc `<`*(x, y: int32): bool {.magic: "LtI", noSideEffect.}
 proc `<`*(x, y: int64): bool {.magic: "LtI", noSideEffect.}
 
+proc `<=`*(x, y: uint): bool {.magic: "LeU", noSideEffect.}
+  ## Returns true if `x <= y`.
 proc `<=`*(x, y: uint8): bool {.magic: "LeU", noSideEffect.}
 proc `<=`*(x, y: uint16): bool {.magic: "LeU", noSideEffect.}
 proc `<=`*(x, y: uint32): bool {.magic: "LeU", noSideEffect.}
 proc `<=`*(x, y: uint64): bool {.magic: "LeU", noSideEffect.}
 
+proc `<`*(x, y: uint): bool {.magic: "LtU", noSideEffect.}
+  ## Returns true if `x < y`.
 proc `<`*(x, y: uint8): bool {.magic: "LtU", noSideEffect.}
 proc `<`*(x, y: uint16): bool {.magic: "LtU", noSideEffect.}
 proc `<`*(x, y: uint32): bool {.magic: "LtU", noSideEffect.}
 proc `<`*(x, y: uint64): bool {.magic: "LtU", noSideEffect.}
 
+proc `==`*(x, y: uint): bool {.magic: "EqI", noSideEffect.}
+  ## Compares two unsigned integers for equality.
 proc `==`*(x, y: uint8): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: uint16): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: uint32): bool {.magic: "EqI", noSideEffect.}
@@ -106,6 +118,8 @@ template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
 
+proc min*(x, y: int): int {.magic: "MinI", noSideEffect.} =
+  if x <= y: x else: y
 proc min*(x, y: int8): int8 {.noSideEffect, inline.} =
   if x <= y: x else: y
 proc min*(x, y: int16): int16 {.noSideEffect, inline.} =
@@ -120,6 +134,8 @@ proc min*(x, y: float32): float32 {.noSideEffect, inline.} =
 proc min*(x, y: float): float {.noSideEffect, inline.} =
   if x <= y or y != y: x else: y
 
+proc max*(x, y: int): int {.magic: "MaxI", noSideEffect.} =
+  if y <= x: x else: y
 proc max*(x, y: int8): int8 {.noSideEffect, inline.} =
   if y <= x: x else: y
 proc max*(x, y: int16): int16 {.noSideEffect, inline.} =

--- a/lib/std/system/comparisons.nim
+++ b/lib/std/system/comparisons.nim
@@ -118,6 +118,9 @@ template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
 
+type Orderable = concept
+  proc `<=`(x, y: Self): bool
+
 proc min*(x, y: int): int {.noSideEffect, inline.} =
   if x <= y: x else: y
 proc min*(x, y: int8): int8 {.noSideEffect, inline.} =
@@ -133,6 +136,10 @@ proc min*(x, y: float32): float32 {.noSideEffect, inline.} =
   if x <= y or y != y: x else: y
 proc min*(x, y: float): float {.noSideEffect, inline.} =
   if x <= y or y != y: x else: y
+# originally used T: not SomeFloat:
+proc min*[T: Orderable](x, y: T): T {.inline.} =
+  ## Generic minimum operator of 2 values based on `<=`.
+  if x <= y: x else: y
 
 proc max*(x, y: int): int {.noSideEffect, inline.} =
   if y <= x: x else: y
@@ -149,6 +156,10 @@ proc max*(x, y: float32): float32 {.noSideEffect, inline.} =
   if y <= x or y != y: x else: y
 proc max*(x, y: float): float {.noSideEffect, inline.} =
   if y <= x or y != y: x else: y
+# originally used T: not SomeFloat:
+proc max*[T: Orderable](x, y: T): T {.inline.} =
+  ## Generic maximum operator of 2 values based on `<=`.
+  if y <= x: x else: y
 
 type
   Comparable* = concept

--- a/lib/std/system/comparisons.nim
+++ b/lib/std/system/comparisons.nim
@@ -118,7 +118,7 @@ template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
 
-proc min*(x, y: int): int {.magic: "MinI", noSideEffect.} =
+proc min*(x, y: int): int {.noSideEffect, inline.} =
   if x <= y: x else: y
 proc min*(x, y: int8): int8 {.noSideEffect, inline.} =
   if x <= y: x else: y
@@ -134,7 +134,7 @@ proc min*(x, y: float32): float32 {.noSideEffect, inline.} =
 proc min*(x, y: float): float {.noSideEffect, inline.} =
   if x <= y or y != y: x else: y
 
-proc max*(x, y: int): int {.magic: "MaxI", noSideEffect.} =
+proc max*(x, y: int): int {.noSideEffect, inline.} =
   if y <= x: x else: y
 proc max*(x, y: int8): int8 {.noSideEffect, inline.} =
   if y <= x: x else: y

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -627,7 +627,9 @@ proc matchIntegralType(m: var Match; f: var Cursor; arg: Item) =
     if fOrigBits != aOrigBits:
       m.args.addParLe HconvX, m.argInfo
       m.args.addSubtree forig
-      if aOrigBits < 0:
+      if isIntLit:
+        inc m.intLitCosts
+      elif aOrigBits < 0:
         inc m.intConvCosts
       else:
         inc m.convCosts

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -631,6 +631,7 @@ proc matchIntegralType(m: var Match; f: var Cursor; arg: Item) =
         inc m.intConvCosts
       else:
         inc m.convCosts
+      inc m.opened
   elif cmp > 0 or (isIntLit and checkIntLitRange(m.context, forig, ex)):
     # f has more bits than a, great!
     if m.skippedMod in {MutT, OutT}:

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -275,7 +275,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor; flags: set[GetTypeFlag]): Cursor =
     result = getTypeImpl(c, result, flags) # typeof(obj.field) == typeof field
   of DerefX, HderefX:
     result = getTypeImpl(c, n.firstSon, flags)
-    if typeKind(result) in {RefT, PtrT, MutT, OutT}:
+    if typeKind(result) in {RefT, PtrT, MutT, OutT}: # and LentT
       inc result
     else:
       assert false, "cannot deref type: " & toString(result, false)

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -275,7 +275,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor; flags: set[GetTypeFlag]): Cursor =
     result = getTypeImpl(c, result, flags) # typeof(obj.field) == typeof field
   of DerefX, HderefX:
     result = getTypeImpl(c, n.firstSon, flags)
-    if typeKind(result) in {RefT, PtrT, MutT, OutT}: # and LentT
+    if typeKind(result) in {RefT, PtrT, MutT, OutT, LentT}:
       inc result
     else:
       assert false, "cannot deref type: " & toString(result, false)

--- a/tests/nimony/const/tconstarrlen.nif
+++ b/tests/nimony/const/tconstarrlen.nif
@@ -20,13 +20,13 @@
  (if 3
   (elif 6
    (eq
-    (i +64) 2,67,lib/std/system.nim
+    (i -1) 2,67,lib/std/system.nim
     (expr ,~4
      (expr 45,2
       (add
-       (i +64) ~23
+       (i -1) ~23
        (sub
-        (i +64) ~5
+        (i -1) ~5
         (conv 30,6,lib/std/system/defaults.nim
          (i -1) ~13
          (conv

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -10,20 +10,20 @@
     (i -1) 4 +0) ,1
    (while 8
     (le
-     (i +64) ~2 i.0 3 n.0) 2,1
+     (i -1) ~2 i.0 3 n.0) 2,1
     (stmts
      (yld 6 i.0) ,1
      (yld 7
       (mul
-       (i +64) ~1 i.0 1 i.0)) ,2
+       (i -1) ~1 i.0 1 i.0)) ,2
      (yld 9
       (mul
-       (i +64) ~2
+       (i -1) ~2
        (mul
-        (i +64) ~1 i.0 1 i.0) 1 i.0)) 2,3
+        (i -1) ~1 i.0 1 i.0) 1 i.0)) 2,3
      (asgn ~2 i.0 4
       (add
-       (i +64) ~2 i.0 2 +1)))))) ,10
+       (i -1) ~2 i.0 2 +1)))))) ,10
  (proc 5 :printf.0.tfo161bfb1 . . . 11
   (params 1
    (param :format.0 . . 8
@@ -58,7 +58,7 @@
     (i -1) 4 a.0) ,1
    (while 8
     (le
-     (i +64) ~2 i.2 3 b.0) 2,1
+     (i -1) ~2 i.2 3 b.0) 2,1
     (stmts
      (yld 6 i.2) ,1
      (cmd inc.0.tfo161bfb1 4
@@ -75,15 +75,15 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 2,103,lib/std/system.nim
+    (elif 2,115,lib/std/system.nim
      (expr 2,1
       (lt
-       (i +64) 9,28,tests/nimony/iter/tforloops1.nim +5 5,28,tests/nimony/iter/tforloops1.nim x.1)) ~1,1
+       (i -1) 9,28,tests/nimony/iter/tforloops1.nim +5 5,28,tests/nimony/iter/tforloops1.nim x.1)) ~1,1
      (stmts
       (break .))) 5,2
     (elif 2
      (lt
-      (i +64) ~2 x.1 2 +3) ~3,1
+      (i -1) ~2 x.1 2 +3) ~3,1
      (stmts
       (continue .)))) 6,6
    (call ~6 printf.0.tfo161bfb1 1
@@ -99,7 +99,7 @@
     (i -1) 4 +0) ,1
    (while 8
     (le
-     (i +64) ~2 i.3 3 n.1) 2,1
+     (i -1) ~2 i.3 3 n.1) 2,1
     (stmts
      (yld 6 i.3) ,1
      (cmd inc.0.tfo161bfb1 4
@@ -119,12 +119,12 @@
      (yld 6 i.4) ,1
      (yld 7
       (mul
-       (i +64) ~1 i.4 1 i.4)) ,2
+       (i -1) ~1 i.4 1 i.4)) ,2
      (yld 9
       (mul
-       (i +64) ~2
+       (i -1) ~2
        (mul
-        (i +64) ~1 i.4 1 i.4) 1 i.4)))))) 4,45
+        (i -1) ~1 i.4 1 i.4) 1 i.4)))))) 4,45
  (for 12
   (call ~7 powers2.0.tfo161bfb1 1 +6)
   (unpackflat
@@ -170,7 +170,7 @@
       (hconv 9,~47
        (cstring) "Hello, world\3A %ld\0A") 25
       (add
-       (i +64) ~1 m.2 1 n.3)))))) ,59
+       (i -1) ~1 m.2 1 n.3)))))) ,59
  (while 6
   (true) 2,1
   (stmts 4
@@ -218,7 +218,7 @@
       (hconv 9,~64
        (cstring) "Hello, world\3A %ld\0A") 25
       (add
-       (i +64) ~1 i.7 1 j.2)))))) 4,77
+       (i -1) ~1 i.7 1 j.2)))))) 4,77
  (for 6
   (infix \2E.<.0.tfo161bfb1 ~1 +0 3 +3)
   (unpackflat
@@ -234,7 +234,7 @@
      (if 3
       (elif 2
        (eq
-        (i +64) ~2 j.3 3 +2) ~1,1
+        (i -1) ~2 j.3 3 +2) ~1,1
        (stmts 2,102,lib/std/syncio.nim
         (stmts 2,1
          (stmts
@@ -245,11 +245,15 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/iter/tforloops1.nim "A i ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/iter/tforloops1.nim i.8)) 2,1
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/iter/tforloops1.nim
+        (hconv 24,44,lib/std/syncio.nim
+         (i +64) i.8))) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 20,83,tests/nimony/iter/tforloops1.nim " j ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim j.3)) ,2
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim
+        (hconv 24,44,lib/std/syncio.nim
+         (i +64) j.3))) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,84
  (block . 2,1
   (stmts 4
@@ -265,10 +269,10 @@
        (let :j.4 . . 11,~84
         (i -1) .)) ~2,1
       (stmts 4
-       (let :a.5 . . 15,44,lib/std/system.nim
-        (i +64) 6
+       (let :a.5 . . 13,45,lib/std/system.nim
+        (i -1) 6
         (add
-         (i +64) ~2 i.9 2 j.4)) 4,1
+         (i -1) ~2 i.9 2 j.4)) 4,1
        (var :sum.0 . . 9,~86
         (i -1) 11 +0) 4,2
        (for 7
@@ -279,10 +283,12 @@
         (stmts 4
          (asgn ~4 sum.0 6
           (add
-           (i +64) ~4 sum.0 2 a.5)))) 2,102,lib/std/syncio.nim
+           (i -1) ~4 sum.0 2 a.5)))) 2,102,lib/std/syncio.nim
        (stmts 2,1
         (stmts
-         (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim sum.0)) ,2
+         (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim
+          (hconv 24,44,lib/std/syncio.nim
+           (i +64) sum.0))) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))))) ,93
  (block . 2,1
   (stmts 4
@@ -308,7 +314,9 @@
      (stmts 2,1
       (stmts
        (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,97,tests/nimony/iter/tforloops1.nim
-        (hderef i.10))) ,2
+        (hconv 24,44,lib/std/syncio.nim
+         (i +64)
+         (hderef i.10)))) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
  (proc :inc.0.tfo161bfb1 . 0,12,lib/std/system.nim .
   (at inc.1.sysvq0asl 19,~4
@@ -369,13 +377,13 @@
     (if 3
      (elif 7
       (eq
-       (i +64) 2,67,lib/std/system.nim
+       (i -1) 2,67,lib/std/system.nim
        (expr ,~4
         (expr 45,2
          (add
-          (i +64) ~23
+          (i -1) ~23
           (sub
-           (i +64) ~5
+           (i -1) ~5
            (conv 30,6,lib/std/system/defaults.nim
             (i -1) ~13
             (conv
@@ -402,9 +410,9 @@
          (expr ,~4
           (expr 45,2
            (add
-            (i +64) ~23
+            (i -1) ~23
             (sub
-             (i +64) ~5
+             (i -1) ~5
              (conv 30,6,lib/std/system/defaults.nim
               (i -1) ~13
               (conv
@@ -426,7 +434,7 @@
     (i -1) 4 +0) ,1
    (while 8
     (lt
-     (i +64) ~2 i.12 5
+     (i -1) ~2 i.12 5
      (call ~3 len.0.tfo161bfb1 1 a.8)) 2,1
     (stmts
      (yld 6
@@ -459,12 +467,12 @@
   (pragmas 2
    (inline) 10
    (requires 19
-    (and 2,102,lib/std/system/comparisons.nim
+    (and 2,114,lib/std/system/comparisons.nim
      (expr 2,1
       (le
-       (i +64) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.1)) 8
+       (i -1) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.1)) 8
      (lt
-      (i +64) ~4 idx.1 3
+      (i -1) ~4 idx.1 3
       (dot ~1 x.6 len.4.Inff8aa1.tfo161bfb1 +0))))) ~10,~33 . 87,~33
   (stmts 3
    (result :result.2 . . ~71

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -235,26 +235,22 @@
       (elif 2
        (eq
         (i -1) ~2 j.3 3 +2) ~1,1
-       (stmts 2,102,lib/std/syncio.nim
+       (stmts 2,116,lib/std/syncio.nim
         (stmts 2,1
          (stmts
           (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,81,tests/nimony/iter/tforloops1.nim "left the loop!")) ,2
-         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-        (break .)))) 2,102,lib/std/syncio.nim
+         (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (break .)))) 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/iter/tforloops1.nim "A i ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/iter/tforloops1.nim
-        (hconv 24,44,lib/std/syncio.nim
-         (i +64) i.8))) 2,1
+       (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/iter/tforloops1.nim i.8)) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 20,83,tests/nimony/iter/tforloops1.nim " j ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim
-        (hconv 24,44,lib/std/syncio.nim
-         (i +64) j.3))) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,84
+       (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim j.3)) ,2
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,84
  (block . 2,1
   (stmts 4
    (for 7
@@ -283,13 +279,11 @@
         (stmts 4
          (asgn ~4 sum.0 6
           (add
-           (i -1) ~4 sum.0 2 a.5)))) 2,102,lib/std/syncio.nim
+           (i -1) ~4 sum.0 2 a.5)))) 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
-         (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim
-          (hconv 24,44,lib/std/syncio.nim
-           (i +64) sum.0))) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))))) ,93
+         (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim sum.0)) ,2
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))))) ,93
  (block . 2,1
   (stmts 4
    (let :i_arr.0 . . 8
@@ -310,14 +304,12 @@
      (let :i.10 . . 19,38,lib/std/system/openarrays.nim
       (mut
        (i -1)) .)) ~2,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,97,tests/nimony/iter/tforloops1.nim
-        (hconv 24,44,lib/std/syncio.nim
-         (i +64)
-         (hderef i.10)))) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
+       (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 9,97,tests/nimony/iter/tforloops1.nim
+        (hderef i.10))) ,2
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
  (proc :inc.0.tfo161bfb1 . 0,12,lib/std/system.nim .
   (at inc.1.sysvq0asl 19,~4
    (i -1)) 21,12,lib/std/system.nim

--- a/tests/nimony/stdlib/tsystem.nim
+++ b/tests/nimony/stdlib/tsystem.nim
@@ -12,6 +12,7 @@ assert testnotin "AZaz"
 assert not testnotin "1"
 assert not testnotin "abc "
 
+# generic min/max:
 assert min("a", "b") == "a"
 assert min("b", "a") == "a"
 assert max("a", "b") == "b"

--- a/tests/nimony/stdlib/tsystem.nim
+++ b/tests/nimony/stdlib/tsystem.nim
@@ -11,3 +11,8 @@ assert testnotin "abc"
 assert testnotin "AZaz"
 assert not testnotin "1"
 assert not testnotin "abc "
+
+assert min("a", "b") == "a"
+assert min("b", "a") == "a"
+assert max("a", "b") == "b"
+assert max("b", "a") == "b"

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -225,55 +225,55 @@
  (proc 5 :classify1.0.tbawx6nu81 . . . 14
   (params 1
    (param :s.0 . . 3 string.0.sysvq0asl .)) . . . 2,1
-  (stmts 2,102,lib/std/syncio.nim
+  (stmts 2,116,lib/std/syncio.nim
    (stmts 2,1
     (stmts
      (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 7,75,tests/nimony/sysbasics/tbasics.nim s.0)) ,2
-    (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,76
+    (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,76
  (call ~9 classify1.0.tbawx6nu81 1 "9123345") ,79
  (block . 2,1
   (stmts
    (proc 5 :classify.0 . . . 13
     (params 1
      (param :s.4 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,82,tests/nimony/sysbasics/tbasics.nim s.4)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.0 1 "9123345") ,4
    (block . 2,1
     (stmts
      (proc 5 :classify2.0 . . . 14
       (params 1
        (param :s.5 . . 3 string.0.sysvq0asl .)) . . . 2,1
-      (stmts 2,102,lib/std/syncio.nim
+      (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,87,tests/nimony/sysbasics/tbasics.nim s.5)) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
      (call ~9 classify2.0 1 "9123345"))))) ,90
  (block . 2,1
   (stmts
    (proc 5 :classify2.1 . . . 14
     (params 1
      (param :s.6 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,93,tests/nimony/sysbasics/tbasics.nim s.6)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
    (call ~9 classify2.1 1 "9123345"))) ,96
  (block . 2,1
   (stmts
    (proc 5 :classify.1 . . . 13
     (params 1
      (param :s.7 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,99,tests/nimony/sysbasics/tbasics.nim s.7)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.1 1 "9123345"))) ,102
  (block . 2,1
   (stmts
@@ -282,11 +282,11 @@
      (proc 5 :classify.2 . . . 13
       (params 1
        (param :s.8 . . 3 string.0.sysvq0asl .)) . . . 2,1
-      (stmts 2,102,lib/std/syncio.nim
+      (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,106,tests/nimony/sysbasics/tbasics.nim s.8)) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
      (call ~8 classify.2 1 "9123345"))))) ,109
  (proc 5 :foo2.1.tbawx6nu81 . . . 9
   (params) . . . 2,1
@@ -294,10 +294,10 @@
    (proc 5 :classify.3 . . . 13
     (params 1
      (param :s.9 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,112,tests/nimony/sysbasics/tbasics.nim s.9)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.3 1 "9123345"))) 4,115
  (call ~4 foo2.1.tbawx6nu81))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -37,7 +37,7 @@
    (if 3
     (elif 5
      (eq
-      (i +64) ~5 size.3 3 +0) ~1,1
+      (i -1) ~5 size.3 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.0 8
        (oconstr 15,1,tests/nimony/sysbasics/temptyseq.nim seq.0.Ipe57hg.temd2l7vy 4
@@ -59,7 +59,7 @@
             (i -1))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.0))))) ,2
       (if 3
-       (elif 2,98,lib/std/system/comparisons.nim
+       (elif 2,110,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -90,7 +90,7 @@
    (if 3
     (elif 5
      (eq
-      (i +64) ~5 size.5 3 +0) ~1,1
+      (i -1) ~5 size.5 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.1 8
        (oconstr ~3,~2 seq.0.Iw9f2pq.temd2l7vy 4
@@ -112,7 +112,7 @@
             (f +64))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.1))))) ,2
       (if 3
-       (elif 2,98,lib/std/system/comparisons.nim
+       (elif 2,110,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -152,7 +152,7 @@
    (if 3
     (elif 5
      (eq
-      (i +64) ~5 size.7 3 +0) ~1,1
+      (i -1) ~5 size.7 3 +0) ~1,1
      (stmts 7
       (asgn ~7 result.2 8
        (oconstr 10,9,tests/nimony/sysbasics/temptyseq.nim seq.0.Iq4ofkp1.temd2l7vy 4
@@ -174,7 +174,7 @@
             (u +8))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.2))))) ,2
       (if 3
-       (elif 2,98,lib/std/system/comparisons.nim
+       (elif 2,110,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -209,7 +209,7 @@
     (stmts 7
      (asgn ~7 result.3 7
       (mul
-       (i +64) ~5 size.9 8
+       (i -1) ~5 size.9 8
        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1)))) ,1
      (if 3
@@ -236,7 +236,7 @@
     (stmts 7
      (asgn ~7 result.4 7
       (mul
-       (i +64) ~5 size.10 8
+       (i -1) ~5 size.10 8
        (sizeof
         (f +64)))) ,1
      (if 3
@@ -263,7 +263,7 @@
     (stmts 7
      (asgn ~7 result.5 7
       (mul
-       (i +64) ~5 size.11 8
+       (i -1) ~5 size.11 8
        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8)))) ,1
      (if 3
@@ -312,7 +312,7 @@
     (i -1) 4 +0) ,1
    (while 8
     (lt
-     (i +64) ~2 i.0 3
+     (i -1) ~2 i.0 3
      (dot ~1 s.6 len.6.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
@@ -321,7 +321,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.0)))) ,4
    (if 3
-    (elif 2,98,lib/std/system/comparisons.nim
+    (elif 2,110,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -369,7 +369,7 @@
     (i -1) 4 +0) ,2
    (while 8
     (lt
-     (i +64) ~2 i.1 3
+     (i -1) ~2 i.1 3
      (dot ~1 a.3 len.6.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
@@ -405,7 +405,7 @@
    (if 3
     (elif 8
      (lt
-      (i +64) ~5
+      (i -1) ~5
       (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0) 6
       (dot ~4
        (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0)) ~1,1
@@ -415,7 +415,7 @@
        (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0)) ,1
       (while 8
        (lt
-        (i +64) ~2 i.2 6
+        (i -1) ~2 i.2 6
         (dot ~4
          (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0)) 2,1
        (stmts 10
@@ -427,19 +427,19 @@
          (haddr i.2)))))) 5,5
     (elif 16
      (lt
-      (i +64) ~12
+      (i -1) ~12
       (call 1 capInBytes.0.temd2l7vy ~4
        (hderef dest.3)) 10
       (mul
-       (i +64) ~5
+       (i -1) ~5
        (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0) 8
        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
         (i -1)))) ~3,1
      (stmts 4
-      (let :oldCap.0 . . 2,~52
-       (i +64) 25
+      (let :oldCap.0 . . 1,~108
+       (i -1) 25
        (div
-        (i +64) ~12
+        (i -1) ~12
         (call 1 capInBytes.0.temd2l7vy ~4
          (hderef dest.3)) 10
         (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
@@ -448,7 +448,7 @@
        (i -1) 18
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.0 17
         (sub
-         (i +64) ~5
+         (i -1) ~5
          (dot ~3 src.3 len.6.Ipe57hg.temd2l7vy +0) 2 oldCap.0))) 4,2
       (let :memSize.3 . . 1,~110
        (i -1) 27
@@ -490,7 +490,7 @@
     (i -1) 4 +0) ,17
    (while 8
     (lt
-     (i +64) ~2 i.3 6
+     (i -1) ~2 i.3 6
      (dot ~4
       (hderef dest.3) len.6.Ipe57hg.temd2l7vy +0)) 2,1
     (stmts 2,23,lib/std/system.nim
@@ -514,7 +514,7 @@
     (i -1) 4 +0) ,1
    (while 8
     (lt
-     (i +64) ~2 i.4 3
+     (i -1) ~2 i.4 3
      (dot ~1 s.9 len.6.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
@@ -523,7 +523,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.4)))) ,4
    (if 3
-    (elif 2,98,lib/std/system/comparisons.nim
+    (elif 2,110,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -571,7 +571,7 @@
     (i -1) 4 +0) ,2
    (while 8
     (lt
-     (i +64) ~2 i.5 3
+     (i -1) ~2 i.5 3
      (dot ~1 a.4 len.6.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
@@ -607,7 +607,7 @@
    (if 3
     (elif 8
      (lt
-      (i +64) ~5
+      (i -1) ~5
       (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0) 6
       (dot ~4
        (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0)) ~1,1
@@ -617,7 +617,7 @@
        (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0)) ,1
       (while 8
        (lt
-        (i +64) ~2 i.6 6
+        (i -1) ~2 i.6 6
         (dot ~4
          (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0)) 2,1
        (stmts 10
@@ -629,19 +629,19 @@
          (haddr i.6)))))) 5,5
     (elif 16
      (lt
-      (i +64) ~12
+      (i -1) ~12
       (call 1 capInBytes.1.temd2l7vy ~4
        (hderef dest.4)) 10
       (mul
-       (i +64) ~5
+       (i -1) ~5
        (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0) 8
        (sizeof
         (f +64)))) ~3,1
      (stmts 4
-      (let :oldCap.1 . . 2,~52
-       (i +64) 25
+      (let :oldCap.1 . . 1,~108
+       (i -1) 25
        (div
-        (i +64) ~12
+        (i -1) ~12
         (call 1 capInBytes.1.temd2l7vy ~4
          (hderef dest.4)) 10
         (sizeof
@@ -650,7 +650,7 @@
        (i -1) 18
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.1 17
         (sub
-         (i +64) ~5
+         (i -1) ~5
          (dot ~3 src.4 len.6.Iw9f2pq.temd2l7vy +0) 2 oldCap.1))) 4,2
       (let :memSize.4 . . 1,~110
        (i -1) 27
@@ -692,7 +692,7 @@
     (i -1) 4 +0) ,17
    (while 8
     (lt
-     (i +64) ~2 i.7 6
+     (i -1) ~2 i.7 6
      (dot ~4
       (hderef dest.4) len.6.Iw9f2pq.temd2l7vy +0)) 2,1
     (stmts 2,23,lib/std/system.nim
@@ -716,7 +716,7 @@
     (i -1) 4 +0) ,1
    (while 8
     (lt
-     (i +64) ~2 i.8 3
+     (i -1) ~2 i.8 3
      (dot ~1 s.12 len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 10
      (destroy 2
@@ -725,7 +725,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.8)))) ,4
    (if 3
-    (elif 2,98,lib/std/system/comparisons.nim
+    (elif 2,110,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -773,7 +773,7 @@
     (i -1) 4 +0) ,2
    (while 8
     (lt
-     (i +64) ~2 i.9 3
+     (i -1) ~2 i.9 3
      (dot ~1 a.5 len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 17
      (asgn ~10
@@ -809,7 +809,7 @@
    (if 3
     (elif 8
      (lt
-      (i +64) ~5
+      (i -1) ~5
       (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0) 6
       (dot ~4
        (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0)) ~1,1
@@ -819,7 +819,7 @@
        (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0)) ,1
       (while 8
        (lt
-        (i +64) ~2 i.10 6
+        (i -1) ~2 i.10 6
         (dot ~4
          (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
        (stmts 10
@@ -831,19 +831,19 @@
          (haddr i.10)))))) 5,5
     (elif 16
      (lt
-      (i +64) ~12
+      (i -1) ~12
       (call 1 capInBytes.2.temd2l7vy ~4
        (hderef dest.5)) 10
       (mul
-       (i +64) ~5
+       (i -1) ~5
        (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0) 8
        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
         (u +8)))) ~3,1
      (stmts 4
-      (let :oldCap.2 . . 2,~52
-       (i +64) 25
+      (let :oldCap.2 . . 1,~108
+       (i -1) 25
        (div
-        (i +64) ~12
+        (i -1) ~12
         (call 1 capInBytes.2.temd2l7vy ~4
          (hderef dest.5)) 10
         (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
@@ -852,7 +852,7 @@
        (i -1) 18
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.2 17
         (sub
-         (i +64) ~5
+         (i -1) ~5
          (dot ~3 src.5 len.6.Iq4ofkp1.temd2l7vy +0) 2 oldCap.2))) 4,2
       (let :memSize.5 . . 1,~110
        (i -1) 27
@@ -894,7 +894,7 @@
     (i -1) 4 +0) ,17
    (while 8
     (lt
-     (i +64) ~2 i.11 6
+     (i -1) ~2 i.11 6
      (dot ~4
       (hderef dest.5) len.6.Iq4ofkp1.temd2l7vy +0)) 2,1
     (stmts 2,23,lib/std/system.nim
@@ -938,7 +938,7 @@
     (i -1) .) 7
    (asgn ~7 result.9 2
     (if 3
-     (elif 2,98,lib/std/system/comparisons.nim
+     (elif 2,110,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq
@@ -970,7 +970,7 @@
     (i -1) .) 7
    (asgn ~7 result.10 2
     (if 3
-     (elif 2,98,lib/std/system/comparisons.nim
+     (elif 2,110,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq
@@ -1002,7 +1002,7 @@
     (i -1) .) 7
    (asgn ~7 result.11 2
     (if 3
-     (elif 2,98,lib/std/system/comparisons.nim
+     (elif 2,110,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq

--- a/tests/nimony/sysbasics/tintlitmatch.nif
+++ b/tests/nimony/sysbasics/tintlitmatch.nif
@@ -37,26 +37,26 @@
   (i -1) .) ,13
  (discard 10
   (eq
-   (i +64) ~2
-   (hconv 17,58,lib/std/system.nim
-    (i +64) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
+   (i -1) ~2
+   (hconv 17,55,lib/std/system.nim
+    (i -1) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
  (discard 10
   (eq
-   (i +64) ~2 y.0.tin4pj0od1 6
-   (hconv 17,58,lib/std/system.nim
-    (i +64)
+   (i -1) ~2 y.0.tin4pj0od1 6
+   (hconv 17,55,lib/std/system.nim
+    (i -1)
     (conv 1
      (i +32) ~3 +123)))) ,15
  (discard 18
   (eq
-   (i +64) ~7
-   (hconv 17,58,lib/std/system.nim
-    (i +64)
+   (i -1) ~7
+   (hconv 17,55,lib/std/system.nim
+    (i -1)
     (conv 6,~1
      (i +32) ~3 +123)) 3 y.0.tin4pj0od1)) ,16
  (discard 16
   (eq
-   (i +64) ~5
+   (i -1) ~5
    (conv 1
     (i -1) ~3 +123) 6
    (conv ~10
@@ -73,17 +73,17 @@
    (i +32) ~7
    (conv 6,~6
     (i +32) ~3 +123) 3
-   (hconv 17,57,lib/std/system.nim
+   (hconv 17,59,lib/std/system.nim
     (i +32) +123))) ,21
  (discard 12
   (eq
    (i +32) ~4
-   (hconv 17,57,lib/std/system.nim
+   (hconv 17,59,lib/std/system.nim
     (i +32) +123) 6
    (conv ~1,~7
     (i +32) ~3 +123))) ,22
  (discard 10
   (eq
    (i +32) ~2 x.0.tin4pj0od1 3
-   (hconv 17,57,lib/std/system.nim
+   (hconv 17,59,lib/std/system.nim
     (i +32) +123))))

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -149,7 +149,7 @@
    (elif
     (not 15,16,tests/nimony/sysbasics/tsets.nim
      (eq
-      (i +64) ~4
+      (i -1) ~4
       (card
        (set Foo.0.tsefy5wha) 1 s.0.tsefy5wha) 3 +4)) ~1,1
     (stmts 2,102,lib/std/syncio.nim
@@ -165,7 +165,7 @@
    (elif
     (not 16,17,tests/nimony/sysbasics/tsets.nim
      (eq
-      (i +64) ~5
+      (i -1) ~5
       (card
        (set Foo.0.tsefy5wha) 1 s1.0.tsefy5wha) 3 +3)) ~1,1
     (stmts 2,102,lib/std/syncio.nim
@@ -186,7 +186,7 @@
    (elif
     (not 16,20,tests/nimony/sysbasics/tsets.nim
      (eq
-      (i +64) ~5
+      (i -1) ~5
       (card
        (set Foo.0.tsefy5wha) 1 s1.0.tsefy5wha) 3 +4)) ~1,1
     (stmts 2,102,lib/std/syncio.nim
@@ -231,7 +231,7 @@
      (elif
       (not 19,30,tests/nimony/sysbasics/tsets.nim
        (eq
-        (i +64) ~6
+        (i -1) ~6
         (card
          (set
           (c +8)) 1 sss.0) 3 +0)) ~1,1
@@ -253,7 +253,7 @@
      (elif
       (not 19,32,tests/nimony/sysbasics/tsets.nim
        (eq
-        (i +64) ~6
+        (i -1) ~6
         (card
          (set
           (c +8)) 1 sss.0) 3 +27)) ~1,1
@@ -273,7 +273,7 @@
      (elif
       (not 19,34,tests/nimony/sysbasics/tsets.nim
        (eq
-        (i +64) ~6
+        (i -1) ~6
         (card
          (set
           (c +8)) 1 sss.0) 3 +26)) ~1,1
@@ -293,7 +293,7 @@
      (elif
       (not 19,36,tests/nimony/sysbasics/tsets.nim
        (eq
-        (i +64) ~6
+        (i -1) ~6
         (card
          (set
           (c +8)) 1 sss.0) 3 +26)) ~1,1

--- a/tests/nimony/sysbasics/tsets.nif
+++ b/tests/nimony/sysbasics/tsets.nif
@@ -64,13 +64,13 @@
     (not 10,9,tests/nimony/sysbasics/tsets.nim
      (ltset
       (set Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 2 s.0.tsefy5wha)) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 4,9
  (glet :y.0.tsefy5wha . . 10,~4
   (set 1 Foo.0.tsefy5wha) 7
@@ -87,13 +87,13 @@
       (setconstr 2,~6
        (set 1 Foo.0.tsefy5wha) 1
        (range A.0.tsefy5wha 3 C.0.tsefy5wha)))) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -104,13 +104,13 @@
       (setconstr 2,~7
        (set 1 Foo.0.tsefy5wha) 1
        (range A.0.tsefy5wha 3 C.0.tsefy5wha)))) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -122,13 +122,13 @@
        (set Foo.0.tsefy5wha) ~2 s.0.tsefy5wha 2 s1.0.tsefy5wha) 3
       (setconstr ~3,~8
        (set 1 Foo.0.tsefy5wha) 1 D.0.tsefy5wha))) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -136,13 +136,13 @@
     (not 10,15,tests/nimony/sysbasics/tsets.nim
      (leset
       (set Foo.0.tsefy5wha) ~3 s1.0.tsefy5wha 3 s.0.tsefy5wha)) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -152,13 +152,13 @@
       (i -1) ~4
       (card
        (set Foo.0.tsefy5wha) 1 s.0.tsefy5wha) 3 +4)) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -168,13 +168,13 @@
       (i -1) ~5
       (card
        (set Foo.0.tsefy5wha) 1 s1.0.tsefy5wha) 3 +3)) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 4,17
  (glet :val.0.tsefy5wha . . 7,~14 Foo.0.tsefy5wha 6 D.0.tsefy5wha) 3,18
  (asgn ~3 s1.0.tsefy5wha 2
@@ -189,13 +189,13 @@
       (i -1) ~5
       (card
        (set Foo.0.tsefy5wha) 1 s1.0.tsefy5wha) 3 +4)) ~1,1
-    (stmts 2,102,lib/std/syncio.nim
+    (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) ,21
  (template 9 :resem.0.tsefy5wha . . . 14
   (params) . . . 2,1
@@ -235,13 +235,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +0)) ~1,1
-      (stmts 2,102,lib/std/syncio.nim
+      (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 4,3
    (asgn ~4 sss.0 2
     (setconstr 6,~3
@@ -257,13 +257,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +27)) ~1,1
-      (stmts 2,102,lib/std/syncio.nim
+      (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,5
    (excl
     (set
@@ -277,13 +277,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +26)) ~1,1
-      (stmts 2,102,lib/std/syncio.nim
+      (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,7
    (incl
     (set
@@ -297,13 +297,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +26)) ~1,1
-      (stmts 2,102,lib/std/syncio.nim
+      (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.9.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))))) ,37
  (block . 2,1
   (stmts

--- a/tests/nimony/sysbasics/tvartuple.exitcode
+++ b/tests/nimony/sysbasics/tvartuple.exitcode
@@ -1,7 +1,7 @@
 lib/std/system/seqimpl.nim(140, 41): (and
  (lt
-  (i +64) i.1
+  (i -1) i.1
   (dot s.1 len.6.I328b0i1.tvaa37zrk +0))
  (expr
   (le
-   (i +64) +0 i.1))) [AssertionDefect]
+   (i -1) +0 i.1))) [AssertionDefect]

--- a/tests/nimony/valgrind/tnewref.nim
+++ b/tests/nimony/valgrind/tnewref.nim
@@ -5,6 +5,7 @@ proc main =
   var x: ref int
   new x
   x[] = 56
-  echo x[]
+  let y = x[]
+  echo y
 
 main()


### PR DESCRIPTION
Integer type matching is brought closer to original sigmatch:

* `int`/`uint` now match their respective bit type (i.e. `int64`/`uint64`) with `isIntConv`, vice versa matches with `isConvertible`
* Integer types with bigger bits than the given type are supposed to match with `isConvertible` and only match with `isIntConv` if the formal type is `int`/`uint`

This means that `int`/`uint` are not considered the same as their corresponding bit types anymore and generate conversions (although `linearMatch` is not updated for this, in original Nim `array[2, int64]` does not match `array[2, int]` but here it does). So overloads for `int`/`uint` are added for each of the numeric operation primitives, same as original Nim. Generic versions of `min`/`max` are also added.

There is a pre-existing behavior in original Nim that an int literal like `1` is ambiguous between `int64` and `uint64`, `syncio.write` is given overloads for `int`/`uint` as well to account for this.