### PR TITLE
fixes enumToStr gen for local enum types

### DIFF
--- a/src/nimony/enumtostr.nim
+++ b/src/nimony/enumtostr.nim
@@ -63,7 +63,8 @@ proc genEnumToStrProc*(c: var SemContext; typeDecl: var Cursor) =
   c.dest.add tagToken("proc", enumSymInfo)
   c.dest.add symdefToken(dollorSymId, enumSymInfo)
 
-  # Todo: defaults to (nodecl)
+  # TODO: defaults to (nodecl)
+  # TODO: static for local functions
   let exportIdent = pool.strings.getOrIncl("x")
   c.dest.add identToken(exportIdent, enumSymInfo)
   c.dest.addDotToken()

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -109,6 +109,7 @@ type
     toBuild*: TokenBuf
     unoverloadableMagics*: HashSet[StrId]
     debugAllowErrors*: bool
+    pending*: TokenBuf
 
 proc typeToCanon*(buf: TokenBuf; start: int): string =
   result = ""

--- a/tests/nimony/casestmt/tsimple_string_case.nim
+++ b/tests/nimony/casestmt/tsimple_string_case.nim
@@ -199,3 +199,33 @@ block:
       of "": result = f
 
     assert foo1() == a
+
+block:
+  proc foo(x: int): string =
+    case x
+    of 1: result = "digit"
+    else: result = "number"
+
+
+  var r = foo(10)
+  assert r == "number"
+
+block:
+  type
+    E = enum A, B, C
+
+  let s = A
+  echo s
+
+block:
+  type
+    E = enum A, B, C
+
+  let s = A
+  echo s
+
+type
+  E = enum A, B, C
+
+let s = A
+echo s

--- a/tests/nimony/casestmt/tsimple_string_case.output
+++ b/tests/nimony/casestmt/tsimple_string_case.output
@@ -4,3 +4,6 @@ bar
 bar
 other
 unknown
+A
+A
+A

--- a/tests/nimony/nosystem/tbool.nif
+++ b/tests/nimony/nosystem/tbool.nif
@@ -13,7 +13,10 @@
    (efld ~7 :true.0.tbokvwxm9
     (true) .
     (bool)
-    (tup +1 "true")))) 5
+    (tup +1 "true")))) 4,3
+ (glet :x.0.tbokvwxm9 . . 3
+  (bool) 10
+  (true)) 5
  (proc :dollar`.bool.0.tbokvwxm9 x . .
   (params
    (param :e.0 . .
@@ -31,7 +34,4 @@
       (true))
      (stmts
       (ret "true"))))
-   (ret result.0))) 4,3
- (glet :x.0.tbokvwxm9 . . 1,~3
-  (bool) 10
-  (true)))
+   (ret result.0))))

--- a/tests/nimony/nosystem/tenumsizes.nif
+++ b/tests/nimony/nosystem/tenumsizes.nif
@@ -10,7 +10,29 @@
    (efld :a2.0.tene657oj . . A.0.tene657oj
     (tup +2 "a2")) 5,1
    (efld :a3.0.tene657oj . . A.0.tene657oj
-    (tup +3 "a3")))) 5
+    (tup +3 "a3")))) 7,2
+ (type ~2 :B.0.tene657oj . . . 2
+  (onum
+   (i +32) ~2,1
+   (efld ~5 :b0.0.tene657oj . . B.0.tene657oj
+    (tup -1 "b0")) 2,1
+   (efld :b1.0.tene657oj . . B.0.tene657oj
+    (tup +0 "b1")) 6,1
+   (efld :b2.0.tene657oj . . B.0.tene657oj
+    (tup +1 "b2")) 15,1
+   (efld ~5 :b3.0.tene657oj . . B.0.tene657oj
+    (tup +5 "b3")))) 7,4
+ (type ~2 :C.0.tene657oj . . . 2
+  (onum
+   (u +16) ~7,1
+   (efld :c0.0.tene657oj . . C.0.tene657oj
+    (tup +0 "c0")) ~3,1
+   (efld :c1.0.tene657oj . . C.0.tene657oj
+    (tup +1 "c1")) 6,1
+   (efld ~5 :c2.0.tene657oj . . C.0.tene657oj
+    (tup +30000 "c2")) 14,1
+   (efld :c3.0.tene657oj . . C.0.tene657oj
+    (tup +30001 "c3")))) 5
  (proc :dollar`.A.0.tene657oj x . .
   (params
    (param :e.0 . . A.0.tene657oj .)) string.0.sysvq0asl . .
@@ -33,18 +55,7 @@
      (ranges a3.0.tene657oj)
      (stmts
       (ret "a3"))))
-   (ret result.0))) 7,2
- (type ~2 :B.0.tene657oj . . . 2
-  (onum
-   (i +32) ~2,1
-   (efld ~5 :b0.0.tene657oj . . B.0.tene657oj
-    (tup -1 "b0")) 2,1
-   (efld :b1.0.tene657oj . . B.0.tene657oj
-    (tup +0 "b1")) 6,1
-   (efld :b2.0.tene657oj . . B.0.tene657oj
-    (tup +1 "b2")) 15,1
-   (efld ~5 :b3.0.tene657oj . . B.0.tene657oj
-    (tup +5 "b3")))) 5,2
+   (ret result.0))) 5,2
  (proc :dollar`.B.0.tene657oj x . .
   (params
    (param :e.1 . . B.0.tene657oj .)) string.0.sysvq0asl . .
@@ -67,18 +78,7 @@
      (ranges ~5 b3.0.tene657oj)
      (stmts
       (ret "b3"))))
-   (ret result.1))) 7,4
- (type ~2 :C.0.tene657oj . . . 2
-  (onum
-   (u +16) ~7,1
-   (efld :c0.0.tene657oj . . C.0.tene657oj
-    (tup +0 "c0")) ~3,1
-   (efld :c1.0.tene657oj . . C.0.tene657oj
-    (tup +1 "c1")) 6,1
-   (efld ~5 :c2.0.tene657oj . . C.0.tene657oj
-    (tup +30000 "c2")) 14,1
-   (efld :c3.0.tene657oj . . C.0.tene657oj
-    (tup +30001 "c3")))) 5,4
+   (ret result.1))) 5,4
  (proc :dollar`.C.0.tene657oj x . .
   (params
    (param :e.2 . . C.0.tene657oj .)) string.0.sysvq0asl . .

--- a/tests/nimony/sets/tsets.nif
+++ b/tests/nimony/sets/tsets.nif
@@ -14,38 +14,7 @@
    (efld :E.0.tseflljd71 . . Foo.0.tseflljd71
     (tup +4 "E")) 6,1
    (efld :F.0.tseflljd71 . . Foo.0.tseflljd71
-    (tup +5 "F")))) 5,2
- (proc :dollar`.Foo.0.tseflljd71 x . .
-  (params
-   (param :e.0 . . Foo.0.tseflljd71 .)) string.0.sysvq0asl . .
-  (stmts 6
-   (result :result.0 . . string.0.sysvq0asl .) 6
-   (case e.0 ~9,1
-    (of
-     (ranges A.0.tseflljd71)
-     (stmts
-      (ret "A"))) ~6,1
-    (of
-     (ranges B.0.tseflljd71)
-     (stmts
-      (ret "B"))) ~3,1
-    (of
-     (ranges C.0.tseflljd71)
-     (stmts
-      (ret "C"))) ,1
-    (of
-     (ranges D.0.tseflljd71)
-     (stmts
-      (ret "D"))) 3,1
-    (of
-     (ranges E.0.tseflljd71)
-     (stmts
-      (ret "E"))) 6,1
-    (of
-     (ranges F.0.tseflljd71)
-     (stmts
-      (ret "F"))))
-   (ret result.0))) 4,5
+    (tup +5 "F")))) 4,5
  (gvar :s.0.tseflljd71 . . 10
   (set 1 Foo.0.tseflljd71) .) 7,5
  (gvar :s1.0.tseflljd71 . . 7
@@ -313,4 +282,35 @@
      (discard 8
       (setconstr 2,~12
        (set 1
-        (c +8)) 1 'a')))))))
+        (c +8)) 1 'a')))))) 5,2
+ (proc :dollar`.Foo.0.tseflljd71 x . .
+  (params
+   (param :e.0 . . Foo.0.tseflljd71 .)) string.0.sysvq0asl . .
+  (stmts 6
+   (result :result.0 . . string.0.sysvq0asl .) 6
+   (case e.0 ~9,1
+    (of
+     (ranges A.0.tseflljd71)
+     (stmts
+      (ret "A"))) ~6,1
+    (of
+     (ranges B.0.tseflljd71)
+     (stmts
+      (ret "B"))) ~3,1
+    (of
+     (ranges C.0.tseflljd71)
+     (stmts
+      (ret "C"))) ,1
+    (of
+     (ranges D.0.tseflljd71)
+     (stmts
+      (ret "D"))) 3,1
+    (of
+     (ranges E.0.tseflljd71)
+     (stmts
+      (ret "E"))) 6,1
+    (of
+     (ranges F.0.tseflljd71)
+     (stmts
+      (ret "F"))))
+   (ret result.0))))

--- a/tests/nimony/sysbasics/tdollar.nif
+++ b/tests/nimony/sysbasics/tdollar.nif
@@ -8,7 +8,12 @@
    (efld :Blue1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v
     (tup +1 "Blue1")) 6,1
    (efld :Green1.0.tdoqc0e0v . . Color1.0.tdoqc0e0v
-    (tup +2 "Green1")))) 2,1
+    (tup +2 "Green1")))) ,5
+ (proc 5 :fooColor.0.tdoqc0e0v . . . 14
+  (params) . . . 2,1
+  (stmts 4
+   (let :m.0 . . string.0.sysvq0asl 4
+    (call dollar`.Color1.0.tdoqc0e0v 1 Blue1.0.tdoqc0e0v)))) 2,1
  (proc :dollar`.Color1.0.tdoqc0e0v x . .
   (params
    (param :e.0 . . Color1.0.tdoqc0e0v .)) string.0.sysvq0asl . .
@@ -27,9 +32,4 @@
      (ranges Green1.0.tdoqc0e0v)
      (stmts
       (ret "Green1"))))
-   (ret result.0))) ,5
- (proc 5 :fooColor.0.tdoqc0e0v . . . 14
-  (params) . . . 2,1
-  (stmts 4
-   (let :m.0 . . string.0.sysvq0asl 4
-    (call dollar`.Color1.0.tdoqc0e0v 1 Blue1.0.tdoqc0e0v)))))
+   (ret result.0))))


### PR DESCRIPTION
We need to lift the `enumToStr` to the top level so that `$` can call them for local enum types (because `$` is a generic that is appended to the top level)