### PR TITLE
implement sum of products form for typeclass matching

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -375,6 +375,19 @@ proc matchConstraintSplitOr(m: var Match; f: var Cursor; a: Cursor): bool =
   else:
     result = matchBooleanConstraint(m, f, a)
 
+proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
+  if a.typeKind in {OrT, AndT, NotT}:
+    # typeclass matching typeclass, might need to be reordered to match properly:
+    if isSumOfProducts(a):
+      result = matchConstraintSplitOr(m, f, a)
+    else:
+      var reorderBuf = createTokenBuf(32)
+      reorderSumOfProducts(reorderBuf, a)
+      var reordered = beginRead(reorderBuf)
+      result = matchConstraintSplitOr(m, f, reordered)
+  else:
+    result = matchBooleanConstraint(m, f, a)
+
 proc matchesConstraint*(m: var Match; f: var Cursor; a: Cursor): bool =
   result = false
   if f.kind == DotToken:
@@ -386,7 +399,7 @@ proc matchesConstraint*(m: var Match; f: var Cursor; a: Cursor): bool =
     if res.decl.symKind == TypevarY:
       var typevar = asTypevar(res.decl)
       return matchesConstraint(m, f, typevar.typ)
-  result = matchConstraintSplitOr(m, f, a)
+  result = matchesConstraintAux(m, f, a)
 
 proc matchesConstraint(m: var Match; f: SymId; a: Cursor): bool =
   let res = tryLoadSym(f)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -382,6 +382,7 @@ proc matchesConstraintAux(m: var Match; f: var Cursor; a: Cursor): bool =
       result = matchConstraintSplitOr(m, f, a)
     else:
       var reorderBuf = createTokenBuf(32)
+      var a = a
       reorderSumOfProducts(reorderBuf, a)
       var reordered = beginRead(reorderBuf)
       result = matchConstraintSplitOr(m, f, reordered)

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -388,7 +388,7 @@ proc skipDistinct*(n: TypeCursor; isDistinct: var bool): TypeCursor =
 
 proc isAtomTypeclass(n: TypeCursor): bool {.inline.} =
   var n = n
-  while n.typeKind == NotT: # maybe just 1?
+  while n.typeKind == NotT: # reordering produces only 1 layer
     inc n
   result = n.typeKind notin {AndT, OrT}
 

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -555,7 +555,7 @@ when isMainModule:
       echo "input: ", typ
       reorderSumOfProducts(buf, typ)
       echo "output: ", beginRead(buf)
-    
+
     test "A"
     test "(and A B)"
     test "(and (and A B) (and C D))"

--- a/tests/nimony/generics/deps/mtypeclassmatch.nim
+++ b/tests/nimony/generics/deps/mtypeclassmatch.nim
@@ -7,7 +7,7 @@ when false: # XXX use when concept matching is implemented
 else:
   type
     ConceptA* = Ordinal
-    ConceptB* = OrdinalEnum
+    ConceptB* = (enum) # orthogonal with Ordinal, also implemented as `or` type
 
 proc foo1*[T: ConceptA](x: T) =
   if false:

--- a/tests/nimony/generics/ttypeclasswrongmatch.msgs
+++ b/tests/nimony/generics/ttypeclasswrongmatch.msgs
@@ -8,6 +8,8 @@ tests/nimony/generics/ttypeclasswrongmatch.nim(17, 9) Error: Type mismatch at [p
 [1] T.1.ttyhdorgt1 does not match constraint T.2.mtyn9ouov1
 tests/nimony/generics/ttypeclasswrongmatch.nim(23, 9) Error: Type mismatch at [position]
 [1] T.2.ttyhdorgt1 does not match constraint T.1.mtyn9ouov1
+tests/nimony/generics/ttypeclasswrongmatch.nim(29, 9) Error: Type mismatch at [position]
+[1] T.3.ttyhdorgt1 does not match constraint T.0.mtyn9ouov1
 tests/nimony/generics/ttypeclasswrongmatch.nim(30, 9) Error: Type mismatch at [position]
 [1] T.3.ttyhdorgt1 does not match constraint T.1.mtyn9ouov1
 tests/nimony/generics/ttypeclasswrongmatch.nim(31, 9) Error: Type mismatch at [position]

--- a/tests/nimony/generics/ttypeclasswrongmatch.nim
+++ b/tests/nimony/generics/ttypeclasswrongmatch.nim
@@ -26,7 +26,7 @@ proc foo3All[T: ConceptA and not ConceptB](x: T) =
 
 proc foo4All[T: ConceptA or ConceptB](x: T) =
   if false:
-    foo1(x) # matches due to ConceptB currently matching ConceptA but shouldn't otherwise
+    foo1(x) # fails as intended
     foo2(x) # fails as intended
     foo3(x) # fails as intended
     foo4(x) # works


### PR DESCRIPTION
follows up #931

Algorithm seems to work but I did not try every test case (cannot find much on this, [typescript](https://github.com/microsoft/TypeScript/blob/027829fbcd0a84172ab4a36d60a0ac915ca7ea09/src/compiler/checker.ts#L8467) seems to do the distributive law but not de morgan since typescript doesn't have `not` types). Since reordering can get quite slow (reordering `(and (or <M terms>) (or <N terms>)` is `O(MN)`) the typeclass is checked if it is already ordered first.

A problem with performance is the complexity of the produced terms also reflects on the complexity of the type match, `(A or B) and (C or D) and (E or F)` expands to:

```
(or
 (and A C E)
 (and A C F)
 (and A D E)
 (and A D F)
 (and B C E)
 (and B C F)
 (and B D E)
 (and B D F))
```

which performs 24 individual matches for only 6 types in the worst case. `A and SomeInteger` for example matches `A` equally as many times as the number of types in `SomeInteger`. An idea would be to cache the match results but getting a key for the type and looking it up might be slower than just matching.

This PR isn't really a priority, I just wanted to get the implementation out of the way