### PR TITLE
match concrete types in constraints

### DIFF
--- a/lib/std/system/arithmetics.nim
+++ b/lib/std/system/arithmetics.nim
@@ -66,24 +66,24 @@ proc `mod`*(x, y: int16): int16 {.magic: "ModI", noSideEffect.}
 proc `mod`*(x, y: int32): int32 {.magic: "ModI", noSideEffect.}
 proc `mod`*(x, y: int64): int64 {.magic: "ModI", noSideEffect.}
 
-type
-  SomeInteger = int # for now just an alias
 
-proc `shr`*(x: int8, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
-proc `shr`*(x: int16, y: SomeInteger): int16 {.magic: "AshrI", noSideEffect.}
-proc `shr`*(x: int32, y: SomeInteger): int32 {.magic: "AshrI", noSideEffect.}
-proc `shr`*(x: int64, y: SomeInteger): int64 {.magic: "AshrI", noSideEffect.}
+# SomeInteger moved to generic param since implicit generics are not implemented yet:
+
+proc `shr`*[I: SomeInteger](x: int8, y: I): int8 {.magic: "AshrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: int16, y: I): int16 {.magic: "AshrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: int32, y: I): int32 {.magic: "AshrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: int64, y: I): int64 {.magic: "AshrI", noSideEffect.}
 
 
-proc `shl`*(x: int8, y: SomeInteger): int8 {.magic: "ShlI", noSideEffect.}
-proc `shl`*(x: int16, y: SomeInteger): int16 {.magic: "ShlI", noSideEffect.}
-proc `shl`*(x: int32, y: SomeInteger): int32 {.magic: "ShlI", noSideEffect.}
-proc `shl`*(x: int64, y: SomeInteger): int64 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: int8, y: I): int8 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: int16, y: I): int16 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: int32, y: I): int32 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: int64, y: I): int64 {.magic: "ShlI", noSideEffect.}
 
-proc ashr*(x: int8, y: SomeInteger): int8 {.magic: "AshrI", noSideEffect.}
-proc ashr*(x: int16, y: SomeInteger): int16 {.magic: "AshrI", noSideEffect.}
-proc ashr*(x: int32, y: SomeInteger): int32 {.magic: "AshrI", noSideEffect.}
-proc ashr*(x: int64, y: SomeInteger): int64 {.magic: "AshrI", noSideEffect.}
+proc ashr*[I: SomeInteger](x: int8, y: I): int8 {.magic: "AshrI", noSideEffect.}
+proc ashr*[I: SomeInteger](x: int16, y: I): int16 {.magic: "AshrI", noSideEffect.}
+proc ashr*[I: SomeInteger](x: int32, y: I): int32 {.magic: "AshrI", noSideEffect.}
+proc ashr*[I: SomeInteger](x: int64, y: I): int64 {.magic: "AshrI", noSideEffect.}
 
 proc `and`*(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
@@ -110,15 +110,15 @@ proc `not`*(x: uint16): uint16 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: uint32): uint32 {.magic: "BitnotI", noSideEffect.}
 proc `not`*(x: uint64): uint64 {.magic: "BitnotI", noSideEffect.}
 
-proc `shr`*(x: uint8, y: SomeInteger): uint8 {.magic: "ShrI", noSideEffect.}
-proc `shr`*(x: uint16, y: SomeInteger): uint16 {.magic: "ShrI", noSideEffect.}
-proc `shr`*(x: uint32, y: SomeInteger): uint32 {.magic: "ShrI", noSideEffect.}
-proc `shr`*(x: uint64, y: SomeInteger): uint64 {.magic: "ShrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: uint8, y: I): uint8 {.magic: "ShrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: uint16, y: I): uint16 {.magic: "ShrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: uint32, y: I): uint32 {.magic: "ShrI", noSideEffect.}
+proc `shr`*[I: SomeInteger](x: uint64, y: I): uint64 {.magic: "ShrI", noSideEffect.}
 
-proc `shl`*(x: uint8, y: SomeInteger): uint8 {.magic: "ShlI", noSideEffect.}
-proc `shl`*(x: uint16, y: SomeInteger): uint16 {.magic: "ShlI", noSideEffect.}
-proc `shl`*(x: uint32, y: SomeInteger): uint32 {.magic: "ShlI", noSideEffect.}
-proc `shl`*(x: uint64, y: SomeInteger): uint64 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: uint8, y: I): uint8 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: uint16, y: I): uint16 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: uint32, y: I): uint32 {.magic: "ShlI", noSideEffect.}
+proc `shl`*[I: SomeInteger](x: uint64, y: I): uint64 {.magic: "ShlI", noSideEffect.}
 
 proc `and`*(x, y: uint8): uint8 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: uint16): uint16 {.magic: "BitandI", noSideEffect.}

--- a/lib/std/system/basic_types.nim
+++ b/lib/std/system/basic_types.nim
@@ -34,6 +34,26 @@ type # we need to start a new type section here, so that ``0`` can have a type
   bool* {.magic: "Bool".} = enum ## Built-in boolean type.
     false = 0, true = 1
 
+type
+  SomeSignedInt* = int|int8|int16|int32|int64
+    ## Type class matching all signed integer types.
+
+  SomeUnsignedInt* = uint|uint8|uint16|uint32|uint64
+    ## Type class matching all unsigned integer types.
+
+  SomeInteger* = SomeSignedInt|SomeUnsignedInt
+    ## Type class matching all integer types.
+
+  SomeFloat* = float|float32|float64
+    ## Type class matching all floating point number types.
+
+  SomeNumber* = SomeInteger|SomeFloat
+    ## Type class matching all number types.
+
+  SomeOrdinal* = int|int8|int16|int32|int64|bool|enum|uint|uint8|uint16|uint32|uint64
+    ## Type class matching all ordinal types; however this includes enums with
+    ## holes. See also `Ordinal`
+
 proc `not`*(x: bool): bool {.magic: "Not", noSideEffect.}
   ## Boolean not; returns true if `x == false`.
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -325,8 +325,9 @@ proc matchesConstraint(m: var Match; f: var Cursor; a: Cursor): bool =
       var typevar = asTypevar(res.decl)
       return matchesConstraint(m, f, typevar.typ)
   if f.kind == Symbol:
-    return matchSymbolConstraint(m, f, a)
-  result = matchesConstraintAux(m, f, a)
+    result = matchSymbolConstraint(m, f, a)
+  else:
+    result = matchesConstraintAux(m, f, a)
 
 proc matchesConstraint(m: var Match; f: SymId; a: Cursor): bool =
   let res = tryLoadSym(f)

--- a/tests/nimony/overload/ttypeclasses.nim
+++ b/tests/nimony/overload/ttypeclasses.nim
@@ -1,0 +1,5 @@
+import std/assertions
+
+# issue #675, shl/shr etc use SomeInteger:
+let x = 1'u shl 3'u
+assert x == 8


### PR DESCRIPTION
closes #675

When matching against a constraint, if the constraint type is not found to be a typeclass, it is matched like a regular type. `linearMatch` is used for this, which for now means conversions from the argument to the constraint type are not allowed (i.e. `"abc"` matching `T: cstring` or `1'i8` matching `T: int`) which is a difference from original Nim (it would also need to infer the typevar to the *converted* type and not the argument type, not to mention considering converters etc).

This is done so that `SomeInteger` can now be implemented as intended and used for `shl`/`shr` etc. However implicit generics are not implemented so the signatures use an explicit generic parameter for it.

To make the call to `linearMatch` here less hacky, `m.err` now just tracks if the match failed so it is harmless to temporarily set it to `false`, and a new field `hasError` is added to track if the error message should be updated.

Generic base symbols i.e. `Foo` in `Foo[T]` are also now considered typeclasses and match their instances/themselves.