### PR TITLE
[draft] nimony: introduce `passC` and `passL` in `{.build.}` pragma

### DIFF
--- a/src/nimony/nifconfig.nim
+++ b/src/nimony/nifconfig.nim
@@ -16,6 +16,8 @@ type
   NifConfig* = object
     defines*: HashSet[string]
     paths*, nimblePaths*: seq[string]
+    passC*: seq[string]
+    passL*: seq[string]
     currentPath*: string
     nifcachePath*: string
     bits*: int
@@ -111,6 +113,11 @@ proc getOptionsAsOneString*(config: NifConfig): string =
   result.add " --bits:" & $config.bits
   result.add " --cpu:" & platform.CPU[config.targetCPU].name
   result.add " --os:" & platform.OS[config.targetOS].name
+
+  for passC in config.passC:
+    result.add " --passC:" & passC
+  for passL in config.passL:
+    result.add " --passL:" & passL
 
 proc isDefined*(config: NifConfig; symbol: string): bool =
   if symbol in config.defines:

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -74,8 +74,6 @@ proc handleCmdLine() =
   var commandLineArgs = ""
   var commandLineArgsNifc = ""
   var isChild = false
-  var passC = ""
-  var passL = ""
   var checkModes = DefaultSettings
   for kind, key, val in getopt():
     case kind
@@ -138,10 +136,10 @@ proc handleCmdLine() =
         isChild = true
         forwardArg = false
       of "passc":
-        passC = val
+        config.passC.add(val)
         forwardArg = false
       of "passl":
-        passL = val
+        config.passL.add(val)
         forwardArg = false
       of "nimcache":
         config.nifcachePath = val
@@ -190,8 +188,7 @@ proc handleCmdLine() =
     requiresTool "nifc", "src/nifc/nifc.nim", forceRebuild
     # compile full project modules
     buildGraph config, args[0], forceRebuild, silentMake,
-      commandLineArgs, commandLineArgsNifc, moduleFlags, (if doRun: DoRun else: DoCompile),
-      passC, passL
+      commandLineArgs, commandLineArgsNifc, moduleFlags, (if doRun: DoRun else: DoCompile)
 
 when isMainModule:
   handleCmdLine()

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -240,14 +240,14 @@ proc filenameVal*(n: var Cursor; res: var seq[ImportedFilename]; hasError: var b
 
 proc replaceSubs*(fmt, currentFile: string; config: NifConfig): string =
   # Unpack Current File to Absolute
-  let nifcache = config.nifcachePath
   var path = absolutePath(currentFile)
   if os.fileExists(path):
     path = parentDir(path)
   # Replace matches with paths
   path = fmt.multiReplace(
     ("${path}", path),
-    ("${nifcache}", nifcache))
+    ("${project}", config.currentPath),
+    ("${nifcache}", config.nifcachePath))
   result = path.normalizedPath()
 
 # ------------------ include/import handling ------------------------

--- a/tests/nimony/ffi/foo.c
+++ b/tests/nimony/ffi/foo.c
@@ -1,3 +1,9 @@
 int myFunc() {
   return 12;
 }
+
+#ifdef NIMONY_BUILD_PASSC
+int myFuncPass() {
+  return 15;
+}
+#endif

--- a/tests/nimony/ffi/tbuild.nim
+++ b/tests/nimony/ffi/tbuild.nim
@@ -1,9 +1,22 @@
 {.build("C", "foo.c").}
 {.build("C", "foo1.c", "-fno-strict-aliasing").}
+{.build("passC", "-DNIMONY_BUILD_PASSC").}
+{.build("passL", "-s").}
 
+{.emit: """
+#ifdef NIMONY_BUILD_PASSC
+  int myFuncPass2() {
+    return 32;
+  }
+#endif
+""".}
 
 proc myFunc(): int {.importc: "myFunc".}
 proc myFunc2(): int {.importc: "myFunc2".}
+proc myFuncPass(): int {.importc: "myFuncPass".}
+proc myFuncPass2(): int {.importc: "myFuncPass2", nodecl.}
 
 let s = myFunc()
 let s2 = myFunc2()
+let s3 = myFuncPass()
+let s4 = myFuncPass2()


### PR DESCRIPTION
- introduce `passC` and `passL` in `{.build.}` pragma
- improve `passC` and `passL` command line arguments allowing use those multiple times like nim 2.x
- add a `${project}` in `semos.replaceSubs` referencing to project path

 `{.compile.}`, `{.link.}`, `{.passC.}` and `{.passL.}` pragmas could be implemented as a sugars of `{.build.}` pragma for compat with nim 2.x but it should be for another pull request