### PR TITLE
fixes #1429

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1856,7 +1856,9 @@ proc semExprSym(c: var SemContext; it: var Item; s: Sym; start: int; flags: set[
 
 proc semLocalTypeExpr(c: var SemContext, it: var Item) =
   let info = it.n.info
-  let val = semLocalType(c, it.n)
+  var val = semLocalType(c, it.n)
+  if val.typeKind == TypedescT:
+    inc val
   let start = c.dest.len
   c.dest.buildTree TypedescT, info:
     c.dest.addSubtree val


### PR DESCRIPTION
When `semLocalTypeExpr` was called and `it.n` points to `(typedesc (i -1))`, it generates `(typedesc (typedesc (i -1)))`.
So when `typeof(1) is int` is semchecked, `semIs` proc compares `(typedesc (typedesc (i -1)))` and `(i -1)` and it returns false.