### PR TITLE
fixes #1355; passes right cursor to `checkReq`

### DIFF
--- a/src/nimony/contracts.nim
+++ b/src/nimony/contracts.nim
@@ -384,6 +384,7 @@ proc analyseExpr(c: var Context; pc: var Cursor) =
     if nested == 0: break
 
 proc analyseCallArgs(c: var Context; n: var Cursor) =
+  let callCursor = n
   var fnType = skipProcTypeToParams(getType(c.typeCache, n))
   analyseExpr c, n # the `fn` itself could be a proc pointer we must ensure was initialized
   assert fnType.isParamsTag
@@ -412,7 +413,7 @@ proc analyseCallArgs(c: var Context; n: var Cursor) =
   let req = extractPragma(fnType, RequiresP)
   if not cursorIsNil(req):
     # ... analyse that the input parameters match the requirements
-    let res = checkReq(c, paramMap, req, n)
+    let res = checkReq(c, paramMap, req, callCursor)
     when isMainModule:
       # XXX Enable when it works
       if res != Proven:

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -193,3 +193,8 @@ block:
   s.addQuoted("ö")
   s.addEscapedChar('\xFF')
   assert s == """"å""ä""ö"\xFF"""
+
+
+block:
+  var s = "foo"
+  s[0] = 'F'


### PR DESCRIPTION
fixes #1355

`checkReq` needs to accept a call skipping the cursor kind according to `argAt`

```nim
proc argAt(call: Cursor; pos: int): Cursor =
  result = call
  inc result
  for i in 0 ..< pos: skip result
```

