### PR TITLE
adds `typeof` to system module

### DIFF
--- a/doc/stdlib.dgn.md
+++ b/doc/stdlib.dgn.md
@@ -261,6 +261,9 @@ Set out of memory handler. Applications can use this to handle the "out of memor
 
 Returns the default value for a type.
 
+###typeof
+
+Returns the type of an expression
 
 ### String and sequence operations
 

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -398,3 +398,6 @@ func `..`*[T, U](a: sink T; b: sink U): HSlice[T, U] {.inline.} =
   ##   echo a[2 .. 3] # @[30, 40]
   ##   ```
   result = HSlice[T, U](a: a, b: b)
+
+proc typeof*[T](x: T): typedesc[T] {.magic: TypeOf.}
+  ## Builtin `typeof` operation for accessing the type of an expression.

--- a/tests/nimony/sysbasics/ttypeof.nim
+++ b/tests/nimony/sysbasics/ttypeof.nim
@@ -1,0 +1,31 @@
+import std/[assertions]
+
+assert typeof(1) is int
+assert typeof(0.1) is float
+assert typeof(1 + 1) is int
+assert typeof("a") is string
+assert typeof("a"[0]) is char
+assert typeof([0, 1]) is array[2, int]
+assert typeof((1, "a")) is (int, string)
+
+block:
+  var x = 1
+  assert typeof(x) is int
+  var str = "foo"
+  assert typeof(str) is string
+
+  const X = 2
+  assert typeof(X) is int
+  const Str = "bar"
+  assert typeof(Str) is string
+
+block:
+  type
+    Foo = object
+      x: int
+      y: string
+
+  let f = Foo()
+  assert typeof(f) is Foo
+  assert typeof(f.x) is int
+  assert typeof(f.y) is string


### PR DESCRIPTION
Fixes https://github.com/nim-lang/nimony/issues/1426.
tests/nimony/sysbasics/ttypeof.nim needs https://github.com/nim-lang/nimony/pull/1430.
