### PR TITLE
disable winget install dependency, use windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,9 @@ jobs:
           echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
           echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
 
-      #- name: Install winget
-      #  if: runner.os == 'Windows'
+      - name: Install winget
+        if: runner.os == 'Windows'
+        run: winget upgrade winget --accept-package-agreements --accept-source-agreements --disable-interactivity
       #  uses: Cyberboss/install-winget@v1
       #  with:
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             builder: macos-15
           - target:
               os: windows
-            builder: windows-latest
+            builder: windows-2025
 
     name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}-nim-${{ matrix.target.nim_branch }} (${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
@@ -111,11 +111,11 @@ jobs:
           echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
           echo '${{ github.workspace }}'"/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
 
-      - name: Install winget
-        if: runner.os == 'Windows'
-        uses: Cyberboss/install-winget@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #- name: Install winget
+      #  if: runner.os == 'Windows'
+      #  uses: Cyberboss/install-winget@v1
+      #  with:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install make dependencies (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             builder: macos-15
           - target:
               os: windows
-            builder: windows-latest
+            builder: windows-2025
 
     name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}-nim-${{ matrix.target.nim_branch }} (${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             builder: macos-15
           - target:
               os: windows
-            builder: windows-2025
+            builder: windows-latest
 
     name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}-nim-${{ matrix.target.nim_branch }} (${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
@@ -113,10 +113,8 @@ jobs:
 
       - name: Install winget
         if: runner.os == 'Windows'
+        # winget included in windows-2025 and above:
         run: winget upgrade winget --accept-package-agreements --accept-source-agreements --disable-interactivity
-      #  uses: Cyberboss/install-winget@v1
-      #  with:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install make dependencies (Windows)
         if: runner.os == 'Windows'

--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -203,8 +203,7 @@ proc testValgrind(c: var TestCounters; file: string; overwrite: bool; cat: Categ
         failure c, file, valgrindSpec, testProgramOutput
 
 proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category) =
-  let t0 = epochTime()
-  echo "TESTING ", file
+  #echo "TESTING ", file
   inc c.total
   var nimonycmd = "--isMain"
   case cat
@@ -265,7 +264,6 @@ proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category)
     if ast.fileExists():
       let nif = generatedFile(file, ".2.nif")
       diffFiles c, file, ast, nif, overwrite
-  echo "TEST FINISHED ", file, " IN ", formatFloat(epochTime() - t0, ffDecimal, precision=2)
 
 proc testDir(c: var TestCounters; dir: string; overwrite: bool; cat: Category) =
   var files: seq[string] = @[]

--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -203,7 +203,8 @@ proc testValgrind(c: var TestCounters; file: string; overwrite: bool; cat: Categ
         failure c, file, valgrindSpec, testProgramOutput
 
 proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category) =
-  #echo "TESTING ", file
+  let t0 = epochTime()
+  echo "TESTING ", file
   inc c.total
   var nimonycmd = "--isMain"
   case cat
@@ -264,6 +265,7 @@ proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category)
     if ast.fileExists():
       let nif = generatedFile(file, ".2.nif")
       diffFiles c, file, ast, nif, overwrite
+  echo "TEST FINISHED ", file, " IN ", formatFloat(epochTime() - t0, ffDecimal, precision=2)
 
 proc testDir(c: var TestCounters; dir: string; overwrite: bool; cat: Category) =
   var files: seq[string] = @[]
@@ -302,7 +304,7 @@ proc nimonytests(overwrite: bool) =
     let cat = parseCategory x.path
     if x.kind == pcDir:
       testDir c, TestDir / x.path, overwrite, cat
-  echo c.total - c.failures, " / ", c.total, " tests successful in ", formatFloat(epochTime() - t0, precision=2), "s."
+  echo c.total - c.failures, " / ", c.total, " tests successful in ", formatFloat(epochTime() - t0, ffDecimal, precision=2), "s."
   if c.failures > 0:
     quit "FAILURE: Some tests failed."
   else:
@@ -341,7 +343,7 @@ proc controlflowTests(tool: string; overwrite: bool) =
           os.removeFile(dest)
         else:
           failure c, t, expectedOutput, destContent
-  echo c.total - c.failures, " / ", c.total, " tests successful in ", formatFloat(epochTime() - t0, precision=2), "s."
+  echo c.total - c.failures, " / ", c.total, " tests successful in ", formatFloat(epochTime() - t0, ffDecimal, precision=2), "s."
   if c.failures > 0:
     quit "FAILURE: Some tests failed."
   else:


### PR DESCRIPTION
The dependency is broken, apparently windows-2025 and above do not need it anyway since winget can be installed without any dependencies