### PR TITLE
implements #1129; detects local variables used in inner procs

### DIFF
--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -362,7 +362,8 @@ proc handleSymDef*(c: var SemContext; n: var Cursor; kind: SymKind): DelayedSym 
     let lit = n.litId
     let def = identToSym(c, lit, kind)
     let s = Sym(kind: kind, name: def,
-                pos: c.dest.len)
+                pos: c.dest.len,
+                parentProcSymId: c.routine.symId)
     result = DelayedSym(status: OkNew, lit: lit, s: s, info: info)
     c.dest.add symdefToken(def, info)
     inc n
@@ -373,7 +374,7 @@ proc handleSymDef*(c: var SemContext; n: var Cursor; kind: SymKind): DelayedSym 
       elif not c.freshSyms.missingOrExcl(n.symId): OkExistingFresh
       else: OkExisting
 
-    let s = Sym(kind: kind, name: n.symId, pos: c.dest.len)
+    let s = Sym(kind: kind, name: n.symId, pos: c.dest.len, parentProcSymId: c.routine.symId)
     result = DelayedSym(status: status, lit: symToIdent(s.name), s: s, info: info)
     c.dest.add n
     inc n
@@ -393,7 +394,7 @@ proc handleSymDef*(c: var SemContext; n: var Cursor; kind: SymKind): DelayedSym 
     else:
       let def = identToSym(c, lit, kind)
       let s = Sym(kind: kind, name: def,
-                  pos: c.dest.len)
+                  pos: c.dest.len, parentProcSymId: c.routine.symId)
       result = DelayedSym(status: OkNew, lit: lit, s: s, info: info)
       c.dest.add symdefToken(def, info)
 

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -22,9 +22,10 @@ type
     pragmas*: set[PragmaKind]
     resId*: SymId
     parent*: SemRoutine
+    symId*: SymId
 
-proc createSemRoutine*(kind: SymKind; parent: SemRoutine): SemRoutine =
-  result = SemRoutine(kind: kind, parent: parent, resId: SymId(0))
+proc createSemRoutine*(kind: SymKind; parent: SemRoutine; symId: SymId): SemRoutine =
+  result = SemRoutine(kind: kind, parent: parent, resId: SymId(0), symId: symId)
 
 const
   MaxNestedTemplates* = 100

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -495,7 +495,7 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
   else:
     buildErr c, it.n.info, "TR pattern not implemented"
     skip it.n
-  c.routine = createSemRoutine(kind, c.routine)
+  c.routine = createSemRoutine(kind, c.routine, symId)
   # 'break' and 'continue' are valid in a template regardless of whether we
   # really have a loop or not:
   if kind == TemplateY:

--- a/src/nimony/symtabs.nim
+++ b/src/nimony/symtabs.nim
@@ -17,6 +17,7 @@ type
     kind*: SymKind
     name*: SymId
     pos*: int
+    parentProcSymId*: SymId
 
   ScopeKind* = enum
     NormalScope, ToplevelScope, ImportScope

--- a/tests/nimony/errmsgs/tclosureunavail.msgs
+++ b/tests/nimony/errmsgs/tclosureunavail.msgs
@@ -1,0 +1,2 @@
+tests/nimony/errmsgs/tclosureunavail.nim(9, 5) Trace: instantiation from here
+lib/std/syncio.nim(117, 5) Error: closures are not yet implemented and cannot capture local variables outside of the procedure: x.0

--- a/tests/nimony/errmsgs/tclosureunavail.nim
+++ b/tests/nimony/errmsgs/tclosureunavail.nim
@@ -1,0 +1,12 @@
+import std/syncio
+
+# Tests if Nimony detects inner procs that uses local variables declared in enclosing proc.
+# Remove this test when closures are supported.
+
+proc outer =
+  var x = 1
+  proc inner =
+    echo x
+  inner()
+
+outer()


### PR DESCRIPTION
This PR doesn't works with templates as it requires more data structure changes to know which proc declares the sym.