### PR TITLE
fixes #1016

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -452,6 +452,11 @@ proc traverseType(c: var EContext; n: var Cursor; flags: set[TypeFlag] = {}) =
         c.dest.addSymUse pool.syms.getOrIncl(pool.strings[n.litId] & ".c"), n.info
         inc n
         skipParRi c, n
+        if n.kind != ParRi and n.pragmaKind == HeaderP:
+          inc n
+          c.headers.incl n.litId
+          inc n
+          skipParRi c, n
         skipParRi c, n
       else:
         takeParRi c, n

--- a/tests/nimony/ffi/cinttypedef.h
+++ b/tests/nimony/ffi/cinttypedef.h
@@ -1,0 +1,1 @@
+typedef int CIntTypeDef;

--- a/tests/nimony/ffi/deps/mimportcinttypedef.nim
+++ b/tests/nimony/ffi/deps/mimportcinttypedef.nim
@@ -1,1 +1,1 @@
-type CIntType* {.importc: "CIntType", header: "cinttype.h".} = int32
+type CIntTypeDef* {.importc: "CIntTypeDef", header: "cinttypedef.h".} = int32

--- a/tests/nimony/ffi/deps/mimportcinttypedef.nim
+++ b/tests/nimony/ffi/deps/mimportcinttypedef.nim
@@ -1,0 +1,1 @@
+type CIntType* {.importc: "CIntType", header: "cinttype.h".} = int32

--- a/tests/nimony/ffi/timportcinttypedef.nim
+++ b/tests/nimony/ffi/timportcinttypedef.nim
@@ -1,0 +1,4 @@
+type CIntType {.importc: "CIntType", header: "cinttype.h".} = int32
+
+var x: CIntType
+discard x

--- a/tests/nimony/ffi/timportcinttypedef.nim
+++ b/tests/nimony/ffi/timportcinttypedef.nim
@@ -1,4 +1,4 @@
-type CIntType {.importc: "CIntType", header: "cinttype.h".} = int32
+type CIntTypeDef {.importc: "CIntTypeDef", header: "cinttypedef.h".} = int32
 
-var x: CIntType
+var x: CIntTypeDef
 discard x

--- a/tests/nimony/ffi/timportcinttypedefinmod.nim
+++ b/tests/nimony/ffi/timportcinttypedefinmod.nim
@@ -1,4 +1,4 @@
-import deps/mimportcinttype
+import deps/mimportcinttypedef
 
-var x: CIntType
+var x: CIntTypeDef
 discard x

--- a/tests/nimony/ffi/timportcinttypedefinmod.nim
+++ b/tests/nimony/ffi/timportcinttypedefinmod.nim
@@ -1,0 +1,4 @@
+import deps/mimportcinttype
+
+var x: CIntType
+discard x


### PR DESCRIPTION
Adds header pragma to `IntT`, `UintT`, `FloatT` and `CharT` types in sem.nim when the type alias is declared with importc/importcpp and header pragma so that Hexer can add `include`.