### PR TITLE
improves error messages for enums with non consts values

### DIFF
--- a/src/nimony/enumtostr.nim
+++ b/src/nimony/enumtostr.nim
@@ -34,7 +34,7 @@ proc genEnumToStrProcCase(c: var SemContext; enumDecl: var Cursor; symId, enumSy
 
     inc enumDecl # skips tupleConstr
     inc enumDecl # skips counter field
-    let fieldValue = enumDecl.litId
+    var fieldValue = enumDecl
     inc enumDecl # skips fieldValue
     inc enumDecl # Skips ParRi
 
@@ -45,7 +45,12 @@ proc genEnumToStrProcCase(c: var SemContext; enumDecl: var Cursor; symId, enumSy
 
     c.dest.add tagToken("stmts", enumDeclInfo)
     c.dest.add tagToken("ret", enumDeclInfo)
-    c.dest.add strToken(fieldValue, enumDeclInfo)
+    if fieldValue.kind == StringLit:
+      c.dest.add strToken(fieldValue.litId, enumDeclInfo)
+    else:
+      # handle errors
+      c.dest.addSubtree fieldValue
+
     c.dest.addParRi() # ret
     c.dest.addParRi() # stmts
 


### PR DESCRIPTION
```nim
import std / [syncio, assertions, strutils]


# block toffset:
let
  strValB = "my value B" & "23"


type
  TMyEnum = enum
    valueA = (1, "my value A"),
    valueB = strValB,
    valueC,
    valueD = (4, "abc")

proc getValue(i:int): TMyEnum = TMyEnum(i)

# trick the optimizer with a variable:
var x = getValue(4)
echo getValue(1), ord(valueA), getValue(2), ord(valueB), getValue(3), getValue(4), ord(valueD), x
```