### PR TITLE
implement {.inject.} in typed templates

### DIFF
--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -255,7 +255,10 @@ type
 
 proc identToSym*(c: var SemContext; str: sink string; kind: SymKind): SymId =
   var name = str
-  if c.currentScope.kind == ToplevelScope or kind in {FldY, EfldY, TypevarY}:
+  if c.currentScope.kind == ToplevelScope or
+      kind in {FldY, EfldY, TypevarY,
+        # required for local enum type dollars to work at least, probably more cases:
+        TypeY}:
     c.makeGlobalSym(name)
   else:
     c.makeLocalSym(name)

--- a/tests/nimony/nosystem/tresemtype.nif
+++ b/tests/nimony/nosystem/tresemtype.nif
@@ -6,11 +6,11 @@
   (params 1
    (param :x.0 . . 3 T.0.treckpe1i1 .)) . . . 2,1
   (stmts 9
-   (type ~4 :Foo.0 . . . 2
+   (type ~4 :Foo.0.treckpe1i1 . . . 2
     (object . ~9,1
      (fld :val.0.treckpe1i1 . . 5 T.0.treckpe1i1 .))) 4,2
-   (var :obj.0 . . 6 Foo.0 9
-    (oconstr ~3 Foo.0 4
+   (var :obj.0 . . 6 Foo.0.treckpe1i1 9
+    (oconstr ~3 Foo.0.treckpe1i1 4
      (kv ~3 val.0.treckpe1i1 2 x.0))))) 3,5
  (call ~3 foo.1.treckpe1i1 1 +123) 3,6
  (call ~3 foo.2.treckpe1i1 1 "abc") ,8
@@ -20,26 +20,26 @@
   (params 1
    (param :x.1 . . 3 T.1.treckpe1i1 .)) . . . 2,1
   (stmts 9
-   (type ~4 :Foo.1 . . . 2
+   (type ~4 :Foo.1.treckpe1i1 . . . 2
     (object . ~9,1
      (fld :val.1.treckpe1i1 . . 5 T.1.treckpe1i1 .))) 4,2
-   (var :obj.1 . . 6 Foo.1 9
-    (oconstr ~3 Foo.1 4
+   (var :obj.1 . . 6 Foo.1.treckpe1i1 9
+    (oconstr ~3 Foo.1.treckpe1i1 4
      (kv ~3 val.1.treckpe1i1 2 x.1))))) 2,9
  (stmts 9
-  (type ~4 :Foo.2 . . . 2
+  (type ~4 :Foo.2.treckpe1i1 . . . 2
    (object . ~9,1
     (fld :val.2.treckpe1i1 . .
      (i -1) .))) 4,2
-  (gvar :obj.2 . . 6 Foo.2 9
-   (oconstr ~3 Foo.2 4
+  (gvar :obj.2 . . 6 Foo.2.treckpe1i1 9
+   (oconstr ~3 Foo.2.treckpe1i1 4
     (kv ~3 val.2.treckpe1i1 ~10,2 +123)))) 2,9
  (stmts 9
-  (type ~4 :Foo.3 . . . 2
+  (type ~4 :Foo.3.treckpe1i1 . . . 2
    (object . ~9,1
     (fld :val.3.treckpe1i1 . . string.0.sysvq0asl .))) 4,2
-  (gvar :obj.3 . . 6 Foo.3 9
-   (oconstr ~3 Foo.3 4
+  (gvar :obj.3 . . 6 Foo.3.treckpe1i1 9
+   (oconstr ~3 Foo.3.treckpe1i1 4
     (kv ~3 val.3.treckpe1i1 ~10,3 "abc")))) 3,5
  (proc :foo.1.treckpe1i1 . ~3,~5 .
   (at foo.0.treckpe1i1
@@ -48,21 +48,21 @@
    (param :x.4 . .
     (i -1) .)) ~3,~5 . ~3,~5 . ~3,~5 . ~1,~4
   (stmts 9
-   (type ~4 :Foo.4 . . . 2
+   (type ~4 :Foo.4.treckpe1i1 . . . 2
     (object . ~9,1
      (fld :val.4.treckpe1i1 . .
       (i -1) .))) 4,2
-   (var :obj.4 . . 6 Foo.4 9
-    (oconstr ~3 Foo.4 4
+   (var :obj.4 . . 6 Foo.4.treckpe1i1 9
+    (oconstr ~3 Foo.4.treckpe1i1 4
      (kv ~3 val.4.treckpe1i1 2 x.4))))) 3,6
  (proc :foo.2.treckpe1i1 . ~3,~6 .
   (at foo.0.treckpe1i1 string.0.sysvq0asl) 8,~6
   (params 1
    (param :x.5 . . string.0.sysvq0asl .)) ~3,~6 . ~3,~6 . ~3,~6 . ~1,~5
   (stmts 9
-   (type ~4 :Foo.5 . . . 2
+   (type ~4 :Foo.5.treckpe1i1 . . . 2
     (object . ~9,1
      (fld :val.5.treckpe1i1 . . string.0.sysvq0asl .))) 4,2
-   (var :obj.5 . . 6 Foo.5 9
-    (oconstr ~3 Foo.5 4
+   (var :obj.5 . . 6 Foo.5.treckpe1i1 9
+    (oconstr ~3 Foo.5.treckpe1i1 4
      (kv ~3 val.5.treckpe1i1 2 x.5))))))

--- a/tests/nimony/object/tcaseobject.nif
+++ b/tests/nimony/object/tcaseobject.nif
@@ -215,19 +215,19 @@
     (call ~2 fx.0.tcauiaoif 1 x.1)))) ,46
  (block . 2,1
   (stmts 8,1
-   (type ~6 :TKind.0 . . . 2
+   (type ~6 :TKind.0.tcauiaoif . . . 2
     (enum
      (u +8) 5
-     (efld :ka.0.tcauiaoif . . TKind.0
+     (efld :ka.0.tcauiaoif . . TKind.0.tcauiaoif
       (tup +0 "ka")) 9
-     (efld :kb.0.tcauiaoif . . TKind.0
+     (efld :kb.0.tcauiaoif . . TKind.0.tcauiaoif
       (tup +1 "kb")) 13
-     (efld :kc.0.tcauiaoif . . TKind.0
+     (efld :kc.0.tcauiaoif . . TKind.0.tcauiaoif
       (tup +2 "kc")))) 5,2
-   (type ~3 :TA.0 . . . 2
+   (type ~3 :TA.0.tcauiaoif . . . 2
     (object . ~3,1
      (case 5
-      (fld :k.0.tcauiaoif . . 3 TKind.0 .) ,1
+      (fld :k.0.tcauiaoif . . 3 TKind.0.tcauiaoif .) ,1
       (of
        (ranges 3 ka.0.tcauiaoif) 2,1
        (stmts
@@ -246,7 +246,7 @@
          (f +64) .) 9
         (fld :d.1.tcauiaoif . . 3
          (f +64) .)))))) 4,10
-   (var :s.1 . . 11,~9 TKind.0 4 ka.0.tcauiaoif) ,11
+   (var :s.1 . . 11,~9 TKind.0.tcauiaoif 4 ka.0.tcauiaoif) ,11
    (case 5 s.1 ,1
     (of
      (ranges 3 ka.0.tcauiaoif) 2,1
@@ -267,9 +267,9 @@
        (stmts
         (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 14,64,tests/nimony/object/tcaseobject.nim +3)) ,2
        (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A'))))))) 4,48
- (proc :dollar`.TKind.0 x . .
+ (proc :dollar`.TKind.0.tcauiaoif x . .
   (params
-   (param :e.0 . . TKind.0 .)) string.0.sysvq0asl . .
+   (param :e.0 . . TKind.0.tcauiaoif .)) string.0.sysvq0asl . .
   (stmts 8
    (result :result.1 . . ~5,~40 string.0.sysvq0asl .) 8
    (case e.0 5

--- a/tests/nimony/templates/ttypedinject.nim
+++ b/tests/nimony/templates/ttypedinject.nim
@@ -1,0 +1,23 @@
+import std/assertions
+
+template typedTempl() =
+  proc injectedProc() {.inject.} = discard
+  proc gensymProc() {.gensym.} = discard
+  let injectedLocal {.inject.} = 123
+  let gensymLocal {.gensym.} = 456
+  type InjectedType {.inject.} = object
+    field: int
+  type GensymType {.gensym.} = object
+    field: int
+  type Enum {.inject.} = enum e1, e2
+
+typedTempl()
+
+injectedProc()
+assert injectedLocal == 123
+let obj = InjectedType(field: 456)
+let efld: Enum = e1
+
+assert not declared(gensymProc)
+assert not declared(gensymLocal)
+assert not declared(GensymType)


### PR DESCRIPTION
refs #1044 (the title, the full code in the issue needs untyped parameters to work)

`{.inject.}` in untyped templates is implemented by just generating an identifier instead of a sym, but this cannot be done in typed templates. So we accept a symbol that was generated by a template/generic and has an `{.inject.}` pragma and add it to scope again. For delayed syms this is done by just setting the status back to `OkNew` from `OkExistingFresh` so that `addSym` can define it, but another status kind like `OkExistingInject` can be added for this. For procs the symbol is manually added after pragmas, but could be done earlier with a syntactic scan for `inject` as in untyped templates.

There was an issue with enum types defined in a scope: the `$` overload for them is still generated in the top module scope but this means it may not be able to load the enum symbol if it doesn't have a global sym module qualifier, so type symbols now always generate a global sym. (i.e. instead of generating `Foo.0` in a scope and `dollar.Foo.0` at top level, it now uses `Foo.0.tabcdef`)

Enum fields are also never gensym'd in original Nim so they are considered always injected here as well. (This caused redefinition errors before overloadable enums.)

Something to note is that the symbols originally defined in the template are still different from the substituted symbols in the instantiation, even if they are fully typed. Injecting does not change this.