### PR TITLE
evaluate `sizeof` at compile time if possible

### DIFF
--- a/src/nimony/sizeof.nim
+++ b/src/nimony/sizeof.nim
@@ -143,6 +143,7 @@ proc getSize(c: var SizeofValue; cache: var Table[SymId, SizeofValue]; n: Cursor
           pragmas = parseTypePragmas local.pragmas
     else:
       bug "could not load: " & pool.syms[n.symId]
+    dec counter
 
   case n.typeKind
   of IntT, UIntT, FloatT:
@@ -222,7 +223,7 @@ proc getSize(c: var SizeofValue; cache: var Table[SymId, SizeofValue]; n: Cursor
   of NoType, ErrT, VoidT, VarargsT, OrT, AndT, NotT,
      ConceptT, StaticT, IteratorT, InvokeT, UarrayT, ItertypeT,
      AutoT, SymKindT, TypeKindT, TypedescT, UntypedT, TypedT, OrdinalT:
-    bug "valid type kind for sizeof computation: " & $n.typeKind
+    bug "invalid type kind for sizeof computation: " & $n.typeKind
 
 proc getSize*(n: Cursor; ptrSize: int; strict=false): xint =
   var c = createSizeofValue(strict)

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -209,9 +209,7 @@
     (stmts 7
      (asgn ~7 result.3 7
       (mul
-       (i +64) ~5 size.9 8
-       (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
-        (i -1)))) ,1
+       (i +64) ~5 size.9 8 +8)) ,1
      (if 3
       (elif 12
        (ovf) ~1,2
@@ -236,9 +234,7 @@
     (stmts 7
      (asgn ~7 result.4 7
       (mul
-       (i +64) ~5 size.10 8
-       (sizeof
-        (f +64)))) ,1
+       (i +64) ~5 size.10 8 +8)) ,1
      (if 3
       (elif 12
        (ovf) ~1,2
@@ -263,9 +259,7 @@
     (stmts 7
      (asgn ~7 result.5 7
       (mul
-       (i +64) ~5 size.11 8
-       (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
-        (u +8)))) ,1
+       (i +64) ~5 size.11 8 +1)) ,1
      (if 3
       (elif 12
        (ovf) ~1,2
@@ -432,18 +426,14 @@
        (hderef dest.3)) 10
       (mul
        (i +64) ~5
-       (dot ~3 src.3 len.3.Ipe57hg.temd2l7vy +0) 8
-       (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
-        (i -1)))) ~3,1
+       (dot ~3 src.3 len.3.Ipe57hg.temd2l7vy +0) 8 +8)) ~3,1
      (stmts 4
       (let :oldCap.0 . . 2,~52
        (i +64) 25
        (div
         (i +64) ~12
         (call 1 capInBytes.0.temd2l7vy ~4
-         (hderef dest.3)) 10
-        (sizeof 16,1,tests/nimony/sysbasics/temptyseq.nim
-         (i -1)))) 4,1
+         (hderef dest.3)) 10 +8)) 4,1
       (let :newCap.0 . . 1,~109
        (i -1) 18
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.0 17
@@ -634,18 +624,14 @@
        (hderef dest.4)) 10
       (mul
        (i +64) ~5
-       (dot ~3 src.4 len.3.Iw9f2pq.temd2l7vy +0) 8
-       (sizeof
-        (f +64)))) ~3,1
+       (dot ~3 src.4 len.3.Iw9f2pq.temd2l7vy +0) 8 +8)) ~3,1
      (stmts 4
       (let :oldCap.1 . . 2,~52
        (i +64) 25
        (div
         (i +64) ~12
         (call 1 capInBytes.1.temd2l7vy ~4
-         (hderef dest.4)) 10
-        (sizeof
-         (f +64)))) 4,1
+         (hderef dest.4)) 10 +8)) 4,1
       (let :newCap.1 . . 1,~109
        (i -1) 18
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.1 17
@@ -836,18 +822,14 @@
        (hderef dest.5)) 10
       (mul
        (i +64) ~5
-       (dot ~3 src.5 len.3.Iq4ofkp1.temd2l7vy +0) 8
-       (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
-        (u +8)))) ~3,1
+       (dot ~3 src.5 len.3.Iq4ofkp1.temd2l7vy +0) 8 +1)) ~3,1
      (stmts 4
       (let :oldCap.2 . . 2,~52
        (i +64) 25
        (div
         (i +64) ~12
         (call 1 capInBytes.2.temd2l7vy ~4
-         (hderef dest.5)) 10
-        (sizeof 11,9,tests/nimony/sysbasics/temptyseq.nim
-         (u +8)))) 4,1
+         (hderef dest.5)) 10 +1)) 4,1
       (let :newCap.2 . . 1,~109
        (i -1) 18
        (call ~9 recalcCap.0.sysvq0asl 1 oldCap.2 17


### PR DESCRIPTION
I think `sizeof` need to be evaluated in nimsem to test `getSize` proc in `nimony/sizeof.nim`.