### PR TITLE
fixes #954; move sink parameter causes compile error

### DIFF
--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -206,7 +206,7 @@ proc borrowsFromReadonly(c: var Context; n: Cursor): bool =
     of VarY, GvarY, TvarY:
       result = local.typ.typeKind == LentT
     of ParamY:
-      result = local.typ.typeKind notin {MutT, OutT, LentT}
+      result = local.typ.typeKind notin {MutT, OutT, LentT, SinkT}
     else:
       result = false
   elif n.kind in {StringLit, IntLit, UIntLit, FloatLit, CharLit} or

--- a/tests/nimony/arc/tsink_string.nim
+++ b/tests/nimony/arc/tsink_string.nim
@@ -1,8 +1,18 @@
 
-import std / syncio
+import std / [syncio, assertions]
 
 proc x(s: sink string) =
   let foo = ensureMove(s)
   echo foo
 
 x("hi")
+
+type
+  Foo = object
+    buf: string
+
+proc test(f: sink Foo): string =
+  result = move(f.buf)
+
+var f = Foo(buf: "1234")
+assert test(f) == "1234"


### PR DESCRIPTION
fixes #954

`sink parameter` can be modified