### PR TITLE
fix object constructors with inheritance

### DIFF
--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -311,9 +311,20 @@ proc genx(c: var GeneratedCode; n: var Cursor) =
       if n.substructureKind == KvU:
         inc n
         c.add Dot
+        var depth = n
+        skip depth
+        skip depth
+        if depth.kind != ParRi:
+          # inheritance depth
+          assert depth.kind == IntLit
+          let d = pool.integers[depth.intId]
+          for _ in 0 ..< d:
+            c.add "Q"
+            c.add Dot
         c.genx n
         c.add AsgnOpr
         c.genx n
+        if n.kind != ParRi: skip n
         skipParRi n
       elif n.exprKind == OconstrC:
         # inheritance

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -13,7 +13,7 @@ type Writeable = concept
   proc write(f: File; x: Self): string
 
 method foo[T: Writeable](x: GenericObj[T]) =
-  echo "at base method : ", x.x
+  echo "at base method: ", x.x
   echo "base check: ", x of GenericObj[T]
   echo "inherited 1 check: ", x of InheritGeneric1[T]
   echo "inherited 2 check: ", x of InheritGeneric2

--- a/tests/nimony/methods/tgenericinheritance.nim
+++ b/tests/nimony/methods/tgenericinheritance.nim
@@ -3,7 +3,7 @@ import std / [syncio, assertions]
 type
   GenericObj[T] = ref object of RootObj
     # object constructors with inherited fields do not work yet
-    #x: T
+    x: T
   InheritGeneric1[T] = ref object of GenericObj[T]
     y: T
   InheritGeneric2 = ref object of GenericObj[int]
@@ -13,30 +13,30 @@ type Writeable = concept
   proc write(f: File; x: Self): string
 
 method foo[T: Writeable](x: GenericObj[T]) =
-  echo "at base method"# : ", x.x
+  echo "at base method : ", x.x
   echo "base check: ", x of GenericObj[T]
   echo "inherited 1 check: ", x of InheritGeneric1[T]
   echo "inherited 2 check: ", x of InheritGeneric2
 
 method foo[T: Writeable](x: InheritGeneric1[T]) =
-  echo "at inherited 1 method: ", #[x.x, ", ",]# x.y
+  echo "at inherited 1 method: ", x.x, ", ", x.y
   echo "base check: ", x of GenericObj[T]
   echo "inherited 1 check: ", x of InheritGeneric1[T]
   # correctly fails with "never a subtype":
   #echo "inherited 2 check: ", x of InheritGeneric2
 
 method foo(x: InheritGeneric2) =
-  echo "at inherited 2 method: ", #[x.x, ", ",]# x.z
+  echo "at inherited 2 method: ", x.x, ", ", x.z
   echo "base check: ", x of GenericObj[int]
   # correctly fails with "never a subtype":
   #echo "inherited 1 check: ", x of InheritGeneric1[int]
   echo "inherited 2 check: ", x of InheritGeneric2
 
-let baseInt = GenericObj[int](#[x: 1]#)
-let inherit1Int = InheritGeneric1[int](#[x: 2,]# y: 3)
-let baseFloat = GenericObj[float](#[x: 4.56]#)
-let inherit1Float = InheritGeneric1[float](#[x: 7.89,]# y: 10.11)
-let inherit2 = InheritGeneric2(#[x: 12,]# z: "abc")
+let baseInt = GenericObj[int](x: 1)
+let inherit1Int = InheritGeneric1[int](x: 2, y: 3)
+let baseFloat = GenericObj[float](x: 4.56)
+let inherit1Float = InheritGeneric1[float](x: 7.89, y: 10.11)
+let inherit2 = InheritGeneric2(x: 12, z: "abc")
 
 proc test[T](x: GenericObj[T]) =
   foo(x)

--- a/tests/nimony/methods/tgenericinheritance.output
+++ b/tests/nimony/methods/tgenericinheritance.output
@@ -1,17 +1,17 @@
-at base method
+at base method: 1
 base check: true
 inherited 1 check: false
 inherited 2 check: false
-at inherited 1 method: 3
+at inherited 1 method: 2, 3
 base check: true
 inherited 1 check: true
-at base method
+at base method: 4.56
 base check: true
 inherited 1 check: false
 inherited 2 check: false
-at inherited 1 method: 10.11
+at inherited 1 method: 7.89, 10.11
 base check: true
 inherited 1 check: true
-at inherited 2 method: abc
+at inherited 2 method: 12, abc
 base check: true
 inherited 2 check: true


### PR DESCRIPTION
Currently adds an optional inheritance level to `(kv)` but only when generating NIFC, going to see if it can be generated directly during sem.