### PR TITLE
implements `wasMoved` for trivial types

### DIFF
--- a/tests/nimony/arc/texplicit_hooks.nim
+++ b/tests/nimony/arc/texplicit_hooks.nim
@@ -32,3 +32,64 @@ block:
 
   `=wasMoved`(x.f)
   assert x.f.id == ""
+
+block:
+  type
+    Object = object
+      id: int
+
+    myseq = object
+      f: Object
+
+  var
+    x: myseq = myseq(f: Object(id: 12))
+
+  `=wasMoved`(x.f)
+  assert x.f.id == 0
+
+block:
+  type
+    myseq = object
+      f: int
+
+  var
+    x: myseq = myseq(f: 12)
+
+  `=wasMoved`(x.f)
+  assert x.f == 0
+
+block:
+  type
+    myseq = object
+      f: float
+
+  var
+    x: myseq = myseq(f: 1.2)
+
+  `=wasMoved`(x.f)
+  assert x.f == 0.0
+
+block:
+  type
+    myseq = object
+      f: array[3, int]
+
+  var
+    x: myseq = myseq(f: [1, 2, 3])
+
+  `=wasMoved`(x.f)
+  assert x.f == [0, 0, 0]
+
+block:
+  type
+    myseq = object
+      f: (int, float, bool, char)
+
+  var
+    x: myseq = myseq(f: (1, 6.6, true, 'a'))
+
+  `=wasMoved`(x.f)
+  assert x.f[0] == 0
+  assert x.f[1] == 0.0
+  assert x.f[2] == false
+  assert x.f[3] == '\0'


### PR DESCRIPTION
Implements assigning defaults to most trivial types. I thought of using the `default` call, but it seems to be generics+overloads, I'm not sure whether I can call it in the hexer. Without `zeromem`, `move` and `=wasmoved` calls don't work properly for trivial types