### PR TITLE
proper fix for identifier pragmas, error instead of crash for too many arguments

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2321,6 +2321,10 @@ proc semPragma(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kin
       buildErr c, n.info, "`semantics` pragma takes a string literal"
     c.dest.addParRi()
   if hasParRi:
+    if n.kind != ParRi:
+      if n.exprKind != ErrX:
+        buildErr c, n.info, "too many arguments for pragma"
+      while n.kind != ParRi: skip n
     skipParRi n
 
 proc semPragmas(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kind: SymKind) =

--- a/tests/nimony/errmsgs/tinvalidpragma.msgs
+++ b/tests/nimony/errmsgs/tinvalidpragma.msgs
@@ -1,0 +1,2 @@
+tests/nimony/errmsgs/tinvalidpragma.nim(1, 17) Error: too many arguments for pragma
+tests/nimony/errmsgs/tinvalidpragma.nim(2, 17) Error: expected pragma

--- a/tests/nimony/errmsgs/tinvalidpragma.nim
+++ b/tests/nimony/errmsgs/tinvalidpragma.nim
@@ -1,0 +1,2 @@
+var x {.noinit: "abc".} = 123
+var y {.noinit, "abc".} = 456


### PR DESCRIPTION
follows up #988

Only process arguments if `hasParRi` is true, otherwise it is a standalone identifier and the next token would be the next pragma

Also if there are too many elements, `skipParRi` would crash the compiler, now it produces an error