### PR TITLE
semchecking implicit result exprs with return types

### DIFF
--- a/tests/nimony/sysbasics/ttuples.nim
+++ b/tests/nimony/sysbasics/ttuples.nim
@@ -5,3 +5,10 @@ type
 var x0: Tuple = (1, 2, 3)
 var x1: Tuple0
 var x2 = (1, 2, 3, 34, 5.6)
+
+proc getTup(x: var int): tuple[x: var int] =
+  (x: x)
+
+var a = 100
+getTup(a).x = 300
+


### PR DESCRIPTION
If we don't semcheck implicit result exprs with return types, `(x: x)` is going to have the correct type of `tuple[x: var int]`, which doesn't pass `commonTypes`