### PR TITLE
fixes #1395; forbids non-string-literals  conversions to cstring

### DIFF
--- a/lib/std/encodings.nim
+++ b/lib/std/encodings.nim
@@ -478,8 +478,8 @@ else:
     result = newString(s.len)
     var inLen = csize_t len(s)
     var outLen = csize_t len(result)
-    var src = cast[cstring](s)
-    var dst = cast[cstring](result)
+    var src = cast[cstring](s.rawData)
+    var dst = cast[cstring](result.rawData)
     var iconvres: csize_t = csize_t(0)
     while inLen > 0:
       iconvres = iconv(c, addr src, addr inLen, addr dst, addr outLen)
@@ -493,10 +493,10 @@ else:
           dec(inLen)
           dec(outLen)
         elif lerr == E2BIG:
-          var offset = cast[int](dst) - cast[int](cast[cstring](result))
+          var offset = cast[int](dst) - cast[int](cast[cstring](result.rawData))
           setLen(result, len(result) + inLen.int * 2 + 5)
           # 5 is minimally one utf-8 char
-          dst = cast[cstring](cast[int](cast[cstring](result)) + offset)
+          dst = cast[cstring](cast[int](cast[cstring](result.rawData)) + offset)
           outLen = csize_t(len(result) - offset)
         else:
           raiseOSError(lerr.OSErrorCode)
@@ -504,10 +504,10 @@ else:
     # not '\0'
     discard iconv(c, nil, nil, addr dst, addr outLen)
     if iconvres == high(csize_t) and errno == E2BIG:
-      var offset = cast[int](dst) - cast[int](cast[cstring](result))
+      var offset = cast[int](dst) - cast[int](cast[cstring](result.rawData))
       setLen(result, len(result) + inLen.int * 2 + 5)
       # 5 is minimally one utf-8 char
-      dst = cast[cstring](cast[int](cast[cstring](result)) + offset)
+      dst = cast[cstring](cast[int](cast[cstring](result.rawData)) + offset)
       outLen = csize_t(len(result) - offset)
       discard iconv(c, nil, nil, addr dst, addr outLen)
     # trim output buffer

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -806,7 +806,7 @@ proc semConvArg(c: var SemContext; destType: Cursor; arg: Item; info: PackedLine
       discard "ok"
       c.dest.addSubtree arg.n
     else:
-      c.buildErr info, "Only string literals can be converted to cstring. Use `cast` for unsafe conversion or `toCString` for safe conversion."
+      c.buildErr info, "Only string literals can be converted to cstring. Use `toCString` for safe conversion."
   elif (destBase.typeKind in IntegralTypes and srcBase.typeKind in IntegralTypes) or
      (destBase.isSomeStringType and srcBase.isSomeStringType) or
      (destBase.containsGenericParams or srcBase.containsGenericParams):

--- a/tests/nimony/casestmt/tsimple_string_case.nim
+++ b/tests/nimony/casestmt/tsimple_string_case.nim
@@ -171,7 +171,7 @@ block:
       of "": result = f
 
     var s = "Andreas"
-    assert foo1(s.cstring) == a
+    assert foo1(s.toCString) == a
 
   block:
     proc foo1(): Result =
@@ -191,7 +191,7 @@ block:
       const y = cstring"hash"
       var x = "Andreas"
       result = none
-      case x.cstring
+      case x.toCString
       of "Andreas", "Rumpf": result = a
       of cstring"aa", "bb": result = b
       of "cc", y, "when": result = c


### PR DESCRIPTION
fixes #1395

I use `cast[string]` for encodings changes because it uses unsafe pointer arithmetic while the original string is changed in a loop. It probably make `toCstring` unfit for this case since address is needed and the original string is changed (which may mean the `\0` is eliminated). Since `iconv` API also takes a length, it might be just fine