### PR TITLE
fixes raises with `var T`

### DIFF
--- a/src/hexer/constparams.nim
+++ b/src/hexer/constparams.nim
@@ -370,6 +370,7 @@ proc trAsgn(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let info = n.info
   var nn = n.firstSon
   if nn.kind == Symbol and ((nn.symId == c.resultSym and c.canRaise) or c.tupleVars.contains(nn.symId)):
+    let isResultSym = nn.symId == c.resultSym
     skip nn
     if nn.exprKind in CallKinds and callCanRaise(c.typeCache, nn):
       # nothing to do, both are in compatible tuple form:
@@ -381,7 +382,11 @@ proc trAsgn(c: var Context; dest: var TokenBuf; n: var Cursor) =
       copyInto dest, n:
         dest.add n # result
         inc n
-        let maybeClose = produceSuccessTuple(c, dest, getType(c.typeCache, n), n.info)
+        let maybeClose: bool
+        if isResultSym:
+          maybeClose = produceSuccessTuple(c, dest, c.retType, n.info)
+        else:
+          maybeClose = produceSuccessTuple(c, dest, getType(c.typeCache, n), n.info)
         tr c, dest, n
         if maybeClose:
           dest.addParRi() # tuple constructor

--- a/tests/nimony/exceptions/ttables.nim
+++ b/tests/nimony/exceptions/ttables.nim
@@ -1,0 +1,151 @@
+
+import std/[hashes, assertions]
+
+type
+  Keyable* = concept
+    proc `==`(a, b: Self): bool
+    proc hash(a: Self): Hash
+
+  HashEntry = object
+    fullhash: Hash
+    position: int # index into `data`; 1 based so that 0 means "unfilled"
+  Table*[K, V] = object
+    data: seq[(K, V)]
+    hashes: seq[HashEntry]
+
+proc mustRehash(length, counter: int): bool {.inline.} =
+  result = (length < counter div 2 + counter) or (length - counter < 4)
+
+proc isFilled(a: HashEntry): bool {.inline.} = a.position > 0
+
+proc resize(t: var seq[HashEntry]) =
+  # does not have to be generic.
+  let newLen = if t.len == 0: 4 else: t.len * 2
+  var s = newSeq[HashEntry](newLen)
+  for i in 0 ..< t.len:
+    if isFilled(t[i]):
+      var h = t[i].fullhash and high(s).uint
+      while isFilled(s[h]): h = nextTry(h, high(s))
+      s[h] = t[i]
+  t = ensureMove s
+
+const
+  HashThreshold = 4
+
+proc fillHashPart[K: Keyable, V](t: var Table[K, V]) =
+  t.hashes = newSeq[HashEntry](HashThreshold*2)
+  for i in 0 ..< t.data.len:
+    let fullhash = hash(t.data[i][0])
+    var hi = fullhash and t.hashes.high.uint
+    while isFilled(t.hashes[hi]): hi = nextTry(hi, high(t.hashes))
+    t.hashes[hi] = HashEntry(fullhash: fullhash, position: i+1)
+
+proc rawGet[K: Keyable, V](t: Table[K, V]; k: K; kh: Hash): int =
+  if t.data.len <= HashThreshold:
+    for i in 0 ..< t.data.len:
+      if t.data[i][0] == k: return i
+  else:
+    var h = kh and t.hashes.high.uint
+    while isFilled(t.hashes[h]):
+      let d = t.hashes[h]
+      if d.fullhash == kh and t.data[d.position-1][0] == k:
+        return d.position-1
+      h = nextTry(h, high(t.hashes))
+  result = -1
+
+proc contains*[K: Keyable, V](t: Table[K, V]; k: K): bool {.inline.} =
+  rawGet(t, k, hash(k)) >= 0
+
+proc hasKey*[K, V](t: Table[K, V]; k: K): bool {.inline.} =
+  contains(t, k)
+
+proc getOrDefault*[K: Keyable, V: HasDefault](t: Table[K, V]; k: K): V =
+  let idx = rawGet(t, k, hash(k))
+  if idx >= 0:
+    t.data[idx][1]
+  else:
+    default(V)
+
+# when defined(nimony):
+proc `[]`*[K: Keyable, V](t: Table[K, V]; k: K): var V {.raises.} =
+  let idx = rawGet(t, k, hash(k))
+  if idx < 0:
+    raise KeyError
+  t.data[idx][1]
+
+# else:
+#   proc `[]`*[K, V](t: var Table[K, V]; k: K): var V =
+#     let idx = rawGet(t, k, hash(k))
+#     assert idx >= 0
+#     t.data[idx][1]
+
+#   proc `[]`*[K, V](t: Table[K, V]; k: K): V =
+#     let idx = rawGet(t, k, hash(k))
+#     assert idx >= 0
+#     t.data[idx][1]
+
+proc rawPut[K, V](t: var Table[K, V]; k: sink K; v: sink V; h: Hash) =
+  if t.data.len == HashThreshold:
+    fillHashPart t
+  elif mustRehash(t.hashes.len, t.data.len):
+    resize t.hashes
+  t.data.add (k, v)
+  var hi = h and t.hashes.high.uint
+  while isFilled(t.hashes[hi]): hi = nextTry(hi, high(t.hashes))
+  t.hashes[hi] = HashEntry(fullhash: h, position: t.data.len)
+
+proc `[]=`*[K: Keyable, V](t: var Table[K, V]; k: sink K; v: sink V) =
+  let h = hash(k)
+  let idx = rawGet(t, k, h)
+  if idx >= 0:
+    t.data[idx][1] = v
+  else:
+    rawPut(t, k, v, h)
+
+proc mgetOrPut*[K: Keyable, V](t: var Table[K, V]; k: sink K; v: sink V): var V =
+  let h = hash(k)
+  var idx = rawGet(t, k, h)
+  if idx < 0:
+    rawPut(t, k, v, h)
+    idx = t.data.len-1
+  result = t.data[idx][1]
+
+proc len*[K, V](t: Table[K, V]): int {.inline.} = t.data.len
+
+iterator pairs*[K, V](t: Table[K, V]): (lent K, lent V) =
+  for i in 0 ..< t.data.len:
+    yield (t.data[i][0], t.data[i][1])
+
+iterator mpairs*[K, V](t: Table[K, V]): (lent K, var V) =
+  for i in 0 ..< t.data.len:
+    yield (t.data[i][0], t.data[i][1])
+
+proc initTable*[K, V](): Table[K, V] =
+  Table[K, V](data: @[], hashes: @[])
+
+when isMainModule:
+  import std/syncio
+
+  var tab: Table[string, int] = initTable[string, int]()
+  for i in 0..<1000:
+    tab[$i] = i
+    assert hasKey(tab, $i)
+    assert not hasKey(tab, $(i+1))
+
+    try:
+      assert tab[$i] == i
+    except:
+      discard
+  #echo tab.data
+  #echo tab.hashes
+  proc foo(tab: var Table[string, int]) {.raises.} =
+    assert tab.hasKey("100")
+    assert tab.getOrDefault("500") == 500
+    assert tab["600"] == 600
+    tab.mgetOrPut("abc", -12) = -24
+    assert tab["abc"] == -24
+
+  try:
+    foo(tab)
+  except:
+    discard

--- a/tests/nimony/exceptions/ttables.nim
+++ b/tests/nimony/exceptions/ttables.nim
@@ -2,150 +2,17 @@
 import std/[hashes, assertions]
 
 type
-  Keyable* = concept
-    proc `==`(a, b: Self): bool
-    proc hash(a: Self): Hash
-
-  HashEntry = object
-    fullhash: Hash
-    position: int # index into `data`; 1 based so that 0 means "unfilled"
   Table*[K, V] = object
     data: seq[(K, V)]
-    hashes: seq[HashEntry]
-
-proc mustRehash(length, counter: int): bool {.inline.} =
-  result = (length < counter div 2 + counter) or (length - counter < 4)
-
-proc isFilled(a: HashEntry): bool {.inline.} = a.position > 0
-
-proc resize(t: var seq[HashEntry]) =
-  # does not have to be generic.
-  let newLen = if t.len == 0: 4 else: t.len * 2
-  var s = newSeq[HashEntry](newLen)
-  for i in 0 ..< t.len:
-    if isFilled(t[i]):
-      var h = t[i].fullhash and high(s).uint
-      while isFilled(s[h]): h = nextTry(h, high(s))
-      s[h] = t[i]
-  t = ensureMove s
-
-const
-  HashThreshold = 4
-
-proc fillHashPart[K: Keyable, V](t: var Table[K, V]) =
-  t.hashes = newSeq[HashEntry](HashThreshold*2)
-  for i in 0 ..< t.data.len:
-    let fullhash = hash(t.data[i][0])
-    var hi = fullhash and t.hashes.high.uint
-    while isFilled(t.hashes[hi]): hi = nextTry(hi, high(t.hashes))
-    t.hashes[hi] = HashEntry(fullhash: fullhash, position: i+1)
-
-proc rawGet[K: Keyable, V](t: Table[K, V]; k: K; kh: Hash): int =
-  if t.data.len <= HashThreshold:
-    for i in 0 ..< t.data.len:
-      if t.data[i][0] == k: return i
-  else:
-    var h = kh and t.hashes.high.uint
-    while isFilled(t.hashes[h]):
-      let d = t.hashes[h]
-      if d.fullhash == kh and t.data[d.position-1][0] == k:
-        return d.position-1
-      h = nextTry(h, high(t.hashes))
-  result = -1
-
-proc contains*[K: Keyable, V](t: Table[K, V]; k: K): bool {.inline.} =
-  rawGet(t, k, hash(k)) >= 0
-
-proc hasKey*[K, V](t: Table[K, V]; k: K): bool {.inline.} =
-  contains(t, k)
-
-proc getOrDefault*[K: Keyable, V: HasDefault](t: Table[K, V]; k: K): V =
-  let idx = rawGet(t, k, hash(k))
-  if idx >= 0:
-    t.data[idx][1]
-  else:
-    default(V)
 
 # when defined(nimony):
-proc `[]`*[K: Keyable, V](t: Table[K, V]; k: K): var V {.raises.} =
-  let idx = rawGet(t, k, hash(k))
-  if idx < 0:
+proc `[]`*[K, V](t: Table[K, V]; k: K): var V {.raises.} =
+  if false:
     raise KeyError
-  t.data[idx][1]
+  t.data[0][1]
 
-# else:
-#   proc `[]`*[K, V](t: var Table[K, V]; k: K): var V =
-#     let idx = rawGet(t, k, hash(k))
-#     assert idx >= 0
-#     t.data[idx][1]
-
-#   proc `[]`*[K, V](t: Table[K, V]; k: K): V =
-#     let idx = rawGet(t, k, hash(k))
-#     assert idx >= 0
-#     t.data[idx][1]
-
-proc rawPut[K, V](t: var Table[K, V]; k: sink K; v: sink V; h: Hash) =
-  if t.data.len == HashThreshold:
-    fillHashPart t
-  elif mustRehash(t.hashes.len, t.data.len):
-    resize t.hashes
-  t.data.add (k, v)
-  var hi = h and t.hashes.high.uint
-  while isFilled(t.hashes[hi]): hi = nextTry(hi, high(t.hashes))
-  t.hashes[hi] = HashEntry(fullhash: h, position: t.data.len)
-
-proc `[]=`*[K: Keyable, V](t: var Table[K, V]; k: sink K; v: sink V) =
-  let h = hash(k)
-  let idx = rawGet(t, k, h)
-  if idx >= 0:
-    t.data[idx][1] = v
-  else:
-    rawPut(t, k, v, h)
-
-proc mgetOrPut*[K: Keyable, V](t: var Table[K, V]; k: sink K; v: sink V): var V =
-  let h = hash(k)
-  var idx = rawGet(t, k, h)
-  if idx < 0:
-    rawPut(t, k, v, h)
-    idx = t.data.len-1
-  result = t.data[idx][1]
-
-proc len*[K, V](t: Table[K, V]): int {.inline.} = t.data.len
-
-iterator pairs*[K, V](t: Table[K, V]): (lent K, lent V) =
-  for i in 0 ..< t.data.len:
-    yield (t.data[i][0], t.data[i][1])
-
-iterator mpairs*[K, V](t: Table[K, V]): (lent K, var V) =
-  for i in 0 ..< t.data.len:
-    yield (t.data[i][0], t.data[i][1])
-
-proc initTable*[K, V](): Table[K, V] =
-  Table[K, V](data: @[], hashes: @[])
-
-when isMainModule:
-  import std/syncio
-
-  var tab: Table[string, int] = initTable[string, int]()
-  for i in 0..<1000:
-    tab[$i] = i
-    assert hasKey(tab, $i)
-    assert not hasKey(tab, $(i+1))
-
-    try:
-      assert tab[$i] == i
-    except:
-      discard
-  #echo tab.data
-  #echo tab.hashes
-  proc foo(tab: var Table[string, int]) {.raises.} =
-    assert tab.hasKey("100")
-    assert tab.getOrDefault("500") == 500
-    assert tab["600"] == 600
-    tab.mgetOrPut("abc", -12) = -24
-    assert tab["abc"] == -24
-
-  try:
-    foo(tab)
-  except:
-    discard
+var s = Table[int, int](data: @[(1, 2)])
+try:
+  assert s[1] == 2
+except:
+  discard


### PR DESCRIPTION
```nim
proc `[]`*[K: Keyable, V](t: Table[K, V]; k: K): var V {.raises.} =
  let idx = rawGet(t, k, hash(k))
  if idx < 0:
    raise KeyError
  t.data[idx][1]
```

For a `var T` return type, we cannot use `getType` because it is a `var T` instead of `ptr T` returned by `getType`


```c
nimcache/ttauegnb4.c:583:12: error: assigning to 'AtupleSX45rrorX43ode0sysvq0aslAmutAiS64_0_t' (aka 'struct AtupleSX45rrorX43ode0sysvq0aslAmutAiS64_0_t') from incompatible type 'AtupleSX45rrorX43ode0sysvq0aslAptrAiS64_0_t' (aka 'struct AtupleSX45rrorX43ode0sysvq0aslAptrAiS64_0_t')
  583 |   result_2 = (AtupleSX45rrorX43ode0sysvq0aslAptrAiS64_0_t){
      |            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  584 |     .fld_0 = Success_0_sysvq0asl, .fld_1 = (&(*getQ_2_ttauegnb4(t_2.data_0_I8uyrpu, IL64(0))).fld_1)}
```