### PR TITLE
fixes return if expr: lowerExprs before injectDups

### DIFF
--- a/src/hexer/pipeline.nim
+++ b/src/hexer/pipeline.nim
@@ -46,10 +46,14 @@ proc transform*(c: var EContext; n: Cursor; moduleSuffix: string): TokenBuf =
   var n1 = desugar(c0, moduleSuffix, c.activeChecks)
   endRead(n0)
 
-  var c2 = beginRead(n1)
-  let ctx = createLiftingCtx(moduleSuffix, c.bits)
-  var n2 = injectDups(c2, n1, ctx)
+  var c1 = beginRead(n1)
+  var nx = lowerExprs(c1, moduleSuffix)
   endRead(n1)
+
+  var c2 = beginRead(nx)
+  let ctx = createLiftingCtx(moduleSuffix, c.bits)
+  var n2 = injectDups(c2, nx, ctx)
+  endRead(nx)
 
   var c3 = beginRead(n2)
   var n3 = lowerExprs(c3, moduleSuffix)

--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -189,14 +189,16 @@ proc trIf(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
         dest.add t0
         #copyIntoKind dest, StmtsS, info:
         if tar.m != IsIgnored:
-          trExprInto c, dest, n, tmp
+          copyIntoKind dest, StmtsS, info:
+            trExprInto c, dest, n, tmp
         else:
           trStmt c, dest, n
       skipParRi n
     of ElseU:
       inc n
       if tar.m != IsIgnored:
-        trExprInto c, dest, n, tmp
+        copyIntoKind dest, StmtsS, info:
+          trExprInto c, dest, n, tmp
       else:
         trStmt c, dest, n
       skipParRi n

--- a/tests/nimony/arc/taddstr.nim
+++ b/tests/nimony/arc/taddstr.nim
@@ -10,3 +10,15 @@ proc main =
     echo "#", abc, "#"
 
 main()
+
+import std/[assertions]
+
+# proc cho(x: string): string =
+#   result = x
+
+proc bar(): string =
+  var x = "1212334"
+  x.add "123"
+  return if true: x else: "123"
+
+assert bar() == "1212334123"


### PR DESCRIPTION
`injectDups` won't work properly without transforming if expressions (i.e. lowerExprs). Otherwise, we need to treat `if` differently in `injectDups` instead of handling it like statements, which causes double free