### PR TITLE
don't construct nested errors in buildErr proc

### DIFF
--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -198,13 +198,14 @@ proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string; orig: Curso
             break
           else:
             inc nested
-  if hasErr:
-    c.dest.addSubtree n
-  else:
-    c.dest.buildTree ErrT, info:
-      c.dest.addSubtree orig
-      for instFrom in items(c.instantiatedFrom):
-        c.dest.add dotToken(instFrom)
+  c.dest.buildTree ErrT, info:
+    c.dest.addSubtree orig
+    for instFrom in items(c.instantiatedFrom):
+      c.dest.add dotToken(instFrom)
+    if hasErr:
+      inc n
+      while n.kind != ParRi: c.dest.takeTree n
+    else:
       c.dest.add strToken(pool.strings.getOrIncl(msg), info)
 
 proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string) =

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -199,12 +199,16 @@ proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string; orig: Curso
           else:
             inc nested
   c.dest.buildTree ErrT, info:
-    c.dest.addSubtree orig
+    if hasErr:
+      inc n
+      c.dest.takeTree n
+    else:
+      c.dest.addSubtree orig
     for instFrom in items(c.instantiatedFrom):
       c.dest.add dotToken(instFrom)
     if hasErr:
-      inc n
-      while n.kind != ParRi: c.dest.takeTree n
+      while n.kind == DotToken: inc n
+      c.dest.takeTree n
     else:
       c.dest.add strToken(pool.strings.getOrIncl(msg), info)
 

--- a/tests/nimony/errmsgs/tdistinctinfos.msgs
+++ b/tests/nimony/errmsgs/tdistinctinfos.msgs
@@ -1,11 +1,23 @@
 tests/nimony/errmsgs/tdistinctinfos.nim(4, 20) Trace: instantiation from here
-lib/std/system/comparisons.nim(105, 3) Error: Type mismatch at [position]
-[1] expected: (bool) but got: (auto)
-[1] expected: (i +8) but got: (auto)
-[1] expected: (i +16) but got: (auto)
-[1] expected: (i +32) but got: (auto)
-[1] expected: (i +64) but got: (auto)
-[1] expected: (u +8) but got: (auto)
-[1] expected: (u +16) but got: (auto)
-[1] expected: (u +32) but got: (auto)
-[1] expected: (u +64) but got: (auto)
+lib/std/system/comparisons.nim(105, 10) Error: Type mismatch at [position]
+[2] BUG: unhandled type: distinct
+[1] WINBOOL.0.tdim13fdy1 does not match constraint Enum.0.sysvq0asl
+[1] WINBOOL.0.tdim13fdy1 does not match constraint Enum.1.sysvq0asl
+[1] expected: (pointer) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (c +8) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (bool) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (set T.32.sysvq0asl) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (ref T.33.sysvq0asl) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (ptr T.34.sysvq0asl) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (i +8) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (i +16) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (i +32) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (i +64) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (u +8) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (u +16) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (u +32) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (u +64) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (f +32) but got: WINBOOL.0.tdim13fdy1
+[1] expected: (f +64) but got: WINBOOL.0.tdim13fdy1
+[1] expected: string.0.sysvq0asl but got: WINBOOL.0.tdim13fdy1
+[1] expected: (at openArray.0.sysvq0asl T.116.sysvq0asl) but got: WINBOOL.0.tdim13fdy1

--- a/tests/nimony/errmsgs/tdistinctinfos.msgs
+++ b/tests/nimony/errmsgs/tdistinctinfos.msgs
@@ -1,5 +1,5 @@
 tests/nimony/errmsgs/tdistinctinfos.nim(4, 20) Trace: instantiation from here
-lib/std/system/comparisons.nim(105, 10) Error: Type mismatch at [position]
+lib/std/system/comparisons.nim(105, 3) Error: Type mismatch at [position]
 [2] BUG: unhandled type: distinct
 [1] WINBOOL.0.tdim13fdy1 does not match constraint Enum.0.sysvq0asl
 [1] WINBOOL.0.tdim13fdy1 does not match constraint Enum.1.sysvq0asl

--- a/tests/nimony/nosystem/tdefinedarg.nif
+++ b/tests/nimony/nosystem/tdefinedarg.nif
@@ -18,5 +18,5 @@
   (bool) 12
   (true)) 4,6
  (glet :z.0.tdej0g1hh1 . .
-  (bool) 15
+  (bool) 12
   (false)))

--- a/tests/nimony/nosystem/tdefinedarg.nif
+++ b/tests/nimony/nosystem/tdefinedarg.nif
@@ -18,5 +18,5 @@
   (bool) 12
   (true)) 4,6
  (glet :z.0.tdej0g1hh1 . .
-  (bool) 12
+  (bool) 15
   (false)))


### PR DESCRIPTION
Unlike https://github.com/nim-lang/nimony/pull/1105, when `orig` param contains error node in `buildErr` proc, use that error to avoid nest errors.
`define(abc.def)` doesn't work correctly with this PR.