### PR TITLE
uses `NAN` in math.h

### DIFF
--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -132,6 +132,10 @@ typedef NU8 NU;
 #define NIM_TRUE true
 #define NIM_FALSE false
 
+// Include math.h to use `NAN` that should be defined in C compilers supports C99.
+#include <math.h>
+
+// Define NAN in case math.h doesn't define it.
 // NAN definition copied from math.h included in the Windows SDK version 10.0.14393.0
 #ifndef NAN
 #  ifndef _HUGE_ENUF


### PR DESCRIPTION
`signbit` called with `NAN` defined in current Nimony doesn't match `signbit` called with `NAN` defined in math.h.
Also when converted Nimony's `NAN` to float64, `signbit` returns the different value.

Following C code uses `NAN` defined in the same way as current Nimony:
```c
#ifndef NAN
#  ifndef _HUGE_ENUF
#    define _HUGE_ENUF  1e+300  // _HUGE_ENUF*_HUGE_ENUF must overflow
#  endif
#  define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
#  define NAN ((float)(NAN_INFINITY * 0.0F))
#endif

#include <math.h>
#include <stdio.h>

int main(void)
{
  printf("isnan(NAN) = %d\n", isnan(NAN));
  printf("signbit(NAN) = %d\n", signbit(NAN));
  printf("signbit(-NAN) = %d\n", signbit(-NAN));
  printf("signbit((double)NAN) = %d\n", signbit((double)NAN));
  printf("signbit((double)(-NAN)) = %d\n", signbit((double)(-NAN)));

  return 0;
}
```

output:
```
$ gcc testNimNan.c 
$ ./a.out
isnan(NAN) = 1
signbit(NAN) = 0
signbit(-NAN) = 0
signbit((double)NAN) = 1
signbit((double)(-NAN)) = 0
```

Following C code uses NAN defined in math.h:
```c
#include <math.h>
#include <stdio.h>

int main(void)
{
  printf("isnan(NAN) = %d\n", isnan(NAN));
  printf("signbit(NAN) = %d\n", signbit(NAN));
  printf("signbit(-NAN) = %d\n", signbit(-NAN));
  printf("signbit((double)NAN) = %d\n", signbit((double)NAN));
  printf("signbit((double)(-NAN)) = %d\n", signbit((double)(-NAN)));

  return 0;
}
```

output:
```
$ gcc testMathNan.c 
$ ./a.out
isnan(NAN) = 1
signbit(NAN) = 0
signbit(-NAN) = 1
signbit((double)NAN) = 0
signbit((double)(-NAN)) = 1
```

C reference says:
> Along with copysign, this macro is one of the only two portable ways to examine the sign of a NaN.
https://en.cppreference.com/w/c/numeric/math/signbit.html

Some of test code for `signbit` and `copySign` proc using `NaN` in Nim 2.0 fails on Nimony.
