### PR TITLE
fixes #977; DistinctType(0) != 0 causes error message with wrong lineinfo

### DIFF
--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -344,8 +344,8 @@ proc replace*(dest: var TokenBuf; by: Cursor; pos: int) =
     dest[pos + i] = by.load
     inc by
 
-proc toString*(b: TokenBuf; produceLineInfo = true): string =
-  result = nifstreams.toString(toOpenArray(b.data, 0, b.len-1), produceLineInfo)
+proc toString*(b: TokenBuf; produceLineInfo = true; useAbsolute = false): string =
+  result = nifstreams.toString(toOpenArray(b.data, 0, b.len-1), produceLineInfo, useAbsolute)
 
 proc toString*(b: TokenBuf; first: int; produceLineInfo = true): string =
   var last = first

--- a/src/lib/nifindexes.nim
+++ b/src/lib/nifindexes.nim
@@ -236,9 +236,9 @@ proc createIndex*(infile: string; root: PackedLineInfo; buildChecksum: bool; sec
   close s
 
   var content = "(.nif24)\n(index\n"
-  content.add toString(public)
+  content.add toString(public, useAbsolute = true)
   content.add "\n"
-  content.add toString(private)
+  content.add toString(private, useAbsolute = true)
   content.add "\n"
 
   for op in AttachedOp:


### PR DESCRIPTION
fixes #977

The problem is that the index file doesn't handle line infos correctly for included statements

```
(index
0,1,lib/std/system.nim( 0,1,lib/std/system/comparisons.nim
 (kv ==.0.sysvq0asl +269) 
 (kv ==.1.sysvq0asl +291) 
 (kv ==.2.sysvq0asl +318)
 (kv ==.3.sysvq0asl +318) 
)
```

When included statements are flattened in the index file, the parent line infos are lost for `==`. So from the second overload of `==`, the parent line info becomes `0,1,lib/std/system.nim` since the nested structure (`stmts`) is lost. 

There are two potential solutions that I could think of. One is to keep `stmts` nested structure in the index files. Or we could write every absolute parent line info for the symbol, which is done in this PR


```
0,1,lib/std/system.nim( 0,1,lib/std/system/comparisons.nim
 (kv ==.0.sysvq0asl +269) 0,1,lib/std/system/comparisons.nim
 (kv ==.1.sysvq0asl +291) 0,1,lib/std/system/comparisons.nim
 (kv ==.2.sysvq0asl +318) 0,1,lib/std/system/comparisons.nim
 (kv ==.3.sysvq0asl +318)
)
```

With this PR, the error becomes `lib/std/system/comparisons.nim(102, 3) Error: Type mismatch at [position]`