### PR TITLE
fixes for ref/ptr inheritance

### DIFF
--- a/src/hexer/lifter.nim
+++ b/src/hexer/lifter.nim
@@ -78,6 +78,8 @@ proc isTrivialObjectBody(c: var LiftingCtx; body: Cursor): bool =
   inc n # skip `(object` token
 
   var baseType = n
+  if baseType.typeKind in {RefT, PtrT}:
+    inc baseType
   skip n # skip basetype
   if n.kind != DotToken:
     result = isTrivialForFields(c, n)
@@ -335,7 +337,10 @@ proc unravelObj(c: var LiftingCtx; n: Cursor; paramA, paramB: TokenBuf) =
   inc n
   # recurse for the inherited object type, if any:
   if n.kind != DotToken:
-    unravelObj c, toTypeImpl(n), paramA, paramB
+    var parent = n
+    if parent.typeKind in {RefT, PtrT}:
+      inc parent
+    unravelObj c, toTypeImpl(parent), paramA, paramB
   skip n # inheritance is gone
   unravelObjFields c, n, paramA, paramB
 

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -530,7 +530,10 @@ proc trType(c: var EContext; n: var Cursor; flags: set[TypeFlag] = {}) =
         inc n
       else:
         # inherited symbol
+        let isPtr = n.typeKind in {RefT, PtrT}
+        if isPtr: inc n
         let (s, sinfo) = getSym(c, n)
+        if isPtr: skipParRi c, n
         c.dest.add symToken(s, sinfo)
         c.demand s
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -728,6 +728,9 @@ proc matchObjectInheritance(m: var Match; f, a: Cursor; fsym, asym: SymId; ptrKi
       else:
         if ptrKind != NoType: m.args.addParLe(ptrKind, f.info)
         m.args.addSubtree f
+        if containsGenericParams(f):
+          # needs to be instantiated, reuse genericConverter
+          m.genericConverter = true
         if ptrKind != NoType: m.args.addParRi()
         m.args.addIntLit diff, m.argInfo
         inc m.inheritanceCosts, diff

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -4,13 +4,12 @@ type
   RootObj {.inheritable.} = object
 
 type
-  # XXX see bugs when turning these into `ref object`
-  GenericObj[T] = object of RootObj
+  GenericObj[T] = ref object of RootObj
     # object constructors with inherited fields do not work yet
     #x: T
-  InheritGeneric1[T] = object of GenericObj[T]
+  InheritGeneric1[T] = ref object of GenericObj[T]
     y: T
-  InheritGeneric2 = object of GenericObj[int]
+  InheritGeneric2 = ref object of GenericObj[int]
     z: string
 
 type Writeable = concept


### PR DESCRIPTION
1. `ref`/`ptr` is skipped for the parent type of objects in hexer. Sem could just generate these skipped but it might be better not to depend on it.
2. In sigmatch, object conversions to generic types can be generated, to instantiate these `genericConverter` is reused. (Non-pointer object conversions ignored the type for upcasts so the type not being instantiated wasn't a problem before)
3. Method instantiations for type instantiations skip modifiers and `ref`/`ptr` when matching the method param, since the type instantiation is always the object type.