### PR TITLE
move `const` keyword to after type for `(const)` variables in NIFC

### DIFF
--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -435,6 +435,7 @@ proc genVarDecl(c: var GeneratedCode; n: var Cursor; vk: VarKind; toExtern = fal
       c.add "__thread "
     genType c, d.typ, name
     if vk == IsConst:
+      c.add Space
       c.add ConstKeyword
     let vis = genVarPragmas(c, d.pragmas)
     if vis == StaticP:

--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -433,10 +433,7 @@ proc genVarDecl(c: var GeneratedCode; n: var Cursor; vk: VarKind; toExtern = fal
 
     if vk == IsThreadlocal:
       c.add "__thread "
-    genType c, d.typ, name
-    if vk == IsConst:
-      c.add Space
-      c.add ConstKeyword
+    genType c, d.typ, name, isConst = vk == IsConst
     let vis = genVarPragmas(c, d.pragmas)
     if vis == StaticP:
       c.code.insert(Token(StaticKeyword), beforeDecl)

--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -431,11 +431,11 @@ proc genVarDecl(c: var GeneratedCode; n: var Cursor; vk: VarKind; toExtern = fal
     if toExtern or isImportC(d.name):
       c.add ExternKeyword
 
-    if vk == IsConst:
-      c.add ConstKeyword
     if vk == IsThreadlocal:
       c.add "__thread "
     genType c, d.typ, name
+    if vk == IsConst:
+      c.add ConstKeyword
     let vis = genVarPragmas(c, d.pragmas)
     if vis == StaticP:
       c.code.insert(Token(StaticKeyword), beforeDecl)


### PR DESCRIPTION
To prevent issues with pointer types i.e. `const int* a = ...`, now `int* const a = ...` is generated.