### PR TITLE
argument dependent lookup

### DIFF
--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -223,6 +223,17 @@ proc loadVTable*(typ: SymId): seq[MethodIndexEntry] =
         return entry.methods
   return @[]
 
+proc loadSyms*(suffix: string; identifier: StrId): seq[SymId] =
+  result = @[]
+  var m = load(suffix)
+  for k, _ in m.index.public:
+    var base = k
+    extractBasename(base)
+    let strId = pool.strings.getOrIncl(base)
+    if strId == identifier:
+      let symId = pool.syms.getOrIncl(k)
+      result.add symId
+
 proc registerHook*(suffix: string; typ: SymId; op: AttachedOp; hook: SymId; isGeneric: bool) =
   let m: NifModule
   if not prog.mods.hasKey(suffix):

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -224,6 +224,7 @@ proc loadVTable*(typ: SymId): seq[MethodIndexEntry] =
   return @[]
 
 proc loadSyms*(suffix: string; identifier: StrId): seq[SymId] =
+  # gives top level exported syms of a module
   result = @[]
   var m = load(suffix)
   for k, _ in m.index.public:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -912,13 +912,9 @@ proc hasAttachedParam(params: Cursor; typ: SymId): bool =
   inc params
   while params.kind != ParRi:
     let param = takeLocal(params, SkipFinalParRi)
-    if param.val.kind != DotToken:
-      # original nim does not consider params with default values as attached for some reason
-      discard
-    else:
-      let root = nominalRoot(param.typ)
-      if root != SymId(0) and root == typ:
-        return true
+    let root = nominalRoot(param.typ)
+    if root != SymId(0) and root == typ:
+      return true
 
 proc addTypeboundOps(c: var SemContext; fn: StrId; s: SymId; cands: var FnCandidates) =
   let res = tryLoadSym(s)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1275,11 +1275,11 @@ proc semReturnType(c: var SemContext; n: var Cursor): TypeCursor =
   result = semLocalType(c, n, InReturnTypeDecl)
 
 proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; fnName: StrId; args: openArray[Item], genericArgs: Cursor, hasNamedArgs: bool) =
-  # XXX maybe only trigger for open symchoice/ident callee, 
   # scope extension: procs attached to argument types are also considered
   # If the type is Typevar and it has attached
   # a concept, use the concepts symbols too:
   if fnName != StrId(0):
+    # XXX maybe only trigger for open symchoice/ident callee, but the latter is not tracked
     var candidates = FnCandidates(marker: initHashSet[SymId]())
     # mark already matched symbols so that they don't get added:
     for i in 0 ..< m.len:

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -73,6 +73,12 @@ proc buildSymChoiceForSelfModule*(c: var SemContext;
     c.dest.shrink oldLen
     c.dest.add identToken(identifier, info)
 
+iterator topLevelSyms*(c: var SemContext; identifier: StrId): SymId =
+  var it = c.currentScope
+  while it.up != nil: it = it.up
+  for sym in it.tab.getOrDefault(identifier):
+    yield sym.name
+
 proc rawBuildSymChoiceForForeignModule(c: var SemContext; module: SymId;
                                        identifier: StrId; info: PackedLineInfo;
                                        marker: var HashSet[SymId]): int =

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -113,6 +113,7 @@ type
     pendingTypePlugins*: Table[SymId, StrId]
     pendingModulePlugins*: seq[StrId]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
+    cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
 
 proc typeToCanon*(buf: TokenBuf; start: int): string =
   result = ""

--- a/tests/nimony/lookups/deps/msandwich1.nim
+++ b/tests/nimony/lookups/deps/msandwich1.nim
@@ -1,0 +1,6 @@
+import std / syncio
+
+type
+  MyS* = distinct string
+
+proc write*(f: File; s: MyS) = write f, string(s)

--- a/tests/nimony/lookups/deps/msandwich2.nim
+++ b/tests/nimony/lookups/deps/msandwich2.nim
@@ -1,0 +1,3 @@
+import msandwich1
+
+proc toMyS*(s: string): MyS = MyS(s)

--- a/tests/nimony/lookups/tcrossmoduleoverload.nim
+++ b/tests/nimony/lookups/tcrossmoduleoverload.nim
@@ -1,0 +1,12 @@
+import std / syncio
+
+type
+  MyS = distinct string
+
+proc write*(f: File; s: MyS) = write f, string(s)
+
+proc main =
+  var s90 = MyS"abc"
+  echo s90
+
+main()

--- a/tests/nimony/lookups/ttypeboundops.nim
+++ b/tests/nimony/lookups/ttypeboundops.nim
@@ -1,0 +1,8 @@
+import std / syncio
+import deps / msandwich2
+
+proc main =
+  var s90 = toMyS("abc")
+  echo s90
+
+main()


### PR DESCRIPTION
closes #1107

Same as the implementation in original Nim, if an argument has a nominal type and the nominal type is exported from a module, the toplevel symbols of the module the type is from are scanned if they are an attachable routine to the nominal type, in which case they are considered in overload resolution.

This is done in the same place as concept procs, they are now built directly in `considerTypeboundOps` as well by iterating over `cs.args` rather than adding them when the arguments are typechecked. This is to simplify preventing symbols that were already considered in overloading from getting added, they now use the same marker set as the added typebound ops.

Apparently the position of the argument is not considered in attachment, every parameter of the routine is checked for the nominal type. Presumably this is to simplify the logic for things like varargs and named arguments. It apparently also ignores parameters with default values. This logic is unchanged.

Something to point out is that attached routines for types from the current semchecked module have to be special cased. One might assume they shouldn't be added at all since it would be redundant with regular lookup, but then the original test case in #1107 would not work without a fix like in #1110, as regular lookup with `OchoiceX` does not work as expected yet. Another problem with adding attached routines from the current module is that using a cache would not be reliable, and so it is not done here, but this means we have to search for attached routines every time for them.

The original Nim implementation also disables type bound ops when the callee is a closed symbol/symchoice. This could be done here for open symchoices but it would be a little arbitrary to track the case where the callee is originally an identifier that gets turned into a symbol, maybe it can produce an open symchoice but this would complicate type conversions etc. So nothing is done for now. 