### PR TITLE
use `toCString` before passed to importc calls

### DIFF
--- a/lib/std/encodings.nim
+++ b/lib/std/encodings.nim
@@ -478,9 +478,8 @@ else:
     result = newString(s.len)
     var inLen = csize_t len(s)
     var outLen = csize_t len(result)
-    var s = s
-    var src = toCString(s)
-    var dst = toCString(result)
+    var src = cstring(s)
+    var dst = cstring(result)
     var iconvres: csize_t = csize_t(0)
     while inLen > 0:
       iconvres = iconv(c, addr src, addr inLen, addr dst, addr outLen)

--- a/lib/std/encodings.nim
+++ b/lib/std/encodings.nim
@@ -356,7 +356,9 @@ proc open*(destEncoding = "UTF-8", srcEncoding = "CP1252"): EncodingConverter =
   ## Opens a converter that can convert from `srcEncoding` to `destEncoding`.
   ## Raises `EncodingError` if it cannot fulfill the request.
   when not defined(windows):
-    result = iconvOpen(destEncoding.cstring, srcEncoding.cstring)
+    var destEncoding = destEncoding
+    var srcEncoding = srcEncoding
+    result = iconvOpen(destEncoding.toCString, srcEncoding.toCString)
     if result == cast[EncodingConverter](-1):
       raiseEncodingError("cannot create encoding converter from " &
         srcEncoding & " to " & destEncoding)
@@ -379,17 +381,18 @@ when defined(windows):
     var cap = s.len + s.len shr 2
     result = newString(cap*2)
     # convert to utf-16 LE
+    var s = s
     var m = multiByteToWideChar(codePage,
                                 dwFlags = 0'i32,
-                                lpMultiByteStr = cstring(s),
+                                lpMultiByteStr = toCString(s),
                                 cbMultiByte = cint(s.len),
-                                lpWideCharStr = cstring(result),
+                                lpWideCharStr = toCString(result),
                                 cchWideChar = cint(cap))
     if m == 0:
       # try again; ask for capacity:
       cap = multiByteToWideChar(codePage,
                                 dwFlags = 0'i32,
-                                lpMultiByteStr = cstring(s),
+                                lpMultiByteStr = toCString(s),
                                 cbMultiByte = cint(s.len),
                                 lpWideCharStr = nil,
                                 cchWideChar = cint(0))
@@ -397,9 +400,9 @@ when defined(windows):
       result = newString(cap*2)
       m = multiByteToWideChar(codePage,
                               dwFlags = 0'i32,
-                              lpMultiByteStr = cstring(s),
+                              lpMultiByteStr = toCString(s),
                               cbMultiByte = cint(s.len),
-                              lpWideCharStr = cstring(result),
+                              lpWideCharStr = toCString(result),
                               cchWideChar = cint(cap))
       if m == 0: raiseOSError(osLastError())
       setLen(result, m*2)
@@ -412,17 +415,18 @@ when defined(windows):
     let charCount = s.len div 2
     var cap = s.len + s.len shr 2
     result = newString(cap)
+    var s = s
     var m = wideCharToMultiByte(codePage,
                                 dwFlags = 0'i32,
-                                lpWideCharStr = cstring(s),
+                                lpWideCharStr = toCString(s),
                                 cchWideChar = cint(charCount),
-                                lpMultiByteStr = cstring(result),
+                                lpMultiByteStr = toCString(result),
                                 cbMultiByte = cap.cint)
     if m == 0:
       # try again; ask for capacity:
       cap = wideCharToMultiByte(codePage,
                                 dwFlags = 0'i32,
-                                lpWideCharStr = cstring(s),
+                                lpWideCharStr = toCString(s),
                                 cchWideChar = cint(charCount),
                                 lpMultiByteStr = nil,
                                 cbMultiByte = cint(0))
@@ -430,9 +434,9 @@ when defined(windows):
       result = newString(cap)
       m = wideCharToMultiByte(codePage,
                               dwFlags = 0'i32,
-                              lpWideCharStr = cstring(s),
+                              lpWideCharStr = toCString(s),
                               cchWideChar = cint(charCount),
-                              lpMultiByteStr = cstring(result),
+                              lpMultiByteStr = toCString(result),
                               cbMultiByte = cap.cint)
       if m == 0: raiseOSError(osLastError())
       setLen(result, m)
@@ -474,8 +478,9 @@ else:
     result = newString(s.len)
     var inLen = csize_t len(s)
     var outLen = csize_t len(result)
-    var src = cstring(s)
-    var dst = cstring(result)
+    var s = s
+    var src = toCString(s)
+    var dst = toCString(result)
     var iconvres: csize_t = csize_t(0)
     while inLen > 0:
       iconvres = iconv(c, addr src, addr inLen, addr dst, addr outLen)


### PR DESCRIPTION
I didn't know Nimony strings are non-null terminated, probably a warning or something would be nicer