### PR TITLE
fixes invalid Cursor dereference

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3686,7 +3686,7 @@ proc semBorrow(c: var SemContext; fn: StrId; beforeParams: int) =
   var it = Item(n: n, typ: c.types.autoType)
   let resId = declareResult(c, it.n.info)
   semProcBody c, it
-  addReturnResult c, resId, it.n.info
+  addReturnResult c, resId, procBody[procBody.len - 1].info
 
 proc getParamsType(c: var SemContext; paramsAt: int): seq[TypeCursor] =
   result = @[]


### PR DESCRIPTION
I found `tests/nimony/sysbasics/tdistincts.nim` causes invalid `PackedLineInfo` in `c.dest` in `src/nimony/sem.nim`.

I added following code to check `it.n` before `addReturnResult c, resId, it.n.info` in `semBorrow` proc in `src/nimony/sem`.
```nim
  assert cursorToPosition(procBody, it.n) < procBody.len

  addReturnResult c, resId, it.n.info
```

That assert failed when compiled `tests/nimony/sysbasics/mdistincts.nim`:
```nim
$ ./bin/nimony c -r tests/nimony/sysbasics/mdistincts.nim 
bin/nimsem  --isMain m nimcache/mdi5tldn4.1.nif nimcache/mdi5tldn4.2.nif nimcache/mdi5tldn4.2.idx.nif
src/nimony/nimsem.nim(126) nimsem
src/nimony/nimsem.nim(123) handleCmdLine
src/nimony/nimsem.nim(54) singleModule
src/nimony/sem.nim(7341) semcheck
src/nimony/sem.nim(7289) semcheckCore
src/nimony/sem.nim(677) semStmt
src/nimony/sem.nim(6823) semExpr
src/nimony/sem.nim(4041) semProc
src/nimony/sem.nim(3690) semBorrow
nim-2.3.1/lib/std/assertions.nim(41) failedAssertImpl
nim-2.3.1/lib/std/assertions.nim(34) raiseAssert
Error: unhandled exception: src/nimony/sem.nim(3690, 3) `cursorToPosition(procBody, it.n) < procBody.len`  [Assert
ionDefect]
```

So `it.n` is dereferenced while `it.n` is referencing outside of `procBody`.