### PR TITLE
accept stdin input in debug mode to resume compilation on errors

### DIFF
--- a/src/nimony/contracts.nim
+++ b/src/nimony/contracts.nim
@@ -46,7 +46,7 @@ proc buildErr(c: var Context; info: PackedLineInfo; msg: string) =
   when defined(debug):
     writeStackTrace()
     echo infoToStr(info) & " Error: " & msg
-    quit msg
+    debugAskToContinue()
   c.errors.buildTree ErrT, info:
     c.errors.addDotToken()
     c.errors.add strToken(pool.strings.getOrIncl(msg), info)

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -423,7 +423,7 @@ proc cannotPassToVar(dest: var TokenBuf; info: PackedLineInfo; arg: Cursor) =
   when defined(debug):
     writeStackTrace()
     echo infoToStr(info) & " Error: " & msg
-    quit msg
+    debugAskToContinue()
   dest.buildTree ErrT, info:
     dest.addSubtree arg
     dest.add strToken(pool.strings.getOrIncl(msg), info)

--- a/src/nimony/reporters.nim
+++ b/src/nimony/reporters.nim
@@ -82,9 +82,9 @@ proc fatal*(msg: string) =
 when defined(debug):
   proc debugAskToContinue*() =
     var msg = ""
-    write stdout, "Enter 'q' to quit, anything else to continue: "
+    write stdout, "Continue? [y/N] "
     let ok = readLine(stdin, msg)
-    if not ok or msg == "q":
+    if not ok or msg.len == 0 or not (msg[0] == 'y' or msg[0] == 'Y'):
       quit 1
 
 proc shortenDir*(x: string): string =

--- a/src/nimony/reporters.nim
+++ b/src/nimony/reporters.nim
@@ -60,8 +60,6 @@ proc warn*(c: var Reporter; p, arg: string) =
   inc c.warnings
 
 proc error*(c: var Reporter; p, arg: string) =
-  when defined(debug):
-    writeStackTrace()
   if c.assertOnError:
     raise newException(AssertionDefect, p & ": " & arg)
   c.message(Error, p, arg)
@@ -80,6 +78,14 @@ proc fatal*(msg: string) =
   when defined(debug):
     writeStackTrace()
   quit "[Error] " & msg
+
+when defined(debug):
+  proc debugAskToContinue*() =
+    var msg = ""
+    write stdout, "Enter 'q' to quit, anything else to continue: "
+    let ok = readLine(stdin, msg)
+    if not ok or msg == "q":
+      quit 1
 
 proc shortenDir*(x: string): string =
   var to = getCurrentDir()

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -170,7 +170,7 @@ proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string; orig: Curso
       echo infoToStr(info) & " Error: " & msg
       if orig.kind != DotToken:
         echo "Source: ", toString(orig, false)
-      quit 1
+      debugAskToContinue()
   c.dest.buildTree ErrT, info:
     c.dest.addSubtree orig
     for instFrom in items(c.instantiatedFrom):
@@ -187,7 +187,7 @@ proc buildLocalErr*(dest: var TokenBuf; info: PackedLineInfo; msg: string; orig:
     if true: # not c.debugAllowErrors: - c not given
       writeStackTrace()
       echo infoToStr(info) & " Error: " & msg
-      quit msg
+      debugAskToContinue()
   dest.buildTree ErrT, info:
     dest.addSubtree orig
     dest.add strToken(pool.strings.getOrIncl(msg), info)


### PR DESCRIPTION
Threw this together if it's useful, when debug mode encounters an error, instead of quitting, it asks for stdin input such that one can either quit or resume compilation. It asks to type "q" to quit and anything else (including just enter) to resume but this can be changed, also ctrl c works.

If this is sufficient for `defined` etc then we can remove the `c.debugAllowErrors` workaround, there is also another workaround in `semDconv` that adds an error message instead of using `buildErr`.