### PR TITLE
fixes top level locals used in the local procs, which should be lifted to the global scope

### DIFF
--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -295,7 +295,7 @@ proc identToSym*(c: var SemContext; str: sink string; kind: SymKind): SymId =
   if c.currentScope.kind == ToplevelScope or
       kind in {FldY, EfldY, TypevarY,
         # required for local enum type dollars to work at least, probably more cases:
-        TypeY}:
+        TypeY} or (c.routine.kind == NoSym and kind in {VarY, LetY}):
     c.makeGlobalSym(name)
   else:
     c.makeLocalSym(name)

--- a/tests/nimony/iter/tforloops.nif
+++ b/tests/nimony/iter/tforloops.nif
@@ -53,62 +53,68 @@
  (for 9
   (call ~4 foo1.0.tfocaa3fp1 1 +2)
   (unpackflat
-   (let :m.0 . . 6,~4
+   (let :m.0.tfocaa3fp1 . . 6,~4
     (i -1) .)) ~2,1
   (stmts 4
-   (let :n.0 . . 4,~5
-    (i -1) 4 m.0))) 4,18
+   (glet :n.0.tfocaa3fp1 . . 4,~5
+    (i -1) .)
+   (asgn 6,16,tests/nimony/iter/tforloops.nim n.0.tfocaa3fp1 10,16,tests/nimony/iter/tforloops.nim m.0.tfocaa3fp1))) 4,18
  (for 11
   (call ~3 foo.0.tfocaa3fp1 1 +2)
   (unpackflat
-   (let :i.0 . . 7,~16
+   (let :i.0.tfocaa3fp1 . . 7,~16
     (i -1) .)
-   (let 3 :j.0 . . 12,~16
+   (let 3 :j.0.tfocaa3fp1 . . 12,~16
     (i -1) .)) ~2,1
   (stmts 4
-   (let :s.0 . . 5,~17
-    (i -1) 4 i.0) 4,1
-   (let :m.1 . . 10,~18
-    (i -1) 4 j.0) 4,2
-   (let :n.1 . . 5,~19
-    (i -1) 4 s.0))) 4,23
+   (glet :s.0.tfocaa3fp1 . . 5,~17
+    (i -1) .)
+   (asgn 6,20,tests/nimony/iter/tforloops.nim s.0.tfocaa3fp1 10,20,tests/nimony/iter/tforloops.nim i.0.tfocaa3fp1) 4,1
+   (glet :m.1.tfocaa3fp1 . . 10,~18
+    (i -1) .)
+   (asgn 6,21,tests/nimony/iter/tforloops.nim m.1.tfocaa3fp1 10,21,tests/nimony/iter/tforloops.nim j.0.tfocaa3fp1) 4,2
+   (glet :n.1.tfocaa3fp1 . . 5,~19
+    (i -1) .)
+   (asgn 6,22,tests/nimony/iter/tforloops.nim n.1.tfocaa3fp1 10,22,tests/nimony/iter/tforloops.nim s.0.tfocaa3fp1))) 4,23
  (for 11
   (call ~3 foo.0.tfocaa3fp1 1 +2)
   (unpackflat
-   (let :i.1 . . 7,~21
+   (let :i.1.tfocaa3fp1 . . 7,~21
     (i -1) .)
-   (let 3 :j.1 . . 12,~21
+   (let 3 :j.1.tfocaa3fp1 . . 12,~21
     (i -1) .)) ~2,1
   (stmts 4
-   (let :s.1 . . 5,~22
-    (i -1) 4 i.1) 4,1
-   (let :m.2 . . 10,~23
-    (i -1) 4 j.1))) ,27
+   (glet :s.1.tfocaa3fp1 . . 5,~22
+    (i -1) .)
+   (asgn 6,25,tests/nimony/iter/tforloops.nim s.1.tfocaa3fp1 10,25,tests/nimony/iter/tforloops.nim i.1.tfocaa3fp1) 4,1
+   (glet :m.2.tfocaa3fp1 . . 10,~23
+    (i -1) .)
+   (asgn 6,26,tests/nimony/iter/tforloops.nim m.2.tfocaa3fp1 10,26,tests/nimony/iter/tforloops.nim j.1.tfocaa3fp1))) ,27
  (proc 5 :bar.0.tfocaa3fp1 . . . 8
   (params) . . . 2,1
   (stmts 4
    (for 11
     (call ~3 foo.0.tfocaa3fp1 1 +2)
     (unpackflat
-     (let :i.2 . . 5,~26
+     (let :i.0 . . 5,~26
       (i -1) .)
-     (let 3 :j.2 . . 10,~26
+     (let 3 :j.0 . . 10,~26
       (i -1) .)) ~2,1
     (stmts 4
-     (let :s.2 . . 3,~27
-      (i -1) 4 i.2) 4,1
-     (let :m.3 . . 8,~28
-      (i -1) 4 j.2))) 4,4
+     (let :s.0 . . 3,~27
+      (i -1) 4 i.0) 4,1
+     (let :m.0 . . 8,~28
+      (i -1) 4 j.0))) 4,4
    (for 13
     (call ~3 foo.0.tfocaa3fp1 1 +2)
     (unpacktup
-     (let 1 :i.3 . . 5,~30
+     (let 1 :i.1 . . 5,~30
       (i -1) .)
-     (let 4 :j.3 . . 10,~30
+     (let 4 :j.1 . . 10,~30
       (i -1) .)) ~2,1
     (stmts 4
-     (let :s.3 . . 3,~31
-      (i -1) 4 i.3) 4,1
-     (let :m.4 . . 8,~32
-      (i -1) 4 j.3))))) 3,36
+     (let :s.1 . . 3,~31
+      (i -1) 4 i.1) 4,1
+     (let :m.1 . . 8,~32
+      (i -1) 4 j.1))))) 3,36
  (call ~3 bar.0.tfocaa3fp1))

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -38,14 +38,15 @@
  (for 11
   (call ~6 powers.0.tfo161bfb1 1 +5)
   (unpackflat
-   (let :i.1 . . 6,~11
+   (let :i.0.tfo161bfb1 . . 6,~11
     (i -1) .)) ~2,1
   (stmts 4
-   (let :m.0 . . 4,~12
-    (i -1) 4 i.1) 6,2
+   (glet :m.0.tfo161bfb1 . . 4,~12
+    (i -1) .)
+   (asgn 6,15,tests/nimony/iter/tforloops1.nim m.0.tfo161bfb1 10,15,tests/nimony/iter/tforloops1.nim i.0.tfo161bfb1) 6,2
    (call ~6 printf.0.tfo161bfb1 1
     (hconv 11,~6
-     (cstring) "Hello, world\3A %ld\0A") 24 m.0))) ,18
+     (cstring) "Hello, world\3A %ld\0A") 24 m.0.tfo161bfb1))) ,18
  (iterator 9 :countup.0.tfo161bfb1 . . . 16
   (params 1
    (param :a.0 . . 6
@@ -54,56 +55,57 @@
     (i -1) .)) 13
   (i -1) . . 2,1
   (stmts 4
-   (var :i.2 . . 17,~1
+   (var :i.1 . . 17,~1
     (i -1) 4 a.0) ,1
    (while 8
     (le
-     (i +64) ~2 i.2 3 b.0) 2,1
+     (i +64) ~2 i.1 3 b.0) 2,1
     (stmts
-     (yld 6 i.2) ,1
+     (yld 6 i.1) ,1
      (cmd inc.0.tfo161bfb1 4
-      (haddr i.2)))))) 4,24
+      (haddr i.1)))))) 4,24
  (for 12
   (call ~7 countup.0.tfo161bfb1 1 +1 4 +5)
   (unpackflat
-   (let :x.1 . . 9,~6
+   (let :x.0.tfo161bfb1 . . 9,~6
     (i -1) .)) ~2,1
   (stmts 4
-   (let :m.1 . . 7,~7
-    (i -1) 4 x.1) 6,1
+   (glet :m.1.tfo161bfb1 . . 7,~7
+    (i -1) .)
+   (asgn 6,26,tests/nimony/iter/tforloops1.nim m.1.tfo161bfb1 10,26,tests/nimony/iter/tforloops1.nim x.0.tfo161bfb1) 6,1
    (call ~6 printf.0.tfo161bfb1 1
     (hconv 11,~16
-     (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
+     (cstring) "countup start\3A %ld\0A") 25 m.1.tfo161bfb1) ,2
    (if 3
     (elif 2,112,lib/std/system/comparisons.nim
      (expr 2,1
       (lt
-       (i +64) 9,28,tests/nimony/iter/tforloops1.nim +5 5,28,tests/nimony/iter/tforloops1.nim x.1)) ~1,1
+       (i +64) 9,28,tests/nimony/iter/tforloops1.nim +5 5,28,tests/nimony/iter/tforloops1.nim x.0.tfo161bfb1)) ~1,1
      (stmts
       (break .))) 5,2
     (elif 2
      (lt
-      (i +64) ~2 x.1 2 +3) ~3,1
+      (i +64) ~2 x.0.tfo161bfb1 2 +3) ~3,1
      (stmts
       (continue .)))) 6,6
    (call ~6 printf.0.tfo161bfb1 1
     (hconv 11,~21
-     (cstring) "countup end\3A %ld\0A") 23 m.1))) ,33
+     (cstring) "countup end\3A %ld\0A") 23 m.1.tfo161bfb1))) ,33
  (iterator 9 :countup2.0.tfo161bfb1 . . . 17
   (params 1
    (param :n.1 . . 3
     (i -1) .)) 10
   (i -1) . . 2,1
   (stmts 4
-   (var :i.3 . .
+   (var :i.2 . .
     (i -1) 4 +0) ,1
    (while 8
     (le
-     (i +64) ~2 i.3 3 n.1) 2,1
+     (i +64) ~2 i.2 3 n.1) 2,1
     (stmts
-     (yld 6 i.3) ,1
+     (yld 6 i.2) ,1
      (cmd inc.0.tfo161bfb1 4
-      (haddr i.3)))))) ,39
+      (haddr i.2)))))) ,39
  (iterator 9 :powers2.0.tfo161bfb1 . . . 16
   (params 1
    (param :n.2 . . 3
@@ -113,27 +115,27 @@
    (for 13
     (call ~8 countup2.0.tfo161bfb1 1 n.2)
     (unpackflat
-     (let :i.4 . . 4,~7
+     (let :i.3 . . 4,~7
       (i -1) .)) ~2,1
     (stmts
-     (yld 6 i.4) ,1
+     (yld 6 i.3) ,1
      (yld 7
       (mul
-       (i +64) ~1 i.4 1 i.4)) ,2
+       (i +64) ~1 i.3 1 i.3)) ,2
      (yld 9
       (mul
        (i +64) ~2
        (mul
-        (i +64) ~1 i.4 1 i.4) 1 i.4)))))) 4,45
+        (i +64) ~1 i.3 1 i.3) 1 i.3)))))) 4,45
  (for 12
   (call ~7 powers2.0.tfo161bfb1 1 +6)
   (unpackflat
-   (let :i.5 . . 6,~6
+   (let :i.1.tfo161bfb1 . . 6,~6
     (i -1) .)) ~2,1
   (stmts 6
    (call ~6 printf.0.tfo161bfb1 1
     (hconv 11,~36
-     (cstring) "Hello, world\3A %ld\0A") 24 i.5))) ,48
+     (cstring) "Hello, world\3A %ld\0A") 24 i.1.tfo161bfb1))) ,48
  (iterator 9 :countup3.0.tfo161bfb1 . . . 17
   (params 1
    (param :a.1 . . 3
@@ -157,30 +159,30 @@
  (for 12
   (call ~7 powers3.0.tfo161bfb1 1 +5)
   (unpackflat
-   (let :m.2 . . 6,~4
+   (let :m.2.tfo161bfb1 . . 6,~4
     (i -1) .)) ~2,1
   (stmts 4
    (for 13
     (call ~8 countup3.0.tfo161bfb1 1 +4)
     (unpackflat
-     (let :n.3 . . 4,~8
+     (let :n.0.tfo161bfb1 . . 4,~8
       (i -1) .)) ~2,1
     (stmts 6
      (call ~6 printf.0.tfo161bfb1 1
       (hconv 9,~47
        (cstring) "Hello, world\3A %ld\0A") 25
       (add
-       (i +64) ~1 m.2 1 n.3)))))) ,59
+       (i +64) ~1 m.2.tfo161bfb1 1 n.0.tfo161bfb1)))))) ,59
  (while 6
   (true) 2,1
   (stmts 4
    (for 7
     (infix \2E.<.0.tfo161bfb1 ~2 +0 4 +1)
     (unpackflat
-     (let :i.6 . . 13,~58
+     (let :i.2.tfo161bfb1 . . 13,~58
       (i -1) .)) ~2,1
     (stmts
-     (discard 8 i.6))) ,2
+     (discard 8 i.2.tfo161bfb1))) ,2
    (break .))) ,65
  (iterator 9 :countup4.0.tfo161bfb1 . . . 17
   (params 1
@@ -205,36 +207,36 @@
  (for 12
   (call ~7 powers4.0.tfo161bfb1 1 +5)
   (unpackflat
-   (let :i.7 . . 6,~4
+   (let :i.3.tfo161bfb1 . . 6,~4
     (i -1) .)) ~2,1
   (stmts 4
    (for 13
     (call ~8 countup4.0.tfo161bfb1 1 +4)
     (unpackflat
-     (let :j.2 . . 4,~8
+     (let :j.0.tfo161bfb1 . . 4,~8
       (i -1) .)) ~2,1
     (stmts 6
      (call ~6 printf.0.tfo161bfb1 1
       (hconv 9,~64
        (cstring) "Hello, world\3A %ld\0A") 25
       (add
-       (i +64) ~1 i.7 1 j.2)))))) 4,77
+       (i +64) ~1 i.3.tfo161bfb1 1 j.0.tfo161bfb1)))))) 4,77
  (for 6
   (infix \2E.<.0.tfo161bfb1 ~1 +0 3 +3)
   (unpackflat
-   (let :i.8 . . 15,~75
+   (let :i.4.tfo161bfb1 . . 15,~75
     (i -1) .)) ~2,1
   (stmts 4
    (for 6
     (infix \2E.<.0.tfo161bfb1 ~1 +0 3 +4)
     (unpackflat
-     (let :j.3 . . 13,~76
+     (let :j.1.tfo161bfb1 . . 13,~76
       (i -1) .)) ~2,1
     (stmts
      (if 3
       (elif 2
        (eq
-        (i +64) ~2 j.3 3 +2) ~1,1
+        (i +64) ~2 j.1.tfo161bfb1 3 +2) ~1,1
        (stmts 2,116,lib/std/syncio.nim
         (stmts 2,1
          (stmts
@@ -245,52 +247,55 @@
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,83,tests/nimony/iter/tforloops1.nim "A i ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/iter/tforloops1.nim i.8)) 2,1
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 17,83,tests/nimony/iter/tforloops1.nim i.4.tfo161bfb1)) 2,1
       (stmts
        (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 20,83,tests/nimony/iter/tforloops1.nim " j ")) 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim j.3)) ,2
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 27,83,tests/nimony/iter/tforloops1.nim j.1.tfo161bfb1)) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,84
  (block . 2,1
   (stmts 4
    (for 7
     (infix \2E.<.0.tfo161bfb1 ~2 +1 4 +3)
     (unpackflat
-     (let :i.9 . . 13,~83
+     (let :i.5.tfo161bfb1 . . 13,~83
       (i -1) .)) ~2,1
     (stmts 4
      (for 7
       (infix \2E.<.0.tfo161bfb1 ~2 +2 4 +4)
       (unpackflat
-       (let :j.4 . . 11,~84
+       (let :j.2.tfo161bfb1 . . 11,~84
         (i -1) .)) ~2,1
       (stmts 4
-       (let :a.5 . . 15,44,lib/std/system/arithmetics.nim
-        (i +64) 6
+       (glet :a.0.tfo161bfb1 . . 15,44,lib/std/system/arithmetics.nim
+        (i +64) .)
+       (asgn 10,88,tests/nimony/iter/tforloops1.nim a.0.tfo161bfb1 16,88,tests/nimony/iter/tforloops1.nim
         (add
-         (i +64) ~2 i.9 2 j.4)) 4,1
-       (var :sum.0 . . 9,~86
-        (i -1) 11 +0) 4,2
+         (i +64) ~2 i.5.tfo161bfb1 2 j.2.tfo161bfb1)) 4,1
+       (gvar :sum.0.tfo161bfb1 . . 9,~86
+        (i -1) .)
+       (asgn 10,89,tests/nimony/iter/tforloops1.nim sum.0.tfo161bfb1 21,89,tests/nimony/iter/tforloops1.nim +0) 4,2
        (for 7
-        (infix \2E.<.0.tfo161bfb1 ~2 +1 4 j.4)
+        (infix \2E.<.0.tfo161bfb1 ~2 +1 4 j.2.tfo161bfb1)
         (unpackflat
-         (let :k.0 . . 9,~87
+         (let :k.0.tfo161bfb1 . . 9,~87
           (i -1) .)) ~2,1
         (stmts 4
-         (asgn ~4 sum.0 6
+         (asgn ~4 sum.0.tfo161bfb1 6
           (add
-           (i +64) ~4 sum.0 2 a.5)))) 2,116,lib/std/syncio.nim
+           (i +64) ~4 sum.0.tfo161bfb1 2 a.0.tfo161bfb1)))) 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
-         (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim sum.0)) ,2
+         (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 11,92,tests/nimony/iter/tforloops1.nim sum.0.tfo161bfb1)) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))))) ,93
  (block . 2,1
   (stmts 4
-   (let :i_arr.0 . . 8
+   (glet :i_arr.0.tfo161bfb1 . . 8
     (array
      (i -1)
      (rangetype
-      (i -1) +0 +5)) 8
+      (i -1) +0 +5)) .)
+   (asgn 6,95,tests/nimony/iter/tforloops1.nim i_arr.0.tfo161bfb1 14,95,tests/nimony/iter/tforloops1.nim
     (aconstr
      (array
       (i -1)
@@ -299,28 +304,30 @@
    (for 10
     (hderef
      (call ~5 items.0.tfo161bfb1 1
-      (hcall toOpenArray.0.tfo161bfb1 i_arr.0)))
+      (hcall toOpenArray.0.tfo161bfb1 i_arr.0.tfo161bfb1)))
     (unpackflat
-     (let :i.10 . . 19,41,lib/std/system/openarrays.nim
+     (let :i.6.tfo161bfb1 . . 19,41,lib/std/system/openarrays.nim
       (mut
        (i -1)) .)) ~2,1
     (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
        (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,97,tests/nimony/iter/tforloops1.nim
-        (hderef i.10))) ,2
+        (hderef i.6.tfo161bfb1))) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))) ,98
  (block 6 :tbreak.0 2,1
   (stmts 2,1
-   (var :x.3 . . 12,35,lib/std/system/basic_types.nim
-    (bool) 4
+   (gvar :x.1.tfo161bfb1 . . 12,35,lib/std/system/basic_types.nim
+    (bool) .)
+   (asgn 4,101,tests/nimony/iter/tforloops1.nim x.1.tfo161bfb1 8,101,tests/nimony/iter/tforloops1.nim
     (false)) 2,2
-   (var :run.0 . . 22,35,lib/std/system/basic_types.nim
-    (bool) 6
+   (gvar :run.0.tfo161bfb1 . . 22,35,lib/std/system/basic_types.nim
+    (bool) .)
+   (asgn 4,102,tests/nimony/iter/tforloops1.nim run.0.tfo161bfb1 10,102,tests/nimony/iter/tforloops1.nim
     (true)) ,4
-   (while 6 run.0 2,1
+   (while 6 run.0.tfo161bfb1 2,1
     (stmts 4
-     (asgn ~4 run.0 2
+     (asgn ~4 run.0.tfo161bfb1 2
       (false)) ,1
      (block 6 :myblock.0 2,1
       (stmts
@@ -333,12 +340,12 @@
         (stmts
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,109,tests/nimony/iter/tforloops1.nim "leaving myblock")) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 2,5
-     (asgn ~2 x.3 2
+     (asgn ~2 x.1.tfo161bfb1 2
       (true)))) 2,4,lib/std/assertions.nim
    (stmts
     (if 3
      (elif
-      (not 9,111,tests/nimony/iter/tforloops1.nim x.3) ~1,1
+      (not 9,111,tests/nimony/iter/tforloops1.nim x.1.tfo161bfb1) ~1,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
@@ -354,7 +361,7 @@
      (for 7
       (infix \2E..0.tfo161bfb1 ~2 +0 3 +9)
       (unpackflat
-       (let :x.4 . . 11,~112
+       (let :x.2 . . 11,~112
         (i -1) .)) ~2,1
       (stmts 4
        (for 5
@@ -373,17 +380,17 @@
         (stmts
          (yld 8
           (add
-           (i +64) ~2 x.4 2
+           (i +64) ~2 x.2 2
            (hderef y.0))))))))) 4,19
    (for 8
     (call ~3 foo.0)
     (unpackflat
-     (let :p.0 . . ~2,~5
+     (let :p.0.tfo161bfb1 . . ~2,~5
       (i -1) .)) ~2,1
     (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,120,tests/nimony/iter/tforloops1.nim p.0)) ,2
+       (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 9,120,tests/nimony/iter/tforloops1.nim p.0.tfo161bfb1)) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
      (break .))) ,23
    (iterator 9 :permutations.0 . . . 21
@@ -394,7 +401,7 @@
    (for 17
     (call ~12 permutations.0)
     (unpackflat
-     (let :p.1 . . ~2,~3
+     (let :p.1.tfo161bfb1 . . ~2,~3
       (i -1) .)) ~2,1
     (stmts
      (break .))) ,30
@@ -413,7 +420,7 @@
           (true) 7
           (false)))))
       (unpackflat
-       (let :x.7 . . 19,41,lib/std/system/openarrays.nim
+       (let :x.5 . . 19,41,lib/std/system/openarrays.nim
         (mut 22,35,lib/std/system/basic_types.nim
          (bool)) .)) ~2,1
       (stmts 4
@@ -436,7 +443,7 @@
          (stmts 2,1
           (stmts
            (cmd write.1.syn1lfpjv 6 stdout.0.syn1lfpjv 13,133,tests/nimony/iter/tforloops1.nim
-            (hderef x.7))) 2,1
+            (hderef x.5))) 2,1
           (stmts
            (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 16,133,tests/nimony/iter/tforloops1.nim " ")) 2,1
           (stmts
@@ -448,24 +455,24 @@
   (at inc.1.sysvq0asl 19,~4
    (i -1)) 21,12,lib/std/system/arithmetics.nim
   (params 1
-   (param :x.8 . . 3
+   (param :x.6 . . 3
     (mut 23,19,tests/nimony/iter/tforloops1.nim
      (i -1)) .)) 0,12,lib/std/system/arithmetics.nim . 32,12,lib/std/system/arithmetics.nim
   (pragmas 2
    (inline)) 0,12,lib/std/system/arithmetics.nim . 2,13,lib/std/system/arithmetics.nim
   (stmts 2,1
    (asgn ~2
-    (hderef x.8) 6
+    (hderef x.6) 6
     (add 23,19,tests/nimony/iter/tforloops1.nim
      (i -1) 1
-     (hderef x.8) 30,~13
+     (hderef x.6) 30,~13
      (conv 23,19,tests/nimony/iter/tforloops1.nim
       (i -1) 1 +1))))) 13,60
  (iterator :\2E.<.0.tfo161bfb1 . 0,1,lib/std/system/iterators.nim .
   (at \2E.<.0.sysvq0asl
    (i -1)) 27,1,lib/std/system/iterators.nim
   (params 1
-   (param :a.9 . .
+   (param :a.8 . .
     (i -1) .) 4
    (param :b.4 . .
     (i -1) .))
@@ -473,22 +480,22 @@
   (pragmas 2
    (inline)) 0,1,lib/std/system/iterators.nim . 2,2,lib/std/system/iterators.nim
   (stmts 4
-   (var :i.11 . . 19,3,tests/nimony/iter/tforloops1.nim
-    (i -1) 4 a.9) ,1
+   (var :i.4 . . 19,3,tests/nimony/iter/tforloops1.nim
+    (i -1) 4 a.8) ,1
    (while 8
     (lt
-     (i -1) ~2 i.11 2 b.4) 2,1
+     (i -1) ~2 i.4 2 b.4) 2,1
     (stmts
-     (yld 6 i.11) ,1
+     (yld 6 i.4) ,1
      (cmd inc.0.tfo161bfb1 4
-      (haddr i.11)))))) 17,95
+      (haddr i.4)))))) 17,95
  (converter :toOpenArray.0.tfo161bfb1 . 0,13,lib/std/system/openarrays.nim .
   (at toOpenArray.0.sysvq0asl ~3,~1
    (rangetype
     (i -1) +0 +5)
    (i -1)) 28,13,lib/std/system/openarrays.nim
   (params 3
-   (param ~2 :x.9 .
+   (param ~2 :x.7 .
     (pragmas 2
      (byref)) 16
     (array
@@ -531,7 +538,7 @@
           (ptr 18
            (uarray
             (i -1))) 32
-          (addr 1 x.9))) 45
+          (addr 1 x.7))) 45
         (kv ~3 len.7.Inff8aa1.tfo161bfb1 2,122,lib/std/system.nim
          (expr ,~4
           (expr 45,2
@@ -552,26 +559,26 @@
   (at items.1.sysvq0asl
    (i -1)) 18,41,lib/std/system/openarrays.nim
   (params 1
-   (param :a.10 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .)) 19,41,lib/std/system/openarrays.nim
+   (param :a.9 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .)) 19,41,lib/std/system/openarrays.nim
   (mut
    (i -1)) 0,41,lib/std/system/openarrays.nim . 0,41,lib/std/system/openarrays.nim . 2,42,lib/std/system/openarrays.nim
   (stmts 4
-   (var :i.12 . . 19,3,tests/nimony/iter/tforloops1.nim
+   (var :i.5 . . 19,3,tests/nimony/iter/tforloops1.nim
     (i -1) 4 +0) ,1
    (while 8
     (lt
-     (i +64) ~2 i.12 5
-     (call ~3 len.0.tfo161bfb1 1 a.10)) 2,1
+     (i +64) ~2 i.5 5
+     (call ~3 len.0.tfo161bfb1 1 a.9)) 2,1
     (stmts
      (yld 6
-      (call \5B\5D.0.tfo161bfb1 a.10 2 i.12)) ,1
+      (call \5B\5D.0.tfo161bfb1 a.9 2 i.5)) ,1
      (cmd inc.0.tfo161bfb1 4
-      (haddr i.12)))))) 15,114
+      (haddr i.5)))))) 15,114
  (iterator :\2E..0.tfo161bfb1 . 0,7,lib/std/system/iterators.nim .
   (at \2E..0.sysvq0asl
    (i -1)) 26,7,lib/std/system/iterators.nim
   (params 1
-   (param :a.12 . .
+   (param :a.11 . .
     (i -1) .) 4
    (param :b.5 . .
     (i -1) .))
@@ -579,22 +586,22 @@
   (pragmas 2
    (inline)) 0,7,lib/std/system/iterators.nim . 2,8,lib/std/system/iterators.nim
   (stmts 4
-   (var :i.13 . . 19,3,tests/nimony/iter/tforloops1.nim
-    (i -1) 4 a.12) ,1
+   (var :i.6 . . 19,3,tests/nimony/iter/tforloops1.nim
+    (i -1) 4 a.11) ,1
    (while 8
     (le
-     (i -1) ~2 i.13 3 b.5) 2,1
+     (i -1) ~2 i.6 3 b.5) 2,1
     (stmts
-     (yld 6 i.13) ,1
+     (yld 6 i.6) ,1
      (cmd inc.0.tfo161bfb1 4
-      (haddr i.13)))))) 15,115
+      (haddr i.6)))))) 15,115
  (converter :toOpenArray.1.tfo161bfb1 . 0,13,lib/std/system/openarrays.nim .
   (at toOpenArray.0.sysvq0asl
    (rangetype
     (i -1) +0 +8)
    (i -1)) 28,13,lib/std/system/openarrays.nim
   (params 3
-   (param ~2 :x.11 .
+   (param ~2 :x.9 .
     (pragmas 2
      (byref)) 16
     (array
@@ -637,7 +644,7 @@
           (ptr 18
            (uarray
             (i -1))) 32
-          (addr 1 x.11))) 45
+          (addr 1 x.9))) 45
         (kv ~3 len.7.Inff8aa1.tfo161bfb1 2,122,lib/std/system.nim
          (expr ,~4
           (expr 45,2
@@ -660,7 +667,7 @@
     (i -1) +0 +1) 22,35,lib/std/system/basic_types.nim
    (bool)) 28,13,lib/std/system/openarrays.nim
   (params 3
-   (param ~2 :x.12 .
+   (param ~2 :x.10 .
     (pragmas 2
      (byref)) 16
     (array 22,35,lib/std/system/basic_types.nim
@@ -703,7 +710,7 @@
           (ptr 18
            (uarray 22,35,lib/std/system/basic_types.nim
             (bool))) 32
-          (addr 1 x.12))) 45
+          (addr 1 x.10))) 45
         (kv ~3 len.7.Ijejnmx1.tfo161bfb1 2,122,lib/std/system.nim
          (expr ,~4
           (expr 45,2
@@ -724,26 +731,26 @@
   (at items.1.sysvq0asl 22,35,lib/std/system/basic_types.nim
    (bool)) 18,41,lib/std/system/openarrays.nim
   (params 1
-   (param :a.13 . . 12 openArray.0.Ijejnmx1.tfo161bfb1 .)) 19,41,lib/std/system/openarrays.nim
+   (param :a.12 . . 12 openArray.0.Ijejnmx1.tfo161bfb1 .)) 19,41,lib/std/system/openarrays.nim
   (mut 22,35,lib/std/system/basic_types.nim
    (bool)) 0,41,lib/std/system/openarrays.nim . 0,41,lib/std/system/openarrays.nim . 2,42,lib/std/system/openarrays.nim
   (stmts 4
-   (var :i.14 . . 19,3,tests/nimony/iter/tforloops1.nim
+   (var :i.7 . . 19,3,tests/nimony/iter/tforloops1.nim
     (i -1) 4 +0) ,1
    (while 8
     (lt
-     (i +64) ~2 i.14 5
-     (call ~3 len.1.tfo161bfb1 1 a.13)) 2,1
+     (i +64) ~2 i.7 5
+     (call ~3 len.1.tfo161bfb1 1 a.12)) 2,1
     (stmts
      (yld 6
-      (call \5B\5D.1.tfo161bfb1 a.13 2 i.14)) ,1
+      (call \5B\5D.1.tfo161bfb1 a.12 2 i.7)) ,1
      (cmd inc.0.tfo161bfb1 4
-      (haddr i.14)))))) 15,43,lib/std/system/openarrays.nim
+      (haddr i.7)))))) 15,43,lib/std/system/openarrays.nim
  (func :len.0.tfo161bfb1 . ~15,~18 .
   (at len.8.sysvq0asl
    (i -1)) ~3,~18
   (params 1
-   (param :a.15 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .)) 4,~18
+   (param :a.14 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .)) 4,~18
   (i -1) 20,~18
   (pragmas 2
    (inline)) ~15,~18 . 33,~18
@@ -751,13 +758,13 @@
    (result :result.3 . . 7,31,lib/std/system/basic_types.nim
     (i -1) .) 1
    (asgn result.3
-    (dot ~1 a.15 len.7.Inff8aa1.tfo161bfb1 +0)) ~48
+    (dot ~1 a.14 len.7.Inff8aa1.tfo161bfb1 +0)) ~48
    (ret result.3))) 10,44,lib/std/system/openarrays.nim
  (proc :\5B\5D.0.tfo161bfb1 . ~10,~36 .
   (at \5B\5D.9.sysvq0asl
    (i -1)) 3,~36
   (params 1
-   (param :x.14 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .) 18
+   (param :x.12 . . 12 openArray.0.Inff8aa1.tfo161bfb1 .) 18
    (param :idx.2 . . 5
     (i -1) .)) 19,~36
   (mut
@@ -771,7 +778,7 @@
        (i +64) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.2)) 8
      (lt
       (i +64) ~4 idx.2 3
-      (dot ~1 x.14 len.7.Inff8aa1.tfo161bfb1 +0))))) ~10,~36 . 87,~36
+      (dot ~1 x.12 len.7.Inff8aa1.tfo161bfb1 +0))))) ~10,~36 . 87,~36
   (stmts 3
    (result :result.4 . . ~71
     (mut
@@ -779,13 +786,13 @@
    (asgn result.4 ~2
     (haddr
      (pat
-      (dot ~1 x.14 a.1.Inff8aa1.tfo161bfb1 +0) 3 idx.2))) ~97
+      (dot ~1 x.12 a.1.Inff8aa1.tfo161bfb1 +0) 3 idx.2))) ~97
    (ret result.4))) 15,43,lib/std/system/openarrays.nim
  (func :len.1.tfo161bfb1 . ~15,~18 .
   (at len.8.sysvq0asl 22,35,lib/std/system/basic_types.nim
    (bool)) ~3,~18
   (params 1
-   (param :a.16 . . 12 openArray.0.Ijejnmx1.tfo161bfb1 .)) 4,~18
+   (param :a.15 . . 12 openArray.0.Ijejnmx1.tfo161bfb1 .)) 4,~18
   (i -1) 20,~18
   (pragmas 2
    (inline)) ~15,~18 . 33,~18
@@ -793,13 +800,13 @@
    (result :result.5 . . 7,31,lib/std/system/basic_types.nim
     (i -1) .) 1
    (asgn result.5
-    (dot ~1 a.16 len.7.Ijejnmx1.tfo161bfb1 +0)) ~48
+    (dot ~1 a.15 len.7.Ijejnmx1.tfo161bfb1 +0)) ~48
    (ret result.5))) 10,44,lib/std/system/openarrays.nim
  (proc :\5B\5D.1.tfo161bfb1 . ~10,~36 .
   (at \5B\5D.9.sysvq0asl 22,35,lib/std/system/basic_types.nim
    (bool)) 3,~36
   (params 1
-   (param :x.15 . . 12 openArray.0.Ijejnmx1.tfo161bfb1 .) 18
+   (param :x.13 . . 12 openArray.0.Ijejnmx1.tfo161bfb1 .) 18
    (param :idx.3 . . 5
     (i -1) .)) 19,~36
   (mut 22,35,lib/std/system/basic_types.nim
@@ -813,7 +820,7 @@
        (i +64) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.3)) 8
      (lt
       (i +64) ~4 idx.3 3
-      (dot ~1 x.15 len.7.Ijejnmx1.tfo161bfb1 +0))))) ~10,~36 . 87,~36
+      (dot ~1 x.13 len.7.Ijejnmx1.tfo161bfb1 +0))))) ~10,~36 . 87,~36
   (stmts 3
    (result :result.6 . . ~71
     (mut 22,35,lib/std/system/basic_types.nim
@@ -821,7 +828,7 @@
    (asgn result.6 ~2
     (haddr
      (pat
-      (dot ~1 x.15 a.1.Ijejnmx1.tfo161bfb1 +0) 3 idx.3))) ~97
+      (dot ~1 x.13 a.1.Ijejnmx1.tfo161bfb1 +0) 3 idx.3))) ~97
    (ret result.6))) 37,13,lib/std/system/openarrays.nim
  (type :openArray.0.Inff8aa1.tfo161bfb1 .
   (at openArray.0.sysvq0asl

--- a/tests/nimony/nosystem/tforloop.nif
+++ b/tests/nimony/nosystem/tforloop.nif
@@ -59,7 +59,7 @@
  (for 20
   (call ~7 countup.0.tfov349y21 1 +0 4 +44)
   (unpackflat
-   (let :mycounter.0 . . 9,~6
+   (let :mycounter.0.tfov349y21 . . 9,~6
     (i -1) .)) ~2,1
   (stmts
-   (discard 8 mycounter.0))))
+   (discard 8 mycounter.0.tfov349y21))))

--- a/tests/nimony/object/tcaseobject.nif
+++ b/tests/nimony/object/tcaseobject.nif
@@ -204,7 +204,8 @@
    (ret result.0))) ,42
  (block . 2,1
   (stmts 4
-   (var :x.1 . . 5,~5 Foo.0.tcauiaoif 7
+   (gvar :x.2.tcauiaoif . . 5,~5 Foo.0.tcauiaoif .)
+   (asgn 6,44,tests/nimony/object/tcaseobject.nim x.2.tcauiaoif 13,44,tests/nimony/object/tcaseobject.nim
     (oconstr ~2,~5 Foo.0.tcauiaoif 2
      (kv ~1 x.0.tcauiaoif 2
       (true)) 11
@@ -212,7 +213,7 @@
      (kv ~1 t.0.tcauiaoif 2
       (false)))) ,1
    (discard 10
-    (call ~2 fx.0.tcauiaoif 1 x.1)))) ,46
+    (call ~2 fx.0.tcauiaoif 1 x.2.tcauiaoif)))) ,46
  (block . 2,1
   (stmts 8,1
    (type ~6 :TKind.0.tcauiaoif . . . 2
@@ -231,7 +232,7 @@
       (of
        (ranges 3 ka.0.tcauiaoif) 2,1
        (stmts
-        (fld :x.2.tcauiaoif . . 3
+        (fld :x.3.tcauiaoif . . 3
          (i -1) .) ,1
         (fld :y.1.tcauiaoif . . 3
          (i -1) .))) ,4
@@ -246,20 +247,25 @@
          (f +64) .) 9
         (fld :d.1.tcauiaoif . . 3
          (f +64) .)))))) 4,10
-   (var :s.1 . . 11,~9 TKind.0.tcauiaoif 4 ka.0.tcauiaoif) ,11
-   (case 5 s.1 ,1
+   (gvar :s.0.tcauiaoif . . 11,~9 TKind.0.tcauiaoif .)
+   (asgn 6,58,tests/nimony/object/tcaseobject.nim s.0.tcauiaoif 10,58,tests/nimony/object/tcaseobject.nim ka.0.tcauiaoif) ,11
+   (case 5 s.0.tcauiaoif ,1
     (of
      (ranges 3 ka.0.tcauiaoif) 2,1
      (stmts 4
-      (var :x.2 . .
-       (i -1) 7 +1) 7
-      (var :y.0 . .
-       (i -1) 4 +1))) ,3
+      (gvar :x.4.tcauiaoif . .
+       (i -1) .)
+      (asgn 8,61,tests/nimony/object/tcaseobject.nim x.4.tcauiaoif 15,61,tests/nimony/object/tcaseobject.nim +1) 7
+      (gvar :y.2.tcauiaoif . .
+       (i -1) .)
+      (asgn 11,61,tests/nimony/object/tcaseobject.nim y.2.tcauiaoif 15,61,tests/nimony/object/tcaseobject.nim +1))) ,3
     (of
      (ranges 3 kb.0.tcauiaoif) 2,1
      (stmts 4
-      (var :a.0 . . string.0.sysvq0asl 7 "") 7
-      (var :b.0 . . string.0.sysvq0asl 4 ""))) ,5
+      (gvar :a.2.tcauiaoif . . string.0.sysvq0asl .)
+      (asgn 8,63,tests/nimony/object/tcaseobject.nim a.2.tcauiaoif 15,63,tests/nimony/object/tcaseobject.nim "") 7
+      (gvar :b.2.tcauiaoif . . string.0.sysvq0asl .)
+      (asgn 11,63,tests/nimony/object/tcaseobject.nim b.2.tcauiaoif 15,63,tests/nimony/object/tcaseobject.nim ""))) ,5
     (of
      (ranges 3 kc.0.tcauiaoif) 7
      (stmts 2,116,lib/std/syncio.nim

--- a/tests/nimony/sets/tsets.nif
+++ b/tests/nimony/sets/tsets.nif
@@ -188,10 +188,10 @@
     (range A.0.tseflljd71 3 B.0.tseflljd71) 7 val.0.tseflljd71 12 F.0.tseflljd71))) ,26
  (block . 2,1
   (stmts 4
-   (var :sss.0 . . 8
+   (gvar :sss.0.tseflljd71 . . 8
     (set 1
      (c +8)) .) 4,1
-   (asgn ~4 sss.0 2
+   (asgn ~4 sss.0.tseflljd71 2
     (setconstr 6,~1
      (set 1
       (c +8)))) 2,4,lib/std/assertions.nim
@@ -203,7 +203,7 @@
         (i +64) ~6
         (card
          (set
-          (c +8)) 1 sss.0) 3 +0)) ~1,1
+          (c +8)) 1 sss.0.tseflljd71) 3 +0)) ~1,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
@@ -212,7 +212,7 @@
          (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
        (cmd quit.0.syn1lfpjv 5 +1))))) 4,3
-   (asgn ~4 sss.0 2
+   (asgn ~4 sss.0.tseflljd71 2
     (setconstr 6,~3
      (set 1
       (c +8)) 1
@@ -225,7 +225,7 @@
         (i +64) ~6
         (card
          (set
-          (c +8)) 1 sss.0) 3 +27)) ~1,1
+          (c +8)) 1 sss.0.tseflljd71) 3 +27)) ~1,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
@@ -236,7 +236,7 @@
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,5
    (excl
     (set
-     (c +8)) ~8 sss.0 1 'm') 2,4,lib/std/assertions.nim
+     (c +8)) ~8 sss.0.tseflljd71 1 'm') 2,4,lib/std/assertions.nim
    (stmts
     (if 3
      (elif
@@ -245,7 +245,7 @@
         (i +64) ~6
         (card
          (set
-          (c +8)) 1 sss.0) 3 +26)) ~1,1
+          (c +8)) 1 sss.0.tseflljd71) 3 +26)) ~1,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
@@ -256,7 +256,7 @@
        (cmd quit.0.syn1lfpjv 5 +1))))) 8,7
    (incl
     (set
-     (c +8)) ~8 sss.0 1 'u') 2,4,lib/std/assertions.nim
+     (c +8)) ~8 sss.0.tseflljd71 1 'u') 2,4,lib/std/assertions.nim
    (stmts
     (if 3
      (elif
@@ -265,7 +265,7 @@
         (i +64) ~6
         (card
          (set
-          (c +8)) 1 sss.0) 3 +26)) ~1,1
+          (c +8)) 1 sss.0.tseflljd71) 3 +26)) ~1,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts

--- a/tests/nimony/sysbasics/tbasics.nif
+++ b/tests/nimony/sysbasics/tbasics.nif
@@ -120,20 +120,23 @@
     (deref s2.0)))) ,29
  (block . 2,1
   (stmts 4
-   (var :s.2 . .
-    (i -1) 4 +2) 4,1
-   (let :m.3 . . 10,~5
+   (gvar :s.1.tbawx6nu81 . .
+    (i -1) .)
+   (asgn 6,31,tests/nimony/sysbasics/tbasics.nim s.1.tbawx6nu81 10,31,tests/nimony/sysbasics/tbasics.nim +2) 4,1
+   (glet :m.0.tbawx6nu81 . . 10,~5
     (ptr 4
-     (i -1)) 9
-    (addr s.2)) 4,2
+     (i -1)) .)
+   (asgn 6,32,tests/nimony/sysbasics/tbasics.nim m.0.tbawx6nu81 15,32,tests/nimony/sysbasics/tbasics.nim
+    (addr s.1.tbawx6nu81)) 4,2
    (call ~4 foo3.0.tbawx6nu81 1
     (hconv 6,~8
-     (pointer) m.3)) 4,3
-   (let :m2.0 . . 7,~9
-    (pointer) 5
+     (pointer) m.0.tbawx6nu81)) 4,3
+   (glet :m2.0.tbawx6nu81 . . 7,~9
+    (pointer) .)
+   (asgn 6,34,tests/nimony/sysbasics/tbasics.nim m2.0.tbawx6nu81 11,34,tests/nimony/sysbasics/tbasics.nim
     (cast 5
-     (pointer) 14 m.3)) 4,4
-   (call ~4 foo3.0.tbawx6nu81 1 m2.0))) 10,37
+     (pointer) 14 m.0.tbawx6nu81)) 4,4
+   (call ~4 foo3.0.tbawx6nu81 1 m2.0.tbawx6nu81))) 10,37
  (type ~8 :Foo1314.0.tbawx6nu81 . . . 2
   (object . ~8,1
    (fld :a.0.tbawx6nu81 . . 15
@@ -150,7 +153,7 @@
   (params 1
    (param :x.1 . . 3 Foo1314.0.tbawx6nu81 .)) . . . 2,1
   (stmts 4
-   (let :s.3 . . 13,~4
+   (let :s.2 . . 13,~4
     (i -1) 5
     (dot ~1 x.1 a.0.tbawx6nu81 +0)))) 4,44
  (gvar :a.1.tbawx6nu81 . . 12,~3 Foo1314.0.tbawx6nu81 11
@@ -235,44 +238,44 @@
   (stmts
    (proc 5 :classify.0 . . . 13
     (params 1
-     (param :s.4 . . 3 string.0.sysvq0asl .)) . . . 2,1
+     (param :s.3 . . 3 string.0.sysvq0asl .)) . . . 2,1
     (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,84,tests/nimony/sysbasics/tbasics.nim s.4)) ,2
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,84,tests/nimony/sysbasics/tbasics.nim s.3)) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.0 1 "9123345") ,4
    (block . 2,1
     (stmts
      (proc 5 :classify2.0 . . . 14
       (params 1
-       (param :s.5 . . 3 string.0.sysvq0asl .)) . . . 2,1
+       (param :s.4 . . 3 string.0.sysvq0asl .)) . . . 2,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
-         (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,89,tests/nimony/sysbasics/tbasics.nim s.5)) ,2
+         (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,89,tests/nimony/sysbasics/tbasics.nim s.4)) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
      (call ~9 classify2.0 1 "9123345"))))) ,92
  (block . 2,1
   (stmts
    (proc 5 :classify2.1 . . . 14
     (params 1
-     (param :s.6 . . 3 string.0.sysvq0asl .)) . . . 2,1
+     (param :s.5 . . 3 string.0.sysvq0asl .)) . . . 2,1
     (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,95,tests/nimony/sysbasics/tbasics.nim s.6)) ,2
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,95,tests/nimony/sysbasics/tbasics.nim s.5)) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 9,3
    (call ~9 classify2.1 1 "9123345"))) ,98
  (block . 2,1
   (stmts
    (proc 5 :classify.1 . . . 13
     (params 1
-     (param :s.7 . . 3 string.0.sysvq0asl .)) . . . 2,1
+     (param :s.6 . . 3 string.0.sysvq0asl .)) . . . 2,1
     (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,101,tests/nimony/sysbasics/tbasics.nim s.7)) ,2
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,101,tests/nimony/sysbasics/tbasics.nim s.6)) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.1 1 "9123345"))) ,104
  (block . 2,1
@@ -281,11 +284,11 @@
     (stmts
      (proc 5 :classify.2 . . . 13
       (params 1
-       (param :s.8 . . 3 string.0.sysvq0asl .)) . . . 2,1
+       (param :s.7 . . 3 string.0.sysvq0asl .)) . . . 2,1
       (stmts 2,116,lib/std/syncio.nim
        (stmts 2,1
         (stmts
-         (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,108,tests/nimony/sysbasics/tbasics.nim s.8)) ,2
+         (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 11,108,tests/nimony/sysbasics/tbasics.nim s.7)) ,2
         (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
      (call ~8 classify.2 1 "9123345"))))) ,111
  (proc 5 :foo2.1.tbawx6nu81 . . . 9
@@ -293,11 +296,11 @@
   (stmts
    (proc 5 :classify.3 . . . 13
     (params 1
-     (param :s.9 . . 3 string.0.sysvq0asl .)) . . . 2,1
+     (param :s.8 . . 3 string.0.sysvq0asl .)) . . . 2,1
     (stmts 2,116,lib/std/syncio.nim
      (stmts 2,1
       (stmts
-       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,114,tests/nimony/sysbasics/tbasics.nim s.9)) ,2
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,114,tests/nimony/sysbasics/tbasics.nim s.8)) ,2
       (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))) 8,3
    (call ~8 classify.3 1 "9123345"))) 4,117
  (call ~4 foo2.1.tbawx6nu81) ,119

--- a/tests/nimony/sysbasics/ttoplevellocals.nim
+++ b/tests/nimony/sysbasics/ttoplevellocals.nim
@@ -1,0 +1,13 @@
+block:
+  var reported = false
+  proc report() =
+    reported = true
+
+  report()
+
+block:
+  var reported = false
+  proc report() =
+    reported = true
+
+  report()

--- a/tests/nimony/types/tscopedtype.nif
+++ b/tests/nimony/types/tscopedtype.nif
@@ -8,13 +8,14 @@
     (object 10 RootObj.0.sysvq0asl ~8,1
      (fld :id.0.tsca4az8i1 . . 4
       (i -1) .))) 4,4
-   (var :s.0 . . 4,~3
-    (ref 4 Foo.Obj.0.tsca4az8i1) 7
+   (gvar :s.0.tsca4az8i1 . . 4,~3
+    (ref 4 Foo.Obj.0.tsca4az8i1) .)
+   (asgn 6,8,tests/nimony/types/tscopedtype.nim s.0.tsca4az8i1 13,8,tests/nimony/types/tscopedtype.nim
     (newobj ~3,~3
      (ref 4 Foo.Obj.0.tsca4az8i1) 3
      (kv ~2 id.0.tsca4az8i1 2 +12))) 2,116,lib/std/syncio.nim
    (stmts 2,1
     (stmts
      (cmd write.2.syn1lfpjv 6 stdout.0.syn1lfpjv 8,9,tests/nimony/types/tscopedtype.nim
-      (ddot ~1 s.0 id.0.tsca4az8i1 +0))) ,2
+      (ddot ~1 s.0.tsca4az8i1 id.0.tsca4az8i1 +0))) ,2
     (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')))))


### PR DESCRIPTION
ref https://github.com/nim-lang/nimony/issues/1191

```nim
block:
  var reported = false
  proc report() =
    reported = true

  report()
```

This is a test from Nim test under the `tests/closures` directory. Top level locals are treated as global variables in Nim. So the function `report` doesn't create a closure env for `reported`.

This test was broken with `nimony` because `reported` was treated as a local variable, but the function `report` was lifted into the top level scope.

In this PR, top level local variables are lifted to the top level scope so that they can be used for lifted functions