### PR TITLE
process `when` in signature phase

### DIFF
--- a/tests/nimony/when/deps/mfoo.nim
+++ b/tests/nimony/when/deps/mfoo.nim
@@ -1,0 +1,2 @@
+type
+  Foo* = object

--- a/tests/nimony/when/twhenimport.nim
+++ b/tests/nimony/when/twhenimport.nim
@@ -1,0 +1,9 @@
+# issue #966
+
+when true:
+  import deps/mfoo
+
+var x: Foo
+
+type Baz = object
+  x: Foo


### PR DESCRIPTION
fixes #966, split from #931

`when` statements were restricted to the semchecking bodies compilation phase, now it is processed as early as the signature phase, so that types can use symbols imported/defined in `when` branches.

Toplevel syms phase still does not process `when` statements for now so symbols declared in them can't be used before they are declared. The reason is that the conditions might not compile in this phase, especially in the system module where stuff like `true` will not be defined yet, or constants in the same module in general. We can either develop the toplevel syms phase so that these will work or figure out how to decide when to delay the `when` statement depending on the condition expression.