### PR TITLE
fix dotted defines deleting the dot

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -5759,6 +5759,7 @@ proc getDottedIdent(n: var Cursor): string =
     if s == StrId(0) or result == "":
       result = ""
     else:
+      result.add(".")
       result.add(pool.strings[s])
     skipParRi n
   else:


### PR DESCRIPTION
refs https://github.com/nim-lang/nimony/pull/1105#issuecomment-2892371137, apparently `-d:abcdef` makes `defined(abc.def)` true when it should be `-d:abc.def`