### PR TITLE
fixes #1352; don't output initial values of imported variables

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1465,8 +1465,13 @@ proc trLocal(c: var EContext; n: var Cursor; tag: SymKind; mode: TraverseMode) =
   else:
     trType c, n
 
-  if mode == TraverseSig and localDecl.substructureKind == ParamU:
-    # Parameter decls in NIFC have no dot token for the default value!
+  if mode == TraverseSig:
+    if localDecl.substructureKind == ParamU:
+      # Parameter decls in NIFC have no dot token for the default value!
+      discard
+    else:
+      # Imported variables don't need initial values.
+      c.dest.addDotToken
     skip n
   else:
     trExpr c, n

--- a/tests/nimony/modules/deps/mvariables.nim
+++ b/tests/nimony/modules/deps/mvariables.nim
@@ -1,0 +1,19 @@
+var
+  varInt* = 123
+  varAry* = [456, 789]
+  varSet* = {'v'}
+
+let
+  letInt* = 1234
+  letAry* = [5678, 9876]
+  letSet* = {'l'}
+
+const
+  ConstInt* = 12345
+  ConstAry* = [67890, 54321]
+  ConstSet* = {'c'}
+
+proc changeVars* =
+  varInt = -123
+  varAry = [-456, -789]
+  varSet = {'V'}

--- a/tests/nimony/modules/tvariables.nim
+++ b/tests/nimony/modules/tvariables.nim
@@ -1,0 +1,20 @@
+import std/assertions
+import deps/mvariables
+
+assert varInt == 123
+assert varAry == [456, 789]
+assert varSet == {'v'}
+
+assert letInt == 1234
+assert letAry == [5678, 9876]
+assert letSet == {'l'}
+
+assert ConstInt == 12345
+assert ConstAry == [67890, 54321]
+assert ConstSet == {'c'}
+
+changeVars()
+
+assert varInt == -123
+assert varAry == [-456, -789]
+assert varSet == {'V'}


### PR DESCRIPTION
Set constructors are transformed in Hexer but set constructors in initial values of imported variables are not transformed and caused the error.
Hexer doesn't need to output initial values of imported variables as they are never used in NIFC.