### PR TITLE
prevents duplicated pragmas

### DIFF
--- a/src/nimony/pragmacanon.nim
+++ b/src/nimony/pragmacanon.nim
@@ -1,0 +1,29 @@
+import std / [sets]
+include nifprelude
+import nimony_model, decls, asthelpers
+
+type
+  CheckedPragmas* = object
+    pragmas: set[NimonyPragma]
+    callconv: CallConv = NoCallConv
+    idents: HashSet[StrId]  # idents of user pragmas and macro pragmas
+
+proc isChecked*(c: var CheckedPragmas; n: Cursor; kind: SymKind): bool =
+  ## Prevents duplicated pragmas by returning true when `CheckedPragmas` get the pragma that is given previously.
+  result = false
+  if not kind.isRoutine and callConvKind(n) != NoCallConv:
+    result = true
+  else:
+    var n2 = n
+    if n2.substructureKind == KvU or n2.exprKind == CallX:
+      inc n2
+    if (let pk = pragmaKind(n2); pk != NoPragma):
+      result = pk in c.pragmas
+      if not result:
+        c.pragmas.incl pk
+    elif kind.isRoutine and (let cc = callConvKind(n2); cc != NoCallConv):
+      result = c.callconv != NoCallConv
+      if not result:
+        c.callconv = cc
+    elif (let ident = getIdent(n2); ident != StrId(0)):
+      result = c.idents.containsOrIncl(ident)

--- a/tests/nimony/pragmas/tpushpop.nif
+++ b/tests/nimony/pragmas/tpushpop.nif
@@ -1,10 +1,9 @@
 (.nif24)
 0,1,tests/nimony/pragmas/tpushpop.nim(stmts 41,4
  (type ~39 :TestStruct1.0.tpu1210461 . . ~27
-  (pragmas ~7,~2
-   (header 8 "pushpop.h") ~7,~2
-   (header 8 "pushpop.h") 2
-   (importc 9 "TestStruct1")) 2
+  (pragmas 2
+   (importc 9 "TestStruct1") ~7,~2
+   (header 8 "pushpop.h")) 2
   (object . ~39,1
    (fld :x.0.tpu1210461 .
     (pragmas 3,~3
@@ -16,38 +15,32 @@
   (params 1
    (param :x.0 .
     (pragmas ~2,~1
-     (header 8 "<math.h>") ~2,~1
      (header 8 "<math.h>")) 43,48,lib/std/system/ctypes.nim
     (f +64
      (importc "double")) .)) 43,48,lib/std/system/ctypes.nim
   (f +64
    (importc "double")) 30
-  (pragmas ~23,~1
-   (header 8 "<math.h>") ~23,~1
-   (header 8 "<math.h>") 2
+  (pragmas 2
    (importc 9 "cos") 18
-   (cdecl)) . .) ,13
+   (cdecl) ~23,~1
+   (header 8 "<math.h>")) . .) ,13
  (proc 5 :sin.0.tpu1210461 . . . 8
   (params 1
    (param :x.1 .
     (pragmas ~2,~3
-     (header 8 "<math.h>") ~2,~3
      (header 8 "<math.h>")) 43,48,lib/std/system/ctypes.nim
     (f +64
      (importc "double")) .)) 43,48,lib/std/system/ctypes.nim
   (f +64
    (importc "double")) 30
-  (pragmas ~23,~3
+  (pragmas 2
+   (importc 9 "sin") ~23,~3
    (header 8 "<math.h>") ~23,~1
-   (cdecl) ~23,~3
-   (header 8 "<math.h>") ~23,~1
-   (cdecl) 2
-   (importc 9 "sin")) . .) ,15
+   (cdecl)) . .) ,15
  (proc 5 :c_fpclassify.0.tpu1210461 . . 17
   (typevars 1
    (typevar :T.0.tpu1210461 .
     (pragmas ~11,~5
-     (header 8 "<math.h>") ~11,~5
      (header 8 "<math.h>")) 28,53,lib/std/system/basic_types.nim
     (or ~13
      (f +64) ~7
@@ -56,17 +49,15 @@
   (params 1
    (param :x.2 .
     (pragmas ~25,~5
-     (header 8 "<math.h>") ~25,~5
      (header 8 "<math.h>")) 3 T.0.tpu1210461 .)) 8
   (i -1) 43
-  (pragmas ~36,~5
-   (header 8 "<math.h>") ~36,~5
-   (header 8 "<math.h>") 2
-   (importc 9 "fpclassify")) . .) 18,16
+  (pragmas 2
+   (importc 9 "fpclassify") ~36,~5
+   (header 8 "<math.h>")) . .) 18,16
  (glet ~14 :c_fpNormal.0.tpu1210461 .
-  (pragmas ~11,~6
-   (header 8 "<math.h>") 2
-   (importc 9 "FP_NORMAL")) 26
+  (pragmas 2
+   (importc 9 "FP_NORMAL") ~11,~6
+   (header 8 "<math.h>")) 26
   (i -1) .) 2,4,lib/std/assertions.nim
  (stmts
   (if 3
@@ -87,30 +78,34 @@
   (params 1
    (param :x.3 .
     (pragmas ~2,~1
-     (discardable) ~2,~1
      (discardable)) 3
     (i -1) .)) 10
   (i -1)
   (pragmas 7,~1
-   (discardable) 7,~1
    (discardable)) . 24
   (stmts
    (result :result.0 . . ~16,~7
     (i -1) .)
    (asgn result.0 x.3) ~24
    (ret result.0))) 3,25
- (call ~3 foo.0.tpu1210461 1 +1) 19,19
+ (call ~3 foo.0.tpu1210461 1 +1) ,30
+ (proc 5 :getchar.0.tpu1210461 . . . 12
+  (params) 37,40,lib/std/system/ctypes.nim
+  (i +32
+   (importc "int")) 21
+  (pragmas 2
+   (importc 9 "putchar") 22
+   (header 8 "<stdio.h>") 43
+   (noconv)) . .) 19,19
  (proc :c_fpclassify.1.tpu1210461 . ~19,~4 .
   (at c_fpclassify.0.tpu1210461
    (f +64)) 12,~4
   (params 1
    (param :x.5 .
     (pragmas ~25,~5
-     (header 8 "<math.h>") ~25,~5
      (header 8 "<math.h>"))
     (f +64) .)) ~11,~4
   (i -1) 24,~4
-  (pragmas ~36,~5
-   (header 8 "<math.h>") ~36,~5
-   (header 8 "<math.h>") 2
-   (importc 9 "fpclassify")) ~19,~4 . ~19,~4 .))
+  (pragmas 2
+   (importc 9 "fpclassify") ~36,~5
+   (header 8 "<math.h>")) ~19,~4 . ~19,~4 .))

--- a/tests/nimony/pragmas/tpushpop.nim
+++ b/tests/nimony/pragmas/tpushpop.nim
@@ -24,3 +24,9 @@ proc foo(x: int): int = x
 {.pop.}
 
 foo(1)
+
+{.push header: "<headerfile_doesnt_exists.h>", thiscall.}
+# header pragma and thiscall calling convention in push pragma is ignored if declarations have both of them.
+# This test uses C function without parameters as current implementation applies pushed header pragma to parameters.
+proc getchar(): cint {.importc: "putchar", header: "<stdio.h>", noconv.}
+{.pop.}


### PR DESCRIPTION
Succeeds https://github.com/nim-lang/nimony/pull/1372

`CheckedPragmas` object and `isChecked` proc in nimony/pragmacanon.nim prevents duplicated pragmas.