### PR TITLE
adds default for pointer type

### DIFF
--- a/lib/std/system/defaults.nim
+++ b/lib/std/system/defaults.nim
@@ -20,6 +20,7 @@ template default*[T: enum](x: typedesc[T]): T = low(T)
 
 template default*[T: ptr](x: typedesc[T]): T = T(nil)
 template default*[T: ref](x: typedesc[T]): T = T(nil)
+template default*(x: typedesc[pointer]): pointer = nil
 
 proc default*[T: object](x: typedesc[T]): T {.magic: DefaultObj.}
 proc default*[T: tuple](x: typedesc[T]): T {.magic: DefaultTup.}

--- a/tests/nimony/sysbasics/tdefault.nim
+++ b/tests/nimony/sysbasics/tdefault.nim
@@ -75,3 +75,14 @@ block:
   assert objs[0].y == 0
   assert objs[1].x == 0
   assert objs[1].y == 0
+
+block:
+  var p = default(pointer)
+  assert p == nil
+
+  type
+    Foo = object
+      p: pointer
+
+  var foo = default(Foo)
+  assert foo.p == nil


### PR DESCRIPTION
`MemFile` object type in memfiles module has a `pointer` type field.
So `result = default(MemFile)` requires default for pointer.