### PR TITLE
Suppress the warning generated when passing const sets to procedures

### DIFF
--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -170,7 +170,11 @@ typedef NU8 NU;
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wpointer-sign"
-#  pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#  if defined(__clang__)
+#    pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#  else
+#    pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#  endif
 #endif
 
 

--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -170,6 +170,7 @@ typedef NU8 NU;
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wpointer-sign"
+#  pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
 #endif
 
 

--- a/tests/nimony/ffi/tpacked.nim.c
+++ b/tests/nimony/ffi/tpacked.nim.c
@@ -169,7 +169,11 @@ typedef NU8 NU;
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wpointer-sign"
-#  pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#  if defined(__clang__)
+#    pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#  else
+#    pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#  endif
 #endif
 
 

--- a/tests/nimony/ffi/tpacked.nim.c
+++ b/tests/nimony/ffi/tpacked.nim.c
@@ -169,6 +169,7 @@ typedef NU8 NU;
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wpointer-sign"
+#  pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
 #endif
 
 

--- a/tests/nimony/ffi/tunion.nim.c
+++ b/tests/nimony/ffi/tunion.nim.c
@@ -169,7 +169,11 @@ typedef NU8 NU;
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wpointer-sign"
-#  pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#  if defined(__clang__)
+#    pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#  else
+#    pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#  endif
 #endif
 
 

--- a/tests/nimony/ffi/tunion.nim.c
+++ b/tests/nimony/ffi/tunion.nim.c
@@ -169,6 +169,7 @@ typedef NU8 NU;
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wpointer-sign"
+#  pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
 #endif
 
 


### PR DESCRIPTION
When compiled following code, gcc generated warning:
```nim
const S = {'a' .. 'z'}
proc test(s: set[char]) = discard
test(S)
```

generated gcc warning:
```
nimcache/tes9hvujc.c: In function 'main':
nimcache/tes9hvujc.c:424:19: warning: passing argument 1 of 'test_1_tes9hvujc' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  424 | test_1_tes9hvujc((&S_0_tes9hvujc));
      |                  ~^~~~~~~~~~~~~~~
nimcache/tes9hvujc.c:417:43: note: expected 'AarrayAuS8ZS32_0_t *' but argument is of type 'const AarrayAuS8ZS32_0_t *'
  417 | void test_1_tes9hvujc(AarrayAuS8ZS32_0_t* s_0){
      |                       ~~~~~~~~~~~~~~~~~~~~^~~
```