### PR TITLE
fixes #1201; Initializing a variable with no return type proc doesn't cause compile error

### DIFF
--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -87,6 +87,7 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
     if n.kind == DotToken:
       # no explicit type given:
       inc n # 3
+      let orig = n
       var it = Item(n: n, typ: c.types.autoType)
       if kind == ConstY:
         withNewScope c:
@@ -95,6 +96,8 @@ proc semLocal(c: var SemContext; n: var Cursor; kind: SymKind) =
         semLocalValue c, it, crucial # 4
       n = it.n
       let typ = skipModifier(it.typ)
+      if classifyType(c, typ) == VoidT:
+         c.buildErr n.info, "expression '" & asNimCode(orig) & "' has no type (or is ambiguous)"
       insertType c, typ, beforeType
     else:
       let typ = semLocalType(c, n) # 3

--- a/tests/nimony/errmsgs/tlocalvoid.msgs
+++ b/tests/nimony/errmsgs/tlocalvoid.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tlocalvoid.nim(5, 5) Error: expression 'foo()' has no type (or is ambiguous)

--- a/tests/nimony/errmsgs/tlocalvoid.nim
+++ b/tests/nimony/errmsgs/tlocalvoid.nim
@@ -1,0 +1,5 @@
+import std / [assertions]
+
+proc foo = discard
+
+var x = foo()


### PR DESCRIPTION
fixes #1201