### PR TITLE
supports mixing unpacktup and unpackflat in the front end

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4473,7 +4473,15 @@ proc semForLoopTupleVar(c: var SemContext; it: var Item; tup: TypeCursor) =
   inc tup
   while it.n.kind != ParRi and tup.kind != ParRi:
     let field = getTupleFieldType(tup)
-    semForLoopVar c, it, field
+    if it.n.substructureKind == UnpacktupU:
+      takeToken c, it.n
+      if field.typeKind == TupleT:
+        semForLoopTupleVar c, it, field
+      else:
+        buildErr c, it.n.info, "tuple types expected, but got: " & $field
+      takeParRi c, it.n
+    else:
+      semForLoopVar c, it, field
     skip tup
   if it.n.kind == ParRi:
     if tup.kind == ParRi:


### PR DESCRIPTION
Nifler couldn't handle this case before, which enters the wrong branch for `let varTuple` instead of `for varTuple`

```nim
import std/syncio


iterator foo3(): (int, int, (int, int)) =
  yield (1, 2, (3, 4))


for i, j, (m, n) in foo3():
  echo i, j, m, n

```

```
  (unpackflat
   (let :i.0 . . 1,~4
    (i -1) .)
   (let 3 :j.0 . . 6,~4
    (i -1) .)
   (unpacktup
    (let 7 :m.0 . . 12,~4
     (i -1) .)
    (let 10 :n.0 . . 17,~4
     (i -1) .))) ~2,1
```

but removes `unpackflat` for a single `unpacktup` for convenience as before