### PR TITLE
Add mimalloc alloc stats

### DIFF
--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -1,4 +1,4 @@
-{.build("C", "${path}/../../../vendor/mimalloc/src/static.c", "-I${path}/../../../vendor/mimalloc/include").}
+{.build("C", "${path}/../../../vendor/mimalloc/src/static.c", "-DMI_STATS=1 -I${path}/../../../vendor/mimalloc/include").}
 
 type
   MiStatCount {.importc: "mi_stat_count_t", bycopy.} = object
@@ -11,17 +11,17 @@ type
   # matches the initial layout of mi_stats_t in C.
   MiStatsPrefix {.importc: "mi_stats_t", bycopy.} = object
     version: cint
-    pages: MiStatCount # count of mimalloc pages
-    reserved: MiStatCount # reserved memory bytes
-    committed: MiStatCount # committed bytes
-    reset: MiStatCount # reset bytes
-    purged: MiStatCount # purged bytes
-    page_committed: MiStatCount # committed memory inside pages
-    pages_abandoned: MiStatCount # abandonded pages count
-    threads: MiStatCount # number of threads
-    malloc_normal: MiStatCount # allocated bytes <= MI_LARGE_OBJ_SIZE_MAX
-    malloc_huge: MiStatCount # allocated bytes in huge pages
-    malloc_requested: MiStatCount # malloc requested bytes
+    pages: MiStatCount             # count of mimalloc pages
+    reserved: MiStatCount          # reserved memory bytes
+    committed: MiStatCount         # committed bytes
+    reset: MiStatCount             # reset bytes
+    purged: MiStatCount            # purged bytes
+    page_committed: MiStatCount    # committed memory inside pages
+    pages_abandoned: MiStatCount   # abandonded pages count
+    threads: MiStatCount           # number of threads
+    malloc_normal: MiStatCount     # allocated bytes <= MI_LARGE_OBJ_SIZE_MAX
+    malloc_huge: MiStatCount       # allocated bytes in huge pages
+    malloc_requested: MiStatCount  # malloc requested bytes
     # Note: the real C struct continues with counters and more fields, we falsely declare it as .completeStruct
     # for sizeof(MiStatsPrefix) to work.
 

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -1,11 +1,72 @@
 {.build("C", "${path}/../../../vendor/mimalloc/src/static.c", "-I${path}/../../../vendor/mimalloc/include").}
 
-proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc".}
-proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc".}
-proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc".}
-proc mi_free(p: pointer) {.importc: "mi_free".}
+# shell32 user32 aren't needed for static linking from my testing
+when defined(vcc):
+  # Specifically for VCC which has different syntax
+  # Add debug flag for debug builds, otherwise use release
+  when defined(debug):
+    {.passC: "/DDEBUG".}
+  else:
+    {.passC: "/DNDEBUG".}
+    {.passC: "/DMI_BUILD_RELEASE".}
+  {.passL: "psapi.lib advapi32.lib bcrypt.lib".}
+else:
+  # Generic GCC-like arguments
+  when defined(debug):
+    {.passC: "-DDEBUG -fvisibility=hidden".}
+  else:
+    {.passC: "-DNDEBUG -fvisibility=hidden".}
+    {.passC: "-DMI_BUILD_RELEASE".}
 
-proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size".}
+  when defined(gcc) or defined(clang):
+    {.passC: "-Wno-unknown-pragmas".}
+  when defined(clang):
+    {.passC: "-Wno-static-in-inline".}
+  {.passC: "-ftls-model=initial-exec -fno-builtin-malloc".}
+  when defined(windows):
+    {.passL: "-lpsapi -ladvapi32 -lbcrypt".}
+  else:
+    {.passL: "-pthread -lrt -latomic".}
+
+type
+  MiStatCount {.importc: "mi_stat_count_t", bycopy.} = object
+    total: int64    # total allocated over time
+    peak: int64     # peak allocation
+    current: int64  # current allocation
+
+  # We only need the first part (prefix) of mi_stats_t up to malloc_requested.
+  # mi_stats_get copies exactly 'stats_size' bytes, so we define a prefix that
+  # matches the initial layout of mi_stats_t in C.
+  MiStatsPrefix {.importc: "mi_stats_t", bycopy.} = object
+    version: cint
+    pages: MiStatCount # count of mimalloc pages
+    reserved: MiStatCount # reserved memory bytes
+    committed: MiStatCount # committed bytes
+    reset: MiStatCount # reset bytes
+    purged: MiStatCount # purged bytes
+    page_committed: MiStatCount # committed memory inside pages
+    pages_abandoned: MiStatCount # abandonded pages count
+    threads: MiStatCount # number of threads
+    malloc_normal: MiStatCount # allocated bytes <= MI_LARGE_OBJ_SIZE_MAX
+    malloc_huge: MiStatCount # allocated bytes in huge pages
+    malloc_requested: MiStatCount # malloc requested bytes
+    # Note: the real C struct continues with counters and more fields, we falsely declare it as .completeStruct
+    # for sizeof(MiStatsPrefix) to work.
+
+proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc", header: "mimalloc.h", cdecl.}
+proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc", header: "mimalloc.h", cdecl.}
+proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc", header: "mimalloc.h", cdecl.}
+proc mi_free(p: pointer) {.importc: "mi_free", header: "mimalloc.h", cdecl.}
+
+proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size", header: "mimalloc.h", cdecl.}
+
+proc mi_stats_merge() {.importc: "mi_stats_merge", header: "mimalloc.h", cdecl.}
+proc mi_stats_get(stats_size: csize_t; stats: ptr MiStatsPrefix) {.importc: "mi_stats_get", header: "mimalloc-stats.h", cdecl.}
+
+# Optional: OS-level process info (independent of MI_STAT), not used here but handy:
+# proc mi_process_info(elapsed_msecs, user_msecs, system_msecs,
+#                      current_rss, peak_rss, current_commit, peak_commit,
+#                      page_faults: ptr csize_t) {.importc: "mi_process_info", header: "mimalloc-stats.h", cdecl.}
 
 proc alloc*(size: int): pointer =
   result = mi_malloc(size.csize_t)
@@ -18,3 +79,35 @@ proc dealloc*(p: pointer) =
 
 proc allocatedSize*(p: pointer): int =
   result = int mi_usable_size(p)
+
+when defined(debug):
+  proc readStats(): MiStatsPrefix =
+    var s: MiStatsPrefix
+    # Fold thread-local stats into main stats so we get process-wide values.
+    mi_stats_merge()
+    mi_stats_get(csize_t(sizeof(s)), addr s)
+    return s
+
+  proc getOccupiedMem*(): int =
+    ## Returns the number of bytes that are owned by the process and hold data.
+    let st = readStats()
+    let allocated = st.malloc_normal.current + st.malloc_huge.current
+    # Cast to Nim int (pointer-sized); beware of overflow on 32-bit if very large.
+    result = int(allocated)
+
+  proc getTotalMem*(): int =
+    ## Returns the number of bytes that are owned by the process.
+    let st = readStats()
+    result = int(st.committed.current)
+
+  proc getFreeMem*(): int =
+    ## Returns the number of bytes that are owned by the process, but do not hold any meaningful data.
+    let st = readStats()
+    let allocated = st.malloc_normal.current + st.malloc_huge.current
+    var freeBytes = st.committed.current - allocated
+    if freeBytes < 0: freeBytes = 0          # be defensive against underflow if stats lag slightly
+    result = int(freeBytes)
+else:
+  proc getOccupiedMem*(): int = discard
+  proc getFreeMem*(): int = discard
+  proc getTotalMem*(): int = discard

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -54,11 +54,10 @@ proc allocatedSize*(p: pointer): int =
 
 when defined(debug):
   proc readStats(): MiStatsPrefix =
-    var s: MiStatsPrefix
+    result = default(MiStatsPrefix)
     # Fold thread-local stats into main stats so we get process-wide values.
     mi_stats_merge()
-    mi_stats_get(csize_t(sizeof(s)), addr s)
-    return s
+    mi_stats_get(csize_t(sizeof(result)), addr result)
 
   proc getOccupiedMem*(): int =
     ## Returns the number of bytes that are owned by the process and hold data.

--- a/lib/std/system/mimalloc.nim
+++ b/lib/std/system/mimalloc.nim
@@ -1,33 +1,5 @@
 {.build("C", "${path}/../../../vendor/mimalloc/src/static.c", "-I${path}/../../../vendor/mimalloc/include").}
 
-# shell32 user32 aren't needed for static linking from my testing
-when defined(vcc):
-  # Specifically for VCC which has different syntax
-  # Add debug flag for debug builds, otherwise use release
-  when defined(debug):
-    {.passC: "/DDEBUG".}
-  else:
-    {.passC: "/DNDEBUG".}
-    {.passC: "/DMI_BUILD_RELEASE".}
-  {.passL: "psapi.lib advapi32.lib bcrypt.lib".}
-else:
-  # Generic GCC-like arguments
-  when defined(debug):
-    {.passC: "-DDEBUG -fvisibility=hidden".}
-  else:
-    {.passC: "-DNDEBUG -fvisibility=hidden".}
-    {.passC: "-DMI_BUILD_RELEASE".}
-
-  when defined(gcc) or defined(clang):
-    {.passC: "-Wno-unknown-pragmas".}
-  when defined(clang):
-    {.passC: "-Wno-static-in-inline".}
-  {.passC: "-ftls-model=initial-exec -fno-builtin-malloc".}
-  when defined(windows):
-    {.passL: "-lpsapi -ladvapi32 -lbcrypt".}
-  else:
-    {.passL: "-pthread -lrt -latomic".}
-
 type
   MiStatCount {.importc: "mi_stat_count_t", bycopy.} = object
     total: int64    # total allocated over time
@@ -53,20 +25,20 @@ type
     # Note: the real C struct continues with counters and more fields, we falsely declare it as .completeStruct
     # for sizeof(MiStatsPrefix) to work.
 
-proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc", header: "mimalloc.h", cdecl.}
-proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc", header: "mimalloc.h", cdecl.}
-proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc", header: "mimalloc.h", cdecl.}
-proc mi_free(p: pointer) {.importc: "mi_free", header: "mimalloc.h", cdecl.}
+proc mi_malloc(size: csize_t): pointer {.importc: "mi_malloc", cdecl.}
+proc mi_calloc(nmemb: csize_t, size: csize_t): pointer {.importc: "mi_calloc", cdecl.}
+proc mi_realloc(pt: pointer, size: csize_t): pointer {.importc: "mi_realloc", cdecl.}
+proc mi_free(p: pointer) {.importc: "mi_free", cdecl.}
 
-proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size", header: "mimalloc.h", cdecl.}
+proc mi_usable_size(p: pointer): csize_t {.importc: "mi_usable_size", cdecl.}
 
-proc mi_stats_merge() {.importc: "mi_stats_merge", header: "mimalloc.h", cdecl.}
-proc mi_stats_get(stats_size: csize_t; stats: ptr MiStatsPrefix) {.importc: "mi_stats_get", header: "mimalloc-stats.h", cdecl.}
+proc mi_stats_merge() {.importc: "mi_stats_merge", cdecl.}
+proc mi_stats_get(stats_size: csize_t; stats: ptr MiStatsPrefix) {.importc: "mi_stats_get", cdecl.}
 
 # Optional: OS-level process info (independent of MI_STAT), not used here but handy:
 # proc mi_process_info(elapsed_msecs, user_msecs, system_msecs,
 #                      current_rss, peak_rss, current_commit, peak_commit,
-#                      page_faults: ptr csize_t) {.importc: "mi_process_info", header: "mimalloc-stats.h", cdecl.}
+#                      page_faults: ptr csize_t) {.importc: "mi_process_info", cdecl.}
 
 proc alloc*(size: int): pointer =
   result = mi_malloc(size.csize_t)

--- a/tests/nimony/sysbasics/temptyseq.nif
+++ b/tests/nimony/sysbasics/temptyseq.nif
@@ -332,9 +332,9 @@
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
-       (hconv 17,16,lib/std/system/mimalloc.nim
+       (hconv 17,49,lib/std/system/mimalloc.nim
         (pointer)
-        (hconv 13,10,lib/std/system/mimalloc.nim
+        (hconv 13,43,lib/std/system/mimalloc.nim
          (pointer)
          (dot ~1 s.6 data.0.Ipe57hg.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.0.temd2l7vy . .
@@ -461,9 +461,9 @@
          (uarray 16,1,tests/nimony/sysbasics/temptyseq.nim
           (i -1))) 35
         (call ~7 realloc.0.sysvq0asl 5
-         (hconv 17,13,lib/std/system/mimalloc.nim
+         (hconv 17,46,lib/std/system/mimalloc.nim
           (pointer)
-          (hconv 13,10,lib/std/system/mimalloc.nim
+          (hconv 13,43,lib/std/system/mimalloc.nim
            (pointer)
            (dot ~4
             (hderef dest.3) data.0.Ipe57hg.temd2l7vy +0))) 12 memSize.3))) ,4
@@ -534,9 +534,9 @@
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
-       (hconv 17,16,lib/std/system/mimalloc.nim
+       (hconv 17,49,lib/std/system/mimalloc.nim
         (pointer)
-        (hconv 13,10,lib/std/system/mimalloc.nim
+        (hconv 13,43,lib/std/system/mimalloc.nim
          (pointer)
          (dot ~1 s.9 data.0.Iw9f2pq.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.1.temd2l7vy . .
@@ -663,9 +663,9 @@
          (uarray
           (f +64))) 35
         (call ~7 realloc.0.sysvq0asl 5
-         (hconv 17,13,lib/std/system/mimalloc.nim
+         (hconv 17,46,lib/std/system/mimalloc.nim
           (pointer)
-          (hconv 13,10,lib/std/system/mimalloc.nim
+          (hconv 13,43,lib/std/system/mimalloc.nim
            (pointer)
            (dot ~4
             (hderef dest.4) data.0.Iw9f2pq.temd2l7vy +0))) 12 memSize.4))) ,4
@@ -736,9 +736,9 @@
         (nil)))) ~1,1
      (stmts
       (cmd dealloc.0.sysvq0asl 9
-       (hconv 17,16,lib/std/system/mimalloc.nim
+       (hconv 17,49,lib/std/system/mimalloc.nim
         (pointer)
-        (hconv 13,10,lib/std/system/mimalloc.nim
+        (hconv 13,43,lib/std/system/mimalloc.nim
          (pointer)
          (dot ~1 s.12 data.0.Iq4ofkp1.temd2l7vy +0))))))))) 0,19,lib/std/system/seqimpl.nim
  (proc :=wasMoved.2.temd2l7vy . .
@@ -865,9 +865,9 @@
          (uarray 11,9,tests/nimony/sysbasics/temptyseq.nim
           (u +8))) 35
         (call ~7 realloc.0.sysvq0asl 5
-         (hconv 17,13,lib/std/system/mimalloc.nim
+         (hconv 17,46,lib/std/system/mimalloc.nim
           (pointer)
-          (hconv 13,10,lib/std/system/mimalloc.nim
+          (hconv 13,43,lib/std/system/mimalloc.nim
            (pointer)
            (dot ~4
             (hderef dest.5) data.0.Iq4ofkp1.temd2l7vy +0))) 12 memSize.5))) ,4
@@ -949,9 +949,9 @@
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
-        (hconv 23,19,lib/std/system/mimalloc.nim
+        (hconv 23,52,lib/std/system/mimalloc.nim
          (pointer)
-         (hconv 13,10,lib/std/system/mimalloc.nim
+         (hconv 13,43,lib/std/system/mimalloc.nim
           (pointer)
           (dot ~1 s.15 data.0.Ipe57hg.temd2l7vy +0)))))) 40
      (else 6
@@ -981,9 +981,9 @@
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
-        (hconv 23,19,lib/std/system/mimalloc.nim
+        (hconv 23,52,lib/std/system/mimalloc.nim
          (pointer)
-         (hconv 13,10,lib/std/system/mimalloc.nim
+         (hconv 13,43,lib/std/system/mimalloc.nim
           (pointer)
           (dot ~1 s.16 data.0.Iw9f2pq.temd2l7vy +0)))))) 40
      (else 6
@@ -1013,9 +1013,9 @@
          (nil)))) 15
       (expr 13
        (call ~13 allocatedSize.0.sysvq0asl 2
-        (hconv 23,19,lib/std/system/mimalloc.nim
+        (hconv 23,52,lib/std/system/mimalloc.nim
          (pointer)
-         (hconv 13,10,lib/std/system/mimalloc.nim
+         (hconv 13,43,lib/std/system/mimalloc.nim
           (pointer)
           (dot ~1 s.17 data.0.Iq4ofkp1.temd2l7vy +0)))))) 40
      (else 6


### PR DESCRIPTION
Based on: https://github.com/planetis-m/mimalloc_nim/blob/master/src/patchedstd/mimalloc.nim

Note 1: https://github.com/nim-lang/mimalloc/ needs to be updated to a recent version as it lacks the header "mimalloc-stats.h"

Note 2: passC is not implemented so the statements at the top of the linked file were removed but it needs either MI_STAT=1 or MI_DEBUG>0