### PR TITLE
implement implicit items/pairs iterators

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4158,6 +4158,29 @@ proc semForLoopTupleVar(c: var SemContext; it: var Item; tup: TypeCursor) =
 
 include semfields
 
+proc isIteratorCall(c: var SemContext; beforeCall: int): bool {.inline.} =
+  result = c.dest.len > beforeCall+1
+  if result:
+    let callKind =
+      if c.dest[beforeCall].kind == ParLe and rawTagIsNimonyExpr(tagEnum(c.dest[beforeCall])):
+        cast[NimonyExpr](tagEnum(c.dest[beforeCall]))
+      else:
+        NoExpr
+    result = callKind in CallKinds and
+      c.dest[beforeCall+1].kind == Symbol and
+      c.isIterator(c.dest[beforeCall+1].symId)
+
+proc isIdentCall(c: var SemContext; beforeCall: int): bool {.inline.} =
+  result = c.dest.len > beforeCall+1
+  if result:
+    let callKind =
+      if c.dest[beforeCall].kind == ParLe and rawTagIsNimonyExpr(tagEnum(c.dest[beforeCall])):
+        cast[NimonyExpr](tagEnum(c.dest[beforeCall]))
+      else:
+        NoExpr
+    result = callKind in CallKinds and
+      c.dest[beforeCall+1].kind == Ident
+
 proc semFor(c: var SemContext; it: var Item) =
   let info = it.n.info
   let orig = it.n
@@ -4168,7 +4191,7 @@ proc semFor(c: var SemContext; it: var Item) =
   semExpr c, iterCall, {PreferIterators, KeepMagics}
   it.n = iterCall.n
   var isMacroLike = false
-  if c.dest.len > beforeCall+1 and c.dest[beforeCall+1].kind == Symbol and c.isIterator(c.dest[beforeCall+1].symId):
+  if isIteratorCall(c, beforeCall):
     discard "fine"
   elif c.dest[beforeCall].kind == ParLe and
       (c.dest[beforeCall].tagId == TagId(FieldsTagId) or
@@ -4182,10 +4205,53 @@ proc semFor(c: var SemContext; it: var Item) =
     return
   elif iterCall.typ.typeKind == UntypedT or
       # for iterators from concepts in generic context:
-      (c.dest.len > beforeCall+1 and c.dest[beforeCall+1].kind == Ident):
+      isIdentCall(c, beforeCall):
     isMacroLike = true
   else:
-    buildErr c, callInfo, "iterator expected"
+    var vars = 0
+    var varsCursor = it.n
+    if varsCursor.substructureKind == UnpackflatU:
+      inc varsCursor
+      while varsCursor.kind != ParRi:
+        inc vars
+        skip varsCursor
+    else:
+      vars = 1
+    var name = ""
+    case vars
+    of 1:
+      name = "items"
+    of 2:
+      name = "pairs"
+    else:
+      c.dest.shrink beforeCall
+      buildErr c, callInfo, "iterator expected"
+    if name != "":
+      # try implicit iterator call
+      var callBuf = createTokenBuf(32)
+      callBuf.addParLe(CallX, callInfo)
+      swap c.dest, callBuf
+      discard buildSymChoice(c, pool.strings.getOrIncl(name), info, FindAll)
+      swap c.dest, callBuf
+      for tok in beforeCall ..< c.dest.len: callBuf.add c.dest[tok]
+      callBuf.addParRi()
+      let argType = iterCall.typ
+      iterCall = Item(n: beginRead(callBuf), typ: c.types.autoType)
+      shrink c.dest, beforeCall
+      semCall c, iterCall, {}
+      if isIteratorCall(c, beforeCall):
+        discard "fine"
+      elif iterCall.typ.typeKind == UntypedT or
+          # for iterators from concepts in generic context:
+          isIdentCall(c, beforeCall):
+        isMacroLike = true
+      else:
+        if c.dest[beforeCall].kind == ParLe and c.dest[beforeCall].tagId == ErrT:
+          # original nim gives `items` overload errors so preserve them
+          discard
+        else:
+          c.dest.shrink beforeCall
+          buildErr c, callInfo, "no implicit `" & name & "` iterator found for type " & typeToString(argType)
   withNewScope c:
     case substructureKind(it.n)
     of UnpackflatU:

--- a/tests/nimony/iter/timplicititems.nim
+++ b/tests/nimony/iter/timplicititems.nim
@@ -1,0 +1,21 @@
+import std/assertions
+
+iterator items(x: int): int =
+  for i in 0 ..< x:
+    yield i
+
+var count = 0
+for i in 5:
+  assert i == count
+  inc count
+assert count == 5
+
+type HasSelfItems = concept
+  iterator `items`(x: Self): Self
+
+proc foo[T: HasSelfItems](x: T): T =
+  for i in x:
+    result = i
+
+assert foo(5) == 4
+assert foo(7) == 6


### PR DESCRIPTION
Behaves as in [original Nim](https://github.com/nim-lang/Nim/blob/d4098e6ca031aba9825980f9a17d3b54a9990577/compiler/semstmts.nim#L1297-L1305): whether to use `items` or `pairs` is decided by the number of variables not wrapped in `()`, and the error for the overloads is kept. I expected the original compiler to restrict the overloads to `iterator` symbols but it doesn't.

The iterator call check (which has to be performed again here) now makes sure the produced expression is a call. The problem with checking for identifiers for concepts is it could be a proc call from a concept and not an iterator. Maybe we could fix this and make the check easier by producing a different tag like `IcallX` for iterator calls or wrapping the call in it, this might help with things like typechecking `toSeq` too.