### PR TITLE
fixes dynlib pragmas when used from other modules

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -759,6 +759,7 @@ proc parsePragmas(c: var EContext; n: var Cursor): CollectedPragmas =
           inc n
           expectStrLit c, n
           result.dynlib = n.litId
+          result.flags.incl DynlibP
           result.flags.incl NodeclP
           inc n
         of AlignP:
@@ -1852,9 +1853,11 @@ proc importSymbol(c: var EContext; s: SymId) =
                       else:
                         asLocal(n).pragmas
         let prag = parsePragmas(c, pragmas)
-        if isR and InlineP in prag.flags:
-          transformInlineRoutines(c, n)
-          return
+        if isR:
+          if {InlineP, DynlibP} * prag.flags != {}:
+            transformInlineRoutines(c, n)
+            return
+
         if NodeclP in prag.flags:
           if prag.externName.len > 0:
             c.registerMangle(s, prag.externName & ".c")
@@ -2045,9 +2048,7 @@ proc expand*(infile: string; bits: int; flags: set[CheckMode]) =
     error c, "expected (stmts) but got: ", n
   swap c.dest, toplevels
 
-  initDynlib(c, rootInfo)
 
-  c.dest.add toplevels
 
   # fix point expansion:
   var i = 0
@@ -2056,6 +2057,17 @@ proc expand*(infile: string; bits: int; flags: set[CheckMode]) =
     if not c.declared.contains(imp):
       importSymbol(c, imp)
     inc i
+
+  initDynlib(c, rootInfo)
+
+  if c.dynlibs.len > 0:
+    let loadLibrary = pool.syms.getOrIncl("nimLoadLibrary.0." & SystemModuleSuffix)
+    let getProcAddr = pool.syms.getOrIncl("nimGetProcAddr.0." & SystemModuleSuffix)
+    if not c.declared.contains(loadLibrary):
+      importSymbol(c, loadLibrary)
+      importSymbol(c, getProcAddr)
+
+  c.dest.add toplevels
   c.dest.add c.pending
   skipParRi c, n
   writeOutput c, rootInfo

--- a/tests/nimony/ffi/tpacked.nim.c
+++ b/tests/nimony/ffi/tpacked.nim.c
@@ -413,14 +413,14 @@ N_INLINE(NB8, _Qnifc_mod_ul_overflow)(unsigned long int a, unsigned long int b, 
 }
 NIM_THREADVAR NB8 NIFC_ERR_;
 #include <stdio.h>
-typedef struct __attribute__ ((__packed__)) Foo_0_tpakvxko41{
-  NC8 c_0_tpakvxko41;
-  NI x_0_tpakvxko41;}
-Foo_0_tpakvxko41;
 typedef struct string_0_sysvq0asl{
   NC8* a_0_sysvq0asl;
   NI i_0_sysvq0asl;}
 string_0_sysvq0asl;
+typedef struct __attribute__ ((__packed__)) Foo_0_tpakvxko41{
+  NC8 c_0_tpakvxko41;
+  NI x_0_tpakvxko41;}
+Foo_0_tpakvxko41;
 extern void write_0_syn1lfpjv(FILE* f_4, string_0_sysvq0asl s_0);
 extern void write_5_syn1lfpjv(FILE* f_9, NC8 c_1);
 extern void quit_0_syn1lfpjv(NI value_1);

--- a/tests/nimony/sysbasics/deps/mdynlibs.nim
+++ b/tests/nimony/sysbasics/deps/mdynlibs.nim
@@ -1,0 +1,20 @@
+when defined(posix):
+  import std/[syncio, assertions]
+
+  type
+    CodePage = distinct int32
+    EncodingConverter = object
+      dest, src: CodePage
+
+  when defined(macosx):
+    const libiconv = "libiconv.dylib"
+  else:
+    const libiconv = "(libc.so.6|libiconv.so)"
+
+  proc iconvOpen*(tocode, fromcode: cstring): EncodingConverter {.
+    importc: "iconv_open", dynlib: libiconv.}
+  proc iconvClose*(c: EncodingConverter) {.
+    importc: "iconv_close", dynlib: libiconv.}
+  proc iconv*(c: EncodingConverter, inbuf: ptr cstring, inbytesLeft: ptr csize_t,
+              outbuf: ptr cstring, outbytesLeft: ptr csize_t): csize_t {.
+    importc: "iconv", dynlib: libiconv.}

--- a/tests/nimony/sysbasics/tdynlibs2.nim
+++ b/tests/nimony/sysbasics/tdynlibs2.nim
@@ -1,0 +1,25 @@
+when defined(posix):
+  import std/[syncio, assertions]
+
+  import deps/mdynlibs
+
+
+  let s = iconvOpen("12", "12")
+  let s2 = iconvOpen("12", "13")
+
+  iconvClose(s)
+  iconvClose(s2)
+
+  proc fox() =
+    let s = iconvOpen("12", "12")
+    let s2 = iconvOpen("12", "13")
+    iconvClose(s)
+    iconvClose(s2)
+
+  fox()
+
+  block:
+    let s = iconvOpen("12", "12")
+    let s2 = iconvOpen("12", "13")
+    iconvClose(s)
+    iconvClose(s2)


### PR DESCRIPTION
This PR implements `dynlib pragmas` cross modules by inline procs. It is not as efficient as it is by `extern` the var symbol. Since `initDynlib` is generated for each module and only when dynlib calls are called in this module, I'm not sure if I can `extern` the var symbol in `nifcgen` since no `initDynlib` is initialized in the original module