### PR TITLE
fixes #1219

### DIFF
--- a/tests/nimony/strings/tand.nim
+++ b/tests/nimony/strings/tand.nim
@@ -1,0 +1,9 @@
+import std/assertions
+
+# issue #1219
+
+var x = "a"
+x = x & "b"
+x = x & "c"
+
+assert x == "abc"


### PR DESCRIPTION
Transform `x = f()` into `let tmp = f(); =destroy(x); x =bitcopy tmp` so that `f()` can read x safely.
Transforming `x = f()` into `=destroy(x); x =bitcopy f()` doesn't work if `f()` reads `x`.