### PR TITLE
fixes methods: expression must be an lvalue to be addressed

### DIFF
--- a/tests/nimony/object/tmethods.nim
+++ b/tests/nimony/object/tmethods.nim
@@ -29,3 +29,21 @@ block:
 
   foo(a)
   assert a.t == 5
+
+
+type
+    Base = ref object of RootObj
+    Derived = ref object of Base
+
+method inner(obj: Base) {.base.} =
+    quit "to override"
+
+method outer(obj: Base) {.base.} =
+    echo "outer"
+    obj.inner()
+
+method inner(obj: Derived) =
+    echo "inner Derived"
+
+var x: Derived = Derived()
+x.outer()


### PR DESCRIPTION
Only lvalues can be addressed. We need to assign the expression that is not a lvalue to a temp

> if n.kind == Symbol:

A symbol has been handled already

> (addr Lvalue (cppref)?)

In nifc, it seems to require lvalues for `addr`, but it doesn't seem to check it