### PR TITLE
fixes #1440; treat Symbol as a non-simple expression while travesing return statement in duplifier

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -197,7 +197,7 @@ proc isResultUsage(c: Context; n: Cursor): bool {.inline.} =
 proc isSimpleExpression(n: var Cursor): bool =
   ## expressions that can be returned safely
   case n.kind
-  of Symbol, UIntLit, StringLit, IntLit, FloatLit, CharLit, DotToken, Ident:
+  of UIntLit, StringLit, IntLit, FloatLit, CharLit, DotToken, Ident:
     result = true
     inc n
   of ParLe:
@@ -224,6 +224,12 @@ proc isSimpleExpression(n: var Cursor): bool =
     else:
       result = false
       skip n
+  of Symbol:
+    # fixes https://github.com/nim-lang/nimony/issues/1440
+    # symbol might be changed in a defer\finally block or indirrectly
+    # during return so a copy the symbol needed (result = sym)
+    result = false
+    inc n
   of ParRi, SymbolDef, UnknownToken, EofToken:
     result = false
     inc n

--- a/tests/nimony/misc/treturn_var_with_defer.nim
+++ b/tests/nimony/misc/treturn_var_with_defer.nim
@@ -1,0 +1,35 @@
+import std/syncio
+
+proc f1(n: int): int =
+  var n = n
+  defer:
+    inc n
+    echo "f1 defer: ", n
+  return n
+
+proc f2(n: int): int =
+  var n = n
+  defer:
+    inc n
+    echo "f2 defer: ", n
+  result = n
+
+proc f3(n: int): int =
+  var n = n
+  defer:
+    inc n
+    echo "f3 defer: ", n
+  result = n
+  return result
+
+proc f4(n: int): int =
+  var n = n
+  defer:
+    inc n
+    echo "f4 defer: ", n
+  n
+
+echo f1(10)
+echo f2(20)
+echo f3(30)
+echo f4(40)

--- a/tests/nimony/misc/treturn_var_with_defer.output
+++ b/tests/nimony/misc/treturn_var_with_defer.output
@@ -1,0 +1,8 @@
+f1 defer: 11
+10
+f2 defer: 21
+20
+f3 defer: 31
+30
+f4 defer: 41
+40


### PR DESCRIPTION
It's unsafe to use a symbol during return as it might be modified indirectly from finally\\defer blocks, which changes `return` semantics.