### PR TITLE
misc fixes extracted from #908

### DIFF
--- a/lib/std/system/comparisons.nim
+++ b/lib/std/system/comparisons.nim
@@ -106,6 +106,9 @@ template `>`*(x, y: untyped): untyped =
   ## "is greater" operator. This is the same as `y < x`.
   y < x
 
+type Orderable = concept
+  proc `<=`(x, y: Self): bool
+
 proc min*(x, y: int8): int8 {.noSideEffect, inline.} =
   if x <= y: x else: y
 proc min*(x, y: int16): int16 {.noSideEffect, inline.} =
@@ -119,6 +122,10 @@ proc min*(x, y: float32): float32 {.noSideEffect, inline.} =
   if x <= y or y != y: x else: y
 proc min*(x, y: float): float {.noSideEffect, inline.} =
   if x <= y or y != y: x else: y
+# originally used T: not SomeFloat:
+proc min*[T: Orderable](x, y: T): T {.inline.} =
+  ## Generic minimum operator of 2 values based on `<=`.
+  if x <= y: x else: y
 
 proc max*(x, y: int8): int8 {.noSideEffect, inline.} =
   if y <= x: x else: y
@@ -133,6 +140,10 @@ proc max*(x, y: float32): float32 {.noSideEffect, inline.} =
   if y <= x or y != y: x else: y
 proc max*(x, y: float): float {.noSideEffect, inline.} =
   if y <= x or y != y: x else: y
+# originally used T: not SomeFloat:
+proc max*[T: Orderable](x, y: T): T {.inline.} =
+  ## Generic maximum operator of 2 values based on `<=`.
+  if y <= x: x else: y
 
 type
   Comparable* = concept

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -630,7 +630,7 @@ proc matchIntegralType(m: var Match; f: var Cursor; arg: Item) =
       m.args.addParLe HconvX, m.argInfo
       m.args.addSubtree forig
       if isIntLit:
-        if f.typeKind == FloatT:
+        if forig.typeKind == FloatT:
           inc m.convCosts
         else:
           inc m.intLitCosts

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -275,7 +275,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor; flags: set[GetTypeFlag]): Cursor =
     result = getTypeImpl(c, result, flags) # typeof(obj.field) == typeof field
   of DerefX, HderefX:
     result = getTypeImpl(c, n.firstSon, flags)
-    if typeKind(result) in {RefT, PtrT, MutT, OutT}:
+    if typeKind(result) in {RefT, PtrT, MutT, OutT, LentT}:
       inc result
     else:
       assert false, "cannot deref type: " & toString(result, false)

--- a/tests/nimony/stdlib/tsystem.nim
+++ b/tests/nimony/stdlib/tsystem.nim
@@ -11,3 +11,9 @@ assert testnotin "abc"
 assert testnotin "AZaz"
 assert not testnotin "1"
 assert not testnotin "abc "
+
+# generic min/max:
+assert min("a", "b") == "a"
+assert min("b", "a") == "a"
+assert max("a", "b") == "b"
+assert max("b", "a") == "b"


### PR DESCRIPTION
1. generic min/max
2. minor bug in sigmatch
3. consider derefs of `lent` types in `getType`