### PR TITLE
implement basic `when` inside object

### DIFF
--- a/tests/nimony/when/twhenobject.nif
+++ b/tests/nimony/when/twhenobject.nif
@@ -1,0 +1,9 @@
+(.nif24)
+0,1,tests/nimony/when/twhenobject.nim(stmts 6,1
+ (type ~4 :Foo.0.twh699we9 . . . 2
+  (object . ~2,4
+   (fld :y.0.twh699we9 . . 3
+    (i -1) .) ~4,5
+   (fld :z.0.twh699we9 . . 3
+    (i -1) .) ~2,7
+   (fld :a.0.twh699we9 . . 3 string.0.sysvq0asl .))))

--- a/tests/nimony/when/twhenobject.nim
+++ b/tests/nimony/when/twhenobject.nim
@@ -1,0 +1,11 @@
+type
+  Foo = object
+    when defined(abcd):
+      x: int
+    else:
+      y: int
+    z: int
+    when defined(nimony):
+      a: string
+    else:
+      b: bool


### PR DESCRIPTION
fixes #965

The same code is reused for both regular `when` statements and `when` statements inside objects, just with different endpoints for the resolved expressions. So the way of handling unresolved conditions depending on generic params etc. could be shared between the two variants when implemented.

Although the real problem is if the `when` statement is left unresolved, then expressions that iterate over the object type AST will encounter `when` trees. The fields inside them would currently be untyped as well. Nothing is done for this yet.