### PR TITLE
fixes #1404

### DIFF
--- a/lib/std/math.nim
+++ b/lib/std/math.nim
@@ -334,7 +334,7 @@ template ceilDivUint[T: SomeUnsignedInt and Arithmetic](x, y: T): T =
   # `x + (y - 1)` can overflow.
   (x + (y - T(1))) div y
 
-template ceilDivSigned[T: SomeInteger](x, y: T; U: untyped): T {.untyped.} =
+template ceilDivSigned[T: SomeInteger; U: SomeUnsignedInt and Arithmetic](x, y: T; _: typedesc[U]): T =
   T(ceilDivUint(x.U, y.U))
 
 func ceilDiv*[T: SomeInteger and Arithmetic](x, y: T): T {.inline.} =

--- a/src/nimony/semuntyped.nim
+++ b/src/nimony/semuntyped.nim
@@ -402,6 +402,10 @@ proc semTemplBody*(c: var UntypedCtx; n: var Cursor) =
         # var yz: T
         c.c.dest.shrink start
         c.c.dest.add symToken(firstSym, n.info)
+      elif c.mode == UntypedTemplate:
+        # leave as ident
+        c.c.dest.shrink start
+        c.c.dest.add n
       else:
         semTemplSymbol(c, n, firstSym, count, start)
     inc n


### PR DESCRIPTION
untyped template doesn't bind identifiers to symbols at the template definition even if matched symbols are found.
Fixed math.nim as fixed code produced the compile error from it.