### PR TITLE
fixes error: unhandled exception: cannot happen

### DIFF
--- a/src/nimony/renderer.nim
+++ b/src/nimony/renderer.nim
@@ -991,6 +991,8 @@ proc gtype(g: var SrcGen, n: var Cursor, c: Context) =
         putWithSpace(g, tkMethod, "method")
       of FuncT:
         putWithSpace(g, tkFunc, "func")
+      of ProctypeT:
+        putWithSpace(g, tkProc, "proc")
       else:
         raiseAssert "cannot happen"
       inc n


### PR DESCRIPTION
When an incorrect type argument is passed to a procedural type parameter, nimsem calls raiseAssert.
Example code:
```nim
proc test(prc: proc ()) = prc()

test(1)
```

Error message:
```
assertions.nim(34)       raiseAssert
Error: unhandled exception: cannot happen [AssertionDefect]
```