### PR TITLE
ignore winget upgrade error when on latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Install winget
         if: runner.os == 'Windows'
+        continue-on-error: true # for some reason errors if latest version already installed
         # winget included in windows-2025 and above:
         run: winget upgrade winget --accept-package-agreements --accept-source-agreements --disable-interactivity
 


### PR DESCRIPTION
For some reason `winget upgrade` gives an error exit code if the latest version was already installed, guessing this is related to the cache. Could not find a way to make winget itself not produce an error exit code for this. Another option might be to not upgrade at all.