### PR TITLE
implements `low` and `high` for arrays

### DIFF
--- a/lib/std/system/basic_types.nim
+++ b/lib/std/system/basic_types.nim
@@ -104,6 +104,11 @@ proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
 proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffect.}
 proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
 
+template low*[I, T](x: array[I, T]): I =
+  low(array[I, T])
+template high*[I, T](x: array[I, T]): I =
+  high(array[I, T])
+
 type
   RootObj* {.inheritable.} =
     object ## The root of Nim's object hierarchy.

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -166,3 +166,9 @@ block:
     result = s.int
 
   assert foo() == 2
+
+block:
+  var s = [1, 2, 3]
+
+  assert s.low == 0
+  assert s.high == 2


### PR DESCRIPTION
Similar to
```nim
template len*[I, T](x: typedesc[array[I, T]]): int =
  ## Returns the length of an array type.
  ## This is roughly the same as `high(T)-low(T)+1`.
  high(array[I, T]).int - low(array[I, T]).int + 1
template len*[I, T](x: array[I, T]): int =
  ## Returns the length of an array.
  ## This is roughly the same as `high(T)-low(T)+1`.
  len(array[I, T])
```
gives errors for `[]` (which is a better than `len([])` crash the compiler). Perhaps all of them should be implemented as magics