### PR TITLE
fixes C errorrs by keeping the #include statements as they are

### DIFF
--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -596,15 +596,16 @@ proc genInclude(c: var GeneratedCode; n: var Cursor) =
   inc n
   if headerAsStr.len > 0 and not c.includedHeaders.containsOrIncl(int header):
     if headerAsStr[0] == '#':
-      discard "skip the #include keyword"
+      # keeps the #include statements as they are
+      c.includes.add header
     else:
       c.includes.add Token(IncludeKeyword)
-    if headerAsStr[0] == '<':
-      c.includes.add header
-    else:
-      c.includes.add Token(DoubleQuote)
-      c.includes.add header
-      c.includes.add Token(DoubleQuote)
+      if headerAsStr[0] == '<':
+        c.includes.add header
+      else:
+        c.includes.add Token(DoubleQuote)
+        c.includes.add header
+        c.includes.add Token(DoubleQuote)
 
     c.includes.add Token NewLine
   skipParRi n

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -198,3 +198,9 @@ block:
 block:
   var s = "foo"
   s[0] = 'F'
+
+when defined(posix):
+  type
+    SysLockObj {.importc: "pthread_mutex_t", pure, final,
+                header: """#include <sys/types.h>
+                          #include <pthread.h>""", byref.} = object


### PR DESCRIPTION
With this PR, `syslocks.nim` compiles