### PR TITLE
add RootObj to system

### DIFF
--- a/lib/std/system/basic_types.nim
+++ b/lib/std/system/basic_types.nim
@@ -103,3 +103,11 @@ proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect
 proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
 proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffect.}
 proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
+
+type
+  RootObj* {.inheritable.} =
+    object ## The root of Nim's object hierarchy.
+           ##
+           ## Objects should inherit from `RootObj` or one of its descendants.
+           ## However, objects that have no ancestor are also allowed.
+  RootRef* = ref RootObj ## Reference to `RootObj`.

--- a/src/hexer/vtables_backend.nim
+++ b/src/hexer/vtables_backend.nim
@@ -755,7 +755,12 @@ proc emitVTables(c: var Context; dest: var TokenBuf) =
         dest.addSymUse pool.syms.getOrIncl(DisplayField & SystemModuleSuffix), NoLineInfo
         if displayName != SymId(0):
           #dest.copyIntoKind AddrX, NoLineInfo:
-          dest.addSymUse displayName, NoLineInfo
+          # cast to pointer type to remove `const` modifier in C
+          copyIntoKind dest, CastX, NoLineInfo:
+            copyIntoKind dest, PtrT, NoLineInfo:
+              copyIntoKind dest, UT, NoLineInfo:
+                dest.addIntLit 32, NoLineInfo
+            dest.addSymUse displayName, NoLineInfo
         else:
           dest.addParPair NilX, NoLineInfo
         dest.addParRi() # KvU

--- a/tests/nimony/methods/deps/mgenericinheritance.nim
+++ b/tests/nimony/methods/deps/mgenericinheritance.nim
@@ -1,17 +1,17 @@
 import std/syncio
 
 type
-  RootObj* {.inheritable.} = object
+  RootObj2* {.inheritable.} = object
 
-type GenericObj*[T] = object of RootObj
+type GenericObj*[T] = object of RootObj2
 
-method foo*(x: RootObj): string = "RootObj"
+method foo*(x: RootObj2): string = "RootObj"
 template name(_: typedesc[int]): string = "int"
 template name(_: typedesc[float]): string = "float"
 method foo*[T](x: GenericObj[T]): string {.untyped.} =
   concat("GenericObj ", name(T))
 
-proc testFoo*(x: RootObj) =
+proc testFoo*(x: RootObj2) =
   echo foo(x)
 
 testFoo(GenericObj[int]())

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -1,9 +1,6 @@
 import std / [syncio, assertions]
 
 type
-  RootObj {.inheritable.} = object
-
-type
   GenericObj[T] = ref object of RootObj
     # object constructors with inherited fields do not work yet
     #x: T

--- a/tests/nimony/methods/tmof.nim
+++ b/tests/nimony/methods/tmof.nim
@@ -2,36 +2,36 @@
 import std / [syncio, assertions]
 
 type
-  RootObj {.inheritable.} = object
+  RootObj2 {.inheritable.} = object
 
-type Obj = object of RootObj
+type Obj = object of RootObj2
   a, b: int
   c: string
 
-method m(o: RootObj) =
+method m(o: RootObj2) =
   echo "RootObj"
 
 method m(o: Obj) =
   echo "Obj"
 
-proc test(o: RootObj) =
-  echo o of RootObj
+proc test(o: RootObj2) =
+  echo o of RootObj2
   echo o of Obj
   m o
 
 test(Obj(a: 1, b: 2, c: "3"))
-test(RootObj())
+test(RootObj2())
 
-type Obj2 = ref object of RootObj
+type Obj2 = ref object of RootObj2
 
 method m(o: Obj2) =
   echo "Obj2"
 
-let x = RootObj(Obj2()[])
+let x = RootObj2(Obj2()[])
 assert x of Obj2
 test(Obj2()[])
 
-let y = (ref RootObj)(Obj2())
+let y = (ref RootObj2)(Obj2())
 assert y of Obj2
 test(y[])
 
@@ -39,9 +39,9 @@ let z = Obj2(y)
 assert z of Obj2
 test(z[])
 
-proc testRef(o: ref RootObj) =
+proc testRef(o: ref RootObj2) =
   echo "testing ref"
-  echo o of RootObj
+  echo o of RootObj2
   echo o of Obj
   echo o of Obj2
   m o[]
@@ -50,8 +50,8 @@ testRef y
 testRef z
 
 proc testNil() =
-  var nilRootObj: ref RootObj = nil
-  #echo "nil of RootObj: ", nilRootObj of RootObj
+  var nilRootObj: ref RootObj2 = nil
+  #echo "nil of RootObj: ", nilRootObj of RootObj2
   # ^ gives always true warning, original nim just compiles it to `true` but here gives `false` at runtime
   echo "nil of Obj: ", nilRootObj of Obj
   echo "nil of Obj2: ", nilRootObj of Obj2


### PR DESCRIPTION
refs #896

Not sure if there is anything else to add to system, `procCall` and `of` are already there

Cast is added to work around C compiler `const` warnings in output which are also fixed by #1053