### PR TITLE
fixes module, type and import plugins

### DIFF
--- a/src/hexer/nifcgen.nim
+++ b/src/hexer/nifcgen.nim
@@ -743,7 +743,7 @@ proc parsePragmas(c: var EContext; n: var Cursor): CollectedPragmas =
           result.externName = pool.strings[n.litId]
           result.flags.incl pk
           inc n
-        of ExportcP, PluginP:
+        of ExportcP:
           inc n
           expectStrLit c, n
           result.externName = pool.strings[n.litId]
@@ -783,7 +783,7 @@ proc parsePragmas(c: var EContext; n: var Cursor): CollectedPragmas =
           inc n
         of RequiresP, EnsuresP, StringP, RaisesP, ErrorP, AssumeP, AssertP, ReportP,
            TagsP, DeprecatedP, SideEffectP, KeepOverflowFlagP, SemanticsP,
-           BaseP, FinalP, PragmaP, CursorP, PassiveP:
+           BaseP, FinalP, PragmaP, CursorP, PassiveP, PluginP:
           skip n
           continue
         of BuildP, EmitP, PushP, PopP, PassLP:

--- a/src/nimony/module_plugins.nim
+++ b/src/nimony/module_plugins.nim
@@ -15,7 +15,7 @@ import ".." / gear2 / modnames
 proc handleTypePlugins*(c: var SemContext) =
   var inp = move c.dest
 
-  for k, v in c.pendingTypePlugins:
+  for k, (v, info) in c.pendingTypePlugins:
     c.pluginBlacklist.incl(v)
 
     var types = createTokenBuf(30)
@@ -24,13 +24,13 @@ proc handleTypePlugins*(c: var SemContext) =
     types.addParRi()
 
     var dest = createTokenBuf(3000)
-    runPlugin(c, dest, NoLineInfo, pool.strings[v], inp.toString, types.toString)
+    runPlugin(c, dest, info, pool.strings[v], inp.toString, types.toString)
     inp = ensureMove dest
 
-  for k in c.pendingModulePlugins:
+  for (k, info) in c.pendingModulePlugins:
     c.pluginBlacklist.incl(k)
     var dest = createTokenBuf(3000)
-    runPlugin(c, dest, NoLineInfo, pool.strings[k], inp.toString)
+    runPlugin(c, dest, info, pool.strings[k], inp.toString)
     inp = ensureMove dest
 
   c.pendingTypePlugins.clear()

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -113,8 +113,8 @@ type
     unoverloadableMagics*: HashSet[StrId]
     debugAllowErrors*: bool
     pending*: TokenBuf
-    pendingTypePlugins*: Table[SymId, StrId]
-    pendingModulePlugins*: seq[StrId]
+    pendingTypePlugins*: Table[SymId, (StrId, PackedLineInfo)]
+    pendingModulePlugins*: seq[(StrId, PackedLineInfo)]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
     cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
     userPragmas*: Table[StrId, TokenBuf]

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -196,7 +196,7 @@ proc filenameVal*(n: var Cursor; res: var seq[ImportedFilename]; hasError: var b
           hasError = true
         for pre in mitems(prefix):
           for suf in mitems(suffix):
-            res.add ImportedFilename(path: pre.path & op & suf.path, name: suf.name)
+            res.add ImportedFilename(path: pre.path & op & suf.path, name: suf.name, plugin: suf.plugin)
     of PrefixX:
       var x = n
       skip n # ensure we skipped it completely
@@ -211,7 +211,7 @@ proc filenameVal*(n: var Cursor; res: var seq[ImportedFilename]; hasError: var b
       if x.kind != ParRi or suffix.len == 0:
         hasError = true
       for suf in mitems(suffix):
-        res.add ImportedFilename(path: op & suf.path, name: suf.name)
+        res.add ImportedFilename(path: op & suf.path, name: suf.name, plugin: suf.plugin)
     of ParX, TupX, BracketX:
       inc n
       if n.kind == ParRi:

--- a/tests/nimony/plugins/deps/mhiddenplugin.nim
+++ b/tests/nimony/plugins/deps/mhiddenplugin.nim
@@ -1,0 +1,3 @@
+
+template eraseToplevelBlocks* =
+  {.plugin: "mmoduleplugin".}

--- a/tests/nimony/plugins/deps/mlistener.nim
+++ b/tests/nimony/plugins/deps/mlistener.nim
@@ -1,0 +1,5 @@
+
+type
+  Listener* {.plugin: "mtypeplugin".} = object
+    i*: int
+    s*: string

--- a/tests/nimony/plugins/deps/mmoduleplugin.nim
+++ b/tests/nimony/plugins/deps/mmoduleplugin.nim
@@ -1,0 +1,23 @@
+
+include ".." / ".." / ".." / ".." / src / lib / nifprelude
+import nimonyplugins
+
+proc tr(n: Node): Tree =
+  result = createTree()
+  let info = n.info
+  var n = n
+  if n.stmtKind == StmtsS: inc n
+  result.withTree StmtsS, info:
+    while n.kind != ParRi:
+      case n.kind
+      of ParLe:
+        case n.stmtKind
+        of BlockS:
+          skip n
+        else:
+          result.takeTree n
+      else:
+        result.takeTree n
+
+var inp = loadTree()
+saveTree tr(beginRead inp)

--- a/tests/nimony/plugins/deps/mtypeplugin.nim
+++ b/tests/nimony/plugins/deps/mtypeplugin.nim
@@ -1,0 +1,124 @@
+
+import std / [os, strutils, tables]
+
+include ".." / ".." / ".." / ".." / src / lib / nifprelude
+import ".." / ".." / ".." / ".." / src / nimony / nimony_model
+import nimonyplugins
+
+
+template traverse*(n: var Node, body: untyped) =
+  let n2 = n
+  body
+  n = n2
+
+proc skip*(n: var Node, count: int) =
+  for _ in 0..<count:
+    skip n
+
+
+var knownInstances: Table[SymId, SymId]  # name -> type
+var knownTypes: seq[SymId]
+var knownOnChanged: Table[SymId, SymId]  # type -> `onChanged` template sym
+
+
+proc typesTr(n: Node) =
+  var n = n
+  inc n
+  while n.kind != ParRi:
+    knownTypes.add n.symId
+    inc n
+  inc n
+
+
+proc trAsgn(n: var Node, o: var TokenBuf) =
+  var
+    fieldName = ""
+    access = createTokenBuf(3)
+    instance = Node()
+    emitOnChanged = false
+  traverse n:
+    inc n
+    if n.kind == ParLe and n.exprKind == DotX:
+      traverse n:
+        takeTree access, n
+      inc n
+      if n.kind == Symbol and n.symId in knownInstances and knownInstances[n.symId] in knownOnChanged:
+        instance = n
+        inc n
+        if n.kind == Symbol:
+          fieldName = pool.syms[n.symId]
+          fieldName.delete fieldName.find('.')..fieldName.high
+          emitOnChanged = true
+  takeTree o, n
+  if emitOnChanged:
+    o.addParLe CallS
+    o.addSymUse knownOnChanged[knownInstances[instance.symId]], n.info
+    o.add instance
+    o.add access
+    o.addStrLit fieldName
+    o.addParRi()
+
+
+proc trGvar(n: var Node, o: var TokenBuf) =
+  traverse n:
+    inc n
+    let nameSym = n.symId
+    skip n, 3
+    if n.kind == Symbol and n.symId in knownTypes:
+      knownInstances[nameSym] = n.symId
+  takeTree o, n
+
+
+proc trTemplate(n: var Node, o: var TokenBuf) =
+  traverse n:
+    inc n
+    let nameSym = n.symId
+    let name = pool.syms[n.symId]
+    if name.startsWith("onChanged"):
+      skip n, 4
+      inc n  # params
+      inc n  # (first) param
+      skip n, 3
+      if n.kind == ParLe and n.typeKind == MutT:
+        inc n
+      if n.kind == Symbol:
+        knownOnChanged[n.symId] = nameSym
+  takeTree o, n
+
+
+proc trAux(n: var Node, o: var TokenBuf) =
+  case n.kind
+  of ParLe:
+    if n.stmtKind == AsgnS:
+      trAsgn n, o
+    elif n.stmtKind == GvarS:
+      trGvar n, o
+    elif n.stmtKind == TemplateS:
+      trTemplate n, o
+    else:
+      o.add n
+      inc n
+      while n.kind != ParRi:
+        trAux(n, o)
+      o.addParRi()
+      inc n
+  else:
+    takeTree o, n
+
+
+proc tr(n: Node): TokenBuf =
+  result = createTokenBuf()
+  let info = n.info
+  var n = n
+  if n.stmtKind == StmtsS: inc n
+  result.addParLe StmtsS, info
+  while n.kind != ParRi:
+    trAux(n, result)
+  result.addParRi()
+
+
+var inp = loadTree()
+var inpTypes = loadTree(paramStr(3))
+
+typesTr(beginRead inpTypes)
+writeFile os.paramStr(2), toString tr(beginRead inp)

--- a/tests/nimony/plugins/tmoduleplugin1.nim
+++ b/tests/nimony/plugins/tmoduleplugin1.nim
@@ -1,0 +1,9 @@
+
+import std / syncio
+
+{.plugin: "deps/mmoduleplugin".}
+
+echo "this should not be erased"
+
+block:
+  echo "should be erased"

--- a/tests/nimony/plugins/tmoduleplugin1.output
+++ b/tests/nimony/plugins/tmoduleplugin1.output
@@ -1,0 +1,1 @@
+this should not be erased

--- a/tests/nimony/plugins/tmoduleplugin2.nim
+++ b/tests/nimony/plugins/tmoduleplugin2.nim
@@ -1,0 +1,10 @@
+
+import std / syncio
+import deps/mhiddenplugin
+
+eraseToplevelBlocks()
+
+echo "this should not be erased"
+
+block:
+  echo "should be erased"

--- a/tests/nimony/plugins/tmoduleplugin2.output
+++ b/tests/nimony/plugins/tmoduleplugin2.output
@@ -1,0 +1,1 @@
+this should not be erased

--- a/tests/nimony/plugins/ttypeplugin.nim
+++ b/tests/nimony/plugins/ttypeplugin.nim
@@ -1,0 +1,12 @@
+
+import std / syncio
+import deps/mlistener
+
+template onChanged(x: var Listener, field: untyped, name: string): untyped =
+  echo name, " changed to ", field
+
+var p = Listener(i: 1, s: "a")
+p.i = 2
+p.s = "b"
+p.i = 3
+

--- a/tests/nimony/plugins/ttypeplugin.output
+++ b/tests/nimony/plugins/ttypeplugin.output
@@ -1,0 +1,3 @@
+i changed to 2
+s changed to b
+i changed to 3


### PR DESCRIPTION
It searches for the plugin relative to directory the string literal originates from

so
`/dirA/a.nim`
```nim
template foo =
  {.plugin: "myplugin".}
```
`/dirB/b.nim`
```nim
import ../dirA/a
foo()
```
will search for myplugin.nim in dirA (and in std)
which is what most people will probably expect it to