### PR TITLE
adds `<` operator for pointers

### DIFF
--- a/lib/std/system/comparisons.nim
+++ b/lib/std/system/comparisons.nim
@@ -61,6 +61,8 @@ proc `<`*[T](x, y: set[T]): bool {.magic: "LtSet", noSideEffect.}
   ## A strict or proper subset `x` has all of its members in `y` but `y` has
   ## more elements than `y`.
 
+proc `<`*(x, y: pointer): bool {.magic: "LtPtr", noSideEffect.}
+
 proc `==`*(x, y: int8): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: int16): bool {.magic: "EqI", noSideEffect.}
 proc `==`*(x, y: int32): bool {.magic: "EqI", noSideEffect.}

--- a/tests/nimony/errmsgs/tdistinctinfos.msgs
+++ b/tests/nimony/errmsgs/tdistinctinfos.msgs
@@ -1,5 +1,5 @@
 tests/nimony/errmsgs/tdistinctinfos.nim(4, 20) Trace: instantiation from here
-lib/std/system/comparisons.nim(105, 3) Error: Type mismatch at [position]
+lib/std/system/comparisons.nim(107, 3) Error: Type mismatch at [position]
 WINBOOL(0) == 0
 [2] BUG: unhandled type: distinct (declared in lib/std/system/comparisons.nim(4, 1))
 [1] WINBOOL does not match constraint Enum (declared in lib/std/system/comparisons.nim(7, 1))
@@ -10,15 +10,15 @@ WINBOOL(0) == 0
 [1] expected: set[T] but got: WINBOOL (declared in lib/std/system/comparisons.nim(18, 1))
 [1] expected: ref T but got: WINBOOL (declared in lib/std/system/comparisons.nim(21, 1))
 [1] expected: ptr T but got: WINBOOL (declared in lib/std/system/comparisons.nim(23, 1))
-[1] expected: int8 but got: WINBOOL (declared in lib/std/system/comparisons.nim(64, 1))
-[1] expected: int16 but got: WINBOOL (declared in lib/std/system/comparisons.nim(65, 1))
-[1] expected: int32 but got: WINBOOL (declared in lib/std/system/comparisons.nim(66, 1))
-[1] expected: int64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(67, 1))
-[1] expected: uint8 but got: WINBOOL (declared in lib/std/system/comparisons.nim(89, 1))
-[1] expected: uint16 but got: WINBOOL (declared in lib/std/system/comparisons.nim(90, 1))
-[1] expected: uint32 but got: WINBOOL (declared in lib/std/system/comparisons.nim(91, 1))
-[1] expected: uint64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(92, 1))
-[1] expected: float32 but got: WINBOOL (declared in lib/std/system/comparisons.nim(100, 1))
-[1] expected: float64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(101, 1))
+[1] expected: int8 but got: WINBOOL (declared in lib/std/system/comparisons.nim(66, 1))
+[1] expected: int16 but got: WINBOOL (declared in lib/std/system/comparisons.nim(67, 1))
+[1] expected: int32 but got: WINBOOL (declared in lib/std/system/comparisons.nim(68, 1))
+[1] expected: int64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(69, 1))
+[1] expected: uint8 but got: WINBOOL (declared in lib/std/system/comparisons.nim(91, 1))
+[1] expected: uint16 but got: WINBOOL (declared in lib/std/system/comparisons.nim(92, 1))
+[1] expected: uint32 but got: WINBOOL (declared in lib/std/system/comparisons.nim(93, 1))
+[1] expected: uint64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(94, 1))
+[1] expected: float32 but got: WINBOOL (declared in lib/std/system/comparisons.nim(102, 1))
+[1] expected: float64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(103, 1))
 [1] expected: string but got: WINBOOL (declared in lib/std/system/stringimpl.nim(250, 1))
 [1] expected: openArray[T] but got: WINBOOL (declared in lib/std/system/openarrays.nim(47, 1))

--- a/tests/nimony/iter/tforloops1.nif
+++ b/tests/nimony/iter/tforloops1.nif
@@ -75,7 +75,7 @@
     (hconv 11,~16
      (cstring) "countup start\3A %ld\0A") 25 m.1) ,2
    (if 3
-    (elif 2,112,lib/std/system/comparisons.nim
+    (elif 2,114,lib/std/system/comparisons.nim
      (expr 2,1
       (lt
        (i +64) 9,28,tests/nimony/iter/tforloops1.nim +5 5,28,tests/nimony/iter/tforloops1.nim x.1)) ~1,1
@@ -765,7 +765,7 @@
   (pragmas 2
    (inline) 10
    (requires 19
-    (and 2,108,lib/std/system/comparisons.nim
+    (and 2,110,lib/std/system/comparisons.nim
      (expr 2,1
       (le
        (i +64) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.2)) 8
@@ -807,7 +807,7 @@
   (pragmas 2
    (inline) 10
    (requires 19
-    (and 2,108,lib/std/system/comparisons.nim
+    (and 2,110,lib/std/system/comparisons.nim
      (expr 2,1
       (le
        (i +64) 75,8,lib/std/system/openarrays.nim +0 68,8,lib/std/system/openarrays.nim idx.3)) 8

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -59,7 +59,7 @@
             (i -1))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.0))))) ,2
       (if 3
-       (elif 2,104,lib/std/system/comparisons.nim
+       (elif 2,106,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -112,7 +112,7 @@
             (f +64))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.1))))) ,2
       (if 3
-       (elif 2,104,lib/std/system/comparisons.nim
+       (elif 2,106,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -174,7 +174,7 @@
             (u +8))) 33
           (call ~5 alloc.0.sysvq0asl 1 memSize.2))))) ,2
       (if 3
-       (elif 2,104,lib/std/system/comparisons.nim
+       (elif 2,106,lib/std/system/comparisons.nim
         (expr ,1
          (not 7
           (eq
@@ -321,7 +321,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.0)))) ,4
    (if 3
-    (elif 2,104,lib/std/system/comparisons.nim
+    (elif 2,106,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -523,7 +523,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.4)))) ,4
    (if 3
-    (elif 2,104,lib/std/system/comparisons.nim
+    (elif 2,106,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -725,7 +725,7 @@
      (cmd inc.0.temd2l7vy 4
       (haddr i.8)))) ,4
    (if 3
-    (elif 2,104,lib/std/system/comparisons.nim
+    (elif 2,106,lib/std/system/comparisons.nim
      (expr ,1
       (not 7
        (eq
@@ -938,7 +938,7 @@
     (i -1) .) 7
    (asgn ~7 result.9 2
     (if 3
-     (elif 2,104,lib/std/system/comparisons.nim
+     (elif 2,106,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq
@@ -970,7 +970,7 @@
     (i -1) .) 7
    (asgn ~7 result.10 2
     (if 3
-     (elif 2,104,lib/std/system/comparisons.nim
+     (elif 2,106,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq
@@ -1002,7 +1002,7 @@
     (i -1) .) 7
    (asgn ~7 result.11 2
     (if 3
-     (elif 2,104,lib/std/system/comparisons.nim
+     (elif 2,106,lib/std/system/comparisons.nim
       (expr ,1
        (not 7
         (eq

--- a/tests/nimony/sysbasics/tintlitmatch.nif
+++ b/tests/nimony/sysbasics/tintlitmatch.nif
@@ -38,19 +38,19 @@
  (discard 10
   (eq
    (i +64) ~2
-   (hconv 17,67,lib/std/system/comparisons.nim
+   (hconv 17,69,lib/std/system/comparisons.nim
     (i +64) x.0.tin4pj0od1) 3 y.0.tin4pj0od1)) ,14
  (discard 10
   (eq
    (i +64) ~2 y.0.tin4pj0od1 6
-   (hconv 17,67,lib/std/system/comparisons.nim
+   (hconv 17,69,lib/std/system/comparisons.nim
     (i +64)
     (conv 1
      (i +32) ~3 +123)))) ,15
  (discard 18
   (eq
    (i +64) ~7
-   (hconv 17,67,lib/std/system/comparisons.nim
+   (hconv 17,69,lib/std/system/comparisons.nim
     (i +64)
     (conv 6,~1
      (i +32) ~3 +123)) 3 y.0.tin4pj0od1)) ,16
@@ -73,17 +73,17 @@
    (i +32) ~7
    (conv 6,~6
     (i +32) ~3 +123) 3
-   (hconv 17,66,lib/std/system/comparisons.nim
+   (hconv 17,68,lib/std/system/comparisons.nim
     (i +32) +123))) ,21
  (discard 12
   (eq
    (i +32) ~4
-   (hconv 17,66,lib/std/system/comparisons.nim
+   (hconv 17,68,lib/std/system/comparisons.nim
     (i +32) +123) 6
    (conv ~1,~7
     (i +32) ~3 +123))) ,22
  (discard 10
   (eq
    (i +32) ~2 x.0.tin4pj0od1 3
-   (hconv 17,66,lib/std/system/comparisons.nim
+   (hconv 17,68,lib/std/system/comparisons.nim
     (i +32) +123))))


### PR DESCRIPTION
`<` for pointers is used in src/lib/nifreader.nim.