### PR TITLE
fixes #1155

### DIFF
--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -98,7 +98,7 @@ proc getLocalInfo*(c: var TypeCache; s: SymId): LocalInfo =
     if it.kind == compareTo:
       crossedProc = true
     if res.kind != NoSym:
-      res.crossedProc = crossedProc
+      res.crossedProc = crossedProc and res.kind in {VarY, LetY}
       return res
     it = it.parent
     compareTo = ProcScope

--- a/tests/nimony/errmsgs/tclosureunavail.msgs
+++ b/tests/nimony/errmsgs/tclosureunavail.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tclosureunavail.nim(17, 13) Error: cannot access local variable `x` from another routine; closures are not supported

--- a/tests/nimony/errmsgs/tclosureunavail.nim
+++ b/tests/nimony/errmsgs/tclosureunavail.nim
@@ -1,0 +1,17 @@
+# Tests if Nimony detects code that requires closures.
+# Remove this test when closures are supported.
+
+# should not report closure error in following code
+var x = 0
+proc foo =
+  discard x
+
+proc bar =
+  proc nested =
+    discard x
+
+# should report the error in following code.
+proc baz =
+  var x = 1
+  proc nested =
+    discard x


### PR DESCRIPTION
`res.crossedProc` is always false when `res.kind` is neither `VarY` nor `LetY` so that nest procs using only global variables doesn't cause the error.