### PR TITLE
fixes borrowing procs with `var T`

### DIFF
--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -618,7 +618,9 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
         trTupleConstr c, n, e
     of ExprX:
       trStmtListExpr c, n, e
-    of DconvX, BaseobjX:
+    of DconvX:
+      trSons c, n, e
+    of BaseobjX:
       trSons c, n, WantT
     of ParX:
       trSons c, n, e

--- a/tests/nimony/sysbasics/tdistincts.nim
+++ b/tests/nimony/sysbasics/tdistincts.nim
@@ -3,9 +3,17 @@ type
 
 proc `+`*(x, y: VarId): VarId {.borrow.}
 
+proc foobar(x: var int, y: var int): var int =
+  x = y
+  result = x
+
+proc foobar(x: var VarId, y: var VarId): var VarId {.borrow.}
+
 var x: VarId
 
 x = x + x
+
+let m = foobar(x, x)
 
 let y = int8(x)
 


### PR DESCRIPTION
`Dconv` should not affect the derefs of the original call since it doesn't do anything and is eliminated in the later phase