### PR TITLE
fix typebound ops with nosystem and no system module in nimcache

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -278,11 +278,11 @@ proc testDir(c: var TestCounters; dir: string; overwrite: bool; cat: Category) =
     if x.kind == pcFile and x.path.endsWith(".nim"):
       files.add x.path
   sort files
-  if cat == Compat:
+  if cat in {Compat, Basics}:
     removeDir "nimcache"
   for f in items files:
     testFile c, f, overwrite, cat
-  if cat == Compat:
+  if cat in {Compat, Basics}:
     removeDir "nimcache"
 
 proc parseCategory(path: string): Category =

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -208,7 +208,12 @@ proc addTypeboundOps(c: var SemContext; fn: StrId; s: SymId; cands: var FnCandid
   let decl = asTypeDecl(res.decl)
   if decl.kind == TypeY:
     let moduleSuffix = extractModule(pool.syms[s])
-    if moduleSuffix == "":
+    if moduleSuffix == "" or
+        # with --noSystem, magic types can have the system module suffix
+        # without the system module being loaded
+        # just ignore symbols from the system module,
+        # their bound ops should be in scope anyway
+        moduleSuffix == SystemModuleSuffix:
       discard
     elif moduleSuffix == c.thisModuleSuffix:
       # XXX probably redundant over normal lookup but `OchoiceX` does not work yet


### PR DESCRIPTION
The string type becomes `string.0.sysvq0asl` even with `--noSystem`, so typebound ops tries to load the system module to find its bound ops, but this fails if the system module nif file does not exist yet. So this triggered a random failure in #1145 when the nosystem category ran after nimcache was wiped. Edit: And in master now in 2dea066.

To fix this, typebound ops just ignore types from the system module, their bound ops should be in scope anyway. Nimcache is now also always deleted before the nosystem category to test that this works.