### PR TITLE
manually insert \0 for parseutils array passed to `strtod`

### DIFF
--- a/lib/std/parseutils.nim
+++ b/lib/std/parseutils.nim
@@ -271,4 +271,6 @@ proc parseBiggestFloat*(s: openArray[char]; number: var BiggestFloat): int {.
   t[ti-2] = ('0'.ord + absExponent mod 10).char
   absExponent = absExponent div 10
   t[ti-3] = ('0'.ord + absExponent mod 10).char
+  # array not zeroed out:
+  t[ti] = '\0'
   number = c_strtod(cast[cstring](addr t), nil)


### PR DESCRIPTION
refs #1023

The array is not zeroed out in nimony AFAIK, so a \0 is manually added here. Another option might be to call `zeroMem`. Passed 5 CI runs without failing.