### PR TITLE
fixes `==` for CharLit (Convs to NU8 needed)

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1219,6 +1219,15 @@ proc trFieldname(c: var EContext; n: var Cursor) =
   else:
     trExpr c, n
 
+proc trCharLit(c: var EContext, n: var Cursor, typeBuf: TokenBuf) =
+  if n.kind == CharLit:
+    c.dest.add tagToken("conv", n.info)
+    c.dest.add typeBuf
+    trExpr(c, n)
+    c.dest.addParRi()
+  else:
+    trExpr(c, n)
+
 proc trExpr(c: var EContext; n: var Cursor) =
   case n.kind
   of EofToken, ParRi:
@@ -1228,11 +1237,19 @@ proc trExpr(c: var EContext; n: var Cursor) =
     of EqX, NeqX, LeX, LtX:
       c.dest.add n
       inc n
-      let beforeType = c.dest.len
+      let isCharType = n.typeKind == CharT
+
+      var typeBuf = createTokenBuf()
+      swap c.dest, typeBuf
       trType(c, n)
-      c.dest.shrink beforeType
-      trExpr(c, n)
-      trExpr(c, n)
+      swap c.dest, typeBuf
+
+      if isCharType:
+        trCharLit(c, n, typeBuf)
+        trCharLit(c, n, typeBuf)
+      else:
+        trExpr(c, n)
+        trExpr(c, n)
       takeParRi c, n
     of CastX:
       c.dest.add n

--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1219,15 +1219,6 @@ proc trFieldname(c: var EContext; n: var Cursor) =
   else:
     trExpr c, n
 
-proc trCharLit(c: var EContext, n: var Cursor, typeBuf: TokenBuf) =
-  if n.kind == CharLit:
-    c.dest.add tagToken("conv", n.info)
-    c.dest.add typeBuf
-    trExpr(c, n)
-    c.dest.addParRi()
-  else:
-    trExpr(c, n)
-
 proc trExpr(c: var EContext; n: var Cursor) =
   case n.kind
   of EofToken, ParRi:
@@ -1237,19 +1228,11 @@ proc trExpr(c: var EContext; n: var Cursor) =
     of EqX, NeqX, LeX, LtX:
       c.dest.add n
       inc n
-      let isCharType = n.typeKind == CharT
-
-      var typeBuf = createTokenBuf()
-      swap c.dest, typeBuf
+      let beforeType = c.dest.len
       trType(c, n)
-      swap c.dest, typeBuf
-
-      if isCharType:
-        trCharLit(c, n, typeBuf)
-        trCharLit(c, n, typeBuf)
-      else:
-        trExpr(c, n)
-        trExpr(c, n)
+      c.dest.shrink beforeType
+      trExpr(c, n)
+      trExpr(c, n)
       takeParRi c, n
     of CastX:
       c.dest.add n

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -254,6 +254,7 @@ proc genx(c: var GeneratedCode; n: var Cursor) =
       inc n
     of CharLit:
       let ch = n.charLit
+      c.add "(NC8)"
       var s = "'"
       toCChar ch, s
       s.add "'"

--- a/tests/nimony/ffi/tpacked.nim.c
+++ b/tests/nimony/ffi/tpacked.nim.c
@@ -422,16 +422,16 @@ int main(int argc, char **argv) {
   cmdCount = argc;
   cmdLine = (NC8**)argv;
 x_1_tpakvxko41 = (Foo_0_tpakvxko41){
-  .c_0_tpakvxko41 = 'a', .x_0_tpakvxko41 = IL64(123)}
+  .c_0_tpakvxko41 = (NC8)'a', .x_0_tpakvxko41 = IL64(123)}
 ;
-if ((!((x_1_tpakvxko41.c_0_tpakvxko41 == ((NC8)'a')) && (x_1_tpakvxko41.x_0_tpakvxko41 == IL64(123))))){
+if ((!((x_1_tpakvxko41.c_0_tpakvxko41 == (NC8)'a') && (x_1_tpakvxko41.x_0_tpakvxko41 == IL64(123))))){
   write_0_syn1lfpjv(stdout, (string_0_sysvq0asl){
     .a_0_sysvq0asl = (NC8*)"[Assertion Failure] ", .i_0_sysvq0asl = IL64(40)}
   );
   write_0_syn1lfpjv(stdout, (string_0_sysvq0asl){
     .a_0_sysvq0asl = (NC8*)"", .i_0_sysvq0asl = IL64(0)}
   );
-  write_5_syn1lfpjv(stdout, '\012');
+  write_5_syn1lfpjv(stdout, (NC8)'\012');
   quit_0_syn1lfpjv(IL64(1));}
 }
 

--- a/tests/nimony/ffi/tpacked.nim.c
+++ b/tests/nimony/ffi/tpacked.nim.c
@@ -424,7 +424,7 @@ int main(int argc, char **argv) {
 x_1_tpakvxko41 = (Foo_0_tpakvxko41){
   .c_0_tpakvxko41 = 'a', .x_0_tpakvxko41 = IL64(123)}
 ;
-if ((!((x_1_tpakvxko41.c_0_tpakvxko41 == 'a') && (x_1_tpakvxko41.x_0_tpakvxko41 == IL64(123))))){
+if ((!((x_1_tpakvxko41.c_0_tpakvxko41 == ((NC8)'a')) && (x_1_tpakvxko41.x_0_tpakvxko41 == IL64(123))))){
   write_0_syn1lfpjv(stdout, (string_0_sysvq0asl){
     .a_0_sysvq0asl = (NC8*)"[Assertion Failure] ", .i_0_sysvq0asl = IL64(40)}
   );

--- a/tests/nimony/ffi/tunion.nim.c
+++ b/tests/nimony/ffi/tunion.nim.c
@@ -413,6 +413,6 @@ NC8 **cmdLine;
 int main(int argc, char **argv) {
   cmdCount = argc;
   cmdLine = (NC8**)argv;
-x_1_tun261nex.c_0_tun261nex = 'a';
+x_1_tun261nex.c_0_tun261nex = (NC8)'a';
 }
 

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -115,3 +115,16 @@ block:
 
 
   assert foo() == 12
+
+proc herz(s1: char) =
+  assert char('\255') == s1
+
+proc hand =
+  let s1 = char('\255')
+  let s2 = '\255'
+  assert s1 == s2
+  assert s1 == '\255'
+  assert '\255' == s1
+  herz('\255')
+
+hand()


### PR DESCRIPTION
found it when debugging `unicode.nim`. Nim does the same thing for `==`

```c
colontmpD__2 = nimBoolToStr((((NU8) s1_1) == ((NU8) 255)));
```

```c
nimcache/tesl2p8x61.c:436:15: warning: result of comparison of constant -1 with expression of type 'NC8' (aka 'unsigned char') is always false [-Wtautological-constant-out-of-range-compare]
  436 |   if ((!(s1_1 == '\377'))){
      |          ~~~~ ^  ~~~~~~
nimcache/tesl2p8x61.c:445:17: warning: result of comparison of constant -1 with expression of type 'NC8' (aka 'unsigned char') is always false [-Wtautological-constant-out-of-range-compare]
  445 |   if ((!('\377' == s1_1))){
      |          ~~~~~~ ^  ~~~~
2 warnings generated.
[Assertion Failure] 
FAILURE: nimcache/tesl2p8x61
```