### PR TITLE
Makes `CommentS` produces void types

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4600,7 +4600,9 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
           semRaise c, it
       of CommentS:
         # XXX ignored for now
+        let info = it.n.info
         skip it.n
+        producesVoid c, info, it.typ
       of EmitS:
         pragmaGuard c:
           semEmit c, it

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -107,3 +107,11 @@ proc `=destroy`(x: var X) =
 
 var o = O(kind: d, d: X(v: 12345))
 assert o.d.v == 12345
+
+block:
+  proc foo(): int =
+    result = 12
+    ## 1234
+
+
+  assert foo() == 12


### PR DESCRIPTION
Found this problem when porting `unicode.nim` to nimony