### PR TITLE
fixes is operators for tuples

### DIFF
--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -267,6 +267,9 @@ proc getTupleFieldType*(c: Cursor): Cursor =
   else:
     result = c
 
+  if result.typeKind == TypedescT:
+    inc result
+
 type
   ForStmt* = object
     kind*: StmtKind

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -50,9 +50,12 @@ proc semObjectType(c: var SemContext; n: var Cursor) =
         semObjectComponent c, n
   takeParRi c, n
 
-proc semTupleType(c: var SemContext; n: var Cursor) =
+proc semTupleType(c: var SemContext; n: var Cursor; isTupConstr = false) =
   c.dest.add parLeToken(TupleT, n.info)
   inc n
+
+  if isTupConstr:
+    skip n
   # tuple fields:
   withNewScope c:
     while n.kind != ParRi:
@@ -623,6 +626,8 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
         skipParRi n
       elif xkind == TupX:
         semTupleType c, n
+      elif xkind == TupConstrX:
+        semTupleType(c, n, isTupConstr = true)
       elif handleNilableType(c, n, context):
         discard "handled"
       elif isOrExpr(n):

--- a/tests/nimony/types/tisopr.nim
+++ b/tests/nimony/types/tisopr.nim
@@ -42,3 +42,16 @@ assert Foo[int, float] is Foo[int, float]
 assert Foo[float, float] is Foo[float, float]
 assert Foo[int, float] isnot Foo[float, float]
 assert Foo[int, int] isnot Bar[int, int]
+
+
+type
+  Person = tuple[name: string, age: int] # type representing a person:
+                                         # it consists of a name and an age.
+var person: Person
+person = (name: "Peter", age: 30)
+assert person.name == "Peter"
+# the same, but less readable:
+person = ("Peter", 30)
+assert person[0] == "Peter"
+assert Person is (string, int)
+assert (string, int) is Person


### PR DESCRIPTION
```nim
proc `is`*[T, S](x: T, y: S): bool {.magic: "Is", noSideEffect.}
```

