### PR TITLE
split `enum` typeclass into ordinal and holey type kinds

### DIFF
--- a/lib/std/syncio.nim
+++ b/lib/std/syncio.nim
@@ -47,7 +47,10 @@ proc write*(f: File; x: int64) =
 proc write*(f: File; x: uint64) =
   fprintf(f, cstring"%llu", x)
 
-proc write*[T: enum](f: File; x: T) =
+# can be merged back into `T: enum` when `or` types can match themselves:
+proc write*[T: OrdinalEnum](f: File; x: T) =
+  write f, $x
+proc write*[T: HoleyEnum](f: File; x: T) =
   write f, $x
 
 proc write*(f: File; c: char) =

--- a/lib/std/system/basic_types.nim
+++ b/lib/std/system/basic_types.nim
@@ -34,6 +34,12 @@ type # we need to start a new type section here, so that ``0`` can have a type
   bool* {.magic: "Bool".} = enum ## Built-in boolean type.
     false = 0, true = 1
 
+# nimony only:
+type
+  OrdinalEnum* {.magic: "OrdinalEnum".}
+  HoleyEnum* {.magic: "HoleyEnum".}
+  `enum`* = OrdinalEnum | HoleyEnum
+
 type
   SomeSignedInt* = int|int8|int16|int32|int64
     ## Type class matching all signed integer types.

--- a/lib/std/system/comparisons.nim
+++ b/lib/std/system/comparisons.nim
@@ -3,8 +3,10 @@
 # not in original nim, so that it works for generic `Ordinal` types:
 proc `==`*[T: Ordinal](x, y: T): bool {.magic: "LeI", noSideEffect.}
 
-proc `==`*[Enum: enum](x, y: Enum): bool {.magic: "EqEnum", noSideEffect.}
+# `enum` typeclass split here to prevent ambiguity with `Ordinal`:
+proc `==`*[Enum: OrdinalEnum](x, y: Enum): bool {.magic: "EqEnum", noSideEffect.}
   ## Checks whether values within the *same enum* have the same underlying value.
+proc `==`*[Enum: HoleyEnum](x, y: Enum): bool {.magic: "EqEnum", noSideEffect.}
 
 proc `==`*(x, y: pointer): bool {.magic: "EqRef", noSideEffect.}
   ## Checks for equality between two `pointer` variables.
@@ -24,7 +26,9 @@ proc `==`*[T](x, y: ptr T): bool {.magic: "EqRef", noSideEffect.}
 # not in original nim, so that it works for generic `Ordinal` types:
 proc `<=`*[T: Ordinal](x, y: T): bool {.magic: "LeI", noSideEffect.}
 
-proc `<=`*[Enum: enum](x, y: Enum): bool {.magic: "LeEnum", noSideEffect.}
+# `enum` typeclass split here to prevent ambiguity with `Ordinal`:
+proc `<=`*[Enum: OrdinalEnum](x, y: Enum): bool {.magic: "LeEnum", noSideEffect.}
+proc `<=`*[Enum: HoleyEnum](x, y: Enum): bool {.magic: "LeEnum", noSideEffect.}
 
 proc `<=`*(x, y: char): bool {.magic: "LeCh", noSideEffect.}
   ## Compares two chars and returns true if `x` is lexicographically
@@ -43,7 +47,9 @@ proc `<=`*(x, y: pointer): bool {.magic: "LePtr", noSideEffect.}
 # not in original nim, so that it works for generic `Ordinal` types:
 proc `<`*[T: Ordinal](x, y: T): bool {.magic: "LtI", noSideEffect.}
 
-proc `<`*[Enum: enum](x, y: Enum): bool {.magic: "LtEnum", noSideEffect.}
+# `enum` typeclass split here to prevent ambiguity with `Ordinal`:
+proc `<`*[Enum: OrdinalEnum](x, y: Enum): bool {.magic: "LtEnum", noSideEffect.}
+proc `<`*[Enum: HoleyEnum](x, y: Enum): bool {.magic: "LtEnum", noSideEffect.}
 
 proc `<`*(x, y: char): bool {.magic: "LtCh", noSideEffect.}
   ## Compares two chars and returns true if `x` is lexicographically

--- a/lib/std/system/defaults.nim
+++ b/lib/std/system/defaults.nim
@@ -16,6 +16,7 @@ template default*(x: typedesc[uint64]): uint64 = 0'u64
 template default*(x: typedesc[float32]): float32 = 0.0'f32
 template default*(x: typedesc[float64]): float64 = 0.0'f64
 template default*(x: typedesc[string]): string = ""
+# can be merged back into `T: enum` when `or` types can match themselves:
 template default*[T: OrdinalEnum](x: typedesc[T]): T = low(T)
 template default*[T: HoleyEnum](x: typedesc[T]): T = low(T)
 

--- a/lib/std/system/defaults.nim
+++ b/lib/std/system/defaults.nim
@@ -16,7 +16,8 @@ template default*(x: typedesc[uint64]): uint64 = 0'u64
 template default*(x: typedesc[float32]): float32 = 0.0'f32
 template default*(x: typedesc[float64]): float64 = 0.0'f64
 template default*(x: typedesc[string]): string = ""
-template default*[T: enum](x: typedesc[T]): T = low(T)
+template default*[T: OrdinalEnum](x: typedesc[T]): T = low(T)
+template default*[T: HoleyEnum](x: typedesc[T]): T = low(T)
 
 template default*[T: ptr](x: typedesc[T]): T = T(nil)
 template default*[T: ref](x: typedesc[T]): T = T(nil)

--- a/src/lib/nifbuilder.nim
+++ b/src/lib/nifbuilder.nim
@@ -303,15 +303,16 @@ proc addHeader*(b: var Builder; vendor = "", dialect = "") =
     b.addStrLit dialect
     b.put ")\n"
 
-proc addFlags*[T: enum](b: var Builder; kind: string; flags: set[T]) =
-  ## Little helper for converting a set of enum to NIF. If `flags` is
-  ## the empty set, nothing is emitted.
-  if flags == {}:
-    discard "omit empty flags in order to save space"
-  else:
-    withTree b, kind:
-      for x in items(flags):
-        b.addIdent $x
+when not defined(nimony): # needs `or` types to match themselves
+  proc addFlags*[T: enum](b: var Builder; kind: string; flags: set[T]) =
+    ## Little helper for converting a set of enum to NIF. If `flags` is
+    ## the empty set, nothing is emitted.
+    if flags == {}:
+      discard "omit empty flags in order to save space"
+    else:
+      withTree b, kind:
+        for x in items(flags):
+          b.addIdent $x
 
 when isMainModule:
   proc test(b: sink Builder) =

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -397,56 +397,59 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
     #   EnumType
     #   (Integer value, "string value")
     relLineInfo(n, parent, c)
-    c.b.addTree(EnumL)
-    if n.len > 0:
+    if n.len == 0:
+      # typeclass, compiles to identifier for nimony
+      c.b.addIdent "enum"
+    else:
+      c.b.addTree(EnumL)
       assert n[0].kind == nkEmpty
       c.b.addEmpty # base type
-    for i in 1..<n.len:
-      let it = n[i]
+      for i in 1..<n.len:
+        let it = n[i]
 
-      var name: PNode
-      var val: PNode
-      var pragma: PNode
+        var name: PNode
+        var val: PNode
+        var pragma: PNode
 
-      if it.kind == nkEnumFieldDef:
-        let first = it[0]
-        if first.kind == nkPragmaExpr:
-          name = first[0]
-          pragma = first[1]
-        else:
+        if it.kind == nkEnumFieldDef:
+          let first = it[0]
+          if first.kind == nkPragmaExpr:
+            name = first[0]
+            pragma = first[1]
+          else:
+            name = it[0]
+            pragma = nil
+          val = it[1]
+        elif it.kind == nkPragmaExpr:
           name = it[0]
+          pragma = it[1]
+          val = nil
+        else:
+          name = it
           pragma = nil
-        val = it[1]
-      elif it.kind == nkPragmaExpr:
-        name = it[0]
-        pragma = it[1]
-        val = nil
-      else:
-        name = it
-        pragma = nil
-        val = nil
+          val = nil
 
-      relLineInfo(it, n, c)
+        relLineInfo(it, n, c)
 
-      c.b.addTree(EfldL)
+        c.b.addTree(EfldL)
 
-      toNif name, it, c
-      c.b.addEmpty # export marker
+        toNif name, it, c
+        c.b.addEmpty # export marker
 
-      if pragma == nil:
-        c.b.addEmpty
-      else:
-        toNif(pragma, it, c)
+        if pragma == nil:
+          c.b.addEmpty
+        else:
+          toNif(pragma, it, c)
 
-      c.b.addEmpty # type (filled by sema)
+        c.b.addEmpty # type (filled by sema)
 
-      if val == nil:
-        c.b.addEmpty
-      else:
-        toNif(val, it, c)
+        if val == nil:
+          c.b.addEmpty
+        else:
+          toNif(val, it, c)
+        c.b.endTree()
+
       c.b.endTree()
-
-    c.b.endTree()
 
   of nkProcDef, nkFuncDef, nkConverterDef, nkMacroDef, nkTemplateDef, nkIteratorDef, nkMethodDef:
     relLineInfo(n, parent, c)

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -118,4 +118,6 @@ proc magicToTag*(m: string): (string, int) =
   of "ProcCall": res ProccallX
   of "InternalTypeName": res InternalTypeNameX
   of "InternalFieldPairs": res InternalFieldPairsX, TypedMagic
+  of "OrdinalEnum": res EnumT
+  of "HoleyEnum": res HoleyEnumT
   else: ("", 0)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2416,7 +2416,7 @@ proc semTypeSym(c: var SemContext; s: Sym; info: PackedLineInfo; start: int; con
         let magic = cursorAt(c.dest, start).typeKind
         endRead(c.dest)
         # magic types that are just symbols and not in the syntax:
-        if magic in {ArrayT, SetT, RangetypeT}:
+        if magic in {ArrayT, SetT, RangetypeT, EnumT, HoleyEnumT}:
           var typeclassBuf = createTokenBuf(4)
           typeclassBuf.addParLe(TypeKindT, info)
           typeclassBuf.addParLe(magic, info)

--- a/tests/nimony/enums/tostring.nim
+++ b/tests/nimony/enums/tostring.nim
@@ -8,7 +8,8 @@ type
 let x = $Value1
 echo x
 
-proc generic[T: enum](a: T): string =
+# can be changed back into `T: enum` when `or` types can match themselves:
+proc generic[T: OrdinalEnum](a: T): string =
   result = $a
 
 echo generic(Value2)

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -75,7 +75,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 2,103,lib/std/system.nim
+    (elif 2,109,lib/std/system.nim
      (expr 2,1
       (lt
        (i +64) 9,28,tests/nimony/iter/tforloops1.nim +5 5,28,tests/nimony/iter/tforloops1.nim x.1)) ~1,1
@@ -235,12 +235,12 @@
       (elif 2
        (eq
         (i +64) ~2 j.3 3 +2) ~1,1
-       (stmts 2,116,lib/std/syncio.nim
+       (stmts 2,119,lib/std/syncio.nim
         (stmts 2,1
          (stmts
           (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,81,tests/nimony/iter/tforloops1.nim "left the loop!")) ,2
-         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
-        (break .)))) 2,116,lib/std/syncio.nim
+         (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (break .)))) 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/iter/tforloops1.nim "A i ")) 2,1
@@ -250,7 +250,7 @@
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 20,83,tests/nimony/iter/tforloops1.nim " j ")) 2,1
       (stmts
        (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim j.3)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,84
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,84
  (block . 2,1
   (stmts 4
    (for 7
@@ -279,11 +279,11 @@
         (stmts 4
          (asgn ~4 sum.0 6
           (add
-           (i +64) ~4 sum.0 2 a.5)))) 2,116,lib/std/syncio.nim
+           (i +64) ~4 sum.0 2 a.5)))) 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim sum.0)) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))))) ,93
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))))) ,93
  (block . 2,1
   (stmts 4
    (let :i_arr.0 . . 8
@@ -304,12 +304,12 @@
      (let :i.10 . . 19,41,lib/std/system/openarrays.nim
       (mut
        (i -1)) .)) ~2,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,97,tests/nimony/iter/tforloops1.nim
         (hderef i.10))) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) 4,22
  (proc :inc.0.tfo161bfb1 . 0,12,lib/std/system.nim .
   (at inc.1.sysvq0asl 19,~4
    (i -1)) 21,12,lib/std/system.nim
@@ -459,7 +459,7 @@
   (pragmas 2
    (inline) 10
    (requires 19
-    (and 2,102,lib/std/system/comparisons.nim
+    (and 2,108,lib/std/system/comparisons.nim
      (expr 2,1
       (le
        (i +64) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.1)) 8

--- a/tests/nimony/sets/tsets.nif
+++ b/tests/nimony/sets/tsets.nif
@@ -64,13 +64,13 @@
     (not 10,9,tests/nimony/sets/tsets.nim
      (ltset
       (set Foo.0.tseflljd71) ~3 s1.0.tseflljd71 2 s.0.tseflljd71)) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 4,9
  (glet :y.0.tseflljd71 . . 10,~4
   (set 1 Foo.0.tseflljd71) 7
@@ -87,13 +87,13 @@
       (setconstr 2,~6
        (set 1 Foo.0.tseflljd71) 1
        (range A.0.tseflljd71 3 C.0.tseflljd71)))) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -104,13 +104,13 @@
       (setconstr 2,~7
        (set 1 Foo.0.tseflljd71) 1
        (range A.0.tseflljd71 3 C.0.tseflljd71)))) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -122,13 +122,13 @@
        (set Foo.0.tseflljd71) ~2 s.0.tseflljd71 2 s1.0.tseflljd71) 3
       (setconstr ~3,~8
        (set 1 Foo.0.tseflljd71) 1 D.0.tseflljd71))) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -136,13 +136,13 @@
     (not 10,15,tests/nimony/sets/tsets.nim
      (leset
       (set Foo.0.tseflljd71) ~3 s1.0.tseflljd71 3 s.0.tseflljd71)) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -152,13 +152,13 @@
       (i +64) ~4
       (card
        (set Foo.0.tseflljd71) 1 s.0.tseflljd71) 3 +4)) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -168,13 +168,13 @@
       (i +64) ~5
       (card
        (set Foo.0.tseflljd71) 1 s1.0.tseflljd71) 3 +3)) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) 4,17
  (glet :val.0.tseflljd71 . . 7,~14 Foo.0.tseflljd71 6 D.0.tseflljd71) 3,18
  (asgn ~3 s1.0.tseflljd71 2
@@ -189,13 +189,13 @@
       (i +64) ~5
       (card
        (set Foo.0.tseflljd71) 1 s1.0.tseflljd71) 3 +4)) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))) ,21
  (template 9 :resem.0.tseflljd71 . . . 14
   (params) . . . 2,1
@@ -235,13 +235,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +0)) ~1,1
-      (stmts 2,116,lib/std/syncio.nim
+      (stmts 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 4,3
    (asgn ~4 sss.0 2
     (setconstr 6,~3
@@ -257,13 +257,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +27)) ~1,1
-      (stmts 2,116,lib/std/syncio.nim
+      (stmts 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,5
    (excl
     (set
@@ -277,13 +277,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +26)) ~1,1
-      (stmts 2,116,lib/std/syncio.nim
+      (stmts 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,7
    (incl
     (set
@@ -297,13 +297,13 @@
         (card
          (set
           (c +8)) 1 sss.0) 3 +26)) ~1,1
-      (stmts 2,116,lib/std/syncio.nim
+      (stmts 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))))) ,37
  (block . 2,1
   (stmts

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -225,55 +225,55 @@
  (proc 5 :classify1.0.tbawx6nu81 . . . 14
   (params 1
    (param :s.0 . . 3 string.0.sysvq0asl .)) . . . 2,1
-  (stmts 2,116,lib/std/syncio.nim
+  (stmts 2,119,lib/std/syncio.nim
    (stmts 2,1
     (stmts
      (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 7,77,tests/nimony/sysbasics/tbasics.nim s.0)) ,2
-    (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,78
+    (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,78
  (call ~9 classify1.0.tbawx6nu81 1 "9123345") ,81
  (block . 2,1
   (stmts
    (proc 5 :classify.0 . . . 13
     (params 1
      (param :s.4 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,84,tests/nimony/sysbasics/tbasics.nim s.4)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.0 1 "9123345") ,4
    (block . 2,1
     (stmts
      (proc 5 :classify2.0 . . . 14
       (params 1
        (param :s.5 . . 3 string.0.sysvq0asl .)) . . . 2,1
-      (stmts 2,116,lib/std/syncio.nim
+      (stmts 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,89,tests/nimony/sysbasics/tbasics.nim s.5)) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
      (call ~9 classify2.0 1 "9123345"))))) ,92
  (block . 2,1
   (stmts
    (proc 5 :classify2.1 . . . 14
     (params 1
      (param :s.6 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,95,tests/nimony/sysbasics/tbasics.nim s.6)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
    (call ~9 classify2.1 1 "9123345"))) ,98
  (block . 2,1
   (stmts
    (proc 5 :classify.1 . . . 13
     (params 1
      (param :s.7 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,101,tests/nimony/sysbasics/tbasics.nim s.7)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.1 1 "9123345"))) ,104
  (block . 2,1
   (stmts
@@ -282,11 +282,11 @@
      (proc 5 :classify.2 . . . 13
       (params 1
        (param :s.8 . . 3 string.0.sysvq0asl .)) . . . 2,1
-      (stmts 2,116,lib/std/syncio.nim
+      (stmts 2,119,lib/std/syncio.nim
        (stmts 2,1
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,108,tests/nimony/sysbasics/tbasics.nim s.8)) ,2
-        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+        (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
      (call ~8 classify.2 1 "9123345"))))) ,111
  (proc 5 :foo2.1.tbawx6nu81 . . . 9
   (params) . . . 2,1
@@ -294,11 +294,11 @@
    (proc 5 :classify.3 . . . 13
     (params 1
      (param :s.9 . . 3 string.0.sysvq0asl .)) . . . 2,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,114,tests/nimony/sysbasics/tbasics.nim s.9)) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.3 1 "9123345"))) 4,117
  (call ~4 foo2.1.tbawx6nu81) ,119
  (proc 5 :bar.0.tbawx6nu81 . . . 8
@@ -314,13 +314,13 @@
   (if 3
    (elif
     (not 13,123,tests/nimony/sysbasics/tbasics.nim
-     (infix ==.19.sysvq0asl ~3
+     (infix ==.20.sysvq0asl ~3
       (call ~3 bar.0.tbawx6nu81) 3 "1212334")) ~1,1
-    (stmts 2,116,lib/std/syncio.nim
+    (stmts 2,119,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
-      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+      (cmd write.6.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (cmd quit.0.syn1lfpjv 5 +1))))))

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -59,7 +59,7 @@
             (i -1))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.0))))) ,2
       (if 3
-       (elif 2,98,lib/std/system/comparisons.nim
+       (elif 2,104,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -112,7 +112,7 @@
             (f +64))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.1))))) ,2
       (if 3
-       (elif 2,98,lib/std/system/comparisons.nim
+       (elif 2,104,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -174,7 +174,7 @@
             (u +8))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.2))))) ,2
       (if 3
-       (elif 2,98,lib/std/system/comparisons.nim
+       (elif 2,104,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -321,7 +321,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.0)))) ,4
    (if 3
-    (elif 2,98,lib/std/system/comparisons.nim
+    (elif 2,104,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -523,7 +523,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.4)))) ,4
    (if 3
-    (elif 2,98,lib/std/system/comparisons.nim
+    (elif 2,104,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -725,7 +725,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.8)))) ,4
    (if 3
-    (elif 2,98,lib/std/system/comparisons.nim
+    (elif 2,104,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -938,7 +938,7 @@
     (i -1) .) 7
    (asgn ~7 result.9 2
     (if 3
-     (elif 2,98,lib/std/system/comparisons.nim
+     (elif 2,104,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq
@@ -970,7 +970,7 @@
     (i -1) .) 7
    (asgn ~7 result.10 2
     (if 3
-     (elif 2,98,lib/std/system/comparisons.nim
+     (elif 2,104,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq
@@ -1002,7 +1002,7 @@
     (i -1) .) 7
    (asgn ~7 result.11 2
     (if 3
-     (elif 2,98,lib/std/system/comparisons.nim
+     (elif 2,104,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq

--- a/tests/nimony/sysbasics/tintlitmatch.nif
+++ b/tests/nimony/sysbasics/tintlitmatch.nif
@@ -38,19 +38,19 @@
  (discard 10
   (eq
    (i +64) ~2
-   (hconv 17,58,lib/std/system.nim
+   (hconv 17,64,lib/std/system.nim
     (i +64) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
  (discard 10
   (eq
    (i +64) ~2 y.0.tin4pj0od1 6
-   (hconv 17,58,lib/std/system.nim
+   (hconv 17,64,lib/std/system.nim
     (i +64)
     (conv 1
      (i +32) ~3 +123)))) ,15
  (discard 18
   (eq
    (i +64) ~7
-   (hconv 17,58,lib/std/system.nim
+   (hconv 17,64,lib/std/system.nim
     (i +64)
     (conv 6,~1
      (i +32) ~3 +123)) 3 y.0.tin4pj0od1)) ,16
@@ -73,17 +73,17 @@
    (i +32) ~7
    (conv 6,~6
     (i +32) ~3 +123) 3
-   (hconv 17,57,lib/std/system.nim
+   (hconv 17,63,lib/std/system.nim
     (i +32) +123))) ,21
  (discard 12
   (eq
    (i +32) ~4
-   (hconv 17,57,lib/std/system.nim
+   (hconv 17,63,lib/std/system.nim
     (i +32) +123) 6
    (conv ~1,~7
     (i +32) ~3 +123))) ,22
  (discard 10
   (eq
    (i +32) ~2 x.0.tin4pj0od1 3
-   (hconv 17,57,lib/std/system.nim
+   (hconv 17,63,lib/std/system.nim
     (i +32) +123))))


### PR DESCRIPTION
refs #968, closes #952

`enum` is split into 2 typeclasses: `OrdinalEnum` and `HoleyEnum`, which compile to `(typekind (enum))` and `(typekind (holeyenum))`. For simplicity, what previously parsed as the `enum` typeclass now parses as an identifier `enum` which is defined in system as `OrdinalEnum | HoleyEnum`.

However since `or` types cannot match themselves yet (#931), some overloads for `enum` have to be temporarily split into overloads for `OrdinalEnum` and `HoleyEnum`. The overloads for `==`, `<` etc though are split so that generic disambiguation works since they are also defined for `Ordinal`: `Ordinal` can be disambiguated with `OrdinalEnum` since `OrdinalEnum` matches `Ordinal` but not vice versa, however it cannot be disambiguated with `enum` in general since neither typeclass matches one another. The other overloads should be able to be merged when #931 or something similar is implemented, though I have not tested this yet.