### PR TITLE
fixes #1404

### DIFF
--- a/src/lib/nifindexes.nim
+++ b/src/lib/nifindexes.nim
@@ -190,6 +190,7 @@ proc createIndex*(infile: string; root: PackedLineInfo; buildChecksum: bool; sec
   var target = -1
   var previousPublicTarget = 0
   var previousPrivateTarget = 0
+  var tagId = TagId(0)
 
   var public = createTokenBuf(30)
   var private = createTokenBuf(30)
@@ -205,6 +206,7 @@ proc createIndex*(infile: string; root: PackedLineInfo; buildChecksum: bool; sec
     if t.kind == ParLe:
       stack.add t.info
       target = offs
+      tagId = t.tagId
     elif t.kind == ParRi:
       if stack.len > 1:
         discard stack.pop()
@@ -214,7 +216,9 @@ proc createIndex*(infile: string; root: PackedLineInfo; buildChecksum: bool; sec
       if pool.syms[sym].isImportant:
         let tb = next(s)
         buf.add tb
-        let isPublic = tb.kind != DotToken
+        # object field symbols are always private so that identifiers outside of dot or
+        # object constructors are not bound to them.
+        let isPublic = tb.kind != DotToken and tagId != TagId(FldTagId)
         var dest =
           if isPublic:
             addr(public)

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -28,9 +28,13 @@ proc considerImportedSymbols(c: var SemContext; name: StrId; info: PackedLineInf
   for moduleId in c.importTab.getOrDefault(name):
     # prevent copies
     let candidates = addr c.importedModules[moduleId].iface[name]
-    inc result, candidates[].len
     for defId in candidates[]:
-      c.dest.add symToken(defId, info)
+      let res = tryLoadSym(defId)
+      if res.status == LacksNothing and res.decl.symKind == FldY:
+        discard "ignores object fields as they are always used with dot or in an object constructor"
+      else:
+        c.dest.add symToken(defId, info)
+        inc result
 
 proc addSymUse*(dest: var TokenBuf; s: Sym; info: PackedLineInfo) =
   dest.add symToken(s.name, info)

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -28,13 +28,9 @@ proc considerImportedSymbols(c: var SemContext; name: StrId; info: PackedLineInf
   for moduleId in c.importTab.getOrDefault(name):
     # prevent copies
     let candidates = addr c.importedModules[moduleId].iface[name]
+    inc result, candidates[].len
     for defId in candidates[]:
-      let res = tryLoadSym(defId)
-      if res.status == LacksNothing and res.decl.symKind == FldY:
-        discard "ignores object fields as they are always used with dot or in an object constructor"
-      else:
-        c.dest.add symToken(defId, info)
-        inc result
+      c.dest.add symToken(defId, info)
 
 proc addSymUse*(dest: var TokenBuf; s: Sym; info: PackedLineInfo) =
   dest.add symToken(s.name, info)

--- a/tests/nimony/modules/deps/mdont_bind_to_obj_field.nim
+++ b/tests/nimony/modules/deps/mdont_bind_to_obj_field.nim
@@ -1,0 +1,5 @@
+# issue #1404
+
+type
+  Foo* = object
+    fooField*: int

--- a/tests/nimony/modules/deps/mdont_bind_to_obj_field2.nim
+++ b/tests/nimony/modules/deps/mdont_bind_to_obj_field2.nim
@@ -1,0 +1,12 @@
+# issue #1404
+
+type
+  Foo* = object
+    fooField*: int
+
+  Bar* = object
+    barField*: int
+
+const fooField* = 12345
+
+proc barField*(): int = 54321

--- a/tests/nimony/modules/tdont_bind_to_obj_field.msgs
+++ b/tests/nimony/modules/tdont_bind_to_obj_field.msgs
@@ -1,0 +1,3 @@
+tests/nimony/modules/tdont_bind_to_obj_field.nim(5, 1) Error: undeclared identifier
+tests/nimony/modules/tdont_bind_to_obj_field.nim(6, 9) Error: undeclared identifier
+tests/nimony/modules/tdont_bind_to_obj_field.nim(7, 9) Error: undeclared identifier: 'fooField'

--- a/tests/nimony/modules/tdont_bind_to_obj_field.nim
+++ b/tests/nimony/modules/tdont_bind_to_obj_field.nim
@@ -1,0 +1,7 @@
+# issue #1404
+
+import deps/mdont_bind_to_obj_field
+
+fooField = 1
+var x = fooField
+fooField()

--- a/tests/nimony/modules/tdont_bind_to_obj_field2.nim
+++ b/tests/nimony/modules/tdont_bind_to_obj_field2.nim
@@ -1,0 +1,7 @@
+# issue #1404
+
+import deps/mdont_bind_to_obj_field2
+import std/assertions
+
+assert fooField == 12345
+assert barField() == 54321


### PR DESCRIPTION
`considerImportedSymbols` proc in nimony/sembasics.nim ignores object field symbols in imported modules so that `buildSymChoice` proc never adds object field symbols to `c.dest`.