### PR TITLE
parses compile pragmas in Nim 2

### DIFF
--- a/src/nimony/indexgen.nim
+++ b/src/nimony/indexgen.nim
@@ -6,7 +6,7 @@
 
 ## Nimony index generator.
 
-import std / [os, assertions, sets, tables]
+import std / [os, assertions, sets, syncio, tables]
 include ".." / lib / nifprelude
 import ".." / lib / [nifindexes, symparser]
 import decls, nimony_model, programs, vtables_frontend, semos
@@ -90,6 +90,8 @@ proc indexFromNif*(infile: string) =
   var converterIndexMap = default seq[(SymId, SymId)]
   var classIndexMap = default seq[ClassIndexEntry]
   var exports = default Table[string, HashSet[SymId]]  # Module suffix -> symbols to export in the module
+  var toBuild = createTokenBuf()
+  let compileTag = pool.strings.getOrIncl("compile")
 
   assert n.stmtKind == StmtsS
   inc n
@@ -135,6 +137,37 @@ proc indexFromNif*(infile: string) =
           exports.mgetOrPut(suffix).incl sym
           inc n
         inc n
+      of PragmasS:
+        var x = n
+        let root = n
+        skip n
+        inc x
+        if x.substructureKind == KvU:
+          inc x
+          if x.kind == Ident and x.litId == compileTag:
+            # In Nim 2, compile pragma can take three forms.
+            # `{.compile: ("file.c", "$1.o").}` form is not supported.
+            inc x
+            if x.kind == StringLit:
+              toBuild.buildTree TagId(TupX), NoLineInfo:
+                toBuild.addStrLit "C"
+                toBuild.add x
+                toBuild.addStrLit ""
+            else:
+              error " Error: Unsupported compile pragma form.", root
+        elif x.stmtKind == CallS:
+          inc x
+          if x.kind == Ident and x.litId == compileTag:
+            inc x
+            assert x.kind == StringLit
+            toBuild.buildTree TagId(TupX), NoLineInfo:
+              toBuild.addStrLit "C"
+              toBuild.add x
+              inc x
+              if x.kind == StringLit:
+                toBuild.add x
+              else:
+                toBuild.addStrLit ""
       else:
         skip n
     else:
@@ -149,3 +182,10 @@ proc indexFromNif*(infile: string) =
       converters: move converterIndexMap,
       classes: move classIndexMap,
       exportBuf: exportBuf)
+
+  var content = "(.nif24)\n"
+  if toBuild.len > 0:
+    content.add "(build\n"
+    content.add toString(toBuild)
+    content.add ")"
+  writeFile changeFileExt(infile, ".deps.nif"), content


### PR DESCRIPTION
Parses compile pragmas in Nim 2 and write the build instructions to `.deps` file.
Compile pragmas that takes output file name like `{.compile: ("file.c", "$1.o").}` is not supported as `build` tag doesn't have an output file name field.