### PR TITLE
fixes fields declared after a proctype field suddenly turning into params

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -591,6 +591,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
       let last {.cursor.} = n[n.len-1]
       if last.kind == nkRecList:
         for child in last:
+          c.section = FldL
           toNif(child, n, c)
       elif last.kind != nkEmpty:
         toNif(last, n, c)


### PR DESCRIPTION
nifler, given the code:
```nim
type
  X = object
    a: int
    f: proc()
    b: int
```
was producing:
```nif
(.nif24)
(.vendor "Nifler")
(.dialect "nim-parsed")
0,2,../../tmp/ntr.nim(stmts 4,1
 (type ~2 X . . . 2
  (object . ~2,1
   (fld a . . 3 int .) ~2,2
   (fld f . . 7
    (proctype ....
     (params) . . ..) .) ~2,3
   (param b . . 3 int .))))
```
and result in the error:
```
../../tmp/ntr.nim(6, 5) Error: illformed AST inside object: 
FAILURE: /d/code/langs/nimony/bin/nifmake -j run /tmp/nimcache/ntrdan17g1.build.nif
```
(fld turned into param)