### PR TITLE
transit `ExprX` to `StmtsS` for implicitlyDiscardable

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -40,9 +40,9 @@ proc combineType(c: var SemContext; info: PackedLineInfo; dest: var Cursor; src:
   else:
     c.typeMismatch info, src, dest
 
-proc implicitlyDiscardable(n: Cursor, noreturnOnly = false): bool =
+proc implicitlyDiscardable(n: Cursor, dest: var TokenBuf, noreturnOnly = false): bool =
   template checkBranch(branch) =
-    if not implicitlyDiscardable(branch, noreturnOnly):
+    if not implicitlyDiscardable(branch, dest, noreturnOnly):
       return false
 
   var it = n
@@ -51,7 +51,10 @@ proc implicitlyDiscardable(n: Cursor, noreturnOnly = false): bool =
   #    nkOfBranch, nkElse, nkFinally, nkExceptBranch,
   #    nkElifBranch, nkElifExpr, nkElseExpr, nkBlockStmt, nkBlockExpr,
   #    nkHiddenStdConv, nkHiddenSubConv, nkHiddenDeref}
-  while it.kind == ParLe and stmtKind(it) in {StmtsS, BlockS}:
+  while it.kind == ParLe and (stmtKind(it) in {StmtsS, BlockS} or exprKind(it) == ExprX):
+    if exprKind(it) == ExprX and dest.len != 0:
+      let pos = cursorToPosition(dest, it)
+      dest[pos] = parLeToken(StmtsS, dest[pos].info)
     inc it
     var last = it
     while true:
@@ -149,7 +152,8 @@ proc implicitlyDiscardable(n: Cursor, noreturnOnly = false): bool =
     result = false
 
 proc isNoReturn(n: Cursor): bool {.inline.} =
-  result = implicitlyDiscardable(n, noreturnOnly = true)
+  var dummy = default(TokenBuf)
+  result = implicitlyDiscardable(n, dummy, noreturnOnly = true)
 
 proc requestRoutineInstance(c: var SemContext; origin: SymId;
                             typeArgs: TokenBuf;
@@ -644,7 +648,7 @@ proc semStmt(c: var SemContext; n: var Cursor; isNewScope: bool) =
   else:
     # analyze the expression that was just produced:
     let ex = cursorAt(c.dest, exPos)
-    let discardable = implicitlyDiscardable(ex)
+    let discardable = implicitlyDiscardable(ex, c.dest)
     endRead(c.dest)
     if not discardable:
       buildErr c, info, "expression of type `" & typeToString(it.typ) & "` must be discarded"

--- a/tests/nimony/sysbasics/tblocks.nim
+++ b/tests/nimony/sysbasics/tblocks.nim
@@ -30,3 +30,10 @@ block:
     discard
 
   check(m)
+
+
+proc test(): int {.discardable.} =
+  discard
+
+block:
+  test()


### PR DESCRIPTION
fixes `discardable` used with `exprx`

```nim
proc test(): int {.discardable.} =
  discard

block:
  discard
  test()
```

For discardable calls in a block statement, it gets resolved to `ExprX`. We need to transit `ExprX` to `StmtsS` for the last branch in `semStmt`, which accepts statements only