### PR TITLE
implements #1268; implement the do notation

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4584,7 +4584,10 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
       semIs c, it
     of TabconstrX:
       semTableConstructor c, it, flags
-    of CurlyatX, DoX,
+    of DoX:
+      procGuard c:
+        semDo c, it, whichPass(c)
+    of CurlyatX,
        CompilesX, AlignofX, OffsetofX:
       # XXX To implement
       buildErr c, it.n.info, "to implement: " & $exprKind(it.n)

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -1016,3 +1016,22 @@ proc semUsing(c: var SemContext; n: var Cursor) =
     takeParRi c, n
 
   takeParRi c, n
+
+proc semDo(c: var SemContext; it: var Item; pass: PassKind) =
+  let info = it.n.info
+  inc it.n
+  var anons = createTokenBuf()
+  # transform the do notation to an anon proc
+  anons.addParLe(ProcS, info)
+  anons.addEmpty info # name
+  anons.addEmpty3 info # export, pattern, typevars
+  anons.takeTree it.n  # params
+  anons.takeTree it.n  # return type
+  anons.addEmpty info  # pragma
+  anons.addEmpty info  # effects
+  anons.takeTree it.n  # body
+  anons.takeParRi it.n
+  var anonIt = Item(n: beginRead(anons), typ: it.typ)
+  semProc c, anonIt, ProcY, pass
+  endRead anons
+  it.typ = anonIt.typ

--- a/tests/nimony/misc/tdo_nonation.nim
+++ b/tests/nimony/misc/tdo_nonation.nim
@@ -1,0 +1,66 @@
+import std/[assertions, syncio]
+
+proc test1(prc: proc ()) =
+  prc()
+
+test1() do ():
+  echo "test"
+
+proc test2(x: int; prc: proc (): int) =
+  assert prc() == x
+
+test2(123) do () -> int:
+  123
+
+proc testparam1(prc: proc(x: int)) =
+  prc(456)
+
+testparam1() do (x: int):
+  assert x == 456
+
+proc testparam2(x: int; prc: proc (x, y: int): int) =
+  assert prc(111, 222) == x
+
+testparam2(333) do (x, y: int) -> int:
+  assert x == 111
+  assert y == 222
+  333
+
+proc testgenerics1[T](x: T; prc: proc (x: T)) =
+  prc(x)
+
+testgenerics1(444) do (x: int):
+  assert x == 444
+
+proc testgenerics2[T, U](x: T; y: U; prc: proc (x: T; y: U): U): U =
+  prc(x, y)
+
+var res = testgenerics2(555, "foo") do (x: int; y: string) -> string:
+  assert x == 555
+  assert y == "foo"
+  "bar"
+assert res == "bar"
+
+proc testLocalProc() =
+  proc test(prc: proc (x: int)) =
+    prc(666)
+
+  test() do (x: int):
+    assert x == 666
+
+testLocalProc()
+
+template testtmpl1(x: untyped): untyped =
+  x
+
+testtmpl1() do:
+  echo "testtmpl1"
+
+template testtmpl2(x, y: untyped): untyped =
+  x
+  y
+
+testtmpl2() do:
+  echo "testtmpl2 1"
+do:
+  echo "testtmpl2 2"


### PR DESCRIPTION
Nifler already outputs `StmtsS` from the do notation without parameters.