### PR TITLE
custom pragmas, process statement pragmas in signatures phase

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -287,6 +287,7 @@
 | `(base)` | NimonyPragma | `base` pragma (currently ignored) |
 | `(pure)` | NimonyPragma | `pure` pragma (currently ignored) |
 | `(final)` | NimonyPragma | `final` pragma |
+| `(pragma D)` | NimonyPragma | `pragma` pragma |
 | `(internalTypeName T)` | NimonyExpr | returns compiler's internal type name |
 | `(internalFieldPairs T X)` | NimonyExpr | variant of fieldPairs iterator returns compiler's internal field name |
 | `(failed X)` | NimonyExpr | used to access the hidden failure flag for raising calls |

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -712,7 +712,7 @@ proc parsePragmas(c: var EContext; n: var Cursor): CollectedPragmas =
           inc n
         of RequiresP, EnsuresP, StringP, RaisesP, ErrorP, AssumeP, AssertP, ReportP,
            TagsP, DeprecatedP, SideEffectP, KeepOverflowFlagP, SemanticsP,
-           BaseP, FinalP:
+           BaseP, FinalP, PragmaP:
           skip n
           continue
         of BuildP, EmitP:

--- a/src/models/nimony_tags.nim
+++ b/src/models/nimony_tags.nim
@@ -311,9 +311,10 @@ type
     BaseP = (ord(BaseTagId), "base")  ## `base` pragma (currently ignored)
     PureP = (ord(PureTagId), "pure")  ## `pure` pragma (currently ignored)
     FinalP = (ord(FinalTagId), "final")  ## `final` pragma
+    PragmaP = (ord(PragmaTagId), "pragma")  ## `pragma` pragma
 
 proc rawTagIsNimonyPragma*(raw: TagEnum): bool {.inline.} =
-  raw in {EmitTagId, InlineTagId, NoinlineTagId, VarargsTagId, SelectanyTagId, AlignTagId, BitsTagId, NodeclTagId, RaisesTagId, UntypedTagId, MagicTagId, ImportcTagId, ImportcppTagId, ExportcTagId, HeaderTagId, ThreadvarTagId, GlobalTagId, DiscardableTagId, NoreturnTagId, BorrowTagId, NoSideEffectTagId, NodestroyTagId, PluginTagId, BycopyTagId, ByrefTagId, NoinitTagId, RequiresTagId, EnsuresTagId, AssumeTagId, AssertTagId, BuildTagId, StringTagId, ViewTagId, InjectTagId, GensymTagId, ErrorTagId, ReportTagId, TagsTagId, DeprecatedTagId, SideEffectTagId, KeepOverflowFlagTagId, SemanticsTagId, InheritableTagId, BaseTagId, PureTagId, FinalTagId}
+  raw in {EmitTagId, InlineTagId, NoinlineTagId, VarargsTagId, SelectanyTagId, AlignTagId, BitsTagId, NodeclTagId, RaisesTagId, UntypedTagId, MagicTagId, ImportcTagId, ImportcppTagId, ExportcTagId, HeaderTagId, ThreadvarTagId, GlobalTagId, DiscardableTagId, NoreturnTagId, BorrowTagId, NoSideEffectTagId, NodestroyTagId, PluginTagId, BycopyTagId, ByrefTagId, NoinitTagId, RequiresTagId, EnsuresTagId, AssumeTagId, AssertTagId, BuildTagId, StringTagId, ViewTagId, InjectTagId, GensymTagId, ErrorTagId, ReportTagId, TagsTagId, DeprecatedTagId, SideEffectTagId, KeepOverflowFlagTagId, SemanticsTagId, InheritableTagId, BaseTagId, PureTagId, FinalTagId, PragmaTagId}
 
 type
   NimonySym* = enum

--- a/src/models/tags.nim
+++ b/src/models/tags.nim
@@ -290,6 +290,7 @@ type
     BaseTagId
     PureTagId
     FinalTagId
+    PragmaTagId
     InternalTypeNameTagId
     InternalFieldPairsTagId
     FailedTagId
@@ -583,7 +584,8 @@ const
     ("base", 285),
     ("pure", 286),
     ("final", 287),
-    ("internalTypeName", 288),
-    ("internalFieldPairs", 289),
-    ("failed", 290)
+    ("pragma", 288),
+    ("internalTypeName", 289),
+    ("internalFieldPairs", 290),
+    ("failed", 291)
   ]

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6549,8 +6549,7 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
     skip it.n
   of PluginP:
     c.dest.add parLeToken(PragmasS, it.n.info)
-    c.dest.add parLeToken(KvU, it.n.info)
-    c.dest.add identToken(pool.strings.getOrIncl("plugin"), it.n.info) #parLeToken(PluginP, it.n.info)
+    c.dest.add parLeToken(PluginP, it.n.info)
     inc it.n
     if it.n.kind == StringLit:
       if c.routine.inGeneric == 0 and it.n.litId notin c.pluginBlacklist:
@@ -6563,8 +6562,7 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
     c.dest.addParRi()
   of PragmaP:
     c.dest.add parLeToken(PragmasS, it.n.info)
-    c.dest.add parLeToken(KvU, it.n.info)
-    c.dest.add identToken(pool.strings.getOrIncl("pragma"), it.n.info) #parLeToken(PragmaP, it.n.info)
+    c.dest.add parLeToken(PragmaP, it.n.info)
     inc it.n
     let name = takeIdent(it.n)
     if name == StrId(0):
@@ -6591,10 +6589,14 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
 proc semPragmasLine(c: var SemContext; it: var Item) =
   let info = it.n.info
   inc it.n
-  while it.n.kind == ParLe and (it.n.stmtKind in CallKindsS or
-            it.n.substructureKind == KvU):
-    inc it.n
-    semPragmaLine c, it, false
+  while true:
+    if it.n.kind == ParLe:
+      if it.n.stmtKind in CallKindsS or
+          it.n.substructureKind == KvU:
+        inc it.n
+      semPragmaLine c, it, false
+    else:
+      break
   skipParRi it.n
   producesVoid c, info, it.typ # in case it was not already produced
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6539,14 +6539,11 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
       c.toBuild.addStrLit name, info
       c.toBuild.addStrLit customArgs, info
   of EmitP:
-    toplevelGuard c:
-      semEmit c, it
+    semEmit c, it
   of AssumeP:
-    toplevelGuard c:
-      semAssumeAssert c, it, AssumeS
+    semAssumeAssert c, it, AssumeS
   of AssertP:
-    toplevelGuard c:
-      semAssumeAssert c, it, AssertS
+    semAssumeAssert c, it, AssertS
   of KeepOverflowFlagP:
     if not isPragmaBlock:
       buildErr c, it.n.info, "`keepOverflowFlag` pragma must be used in a pragma block"
@@ -7027,7 +7024,7 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
         # XXX ignored for now
         skip it.n
       of EmitS:
-        toplevelGuard c:
+        pragmaGuard c:
           semEmit c, it
       of PragmasS:
         pragmaGuard c:
@@ -7036,7 +7033,7 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
         toplevelGuard c:
           semInclExcl c, it
       of AssumeS, AssertS:
-        toplevelGuard c:
+        pragmaGuard c:
           semAssumeAssert c, it, it.n.stmtKind
     of FalseX, TrueX, OvfX:
       literalB c, it, c.types.boolType

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6489,6 +6489,12 @@ template constGuard(c: var SemContext; body: untyped) =
   else:
     c.takeTree it.n
 
+template pragmaGuard(c: var SemContext; body: untyped) =
+  if c.phase in {SemcheckSignatures, SemcheckBodies}:
+    body
+  else:
+    c.takeTree it.n
+
 proc semAssumeAssert(c: var SemContext; it: var Item; kind: StmtKind) =
   let info = it.n.info
   inc it.n
@@ -7022,7 +7028,7 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
       of EmitS:
         bug "unreachable"
       of PragmasS:
-        constGuard c:
+        pragmaGuard c:
           semPragmasLine c, it
       of InclS, ExclS:
         toplevelGuard c:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -7026,7 +7026,8 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
         # XXX ignored for now
         skip it.n
       of EmitS:
-        bug "unreachable"
+        pragmaGuard c:
+          semEmit c, it
       of PragmasS:
         pragmaGuard c:
           semPragmasLine c, it

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6539,7 +6539,8 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
       c.toBuild.addStrLit name, info
       c.toBuild.addStrLit customArgs, info
   of EmitP:
-    semEmit c, it
+    toplevelGuard c:
+      semEmit c, it
   of AssumeP:
     toplevelGuard c:
       semAssumeAssert c, it, AssumeS
@@ -7026,7 +7027,7 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
         # XXX ignored for now
         skip it.n
       of EmitS:
-        pragmaGuard c:
+        toplevelGuard c:
           semEmit c, it
       of PragmasS:
         pragmaGuard c:

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -114,6 +114,7 @@ type
     pendingModulePlugins*: seq[StrId]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
     cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
+    userPragmas*: Table[StrId, TokenBuf]
 
 proc typeToCanon*(buf: TokenBuf; start: int): string =
   result = ""

--- a/tests/nimony/pragmas/tcustompragma.nif
+++ b/tests/nimony/pragmas/tcustompragma.nif
@@ -1,0 +1,22 @@
+(.nif24)
+0,1,tests/nimony/pragmas/tcustompragma.nim(stmts 2
+ (pragmas
+  (pragma 6 customPragma) 22 noinit 30 discardable 47
+  (kv ~4 tags 2
+   (bracket))) ,2
+ (proc 5 :foo.0.tcui0hn981 . . . 8
+  (params) 4
+  (i -1) 16
+  (pragmas 8,~2
+   (noinit) 16,~2
+   (discardable) 29,~2
+   (tags 6
+    (bracket))) . 35
+  (stmts
+   (result :result.0 .
+    (pragmas
+     (noinit)) ~31
+    (i -1) .)
+   (discard .) ~35
+   (ret result.0))) 3,4
+ (call ~3 foo.0.tcui0hn981))

--- a/tests/nimony/pragmas/tcustompragma.nim
+++ b/tests/nimony/pragmas/tcustompragma.nim
@@ -1,0 +1,5 @@
+{.pragma: customPragma, noinit, discardable, tags: [].}
+
+proc foo(): int {.customPragma.} = discard
+
+foo()


### PR DESCRIPTION
closes #523

Custom pragmas are implemented similar to original Nim, a global table on identifiers in the sem context that doesn't care about redefinitions (though here it gets overwritten, the original compiler uses `strTableAdd` which can end up giving previous definitions). They can't have arguments so they are only invoked as standalone identifiers.

Statement pragmas are now processed as early as `SemcheckSignatures`. This is needed for custom pragmas to be used in proc signatures. Originally thought of making `assume`/`assert`/`emit` not semcheck until the bodies phase but this is not necessary since they just call `semExpr` again, they now semcheck in the signature phase just like other pragmas.