### PR TITLE
fixes local type decls by lifting them into top levels

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -865,21 +865,9 @@ proc trDeref(c: var Context; n: var Cursor) =
     c.dest.addIntLit(0, info) # inheritance
   takeParRi c.dest, n
 
-proc trTypeDecl(c: var Context; n: var Cursor) =
-  var iter = n
-  inc iter
-  let symId = iter.symId
-  var dest = createTokenBuf()
-  takeTree(dest, n)
-  c.dest.add dest
-  if isLocalDecl(symId):
-    publish(symId, dest)
-
 proc tr(c: var Context; n: var Cursor; e: Expects) =
   if n.kind == Symbol:
     trLocation c, n, e
-  elif n.stmtKind == TypeS:
-    trTypeDecl c, n
   elif n.kind in {Ident, SymbolDef, IntLit, UIntLit, CharLit, StringLit, FloatLit, DotToken} or isDeclarative(n):
     takeTree c.dest, n
   else:

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -882,14 +882,22 @@ proc trTypeDecl(c: var EContext; n: var Cursor; mode: TraverseMode) =
   var dst = createTokenBuf(50)
   swap c.dest, dst
   #let toPatch = c.dest.len
+  let decl = asTypeDecl(n)
+  let isDistinct = decl.body.typeKind == DistinctT
   let vinfo = n.info
   c.add "type", vinfo
   inc n
   let (s, sinfo) = getSymDef(c, n)
   let oldOwner = setOwner(c, s)
 
-  assert mode == TraverseAll, "local type decls should be eliminated by desugar"
-  c.dest.add symdefToken(s, sinfo)
+  let newSym: SymId
+
+  if mode == TraverseAll and not isDistinct:
+    newSym = makeLocalSymId(c, s, false)
+    c.dest.add symdefToken(newSym, sinfo)
+  else:
+    newSym = s
+    c.dest.add symdefToken(s, sinfo)
   c.offer s
 
   var isGeneric = n.kind == ParLe
@@ -913,7 +921,7 @@ proc trTypeDecl(c: var EContext; n: var Cursor; mode: TraverseMode) =
   c.dest.addDotToken() # adds pragmas
 
   if prag.externName.len > 0:
-    c.registerMangle(s, prag.externName & ".c")
+    c.registerMangle(newSym, prag.externName & ".c")
   if n.typeKind in TypeclassKinds:
     isGeneric = true
   if isGeneric:
@@ -1698,7 +1706,8 @@ proc trStmt(c: var EContext; n: var Cursor; mode = TraverseAll) =
       # pure compile-time construct, ignore:
       skip n
     of TypeS:
-      trTypeDecl c, n, mode
+      moveToTopLevel(c, mode):
+        trTypeDecl c, n, mode
     of ContinueS, WhenS:
       error c, "unreachable: ", n
     of PragmasS, AssumeS, AssertS:

--- a/tests/nimony/object/tinheritance.nim
+++ b/tests/nimony/object/tinheritance.nim
@@ -14,3 +14,56 @@ let
 # object construction:
 student = Student(name: "Anton", age: 5, id: 2)
 assert student.name == "Anton"
+
+
+
+type
+  TestTestObj = object of RootObj
+    id: int
+
+var x = TestTestObj(id: 12)
+assert x.id == 12
+
+
+proc foo =
+  type
+    TestTestObj = object of RootObj
+      id: int
+
+  var x = TestTestObj(id: 12)
+  assert x.id == 12
+
+  block:
+    type
+      TestTestObj = object of RootObj
+        id: int
+
+    var x = TestTestObj(id: 12)
+    assert x.id == 12
+
+  block:
+    type
+      TestTestObj = object
+        id: int
+
+    var x = TestTestObj(id: 12)
+    assert x.id == 12
+
+foo()
+
+block:
+  type
+    TestTestObj = object of RootObj
+      id: int
+
+  var x = TestTestObj(id: 12)
+  assert x.id == 12
+
+
+block:
+  type
+    TestTestObj = object of RootObj
+      id: int
+
+  var x = TestTestObj(id: 12)
+  assert x.id == 12


### PR DESCRIPTION
It lifts local type decls before hexer handling. In sem phases, every type decls have gotten a global name. All is left to do is to lift them to the top levels. It alleviates pain for hexer. e.g. in `collectMethods`, only top level type decls are handled. But vtable infos are still needed for inherited objects for display checking at least. It's better to lift them instead of special cases local type decls in the multiple hexer phases