### PR TITLE
turns anonymous procs into normal procs

### DIFF
--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -645,9 +645,9 @@ proc semProcImpl(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind;
 
 proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
   var n = it.n
-  var typ = asRoutine(n).params
   inc n
   if n.kind == DotToken:
+    var typ = asRoutine(it.n).params
     let name = identToSym(c, "`anonproc", ProcY)
 
     swap c.dest, c.pending

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -487,12 +487,21 @@ proc hookThatShouldBeMethod(c: var SemContext; hk: HookKind; beforeParams: int):
   else:
     result = false
 
-proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
+proc semProcImpl(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind; newName = NoSymId) =
   let info = it.n.info
   let declStart = c.dest.len
   takeToken c, it.n
   let beforeName = c.dest.len
-  let (symId, status) = declareOverloadableSym(c, it, kind)
+
+  let symId: SymId
+  let status: SymStatus
+  if it.n.kind == DotToken:
+    symId = newName
+    status = OkNew
+    c.dest.add symdefToken(symId, it.n.info)
+    inc it.n
+  else:
+    (symId, status) = declareOverloadableSym(c, it, kind)
 
   let beforeExportMarker = c.dest.len
   wantExportMarker c, it.n
@@ -633,6 +642,24 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
   takeParRi c, it.n
   producesVoid c, info, it.typ
   publish c, symId, declStart
+
+proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
+  var n = it.n
+  var typ = asRoutine(n).params
+  inc n
+  if n.kind == DotToken:
+    let name = identToSym(c, "`anonproc", ProcY)
+
+    swap c.dest, c.pending
+    semProcImpl c, it, kind, pass, name
+    swap c.dest, c.pending
+
+
+    c.dest.add symToken(name, n.info)
+    it.typ = typ
+
+  else:
+    semProcImpl c, it, kind, pass
 
 proc semTypePragmas(c: var SemContext; n: var Cursor; sym: SymId; beforeExportMarker: int): CrucialPragma =
   result = CrucialPragma(sym: sym)

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -646,6 +646,7 @@ proc semProcImpl(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind;
 proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
   if it.n.firstSon.kind == DotToken:
     # anon routine
+    let info = it.n.firstSon.info
     var typ = asRoutine(it.n).params
     let name = identToSym(c, "`anonproc", ProcY)
 
@@ -655,7 +656,7 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
     swap c.dest, anons
     c.pending.add anons
 
-    c.dest.add symToken(name, n.info)
+    c.dest.add symToken(name, info)
     it.typ = typ
 
   else:

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -650,10 +650,11 @@ proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
     var typ = asRoutine(it.n).params
     let name = identToSym(c, "`anonproc", ProcY)
 
-    swap c.dest, c.pending
+    var anons = createTokenBuf()
+    swap c.dest, anons
     semProcImpl c, it, kind, pass, name
-    swap c.dest, c.pending
-
+    swap c.dest, anons
+    c.pending.add anons
 
     c.dest.add symToken(name, n.info)
     it.typ = typ

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -644,9 +644,8 @@ proc semProcImpl(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind;
   publish c, symId, declStart
 
 proc semProc(c: var SemContext; it: var Item; kind: SymKind; pass: PassKind) =
-  var n = it.n
-  inc n
-  if n.kind == DotToken:
+  if it.n.firstSon.kind == DotToken:
+    # anon routine
     var typ = asRoutine(it.n).params
     let name = identToSym(c, "`anonproc", ProcY)
 


### PR DESCRIPTION
ref #1231

```nim
let s = proc (name: string): string = "Hello "
```


It becomes

```
 (glet :s.0.teskvlx9c . . 9
  (params 1
   (param name . . 6 string .)) 9 `anonproc.0.teskvlx9c) 4,9

 (proc :`anonproc.0.teskvlx9c . . .
  (params 1
   (param :name.0 . . 6 string.0.sysvq0asl .)) 16 string.0.sysvq0asl . . 25
  (stmts
   (result :result.4 . . ~18 string.0.sysvq0asl .)
   (result :result.0 . . ~18 string.0.sysvq0asl .)
   (asgn result.0 "Hello ") ~25
   (ret result.0) ~25
   (ret result.4))) 14,9
```