### PR TITLE
implement constraints for type generic params

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2776,9 +2776,8 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
   takeParRi c, n
   if paramCount != argCount:
     c.dest.shrink typeStart
-    c.buildErr info, "type " & pool.syms[headId] &
-      " expects " & $paramCount & " generic parameters" &
-      " but got " & $argCount
+    c.buildErr info, "wrong amount of generic parameters for type " & pool.syms[headId] &
+      ", expected " & $paramCount & " but got " & $argCount
     return
 
   if ok and (genericArgs == 0 or

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2741,13 +2741,46 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     else:
       c.buildErr info, "cannot attempt to instantiate a non-type"
 
+  var params = decl.typevars
+  inc params
+  var paramCount = 0
+  var argCount = 0
+  var m = createMatch(addr c)
   var genericArgs = 0
   swap c.usedTypevars, genericArgs
   let beforeArgs = c.dest.len
   while n.kind != ParRi:
+    inc argCount
+    let argInfo = n.info
+    var argBuf = createTokenBuf(16)
+    swap c.dest, argBuf
     semLocalTypeImpl c, n, AllowValues
+    swap c.dest, argBuf
+    var addArg = true
+    if params.kind == ParRi:
+      # will error later
+      discard
+    else:
+      inc paramCount
+      let constraint = takeLocal(params, SkipFinalParRi).typ
+      if constraint.kind != DotToken:
+        var arg = beginRead(argBuf)
+        var constraintMatch = constraint
+        if not matchesConstraint(m, constraintMatch, arg):
+          c.buildErr argInfo, "type " & typeToString(arg) & " does not match constraint: " & typeToString(constraint)
+          ok = false
+          addArg = false
+    if addArg:
+      c.dest.add argBuf
   swap c.usedTypevars, genericArgs
   takeParRi c, n
+  if paramCount != argCount:
+    c.dest.shrink typeStart
+    c.buildErr info, "type " & pool.syms[headId] &
+      " expects " & $paramCount & " generic parameters" &
+      " but got " & $argCount
+    return
+
   if ok and (genericArgs == 0 or
       # structural types are inlined even with generic arguments
       not isNominal(decl.body.typeKind)):

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2758,7 +2758,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     swap c.dest, argBuf
     var addArg = true
     if params.kind == ParRi:
-      # will error later
+      # will error later from param/arg count not matching
       discard
     else:
       inc paramCount

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -203,7 +203,7 @@ type LinearMatchFlag = enum
 
 proc linearMatch(m: var Match; f, a: var Cursor; flags: set[LinearMatchFlag] = {})
 
-proc matchesConstraint(m: var Match; f: var Cursor; a: Cursor): bool
+proc matchesConstraint*(m: var Match; f: var Cursor; a: Cursor): bool
 
 proc matchSymbolConstraint(m: var Match; f: var Cursor; a: Cursor): bool =
   result = false
@@ -313,7 +313,7 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
     swap m.err, err
     result = not err
 
-proc matchesConstraint(m: var Match; f: var Cursor; a: Cursor): bool =
+proc matchesConstraint*(m: var Match; f: var Cursor; a: Cursor): bool =
   result = false
   if f.kind == DotToken:
     inc f

--- a/tests/nimony/generics/tgenerictypeconstraints.msgs
+++ b/tests/nimony/generics/tgenerictypeconstraints.msgs
@@ -11,4 +11,4 @@ tests/nimony/generics/tgenerictypeconstraints.nim(6, 12) Error: type (f +64) doe
   (u +16)
   (u +32)
   (u +64)))
-tests/nimony/generics/tgenerictypeconstraints.nim(7, 11) Error: type Foo.0.tge70svym expects 1 generic parameters but got 2
+tests/nimony/generics/tgenerictypeconstraints.nim(7, 11) Error: wrong amount of generic parameters for type Foo.0.tge70svym, expected 1 but got 2

--- a/tests/nimony/generics/tgenerictypeconstraints.msgs
+++ b/tests/nimony/generics/tgenerictypeconstraints.msgs
@@ -1,0 +1,14 @@
+tests/nimony/generics/tgenerictypeconstraints.nim(6, 12) Error: type (f +64) does not match constraint: (or
+ (or
+  (i -1)
+  (i +8)
+  (i +16)
+  (i +32)
+  (i +64))
+ (or
+  (u -1)
+  (u +8)
+  (u +16)
+  (u +32)
+  (u +64)))
+tests/nimony/generics/tgenerictypeconstraints.nim(7, 11) Error: type Foo.0.tge70svym expects 1 generic parameters but got 2

--- a/tests/nimony/generics/tgenerictypeconstraints.nim
+++ b/tests/nimony/generics/tgenerictypeconstraints.nim
@@ -1,0 +1,7 @@
+type Foo[T: SomeInteger] = object
+  x: T
+
+var a: Foo[int]
+var b: Foo[uint8]
+var c: Foo[float]
+var d: Foo[int, int]


### PR DESCRIPTION
Type invocations like `Foo[int]` now check constraints. `matchesConstraint` is reused from sigmatch, probably this will reuse `static` handling when implemented as well.