### PR TITLE
fixes #1380; calling iterators not at for statements is compile errror

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -1813,6 +1813,7 @@ proc trStmt(c: var EContext; n: var Cursor; mode = TraverseAll) =
     of PragmasS, AssumeS, AssertS:
       skip n
   else:
+    assert n.kind != ParRi
     error c, "statement expected, but got: ", n
 
 proc transformInlineRoutines(c: var EContext; n: var Cursor) =

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2461,7 +2461,7 @@ proc semFor(c: var SemContext; it: var Item) =
       let argType = iterCall.typ
       iterCall = Item(n: beginRead(callBuf), typ: c.types.autoType)
       shrink c.dest, beforeCall
-      semCall c, iterCall, {}
+      semCall c, iterCall, {PreferIterators}
       if isIteratorCall(c, beforeCall):
         discard "fine"
       elif iterCall.typ.typeKind == UntypedT or

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -742,6 +742,8 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
       var magicExpr = Item(n: cursorAt(magicExprBuf, 0), typ: it.typ)
       semExpr c, magicExpr, cs.flags
       it.typ = magicExpr.typ
+    elif finalFn.kind == IteratorY and PreferIterators notin cs.flags:
+      buildErr c, cs.callNode.info, "Iterators can be called only at for statements"
     elif m[idx].inferred.len > 0:
       var matched = m[idx]
       let returnType: Cursor

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -743,7 +743,7 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
       semExpr c, magicExpr, cs.flags
       it.typ = magicExpr.typ
     elif finalFn.kind == IteratorY and PreferIterators notin cs.flags:
-      buildErr c, cs.callNode.info, "Iterators can be called only at for statements"
+      buildErr c, cs.callNode.info, "Iterators can be called only in `for` statements"
     elif m[idx].inferred.len > 0:
       var matched = m[idx]
       let returnType: Cursor

--- a/tests/nimony/errmsgs/titerator_call_not_in_for.msgs
+++ b/tests/nimony/errmsgs/titerator_call_not_in_for.msgs
@@ -1,1 +1,1 @@
-tests/nimony/errmsgs/titerator_call_not_in_for.nim(3, 21) Error: Iterators can be called only at for statements
+tests/nimony/errmsgs/titerator_call_not_in_for.nim(3, 21) Error: Iterators can be called only in `for` statements

--- a/tests/nimony/errmsgs/titerator_call_not_in_for.msgs
+++ b/tests/nimony/errmsgs/titerator_call_not_in_for.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/titerator_call_not_in_for.nim(3, 21) Error: Iterators can be called only at for statements

--- a/tests/nimony/errmsgs/titerator_call_not_in_for.nim
+++ b/tests/nimony/errmsgs/titerator_call_not_in_for.nim
@@ -1,0 +1,3 @@
+iterator testIterator(x, y: int): int = discard
+
+var x = testIterator(0, 1)


### PR DESCRIPTION
When the iterator matches at the call site but it is not at for statements, Nimony prints the compile error.
Also adds assert to hexer/nifcgen.nim so that it prints better error message when `trStmt` was called with `n.kind == ParRi`.
