### PR TITLE
hexer: stringcases support `cstring` selectors

### DIFF
--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -93,7 +93,7 @@ proc borrowCStringUnsafe*(s: cstring; len: int): string =
   ## use `fromCString` instead.
   string(a: cast[StrData](s), i: (len shl LenShift))
 
-proc borrowCStringUnsafe*(s: cstring): string =
+proc borrowCStringUnsafe*(s: cstring): string {.exportc: "nimBorrowCStringUnsafe".} =
   ## Creates a Nim string from a `cstring` by borrowing the
   ## underlying storage. You have to ensure the `cstring` lives
   ## long enough for this to be safe! If in doubt,

--- a/src/hexer/stringcases.nim
+++ b/src/hexer/stringcases.nim
@@ -72,8 +72,6 @@ proc getSimpleStringLit(c: var EContext; n: var Cursor): StrId =
 proc transformStringCase*(c: var EContext; n: var Cursor) =
   c.demand pool.syms.getOrIncl("equalStrings.0." & SystemModuleSuffix)
   c.demand pool.syms.getOrIncl("nimStrAtLe.0." & SystemModuleSuffix)
-  # the other overload of `borrowCStringUnsafe`
-  c.demand pool.syms.getOrIncl("borrowCStringUnsafe.1." & SystemModuleSuffix)
 
   # Prepare the list of (key, value) pairs:
   var pairs: seq[Key] = @[]
@@ -85,6 +83,8 @@ proc transformStringCase*(c: var EContext; n: var Cursor) =
 
   let selectorType = getType(c.typeCache, selectorNode)
   if selectorType.typeKind == CstringT:
+    # the other overload of `borrowCStringUnsafe`
+    c.demand pool.syms.getOrIncl("borrowCStringUnsafe.1." & SystemModuleSuffix)
     selector = pool.syms.getOrIncl(":tmp.c." & $c.getTmpId)
     c.dest.copyIntoUnchecked "var", sinfo:
       c.dest.add symdefToken(selector, sinfo)

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -245,10 +245,10 @@ proc eval*(c: var EvalContext; n: var Cursor): Cursor =
       var local = asLocal(sym.decl)
       case local.kind
       of ConstY:
-        return local.val
+        return eval(c, local.val)
       of EfldY:
         inc local.val # takes the first counter field
-        return local.val
+        return eval(c, local.val)
       else: discard
     error "cannot evaluate symbol at compile time: " & pool.syms[symId], info
   of StringLit, CharLit, IntLit, UIntLit, FloatLit:

--- a/tests/nimony/casestmt/tsimple_string_case.nim
+++ b/tests/nimony/casestmt/tsimple_string_case.nim
@@ -155,3 +155,47 @@ assert not isCppKeyword("quux")
 assert not isCppKeyword("corge")
 assert not isCppKeyword("grault")
 assert not isCppKeyword("")
+
+block:
+  type Result = enum none, a, b, c, d, e, f
+
+  block:
+    proc foo1(x: cstring): Result =
+      const y = cstring"hash"
+      result = none
+      case x
+      of "Andreas", "Rumpf": result = a
+      of cstring"aa", "bb": result = b
+      of "cc", y, "when": result = c
+      of "will", "be", "generated": result = d
+      of "": result = f
+
+    var s = "Andreas"
+    assert foo1(s.cstring) == a
+
+  block:
+    proc foo1(): Result =
+      const y = cstring"hash"
+      result = none
+      case "Andreas".cstring
+      of "Andreas", "Rumpf": result = a
+      of cstring"aa", "bb": result = b
+      of "cc", y, "when": result = c
+      of "will", "be", "generated": result = d
+      of "": result = f
+
+    assert foo1() == a
+
+  block:
+    proc foo1(): Result =
+      const y = cstring"hash"
+      var x = "Andreas"
+      result = none
+      case x.cstring
+      of "Andreas", "Rumpf": result = a
+      of cstring"aa", "bb": result = b
+      of "cc", y, "when": result = c
+      of "will", "be", "generated": result = d
+      of "": result = f
+
+    assert foo1() == a


### PR DESCRIPTION
changes:

- `eval` now recursively solve the value of constants so that we don't miss suf/convs in the value of constants
- stringcases uses `nimStrAtLe` which requires a string parameter, so we need to use `borrowCStringUnsafe` from the selector
