### PR TITLE
implements `default` for case objects

### DIFF
--- a/tests/nimony/object/tcaseobject.nif
+++ b/tests/nimony/object/tcaseobject.nif
@@ -33,7 +33,9 @@
   (oconstr ~2,23 Foo.0.tcauiaoif
    (kv x.0.tcauiaoif 45,4,lib/std/system/defaults.nim
     (expr
-     (false))))) 4,16
+     (false)))
+   (kv y.0.tcauiaoif 43,6,lib/std/system/defaults.nim
+    (expr +0)))) 4,16
  (asgn ~4 foo.0.tcauiaoif 5
   (oconstr 2,22 Foo.0.tcauiaoif 2
    (kv ~1 x.0.tcauiaoif 2

--- a/tests/nimony/object/tcaseobject2.nim
+++ b/tests/nimony/object/tcaseobject2.nim
@@ -1,0 +1,21 @@
+import std/[assertions, syncio]
+
+block:
+  type
+    Foo = object
+      case kind: bool
+      of true:
+        x: int
+        m: float
+      of false:
+        y: int
+
+  block:
+    var a = default(Foo)
+    assert a.x == 0
+    assert a.m == 0.0
+
+  block:
+    var a = Foo()
+    assert a.x == 0
+    assert a.m == 0.0


### PR DESCRIPTION
fixes #1029

picks up the first branch if nothing is selected