### PR TITLE
hexer: fixes explicit hooks; skipping `haddr`

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -439,7 +439,12 @@ proc trExplicitCopy(c: var Context; n: var Cursor; op: AttachedOp) =
   else:
     c.dest.addParLe AsgnS, info
     inc n
-    tr c, n, DontCare
+    if n.exprKind == HaddrX:
+      inc n
+      tr c, n, DontCare
+      skipParRi(n)
+    else:
+      tr c, n, DontCare
     tr c, n, DontCare
     takeParRi c.dest, n
 

--- a/tests/nimony/arc/texplicit_hooks.nim
+++ b/tests/nimony/arc/texplicit_hooks.nim
@@ -1,0 +1,16 @@
+import std/assertions
+
+proc f(s: string): string = s
+
+proc main =
+  var a = "abc"
+  var b = "de"
+  `=copy`(a, b)
+  a = `=dup`(b)
+  assert a == b
+  var c = f "edg"
+  `=sink`(c, a)
+  assert a == "de"
+  `=wasMoved`(a)
+
+main()


### PR DESCRIPTION
Explicit `=sink` and `=copy` are transformed to an asgn if they don't exist for a type. `derefs` will insert a haddr for the parameter of these functions, which take a `var T` parameter. We need to skip it because it is not needed for asgn