### PR TITLE
adds $ for bools

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -80,6 +80,9 @@ proc addInt*(s: var string; x: int64) {.inline.} =
 proc addInt*(s: var string; x: uint64) {.inline.} =
   s.add $x
 
+proc `$`*(b: bool): string =
+  if b: "true" else: "false"
+
 proc `$`*[T: enum](x: T): string {.magic: "EnumToStr", noSideEffect.}
   ## Converts an enum value to a string.
 

--- a/tests/nimony/const/tconstarrlen.nif
+++ b/tests/nimony/const/tconstarrlen.nif
@@ -20,7 +20,7 @@
  (if 3
   (elif 6
    (eq
-    (i +64) 2,111,lib/std/system.nim
+    (i +64) 2,114,lib/std/system.nim
     (expr ,~4
      (expr 45,2
       (add

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -369,7 +369,7 @@
     (if 3
      (elif 7
       (eq
-       (i +64) 2,111,lib/std/system.nim
+       (i +64) 2,114,lib/std/system.nim
        (expr ,~4
         (expr 45,2
          (add
@@ -398,7 +398,7 @@
            (uarray
             (i -1))) 32
           (addr 1 x.4))) 45
-        (kv ~45 len.6.Inff8aa1.tfo161bfb1 2,111,lib/std/system.nim
+        (kv ~45 len.6.Inff8aa1.tfo161bfb1 2,114,lib/std/system.nim
          (expr ,~4
           (expr 45,2
            (add

--- a/tests/nimony/sysbasics/tdollarints.nim
+++ b/tests/nimony/sysbasics/tdollarints.nim
@@ -28,3 +28,6 @@ assert $123'u == "123"
 assert $1234567890'u == "1234567890"
 assert $9223372036854775807'u == "9223372036854775807"
 assert $0xffffffffffffffff'u == "18446744073709551615"
+
+assert $true == "true"
+assert $false == "false"


### PR DESCRIPTION
It is used to implement `proc toNif(b: var NifBuilder; x: bool)`.