### PR TITLE
fixes duplifier cannot find hooks

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -394,7 +394,13 @@ proc trAsgn(c: var Context; n: var Cursor) =
           callDup c, n
 
 proc getHookType(c: var Context; n: Cursor): Cursor =
-  result = skipModifier(getType(c.typeCache, n.firstSon))
+  var n = n
+  inc n
+  if n.exprKind == HaddrX:
+    # skips `HaddrX` to get the correct type; otherwise
+    # we get a `ptr` type
+    inc n
+  result = skipModifier(getType(c.typeCache, n))
 
 proc trExplicitDestroy(c: var Context; n: var Cursor) =
   let typ = getHookType(c, n)

--- a/tests/nimony/arc/texplicit_hooks.nim
+++ b/tests/nimony/arc/texplicit_hooks.nim
@@ -14,3 +14,21 @@ proc main =
   `=wasMoved`(a)
 
 main()
+
+
+block:
+  type
+    TestObj = object
+      id: string
+
+    myseq = object
+      f: TestObj
+
+  var
+    x: myseq = myseq()
+  x.f = TestObj(id: "12")
+
+  assert x.f.id == "12"
+
+  `=wasMoved`(x.f)
+  assert x.f.id == ""


### PR DESCRIPTION
Because hooks may take a `var T` parameter, a `haddr` may be inserted to the first parameter of the hook call. `getType` returns `ptr T` for `haddr`. We need to skip `haddr` to get the correct type