### PR TITLE
fixes #1209

### DIFF
--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -12,7 +12,7 @@ proc semProcBody(c: var SemContext; itB: var Item) =
       beforeLastSon = c.dest.len
       lastSonInfo = it.n.info
       beforeLastSonCursor = it.n
-      semExpr c, it
+      semExpr c, it, {AllowEmpty}
   if c.routine.kind == TemplateY:
     case c.routine.returnType.typeKind
     of UntypedT:


### PR DESCRIPTION
`semProcBody` proc in `nimony/semdecls.nim` calls `semExpr` twice for the last expression of the proc body.
If the last expression was `[]` or `{}` and `semExpr` was called without `AllowEmpty`, `semBracket` or `semCurly` calls `buildErr` proc.
If nimsem was built with `-d:debug`, `buildErr` prints given error and quit.
If it was build without `-d:debug`, `buildErr` outputs `ErrT` node and doesnt quit. Then `semProcBody` removes that `ErrT` node and no compiler error is reported.
That is why the compile error was generated only when `-d:debug` is defined.

This PR calls `semExpr` with `AllowEmpty` in `semProcBody` so that `semBracket` or `semCurly` doesn't calls `buildErr` when they got `[]` or `{}`.