### PR TITLE
fixes #1176; when remove build artifacts, remove cached timestamp

### DIFF
--- a/src/nifmake/nifmake.nim
+++ b/src/nifmake/nifmake.nim
@@ -213,6 +213,8 @@ proc getFileTime(dag: var Dag; filename: string): Time =
 proc removeOutdatedArtifacts(dag: var Dag; node: Node; opt: set[CliOption]) =
   ## Remove outdated build artifacts for a node
   for output in node.outputs:
+    # Remove its cached timestamp as it is no longer valid
+    dag.timestampCache.del output
     if fileExists(output):
       try:
         removeFile(output)


### PR DESCRIPTION
Timestamps of output files are cached before they are updated.
Even after output files are updated, nodes that uses them as input uses cached old timestamp in `needsRebuild`.
