### PR TITLE
adds Inf and NaN const

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -8,6 +8,14 @@ proc unpackToCall(fn: untyped) {.magic: Unpack.}
 
 const
   isMainModule* {.magic: "IsMainModule".}: bool = false
+  Inf* {.magic: "Inf".}: float64 = 0.0
+    ## Contains the IEEE floating point value of positive infinity.
+  NaN* {.magic: "NaN".}: float64 = 0.0
+    ## Contains an IEEE floating point value of *Not A Number*.
+    ##
+    ## Note that you cannot compare a floating point value to this value
+    ## and expect a reasonable result - use the `isNaN` or `classify` procedure
+    ## in the `math module <math.html>`_ for checking for NaN.
 
 proc `[]`*[T: tuple](x: T, i: int): untyped {.magic: "TupAt".}
 proc `[]`*[I, T](x: array[I, T], i: I): var T {.magic: "ArrAt".}

--- a/src/nimony/magics.nim
+++ b/src/nimony/magics.nim
@@ -120,4 +120,6 @@ proc magicToTag*(m: string): (string, int) =
   of "InternalFieldPairs": res InternalFieldPairsX, TypedMagic
   of "OrdinalEnum": res EnumT
   of "HoleyEnum": res HoleyEnumT
+  of "NaN": res NanX
+  of "Inf": res InfX
   else: ("", 0)

--- a/tests/nimony/stdlib/tmath.nim
+++ b/tests/nimony/stdlib/tmath.nim
@@ -12,3 +12,5 @@ assert classify(0.0 * -1.0) == fcNegZero
 assert classify(0.0 / 0.0) == fcNan
 assert classify(1.0 / 0.0) == fcInf
 assert classify(-1.0 / 0.0) == fcNegInf
+assert classify(Inf) == fcInf
+assert classify(NaN) == fcNan


### PR DESCRIPTION
Implementation of `parseutils.parseBiggestFloat` uses `Inf` and `NaN` constants.