### PR TITLE
documents `--ff` and adds it to nimsem to avoid help messages

### DIFF
--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -34,6 +34,7 @@ Options:
   -d, --define:SYMBOL       define a symbol for conditional compilation
   -p, --path:PATH           add PATH to the search path
   -f, --forcebuild          force a rebuild
+  --ff                      force a full build
   -r, --run                 also run the compiled program
   --compat                  turn on compatibility mode
   --noenv                   do not read configuration from `NIM_*`

--- a/src/nimony/nimsem.nim
+++ b/src/nimony/nimsem.nim
@@ -78,7 +78,7 @@ proc handleCmdLine() =
       case normalize(key)
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
-      of "forcebuild", "f": forceRebuild = true
+      of "forcebuild", "f", "ff": forceRebuild = true
       of "compat": config.compat = true
       of "path", "p": config.paths.add val
       of "define", "d": config.defines.incl val


### PR DESCRIPTION
`nimsem` didn't support `--ff` flags, which are passed to it by `nimony`. It printed help messages for each module when `--ff` is used for `nimony`