### PR TITLE
fixes `getRtti`, inheritance and `nimChckNilDisp`

### DIFF
--- a/tests/nimony/object/tmethods.nim
+++ b/tests/nimony/object/tmethods.nim
@@ -1,0 +1,31 @@
+import std/[assertions, syncio]
+
+type
+  TestObj = object of RootObj
+    t: int
+
+  SubObject = object of TestObj
+
+method test(t: ptr TestObj) {.base.} =
+  echo "test called"
+
+method test(t: ptr SubObject) =
+  t.t = 5
+
+block:
+  var a: SubObject = SubObject()
+
+  test(addr a)
+  assert a.t == 5
+
+method foo(t: var TestObj) {.base.} =
+  echo "test called"
+
+method foo(t: var SubObject) =
+  t.t = 5
+
+block:
+  var a: SubObject = SubObject()
+
+  foo(a)
+  assert a.t == 5


### PR DESCRIPTION
fixes `nimChckNilDisp` called for `var object`
fixes `getRtti` for `ptr` and `var` objects