### PR TITLE
fixes `block` and `break` misc issues

### DIFF
--- a/src/hexer/iterinliner.nim
+++ b/src/hexer/iterinliner.nim
@@ -186,11 +186,12 @@ proc inlineLoopBody(e: var EContext; c: var Cursor; mapping: var Table[SymId, Sy
       discard e.breaks.pop()
       discard e.continues.pop()
     of BlockS:
-      e.dest.add c
-      inc c
-      e.breaks.add SymId(0)
-      e.dest.add c
-      inc c
+      e.dest.takeToken(c)
+      if c.kind == SymbolDef:
+        e.breaks.add c.symId
+      else:
+        e.breaks.add SymId(0)
+      e.dest.takeToken(c)
       inlineLoopBody(e, c, mapping)
       discard e.breaks.pop
       takeParRi(e, c)
@@ -517,11 +518,12 @@ proc transformStmt(e: var EContext; c: var Cursor) =
     of ContinueS:
       transformContinueStmt(e, c)
     of BlockS:
-      e.dest.add c
-      inc c
-      e.breaks.add SymId(0)
-      e.dest.add c
-      inc c
+      e.dest.takeToken(c)
+      if c.kind == SymbolDef:
+        e.breaks.add c.symId
+      else:
+        e.breaks.add SymId(0)
+      e.dest.takeToken(c)
       transformStmt(e, c)
       discard e.breaks.pop
       takeParRi(e, c)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2115,6 +2115,7 @@ proc semBreak(c: var SemContext; it: var Item) =
   takeToken c, it.n
   if c.routine.inLoop+c.routine.inBlock == 0:
     buildErr c, info, "`break` only possible within a `while` or `block` statement"
+    skip it.n
   else:
     if it.n.kind == DotToken:
       wantDot c, it.n
@@ -3862,6 +3863,8 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
     if KeepMagics notin flags and c.routine.kind != TemplateY:
       c.buildErr c.dest[start].info, "ambiguous identifier"
     it.typ = c.types.autoType
+  elif s.kind == BlockY:
+    it.typ = c.types.autoType
   elif s.kind in {TypeY, TypevarY}:
     let typeStart = c.dest.len
     let info = c.dest[c.dest.len-1].info
@@ -3882,8 +3885,6 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
         skipToLocalType n
       elif s.kind.isRoutine:
         skipToParams n
-      elif s.kind == BlockY:
-        discard
       elif s.kind == ModuleY:
         if AllowModuleSym notin flags:
           c.buildErr c.dest[start].info, "module symbol '" & pool.syms[s.name] & "' not allowed in this context"

--- a/tests/nimony/sysbasics/tblocks.nim
+++ b/tests/nimony/sysbasics/tblocks.nim
@@ -6,3 +6,14 @@ proc foo =
   assert x == "?"
 
 foo()
+
+proc main =
+  block endLess:
+    let s = 12
+    break
+
+  block endLess:
+    let s = 12
+    break endLess
+
+main()


### PR DESCRIPTION
fixes `break` with/without a label in the `block`; improves error messages for `break` not under the `while` or `block`