### PR TITLE
fixes `ensureMove` can't move calls with var types

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -93,6 +93,8 @@ proc constructsValue*(n: Cursor): bool =
     of CastX, ConvX, HconvX, DconvX:
       inc n
       skip n
+    of DerefX, HDerefX:
+      inc n
     of BaseobjX:
       inc n
       skip n
@@ -846,7 +848,7 @@ proc trEnsureMove(c: var Context; n: var Cursor; e: Expects) =
       tr c, n, e
       skipParRi n
   else:
-    let m = "not the last usage of: " & asNimCode(n)
+    let m = "not the last usage of: " & asNimCode(arg)
     c.dest.buildTree ErrT, info:
       c.dest.addSubtree n
       c.dest.add strToken(pool.strings.getOrIncl(m), info)

--- a/tests/nimony/arc/tensuremove.nim
+++ b/tests/nimony/arc/tensuremove.nim
@@ -148,15 +148,14 @@ block:
     assert y == 1
   foo()
 
-# TODO:
-# block:
-#   proc foo =
-#     var x = @[1, 2, 3]
-#     let y = ensureMove x[0] # move
-#     assert y == 1
-#     # when not defined(js):
-#     #   assert x == @[0, 2, 3]
-#   foo()
+block:
+  proc foo =
+    var x = @[1, 2, 3]
+    let y = ensureMove x[0] # move
+    assert y == 1
+    # when not defined(js):
+    #   assert x == @[0, 2, 3]
+  foo()
 
 block:
   proc foo =
@@ -167,11 +166,10 @@ block:
     #   assert x == @[0, 2, 3]
   foo()
 
-# TODO:
-# block:
-#   proc foo =
-#     var x = @["1", "2", "3"]
-#     let y = ensureMove x[0] # move
-#     assert y == "1"
-#   foo()
+block:
+  proc foo =
+    var x = @["1", "2", "3"]
+    let y = ensureMove x[0] # move
+    assert y == "1"
+  foo()
 


### PR DESCRIPTION
`[]` is a call that returns a var type, so a `deref` is needed. `(deref (call [] x))` should be moveable