### PR TITLE
nifgram: implement STACK\POP operations

### DIFF
--- a/src/nifgram/nifgram.nim
+++ b/src/nifgram/nifgram.nim
@@ -45,13 +45,18 @@ type
     
     rules: seq[string] # all declared rules
 
+proc normalizedPopVar(popVar: string): string = 
+  result = "st"
+  result.add toUpperAscii(popVar[0])
+  result.add nimIdentNormalize(substr(popVar, 1))
+
 proc signature(c: Context, rule: string): string {.inline.} = 
   if c.kind == Generator:
     result = ""
     result.add "(c: var Context"
     for popVar in c.popVars.getOrDefault(rule):
       result.add ", "
-      result.add popVar
+      result.add normalizedPopVar(popVar)
       result.add ": string"
     result.add "): bool"
   else:
@@ -302,7 +307,7 @@ proc compileKeyw(c: var Context; it: string): string =
 
 proc compilePopVar(c: var Context; it: string): string =
   ind c
-  c.outp.add "emit(" & c.args0 & ", " & $c.t.s & ")"
+  c.outp.add "emit(" & c.args0 & ", " & normalizedPopVar($c.t.s) & ")"
   result = "true"
 
 proc compileRuleInvocation(c: var Context; it: string): string =
@@ -316,7 +321,7 @@ proc compileRuleInvocation(c: var Context; it: string): string =
   result = c.procPrefix & ruleName & "(" & c.args
   for popVar in c.popVars[ruleName]:
     result.add ", "
-    result.add popVar
+    result.add normalizedPopVar(popVar)
   result.add ")"
   if c.inBinding > 0:
     result = declTemp(c, "m", result)
@@ -601,7 +606,7 @@ proc compilePop(c: var Context; it: string): string =
   inc c.localPopCounts[^1]
 
   ind c
-  c.outp.add "var " & varName & " = popStack(" & c.args & ")"
+  c.outp.add "var " & normalizedPopVar(varName) & " = popStack(" & c.args & ")"
   result = "true"
 
 proc compileExpr(c: var Context; it: string): string =

--- a/src/nifgram/nifgram.nim
+++ b/src/nifgram/nifgram.nim
@@ -47,8 +47,7 @@ type
 
 proc normalizedPopVar(popVar: string): string = 
   result = "st"
-  result.add toUpperAscii(popVar[0])
-  result.add nimIdentNormalize(substr(popVar, 1))
+  result.add nimIdentNormalize(popVar)
 
 proc signature(c: Context, rule: string): string {.inline.} = 
   if c.kind == Generator:

--- a/src/nifgram/nifgram.nim
+++ b/src/nifgram/nifgram.nim
@@ -938,14 +938,17 @@ proc scan(c: var ScanContext) =
   var sccRules = initTable[int, seq[string]]()
   var sccPopVars =  initTable[int, HashSet[string]]()
   for rule, scc in sccs.pairs:
-    mgetOrPut(sccPopVars, scc).incl c.popVars.getOrDefault(rule) # same rules in same SCC
+    mgetOrPut(sccPopVars, scc).incl c.popVars.getOrDefault(rule) # get maximum declared pop var number
     mgetOrPut(sccRules, scc).add rule
+
+    for invokedRule in c.ruleInvocations[rule]:
+      mgetOrPut(sccPopVars, sccs[invokedRule]).incl sccPopVars[scc]
   
-  for i in 0..<c.rules.len: # N times
-    if i in sccPopVars:
-      for rule in sccRules[i]: # N times
-        for invokedRule in c.ruleInvocations[rule]:
-          mgetOrPut(c.popVars, invokedRule).incl c.popVars.getOrDefault(rule)
+  for scc in 0..<c.rules.len: # only N times
+    if scc in sccPopVars:
+      for rule in sccRules[scc]:
+        mgetOrPut(c.popVars, rule).incl sccPopVars[scc]
+    
 
 proc main(inp, outp: string;
           specTags: sink OrderedTable[string, int]): OrderedTable[string, int] =


### PR DESCRIPTION
Now you can write this grammar:
```lisp
(RULE :DataValue TYP (OR STRINGLITERAL INTLIT UINTLIT FLOATLIT))
(RULE :DataKey (POP :TYP) (OR DataValue (times ".rept " INTLIT (DO "nl") DataValue (DO "nl") ".endr")) (DO "nl"))
(RULE :DataDecl SYMBOLDEF ":" (DO "nl") (STACK (ONE_OR_MANY (OR
  (string ".string " DataKey)
  (byte ".byte " DataKey)
  (word ".short " DataKey)
  (long ".long " DataKey)
  (quad ".quad " DataKey)

))) (DO "nl"))
```
And this means that need to pop the DataKey from the stack, write it to the variable TYP, and then add it to stack.