### PR TITLE
prints errors when object type only pragmas are used incorrectly

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1378,7 +1378,7 @@ proc semPragma(c: var SemContext; n: var Cursor; crucial: var CrucialPragma; kin
     if kind != TypeY:
       buildErr c, n.info, $pk & " pragma is only allowed on types"
       hasErr = true
-    elif pk in {InheritableP, FinalP, PackedP, UnionP}:
+    elif pk in {ViewP, InheritableP, FinalP, PackedP, UnionP}:
       var n2 = n
       skipToEnd n2
       if n2.typeKind in {RefT, PtrT}:

--- a/tests/nimony/errmsgs/twrongpragmas.msgs
+++ b/tests/nimony/errmsgs/twrongpragmas.msgs
@@ -9,3 +9,4 @@ tests/nimony/errmsgs/twrongpragmas.nim(16, 16) Error: inheritable pragma is only
 tests/nimony/errmsgs/twrongpragmas.nim(17, 16) Error: final pragma is only allowed on object types
 tests/nimony/errmsgs/twrongpragmas.nim(17, 23) Error: union pragma is only allowed on object types
 tests/nimony/errmsgs/twrongpragmas.nim(17, 30) Error: packed pragma is only allowed on object types
+tests/nimony/errmsgs/twrongpragmas.nim(18, 16) Error: view pragma is only allowed on object types

--- a/tests/nimony/errmsgs/twrongpragmas.nim
+++ b/tests/nimony/errmsgs/twrongpragmas.nim
@@ -15,3 +15,4 @@ proc procWithPragmaOnlyForObj() {.final, union.} = discard
 type
   FooNonObj1 {.inheritable.} = int
   FooNonObj2 {.final, union, packed.} = int
+  FooNonObj3 {.view.} = int


### PR DESCRIPTION
prints errors when pragmas that are allowed only on object types used with types other than object types.