### PR TITLE
propagate used typevar count in nested invoke

### DIFF
--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -374,7 +374,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
       let instSuffix = instToSuffix(c.dest, typeStart)
       let targetSym = newInstSymId(c, headId, instSuffix)
       c.instantiatedTypes[key] = targetSym
-      if genericArgs == 0:
+      if isConcrete:
         c.typeInstDecls.add targetSym
       var sub = createTokenBuf(30)
       subsGenericTypeFromArgs c, sub, info, instSuffix, headId, targetSym, decl, args

--- a/tests/nimony/generics/tnestedgenericinvoke.nim
+++ b/tests/nimony/generics/tnestedgenericinvoke.nim
@@ -1,0 +1,7 @@
+type
+  Foo[T] = object
+  Bar[T] = object
+
+proc foo[T](x: Foo[Bar[T]]) = discard
+var x = Foo[Bar[int]]()
+foo x


### PR DESCRIPTION
fixes #1167

Invocations track if semchecking their arguments adds to a counter of used typevar symbols, to decide if the invocation is concrete or not so that it can be instantiated. However it does this by swapping the counter with a local variable, which isolates the typevar count in the arguments from the typevar count of the invocation itself. So invocations with generic parameters do not count as generic when nested inside another invocation, which wrongly instantiates it. To fix this, the typevar counter is not isolated, only the counter changing is tracked.

Worst case `containsGenericParams` can be used on each of the arguments.