### PR TITLE
don't add pushed pragmas that already exists in the declaration

### DIFF
--- a/tests/nimony/pragmas/tpushpop.nif
+++ b/tests/nimony/pragmas/tpushpop.nif
@@ -51,4 +51,12 @@
     (i -1) .)
    (asgn result.0 x.2) ~24
    (ret result.0))) 3,19
- (call ~3 foo.0.tpu1210461 1 +1))
+ (call ~3 foo.0.tpu1210461 1 +1) ,24
+ (proc 5 :getchar.0.tpu1210461 . . . 12
+  (params) 37,40,lib/std/system/ctypes.nim
+  (i +32
+   (importc "int")) 21
+  (pragmas 2
+   (importc 9 "putchar") 22
+   (header 8 "<stdio.h>") 43
+   (noconv)) . .))

--- a/tests/nimony/pragmas/tpushpop.nim
+++ b/tests/nimony/pragmas/tpushpop.nim
@@ -18,3 +18,9 @@ proc foo(x: int): int = x
 {.pop.}
 
 foo(1)
+
+{.push header: "<headerfile_doesnt_exists.h>", thiscall.}
+# header pragma and thiscall calling convention in push pragma is ignored if declarations have both of them.
+# This test uses C function without parameters as current implementation applies pushed header pragma to parameters.
+proc getchar(): cint {.importc: "putchar", header: "<stdio.h>", noconv.}
+{.pop.}


### PR DESCRIPTION
For example,
```nim
{.push header: "<headerX.h>", cdecl.}
proc foo() {.importc: "foo", header: "<headerY.h>".}
{.pop.}
```
Pushed pragma `header: "<headerX.h>"` is not added to `foo` proc as it already have `header: "<headerY.h>"`.
So above code is the same to following code:
```nim
proc foo() {.importc: "foo", header: "<headerY.h>", cdecl.}
```

https://github.com/nim-lang/nimony/pull/1317 has a problem that pushed pragmas are added to procedures twice.
This PR can fix it.