### PR TITLE
makes push/pop pragma works with variables

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4316,12 +4316,27 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
       discard "empty push"
     else:
       c.pragmaStack.add n
-    skipUntilEnd it.n
+    # semcheck push/pop pragmas in both SemcheckSignatures and SemcheckBodies phases
+    # so that pushed pragmas works for both procs and variables
+    if c.phase == SemcheckBodies:
+      skipUntilEnd it.n
+    else:
+      c.dest.addParLe PragmasS, it.n.info
+      c.takeToken it.n
+      while it.n.kind != ParRi:
+        c.takeTree it.n
+      c.dest.addParRi
   of PopP:
     if c.pragmaStack.len > 0:
       discard c.pragmaStack.pop
     else:
       buildErr c, it.n.info, "{.pop.} without a corresponding {.push.}"
+    if c.phase == SemcheckBodies:
+      inc it.n
+    else:
+      c.dest.addParLe PragmasS, it.n.info
+      c.takeToken it.n
+      c.dest.addParRi
     inc it.n
   of PassLP:
     inc it.n
@@ -4995,6 +5010,8 @@ proc phaseX(c: var SemContext; n: Cursor; x: SemPhase): TokenBuf =
     semStmt c, n, false
   takeParRi c, n
   result = move c.dest
+  # clear pragmaStack in case {.pop.} was not called
+  c.pragmaStack.setLen(0)
 
 proc requestHookInstance(c: var SemContext; decl: Cursor) =
   let decl = asTypeDecl(decl)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4337,7 +4337,6 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
       c.dest.addParLe PragmasS, it.n.info
       c.takeToken it.n
       c.dest.addParRi
-    inc it.n
   of PassLP:
     inc it.n
     let start = c.dest.len
@@ -4347,7 +4346,7 @@ proc semPragmaLine(c: var SemContext; it: var Item; isPragmaBlock: bool) =
       c.passL.add pool.strings[s]
     skipParRi it.n
   else:
-    buildErr c, it.n.info, "unsupported pragma"
+    buildErr c, it.n.info, "unsupported pragma", it.n
     skip it.n
     while it.n.kind != ParRi: skip it.n
 

--- a/tests/nimony/pragmas/tpushpop.nif
+++ b/tests/nimony/pragmas/tpushpop.nif
@@ -1,7 +1,8 @@
 (.nif24)
-0,1,tests/nimony/pragmas/tpushpop.nim(stmts 41,2
+0,1,tests/nimony/pragmas/tpushpop.nim(stmts 41,4
  (type ~39 :TestStruct1.0.tpu1210461 . . ~27
   (pragmas ~7,~2
+   (header 8 "pushpop.h") ~7,~2
    (header 8 "pushpop.h") 2
    (importc 9 "TestStruct1")) 2
   (object . ~39,1
@@ -9,25 +10,28 @@
     (pragmas 3,~3
      (header 8 "pushpop.h")) 37,40,lib/std/system/ctypes.nim
     (i +32
-     (importc "int")) .))) 4,6
- (gvar :tests1.0.tpu1210461 . . 8 TestStruct1.0.tpu1210461 .) ,9
+     (importc "int")) .))) 4,8
+ (gvar :tests1.0.tpu1210461 . . 8 TestStruct1.0.tpu1210461 .) ,11
  (proc 5 :cos.0.tpu1210461 . . . 8
   (params 1
    (param :x.0 .
     (pragmas ~2,~1
+     (header 8 "<math.h>") ~2,~1
      (header 8 "<math.h>")) 43,48,lib/std/system/ctypes.nim
     (f +64
      (importc "double")) .)) 43,48,lib/std/system/ctypes.nim
   (f +64
    (importc "double")) 30
   (pragmas ~23,~1
+   (header 8 "<math.h>") ~23,~1
    (header 8 "<math.h>") 2
    (importc 9 "cos") 18
-   (cdecl)) . .) ,11
+   (cdecl)) . .) ,13
  (proc 5 :sin.0.tpu1210461 . . . 8
   (params 1
    (param :x.1 .
     (pragmas ~2,~3
+     (header 8 "<math.h>") ~2,~3
      (header 8 "<math.h>")) 43,48,lib/std/system/ctypes.nim
     (f +64
      (importc "double")) .)) 43,48,lib/std/system/ctypes.nim
@@ -35,20 +39,78 @@
    (importc "double")) 30
   (pragmas ~23,~3
    (header 8 "<math.h>") ~23,~1
+   (cdecl) ~23,~3
+   (header 8 "<math.h>") ~23,~1
    (cdecl) 2
-   (importc 9 "sin")) . .) ,16
- (proc 5 :foo.0.tpu1210461 . . . 8
+   (importc 9 "sin")) . .) ,15
+ (proc 5 :c_fpclassify.0.tpu1210461 . . 17
+  (typevars 1
+   (typevar :T.0.tpu1210461 .
+    (pragmas ~11,~5
+     (header 8 "<math.h>") ~11,~5
+     (header 8 "<math.h>")) 28,53,lib/std/system/basic_types.nim
+    (or ~13
+     (f +64) ~7
+     (f +32) 1
+     (f +64)) .)) 31
   (params 1
    (param :x.2 .
+    (pragmas ~25,~5
+     (header 8 "<math.h>") ~25,~5
+     (header 8 "<math.h>")) 3 T.0.tpu1210461 .)) 8
+  (i -1) 43
+  (pragmas ~36,~5
+   (header 8 "<math.h>") ~36,~5
+   (header 8 "<math.h>") 2
+   (importc 9 "fpclassify")) . .) 18,16
+ (glet ~14 :c_fpNormal.0.tpu1210461 .
+  (pragmas ~11,~6
+   (header 8 "<math.h>") 2
+   (importc 9 "FP_NORMAL")) 26
+  (i -1) .) 2,4,lib/std/assertions.nim
+ (stmts
+  (if 3
+   (elif
+    (not 25,20,tests/nimony/pragmas/tpushpop.nim
+     (eq
+      (i +64) ~6
+      (call ~12 c_fpclassify.1.tpu1210461 1 +1.0) 3 c_fpNormal.0.tpu1210461)) ~1,1
+    (stmts 2,116,lib/std/syncio.nim
+     (stmts 2,1
+      (stmts
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 9,5,lib/std/assertions.nim "\5BAssertion Failure\5D ")) 2,1
+      (stmts
+       (cmd write.0.syn1lfpjv 6 stdout.0.syn1lfpjv 35,3,lib/std/assertions.nim "")) ,2
+      (cmd write.5.syn1lfpjv 6 stdout.0.syn1lfpjv 14 '\0A')) ,1
+     (cmd quit.0.syn1lfpjv 5 +1))))) ,22
+ (proc 5 :foo.0.tpu1210461 . . . 8
+  (params 1
+   (param :x.3 .
     (pragmas ~2,~1
+     (discardable) ~2,~1
      (discardable)) 3
     (i -1) .)) 10
   (i -1)
   (pragmas 7,~1
+   (discardable) 7,~1
    (discardable)) . 24
   (stmts
-   (result :result.0 . . ~12
+   (result :result.0 . . ~16,~7
     (i -1) .)
-   (asgn result.0 x.2) ~24
-   (ret result.0))) 3,19
- (call ~3 foo.0.tpu1210461 1 +1))
+   (asgn result.0 x.3) ~24
+   (ret result.0))) 3,25
+ (call ~3 foo.0.tpu1210461 1 +1) 19,19
+ (proc :c_fpclassify.1.tpu1210461 . ~19,~4 .
+  (at c_fpclassify.0.tpu1210461
+   (f +64)) 12,~4
+  (params 1
+   (param :x.5 .
+    (pragmas ~25,~5
+     (header 8 "<math.h>") ~25,~5
+     (header 8 "<math.h>"))
+    (f +64) .)) ~11,~4
+  (i -1) 24,~4
+  (pragmas ~36,~5
+   (header 8 "<math.h>") ~36,~5
+   (header 8 "<math.h>") 2
+   (importc 9 "fpclassify")) ~19,~4 . ~19,~4 .))

--- a/tests/nimony/pragmas/tpushpop.nim
+++ b/tests/nimony/pragmas/tpushpop.nim
@@ -1,3 +1,5 @@
+import std/[assertions]
+
 {.push header: "pushpop.h".}
 type
   TestStruct1 {.importc: "TestStruct1".} = object
@@ -11,7 +13,11 @@ proc cos(x: cdouble): cdouble {.importc: "cos", cdecl.}
 {.push cdecl.}
 proc sin(x: cdouble): cdouble {.importc: "sin".}
 {.pop.}
+proc c_fpclassify[T: SomeFloat](x: T): int {.importc: "fpclassify".}
+let c_fpNormal    {.importc: "FP_NORMAL".}: int
 {.pop.}
+
+assert c_fpclassify(1.0) == c_fpNormal
 
 {.push discardable.}
 proc foo(x: int): int = x


### PR DESCRIPTION
nimsem semchecks procedures in `SemcheckSignatures` and `SemcheckBodies` phases, but semchecks variables only in `SemcheckBodies` phase.
So makes push/pop pragma processed in both `SemcheckSignatures` and `SemcheckBodies` phases so that pushed pragmas are applied to both procedures and variables.
But pushed pragmas are added to procedures twice.