### PR TITLE
improves `renderer` for `[]` etc.

### DIFF
--- a/tests/nimony/plugins/trenderer.nim
+++ b/tests/nimony/plugins/trenderer.nim
@@ -13,3 +13,6 @@ renderTree:
     result = s
 
   discard foo(2)
+
+  var s = @[1, 2, 3]
+  echo s[0]

--- a/tests/nimony/plugins/trenderer.output
+++ b/tests/nimony/plugins/trenderer.output
@@ -9,3 +9,6 @@ proc foo(x: int): int =
   return result
 
 discard foo(2)
+var s: seq = @([1, 2, 3])
+write stdout, s[0]
+write stdout, '\n'


### PR DESCRIPTION
So that `s[0]` is rendered properly