### PR TITLE
basic generic/ref inheritance

### DIFF
--- a/src/hexer/vtables_backend.nim
+++ b/src/hexer/vtables_backend.nim
@@ -744,7 +744,8 @@ proc emitVTables(c: var Context; dest: var TokenBuf) =
               dest.addSymUse m, NoLineInfo
           dest.addParRi() # AconstrX
         else:
-          dest.addParPair NilX, NoLineInfo
+          dest.copyIntoKind AconstrX, NoLineInfo:
+            dest.addParPair NilX, NoLineInfo
         dest.addParRi() # KvU
 
 proc transformVTables*(n: Cursor; moduleSuffix: string; needsXelim: var bool): TokenBuf =

--- a/src/hexer/vtables_backend.nim
+++ b/src/hexer/vtables_backend.nim
@@ -114,7 +114,12 @@ proc evalOnce(c: var Context; dest: var TokenBuf; n: var Cursor): TempLoc =
     copyIntoKind dest, VarS, info:
       addSymDef dest, symId, info
       dest.addEmpty2 info # export marker, pragma
-      copyTree dest, argType
+      # type:
+      if takeAddr:
+        copyIntoKind dest, PtrT, info:
+          copyTree dest, argType
+      else:
+        copyTree dest, argType
       # value:
       if takeAddr:
         copyIntoKind dest, AddrX, info:

--- a/src/hexer/vtables_backend.nim
+++ b/src/hexer/vtables_backend.nim
@@ -321,10 +321,10 @@ proc genVtableField(c: var Context; dest: var TokenBuf; x: Cursor; info: PackedL
 
     if xk == RefT:
       # past duplifier, so need to do the deref transform here
+      dest.addParRi()
       let dataField = pool.syms.getOrIncl(DataField)
       dest.add symToken(dataField, info)
       dest.addIntLit(0, info) # inheritance
-      dest.addParRi()
       dest.addParRi()
     elif xk == PtrT:
       dest.addParRi()

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -683,18 +683,8 @@ proc useArg(m: var Match; arg: Item) =
 
 proc singleArgImpl(m: var Match; f: var Cursor; arg: Item)
 
-proc baseSym(s: SymId): SymId =
-  let decl = getTypeSection(s)
-  if decl.typevars.typeKind == InvokeT:
-    var base = decl.typevars
-    inc base
-    result = base.symId
-  else:
-    # generic base or not generic
-    result = s
-
 proc matchObjectInheritance(m: var Match; f, a: Cursor; fsym, asym: SymId; ptrKind: TypeKind) =
-  let fbase = baseSym(fsym)
+  let fbase = skipTypeInstSym(fsym)
   var diff = 1
   var objbody = objtypeImpl(asym)
   while true:
@@ -714,7 +704,7 @@ proc matchObjectInheritance(m: var Match; f, a: Cursor; fsym, asym: SymId; ptrKi
       pbase = psym
     elif parent.kind == Symbol:
       psym = parent.symId
-      pbase = baseSym(psym)
+      pbase = skipTypeInstSym(psym)
     else:
       break
     if sameSymbol(fbase, pbase):

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -183,6 +183,15 @@ proc isObjectType(s: SymId): bool =
   else:
     result = false
 
+proc isObjectType(n: Cursor): bool =
+  var n = n
+  if n.typeKind == InvokeT:
+    inc n
+  if n.kind == Symbol:
+    result = isObjectType(n.symId)
+  else:
+    result = false
+
 proc isEnumType*(n: Cursor): bool =
   if n.kind == Symbol:
     let impl = getTypeSection(n.symId)
@@ -674,6 +683,102 @@ proc useArg(m: var Match; arg: Item) =
 
 proc singleArgImpl(m: var Match; f: var Cursor; arg: Item)
 
+proc baseSym(s: SymId): SymId =
+  let decl = getTypeSection(s)
+  if decl.typevars.typeKind == InvokeT:
+    var base = decl.typevars
+    inc base
+    result = base.symId
+  else:
+    # generic base or not generic
+    result = s
+
+proc matchObjectInheritance(m: var Match; f, a: Cursor; fsym, asym: SymId; ptrKind: TypeKind) =
+  let fbase = baseSym(fsym)
+  var diff = 1
+  var objbody = objtypeImpl(asym)
+  while true:
+    let od = asObjectDecl(objbody)
+    if od.kind != ObjectT:
+      m.error InvalidMatch, f, a
+      return
+    var parent = od.parentType
+    if parent.typeKind in {RefT, PtrT}:
+      inc parent
+    var psym = SymId(0)
+    var pbase = SymId(0)
+    if parent.typeKind == InvokeT:
+      var base = parent
+      inc base
+      psym = base.symId
+      pbase = psym
+    elif parent.kind == Symbol:
+      psym = parent.symId
+      pbase = baseSym(psym)
+    else:
+      break
+    if sameSymbol(fbase, pbase):
+      if f.typeKind == InvokeT:
+        # infer generic params
+        var f2 = f
+        var p2 = parent
+        linearMatch m, f2, p2
+      m.args.addParLe BaseobjX, m.argInfo
+      if m.flipped:
+        if ptrKind != NoType: m.args.addParLe(ptrKind, a.info)
+        m.args.addSubtree a
+        if ptrKind != NoType: m.args.addParRi()
+        m.args.addIntLit -diff, m.argInfo
+        dec m.inheritanceCosts, diff
+      else:
+        if ptrKind != NoType: m.args.addParLe(ptrKind, f.info)
+        m.args.addSubtree f
+        if ptrKind != NoType: m.args.addParRi()
+        m.args.addIntLit diff, m.argInfo
+        inc m.inheritanceCosts, diff
+      inc m.opened
+      diff = 0 # mark as success
+      break
+    inc diff
+    objbody = objtypeImpl(psym)
+  if diff != 0:
+    m.error InvalidMatch, f, a
+  elif m.skippedMod == OutT:
+    m.error UnavailableSubtypeRelation, f, a
+
+proc matchObjectTypes(m: var Match; f: var Cursor, a: Cursor; ptrKind: TypeKind) =
+  if f.kind == Symbol:
+    if a.kind != Symbol:
+      m.error InvalidMatch, f, a
+    elif sameSymbol(f.symId, a.symId):
+      discard "direct match, no annotation required"
+    elif not isObjectType(a.symId):
+      m.error InvalidMatch, f, a
+    else:
+      matchObjectInheritance m, f, a, f.symId, a.symId, NoType
+    inc f
+  elif f.typeKind == InvokeT:
+    var aInvoke = a
+    if a.kind == Symbol:
+      let ad = getTypeSection(a.symId)
+      if ad.kind == TypeY and ad.typevars.typeKind == InvokeT:
+        aInvoke = ad.typevars
+    if aInvoke.typeKind == InvokeT:
+      var fBase = f
+      var aBase = aInvoke
+      inc fBase
+      inc aBase
+      if sameSymbol(fBase.symId, aBase.symId):
+        linearMatch m, f, aInvoke
+      else:
+        let fsym = fBase.symId
+        let asym = if a.kind == Symbol: a.symId else: aBase.symId
+        matchObjectInheritance m, f, a, fsym, asym, NoType
+        skip f
+    else:
+      m.error InvalidMatch, f, a
+      skip f
+
 proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
   let a = skipModifier(arg.typ)
   let fs = f.symId
@@ -695,33 +800,8 @@ proc matchSymbol(m: var Match; f: Cursor; arg: Item) =
     else:
       m.error ConstraintMismatch, f, a
   elif isObjectType(fs):
-    if a.kind != Symbol:
-      m.error InvalidMatch, f, a
-    elif sameSymbol(fs, a.symId):
-      discard "direct match, no annotation required"
-    elif not isObjectType(a.symId):
-      m.error InvalidMatch, f, a
-    else:
-      var diff = 1
-      for fparent in inheritanceChain(a.symId):
-        if sameSymbol(fparent, fs):
-          m.args.addParLe BaseobjX, m.argInfo
-          if m.flipped:
-            m.args.addSubtree a
-            m.args.addIntLit -diff, m.argInfo
-            dec m.inheritanceCosts, diff
-          else:
-            m.args.addSubtree f
-            m.args.addIntLit diff, m.argInfo
-            inc m.inheritanceCosts, diff
-          inc m.opened
-          diff = 0 # mark as success
-          break
-        inc diff
-      if diff != 0:
-        m.error InvalidMatch, f, a
-      elif m.skippedMod == OutT:
-        m.error UnavailableSubtypeRelation, f, a
+    var f = f
+    matchObjectTypes m, f, a, NoType
   elif isConcept(fs):
     m.error NotImplementedConcept, f, a
   else:
@@ -871,10 +951,13 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
       inc f
       expectParRi m, f
     of InvokeT:
-      # handled in linearMatch
-      # XXX except for inheritance
       var a = skipModifier(arg.typ)
-      linearMatch m, f, a
+      if isObjectType(f) and isObjectType(a):
+        # specialized to handle inheritance
+        matchObjectTypes m, f, a, NoType
+      else:
+        # handled in linearMatch
+        linearMatch m, f, a
     of RangetypeT:
       # for now acts the same as base type
       var a = skipModifier(arg.typ)
@@ -922,14 +1005,23 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: Item) =
         linearMatch m, f, a
     of PtrT, RefT:
       var a = skipModifier(arg.typ)
-      case a.typeKind
-      of NiltT:
+      let ak = a.typeKind
+      if ak == NiltT:
         discard "ok"
         inc f
         skip f
         expectParRi m, f
+      elif ak == fk:
+        inc f
+        inc a
+        if isObjectType(f) and isObjectType(a):
+          # handle inheritance
+          matchObjectTypes m, f, a, fk
+        else:
+          linearMatch m, f, a
+        expectParRi m, f
       else:
-        linearMatch m, f, a
+        m.error InvalidMatch, f, a
     of TypedescT:
       # do not skip modifier
       var a = arg.typ

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -755,7 +755,7 @@ proc matchObjectTypes(m: var Match; f: var Cursor, a: Cursor; ptrKind: TypeKind)
     elif not isObjectType(a.symId):
       m.error InvalidMatch, f, a
     else:
-      matchObjectInheritance m, f, a, f.symId, a.symId, NoType
+      matchObjectInheritance m, f, a, f.symId, a.symId, ptrKind
     inc f
   elif f.typeKind == InvokeT:
     var aInvoke = a
@@ -773,7 +773,7 @@ proc matchObjectTypes(m: var Match; f: var Cursor, a: Cursor; ptrKind: TypeKind)
       else:
         let fsym = fBase.symId
         let asym = if a.kind == Symbol: a.symId else: aBase.symId
-        matchObjectInheritance m, f, a, fsym, asym, NoType
+        matchObjectInheritance m, f, a, fsym, asym, ptrKind
         skip f
     else:
       m.error InvalidMatch, f, a

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -312,6 +312,8 @@ iterator inheritanceChain*(s: SymId): SymId =
       var parent = od.parentType
       if parent.typeKind in {RefT, PtrT}:
         inc parent
+      if parent.typeKind == InvokeT:
+        inc parent
       if parent.kind == Symbol:
         let ps = parent.symId
         yield ps

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -296,6 +296,21 @@ proc getClass*(t: TypeCursor): SymId =
     else:
       break
 
+proc skipTypeInstSym*(s: SymId): SymId =
+  # if `s` is a generic instantiation, return the generic base sym, otherwise return itself
+  let res = tryLoadSym(s)
+  if res.status == LacksNothing and res.decl.symKind == TypeY:
+    let decl = asTypeDecl(res.decl)
+    if decl.typevars.typeKind == InvokeT:
+      var base = decl.typevars
+      inc base
+      result = base.symId
+    else:
+      # generic base or not generic
+      result = s
+  else:
+    result = s
+
 proc typeHasPragma*(n: Cursor; pragma: NimonyPragma; bodyKindRestriction = NoType): bool =
   var counter = 20
   var n = n

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -1,0 +1,40 @@
+import std / [syncio, assertions]
+
+type
+  RootObj {.inheritable.} = object
+
+type
+  GenericObj[T] = object of RootObj
+    x: T
+  InheritGeneric1[T] = object of GenericObj[T]
+    y: T
+  InheritGeneric2 = object of GenericObj[int]
+    z: string
+
+type Writeable = concept
+  proc write(f: File; x: Self): string
+
+method foo[T: Writeable](x: GenericObj[T]) =
+  echo "at base method: ", x.x
+  echo "base: ", x of GenericObj[T]
+  echo "inherited 1: ", x of InheritGeneric1[T]
+  #echo "inherited 2: ", x of InheritGeneric2
+
+method foo[T: Writeable](x: InheritGeneric1[T]) =
+  echo "at inherited 1 method: ", x.x, ", ", x.y
+  echo "base: ", x of GenericObj[T]
+  echo "inherited 1: ", x of InheritGeneric1[T]
+  #echo "inherited 2: ", x of InheritGeneric2
+
+method foo(x: InheritGeneric2) =
+  echo "at inherited 2 method: ", x.x, ", ", x.z
+  echo "base: ", x of GenericObj[int]
+  #echo "inherited 1: ", x of InheritGeneric1[int]
+  echo "inherited 2: ", x of InheritGeneric2
+
+# object constructors with inherited fields do not work yet
+foo(GenericObj[int](x: 1))
+foo(InheritGeneric1[int](x: 2, y: 3))
+foo(GenericObj[float](x: 4.56))
+foo(InheritGeneric1[float](x: 7.89, y: 10.11))
+foo(InheritGeneric2(x: 12, z: "abc"))

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -5,7 +5,8 @@ type
 
 type
   GenericObj[T] = object of RootObj
-    x: T
+    # object constructors with inherited fields do not work yet
+    #x: T
   InheritGeneric1[T] = object of GenericObj[T]
     y: T
   InheritGeneric2 = object of GenericObj[int]
@@ -15,26 +16,27 @@ type Writeable = concept
   proc write(f: File; x: Self): string
 
 method foo[T: Writeable](x: GenericObj[T]) =
-  echo "at base method: ", x.x
-  echo "base: ", x of GenericObj[T]
-  echo "inherited 1: ", x of InheritGeneric1[T]
-  #echo "inherited 2: ", x of InheritGeneric2
+  echo "at base method"# : ", x.x
+  echo "base check: ", x of GenericObj[T]
+  echo "inherited 1 check: ", x of InheritGeneric1[T]
+  echo "inherited 2 check: ", x of InheritGeneric2
 
 method foo[T: Writeable](x: InheritGeneric1[T]) =
-  echo "at inherited 1 method: ", x.x, ", ", x.y
-  echo "base: ", x of GenericObj[T]
-  echo "inherited 1: ", x of InheritGeneric1[T]
-  #echo "inherited 2: ", x of InheritGeneric2
+  echo "at inherited 1 method: ", #[x.x, ", ",]# x.y
+  echo "base check: ", x of GenericObj[T]
+  echo "inherited 1 check: ", x of InheritGeneric1[T]
+  # correctly fails with "never a subtype":
+  #echo "inherited 2 check: ", x of InheritGeneric2
 
 method foo(x: InheritGeneric2) =
-  echo "at inherited 2 method: ", x.x, ", ", x.z
-  echo "base: ", x of GenericObj[int]
-  #echo "inherited 1: ", x of InheritGeneric1[int]
-  echo "inherited 2: ", x of InheritGeneric2
+  echo "at inherited 2 method: ", #[x.x, ", ",]# x.z
+  echo "base check: ", x of GenericObj[int]
+  # correctly fails with "never a subtype":
+  #echo "inherited 1 check: ", x of InheritGeneric1[int]
+  echo "inherited 2 check: ", x of InheritGeneric2
 
-# object constructors with inherited fields do not work yet
-foo(GenericObj[int](x: 1))
-foo(InheritGeneric1[int](x: 2, y: 3))
-foo(GenericObj[float](x: 4.56))
-foo(InheritGeneric1[float](x: 7.89, y: 10.11))
-foo(InheritGeneric2(x: 12, z: "abc"))
+foo(GenericObj[int](#[x: 1]#))
+foo(InheritGeneric1[int](#[x: 2,]# y: 3))
+foo(GenericObj[float](#[x: 4.56]#))
+foo(InheritGeneric1[float](#[x: 7.89,]# y: 10.11))
+foo(InheritGeneric2(#[x: 12,]# z: "abc"))

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -35,8 +35,30 @@ method foo(x: InheritGeneric2) =
   #echo "inherited 1 check: ", x of InheritGeneric1[int]
   echo "inherited 2 check: ", x of InheritGeneric2
 
-foo(GenericObj[int](#[x: 1]#))
-foo(InheritGeneric1[int](#[x: 2,]# y: 3))
-foo(GenericObj[float](#[x: 4.56]#))
-foo(InheritGeneric1[float](#[x: 7.89,]# y: 10.11))
-foo(InheritGeneric2(#[x: 12,]# z: "abc"))
+let baseInt = GenericObj[int](#[x: 1]#)
+let inherit1Int = InheritGeneric1[int](#[x: 2,]# y: 3)
+let baseFloat = GenericObj[float](#[x: 4.56]#)
+let inherit1Float = InheritGeneric1[float](#[x: 7.89,]# y: 10.11)
+let inherit2 = InheritGeneric2(#[x: 12,]# z: "abc")
+
+if false: # temporary workaround, instantiate all the methods:
+  foo(baseInt)
+  foo(inherit1Int)
+  foo(baseFloat)
+  foo(inherit1Float)
+  foo(inherit2)
+
+proc test[T](x: GenericObj[T]) =
+  foo(x)
+
+test(baseInt)
+test(inherit1Int)
+test(baseFloat)
+test(inherit1Float)
+test(inherit2)
+# same test as:
+#foo(baseInt)
+#foo(GenericObj[int](inherit1Int))
+#foo(baseFloat)
+#foo(GenericObj[float](inherit1Float))
+#foo(GenericObj[int](inherit2))

--- a/tests/nimony/methods/tgenericinheritance.output
+++ b/tests/nimony/methods/tgenericinheritance.output
@@ -1,0 +1,17 @@
+at base method
+base check: true
+inherited 1 check: false
+inherited 2 check: false
+at inherited 1 method: 3
+base check: true
+inherited 1 check: true
+at base method
+base check: true
+inherited 1 check: false
+inherited 2 check: false
+at inherited 1 method: 10.11
+base check: true
+inherited 1 check: true
+at inherited 2 method: abc
+base check: true
+inherited 2 check: true

--- a/tests/nimony/methods/tmof.nim
+++ b/tests/nimony/methods/tmof.nim
@@ -30,3 +30,13 @@ method m(o: Obj2) =
 let x = RootObj(Obj2()[])
 assert x of Obj2
 test(Obj2()[])
+
+let y = (ref RootObj)(Obj2())
+assert y of Obj2
+
+#proc testRef(o: ref RootObj) =
+#  echo o of RootObj
+#  echo o of Obj
+#  m o[]
+#
+#testRef y

--- a/tests/nimony/methods/tmof.nim
+++ b/tests/nimony/methods/tmof.nim
@@ -39,9 +39,12 @@ let z = Obj2(y)
 assert z of Obj2
 test(z[])
 
-#proc testRef(o: ref RootObj) =
-#  echo o of RootObj
-#  echo o of Obj
-#  m o[]
-#
-#testRef y
+proc testRef(o: ref RootObj) =
+  echo "testing ref"
+  echo o of RootObj
+  echo o of Obj
+  echo o of Obj2
+  m o[]
+
+testRef y
+testRef z

--- a/tests/nimony/methods/tmof.nim
+++ b/tests/nimony/methods/tmof.nim
@@ -33,6 +33,11 @@ test(Obj2()[])
 
 let y = (ref RootObj)(Obj2())
 assert y of Obj2
+test(y[])
+
+let z = Obj2(y)
+assert z of Obj2
+test(z[])
 
 #proc testRef(o: ref RootObj) =
 #  echo o of RootObj

--- a/tests/nimony/methods/tmof.nim
+++ b/tests/nimony/methods/tmof.nim
@@ -1,5 +1,5 @@
 
-import std / [syncio]
+import std / [syncio, assertions]
 
 type
   RootObj {.inheritable.} = object
@@ -21,3 +21,12 @@ proc test(o: RootObj) =
 
 test(Obj(a: 1, b: 2, c: "3"))
 test(RootObj())
+
+type Obj2 = ref object of RootObj
+
+method m(o: Obj2) =
+  echo "Obj2"
+
+let x = RootObj(Obj2()[])
+assert x of Obj2
+test(Obj2()[])

--- a/tests/nimony/methods/tmof.output
+++ b/tests/nimony/methods/tmof.output
@@ -13,3 +13,13 @@ Obj2
 true
 false
 Obj2
+testing ref
+true
+false
+true
+Obj2
+testing ref
+true
+false
+true
+Obj2

--- a/tests/nimony/methods/tmof.output
+++ b/tests/nimony/methods/tmof.output
@@ -7,3 +7,9 @@ RootObj
 true
 false
 Obj2
+true
+false
+Obj2
+true
+false
+Obj2

--- a/tests/nimony/methods/tmof.output
+++ b/tests/nimony/methods/tmof.output
@@ -4,3 +4,6 @@ Obj
 true
 false
 RootObj
+true
+false
+Obj2


### PR DESCRIPTION
refs #896

Inheritance is implemented in sigmatch for `ref`/`ptr` and generic versions of object types. This is not perfectly implemented for edge cases like "generic objects matching generic objects" but should handle the most common cases fine.

Changes to vtables_backend:

* Upcasts for ref/ptr types are just `cast`s of their pointers, this works since the first field is always the parent object and makes the refcount field for `ref`s work.
* Access to the vtable field needs an upcast to the hierarchy root
* Misc fixes: Temps are fixed (leaves `(expr` open instead of immediately closing, generates `ptr` type for `addr` case), generic types do not generate unused vtables, empty methods array generates `{ NIL }` since it is a flexible array.

Leaving for followup, added to issue todo and as XXX comments:

* Generic methods need to be instantiated for every single instantiation of the attached generic type like hooks are at the end of sem, in the test this is worked around by the methods matching statically for each instance.
* Nil checks are needed for method dispatch and for `of` with pointer type operands. Method dispatch is straightforward but I don't fully understand what `of` does in the old compiler, the codegen implies it should always return `false` when the operand is nil but it behaves like a static match instead. In any case this would probably pollute the diff.