### PR TITLE
include holey enums in `enum` typeclass, add `sumGeneric` disambiguation

### DIFF
--- a/lib/std/system/setops.nim
+++ b/lib/std/system/setops.nim
@@ -50,3 +50,12 @@ iterator items*[T: Ordinal](x: set[T]): T =
       if x.contains(i): yield i
       if i >= high(T): break
       inc(i)
+
+iterator items*[T: enum](x: set[T]): T =
+  # original system implementation, here so holey enums work
+  var i = low(T).int
+  if i <= high(T).int:
+    while true:
+      if x.contains(cast[T](i)): yield cast[T](i)
+      if i >= high(T).int: break
+      inc(i)

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -415,7 +415,7 @@
                (i -1) 14,95,tests/nimony/iter/tforloops1.nim +0))) 2 +1))))))))) ~2,~1
    (ret result.0))) 16,95
  (iterator :items.0.tfo161bfb1 . 0,41,lib/std/system/openarrays.nim .
-  (at items.1.sysvq0asl
+  (at items.2.sysvq0asl
    (i -1)) 18,41,lib/std/system/openarrays.nim
   (params 1
    (param :a.8 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .)) 19,41,lib/std/system/openarrays.nim


### PR DESCRIPTION
closes #952

The `enum` typeclass now matches holey enums, and so the `Ordinal` typeclass does not match the `enum` typeclass anymore. Because of this the mutual generic match disambiguation fails now between the `Ordinal` and `enum` overloads of `==` etc so the `sumGeneric` method of disambiguation in the original compiler is added which considers `enum` more specific than `Ordinal`.

Another `items` overload for sets of `enum` is added since the original one only matches `Ordinal`. This one converts the enum to `int` to iterate over as in the original system implementation. The `items` overload needs a constraint so that it can match the `low`/`high` overloads, `Ordinal | enum` does not work since constraints cannot match other `or` types right now (#931). Maybe we can remove the constraint on the magic overloads of `low`/`high` though.