### PR TITLE
implements more set ops for `expreval`

### DIFF
--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -1,7 +1,7 @@
 func symmetricDifference*[T](x, y: set[T]): set[T] {.magic: "XorSet".}
 
 func `-+-`*[T](x, y: set[T]): set[T] {.magic: "XorSet".}
- 
+
 proc toggle*[T: Ordinal](x: var set[T], y: T) {.inline.} =
   ## Toggles the element `y` in the set `x`.
   if x.contains(y):

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -491,7 +491,7 @@ proc eval*(c: var EvalContext; n: var Cursor): Cursor =
     of CallKinds:
       result = evalCall(c, n)
       skip n
-    of PlusSetX, MinusSetX:
+    of PlusSetX, MinusSetX, XorSetX, MulSetX:
       result = evalSetOp(c, n, n.exprKind)
     else:
       if n.tagId == ErrT:

--- a/tests/nimony/const/tconstset.nim
+++ b/tests/nimony/const/tconstset.nim
@@ -1,11 +1,22 @@
-import std/assertions
+import std/[assertions, setutils]
 
 const a = {'a', 'b'}
 const b = {'0', '1'} + {'8', '9'}
 assert b == {'0', '1', '8', '9'}
 
+block:
+  const c = b - {'0', '1'}
+  assert c == {'8', '9'}
+
 const c = a + {'x'}
 assert c == {'a', 'b', 'x'}
+
+block:
+  const d = a - {'b'}
+  assert d == {'a'}
+
+  const e = c - {'x'}
+  assert e == {'a', 'b'}
 
 const d = {'a'..'c'}
 assert d == {'a', 'b', 'c'}
@@ -15,3 +26,37 @@ const f = {5'i8..8, 9'i8..10}
 assert f == {5'i8, 6, 7, 8, 9, 10}
 const g = {1'i8..3} + {5'i8..8} + {10'i8..14'i8}
 assert g == {1'i8, 2, 3, 5, 6, 7, 8, 10, 11, 12, 13, 14}
+
+
+block:
+  # Set subtraction (-)
+  const a = {'a', 'b', 'c'}
+  const b = a - {'b'}
+  assert b == {'a', 'c'} # {'a', 'b', 'c'} - {'b'} == {'a', 'c'}
+
+  const c = {'0', '1', '2', '3'}
+  const d = c - {'2', '3'}
+  assert d == {'0', '1'} # {'0', '1', '2', '3'} - {'2', '3'} == {'0', '1'}
+
+  # Set symmetric difference (-+-)
+  const e = {'a', 'b', 'c'}
+  const f = {'b', 'c', 'd'}
+  const g = e -+- f
+  assert g == {'a', 'd'} # {'a', 'b', 'c'} -+- {'b', 'c', 'd'} == {'a', 'd'}
+
+  const h = {'1', '2', '3'}
+  const i = {'2', '3', '4'}
+  const j = h -+- i
+  assert j == {'1', '4'} # {'1', '2', '3'} -+- {'2', '3', '4'} == {'1', '4'}
+
+  # Set intersection (*)
+  const k = {'a', 'b', 'c'}
+  const l = {'b', 'c', 'd'}
+  const m = k * l
+  assert m == {'b', 'c'} # {'a', 'b', 'c'} * {'b', 'c', 'd'} == {'b', 'c'}
+
+  const n = {'1', '2', '3'}
+  const o = {'2', '3', '4'}
+  const p = n * o
+  assert p == {'2', '3'} # {'1', '2', '3'} * {'2', '3', '4'} == {'2', '3'}
+


### PR DESCRIPTION
So I can make `const toEscapedChars = {'\32'..'\126'} - {'\\', '\'', '\"'}` work