### PR TITLE
fixes Hexer generates invalid Cursor

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -360,6 +360,9 @@ proc trAsNamedType(c: var EContext; n: var Cursor) =
 
     swap c.dest, buf
     c.pending.add buf
+    # Convert NifC type decl to Nim-gear2 type decl by
+    # inserting empty export marker and type vars
+    buf.insert [dotToken(NoLineInfo), dotToken(NoLineInfo)], 1
     programs.publish val, buf
   # regardless of what we had to do, we still need to add the typename:
   if k == RefT:


### PR DESCRIPTION
In `trAsNamedType` proc in `hexer/nifcgen.nim`, a type declaration for NifC is created and it is passed to `programs.publish` proc.
When `trType` proc is called with the symbol, that type declaration is passed to `asTypeDecl` proc `in nimony/decls.nim`.
But that proc assumes given type declaration is `Nim-gear2`.
As type declaration for NifC has fewer child nodes, `takeTypeDecl` proc produces invalid `Cursor`.