### PR TITLE
implements `void` as return types

### DIFF
--- a/lib/std/system/basic_types.nim
+++ b/lib/std/system/basic_types.nim
@@ -81,6 +81,8 @@ type
   untyped* {.magic: Expr.}
   typed* {.magic: Stmt.}
 
+  void* {.magic: "VoidType".} ## Meta type to denote the absence of any type.
+
 type
   Ordinal*[T] {.magic: Ordinal.} ## Generic ordinal type. Includes integer,
                                   ## bool, character, and enumeration types

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3107,9 +3107,15 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
         semRangeTypeFromExpr c, n, info
       else:
         semTypeExpr c, n, context, info
-    of IntT, FloatT, CharT, BoolT, UIntT, VoidT, NiltT, AutoT,
+    of IntT, FloatT, CharT, BoolT, UIntT, NiltT, AutoT,
         SymKindT, UntypedT, TypedT, CstringT, PointerT, TypeKindT, OrdinalT:
       takeTree c, n
+    of VoidT:
+      if context == InReturnTypeDecl:
+        skip n
+        c.dest.addDotToken()
+      else:
+        takeTree c, n
     of PtrT, RefT, MutT, OutT, LentT, SinkT, NotT, UarrayT,
        StaticT, TypedescT:
       if tryTypeClass(c, n):

--- a/tests/nimony/sysbasics/tprocs.nim
+++ b/tests/nimony/sysbasics/tprocs.nim
@@ -1,0 +1,5 @@
+proc foo(x: int): void =
+  var y = x
+  y = y + 1
+
+foo(12)


### PR DESCRIPTION
`InReturnTypeDecl` indicts it's a return type, not in the return type