### PR TITLE
porting `std/appdirs` to Nimony

### DIFF
--- a/doc/stdlib.dgn.md
+++ b/doc/stdlib.dgn.md
@@ -1167,6 +1167,35 @@ Returns the absolute path of `path`, rooted at `root` (which must be absolute; d
 Expands `~` or a path starting with `~/` to a full path, replacing `~` with getHomeDir() (otherwise returns `path` unmodified). Windows: this is still supported despite the Windows platform not having this convention; also, both `~/` and `~\` are handled.
 
 
+### appdirs
+
+@../lib/std/appdirs.nim
+
+This module implements helpers for determining special directories used by apps.
+
+####getHomeDir
+Returns the home directory of the current user as a Path. Used for expanding `~` in user configuration files.
+
+####getDataDir
+Returns the data directory of the current user for applications. On non-Windows OSs, this follows the XDG Base Directory spec and uses the `XDG_DATA_HOME` environment variable if set, otherwise defaults to `~/.local/share` or `~/Library/Application Support` on macOS.
+
+####getConfigDir
+Returns the config directory of the current user for applications. On non-Windows OSs, this follows the XDG Base Directory spec and uses the `XDG_CONFIG_HOME` environment variable if set, otherwise defaults to `~/.config/`. The returned string always ends with an OS-dependent trailing slash.
+
+####getCacheDir
+Returns the cache directory of the current user for applications. Uses platform-specific environment variables:
+- Windows: `LOCALAPPDATA`
+- macOS: `XDG_CACHE_HOME` or `HOME/Library/Caches`
+- Other: `XDG_CACHE_HOME` or `HOME/.cache`
+
+####getCacheDir(app: Path)
+Returns the cache directory for a specific application. On Windows, this is `getCacheDir() / app / "cache"`; on other platforms, `getCacheDir() / app`.
+
+####getTempDir
+Returns the temporary directory for the current user. On Windows, uses `GetTempPath`. On POSIX, checks `TMPDIR`, `TEMP`, `TMP`, and `TEMPDIR` environment variables, defaulting to `/tmp` if none are set. The implementation can be overridden with `-d:tempDir=mytempname` at compile time. Does not check if the returned path exists.
+
+
+
 ### Threads
 
 @../lib/std/rawthreads.nim

--- a/lib/std/appdirs.nim
+++ b/lib/std/appdirs.nim
@@ -1,0 +1,94 @@
+## This module implements helpers for determining special directories used by apps.
+
+## .. importdoc:: paths.nim
+
+from std/private/osappdirs import nil
+import std/paths
+import std/envvars
+
+proc getHomeDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the home directory of the current user.
+  ##
+  ## This proc is wrapped by the `expandTilde proc`_
+  ## for the convenience of processing paths coming from user configuration files.
+  ##
+  ## See also:
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  result = Path(osappdirs.getHomeDir())
+
+proc getDataDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the data directory of the current user for applications.
+  ## 
+  ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+  ## spec. Thus, this proc returns the value of the `XDG_DATA_HOME` environment
+  ## variable if it is set, otherwise it returns the default configuration
+  ## directory ("~/.local/share" or "~/Library/Application Support" on macOS).
+  ## 
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
+  result = Path(osappdirs.getDataDir())
+
+proc getConfigDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the config directory of the current user for applications.
+  ##
+  ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+  ## spec. Thus, this proc returns the value of the `XDG_CONFIG_HOME` environment
+  ## variable if it is set, otherwise it returns the default configuration
+  ## directory ("~/.config/").
+  ##
+  ## An OS-dependent trailing slash is always present at the end of the
+  ## returned string: `\\` on Windows and `/` on all other OSs.
+  ##
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getTempDir proc`_
+  result = Path(osappdirs.getConfigDir())
+
+proc getCacheDir*(): Path {.inline.} =
+  ## Returns the cache directory of the current user for applications.
+  ##
+  ## This makes use of the following environment variables:
+  ##
+  ## * On Windows: `getEnv("LOCALAPPDATA")`
+  ##
+  ## * On macOS: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches")`
+  ##
+  ## * On other platforms: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")`
+  ##
+  ## **See also:**
+  ## * `getHomeDir proc`_
+  ## * `getTempDir proc`_
+  ## * `getConfigDir proc`_
+  # follows https://crates.io/crates/platform-dirs
+  result = Path(osappdirs.getCacheDir())
+
+proc getCacheDir*(app: Path): Path {.inline.} =
+  ## Returns the cache directory for an application `app`.
+  ##
+  ## * On Windows, this uses: `getCacheDir() / app / "cache"`
+  ## * On other platforms, this uses: `getCacheDir() / app`
+  result = Path(osappdirs.getCacheDir(app.string))
+
+proc getTempDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+  ## Returns the temporary directory of the current user for applications to
+  ## save temporary files in.
+  ##
+  ## On Windows, it calls [GetTempPath](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw).
+  ## On Posix based platforms, it will check `TMPDIR`, `TEMP`, `TMP` and `TEMPDIR` environment variables in order.
+  ## On all platforms, `/tmp` will be returned if the procs fails.
+  ##
+  ## You can override this implementation
+  ## by adding `-d:tempDir=mytempname` to your compiler invocation.
+  ##
+  ## .. Note:: This proc does not check whether the returned path exists.
+  ##
+  ## See also:
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  result = Path(osappdirs.getTempDir())

--- a/lib/std/appdirs.nim
+++ b/lib/std/appdirs.nim
@@ -1,12 +1,12 @@
-## This module implements helpers for determining special directories used by apps.
+# This module implements helpers for determining special directories used by apps.
 
-## .. importdoc:: paths.nim
+# .. importdoc:: paths.nim
 
-from std/private/osappdirs import nil
-import std/paths
-import std/envvars
+import paths
+from private/osappdirs import nil
 
-proc getHomeDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+
+proc getHomeDir*(): Path {.tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the home directory of the current user.
   ##
   ## This proc is wrapped by the `expandTilde proc`_
@@ -15,9 +15,9 @@ proc getHomeDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## See also:
   ## * `getConfigDir proc`_
   ## * `getTempDir proc`_
-  result = Path(osappdirs.getHomeDir())
+  result = initPath(osappdirs.getHomeDir())
 
-proc getDataDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+proc getDataDir*(): Path {.tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the data directory of the current user for applications.
   ## 
   ## On non-Windows OSs, this proc conforms to the XDG Base Directory
@@ -32,9 +32,9 @@ proc getDataDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## * `expandTilde proc`_
   ## * `getCurrentDir proc`_
   ## * `setCurrentDir proc`_
-  result = Path(osappdirs.getDataDir())
+  result = initPath(osappdirs.getDataDir())
 
-proc getConfigDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+proc getConfigDir*(): Path {.tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the config directory of the current user for applications.
   ##
   ## On non-Windows OSs, this proc conforms to the XDG Base Directory
@@ -48,9 +48,9 @@ proc getConfigDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getTempDir proc`_
-  result = Path(osappdirs.getConfigDir())
+  result = initPath(osappdirs.getConfigDir())
 
-proc getCacheDir*(): Path {.inline.} =
+proc getCacheDir*(): Path =
   ## Returns the cache directory of the current user for applications.
   ##
   ## This makes use of the following environment variables:
@@ -66,16 +66,16 @@ proc getCacheDir*(): Path {.inline.} =
   ## * `getTempDir proc`_
   ## * `getConfigDir proc`_
   # follows https://crates.io/crates/platform-dirs
-  result = Path(osappdirs.getCacheDir())
+  result = initPath(osappdirs.getCacheDir())
 
-proc getCacheDir*(app: Path): Path {.inline.} =
+proc getCacheDir*(app: Path): Path =
   ## Returns the cache directory for an application `app`.
   ##
   ## * On Windows, this uses: `getCacheDir() / app / "cache"`
   ## * On other platforms, this uses: `getCacheDir() / app`
-  result = Path(osappdirs.getCacheDir(app.string))
+  result = initPath(osappdirs.getCacheDir($app))
 
-proc getTempDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
+proc getTempDir*(): Path {.tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the temporary directory of the current user for applications to
   ## save temporary files in.
   ##
@@ -91,4 +91,4 @@ proc getTempDir*(): Path {.inline, tags: [ReadEnvEffect, ReadIOEffect].} =
   ## See also:
   ## * `getHomeDir proc`_
   ## * `getConfigDir proc`_
-  result = Path(osappdirs.getTempDir())
+  result = initPath(osappdirs.getTempDir())

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -6,7 +6,6 @@
 import private/osseps
 export osseps
 
-import envvars
 import private/osappdirs
 
 import pathnorm, hashes, strutils

--- a/lib/std/paths.nim
+++ b/lib/std/paths.nim
@@ -311,9 +311,4 @@ proc expandTilde*(path: Path): Path {.inline,
   ##
   ## Windows: this is still supported despite the Windows platform not having this
   ## convention; also, both ``~/`` and ``~\`` are handled.
-  runnableExamples:
-    import std/appdirs
-    assert expandTilde(Path("~") / Path("appname.cfg")) == getHomeDir() / Path("appname.cfg")
-    assert expandTilde(Path("~/foo/bar")) == getHomeDir() / Path("foo/bar")
-    assert expandTilde(Path("/foo/bar")) == Path("/foo/bar")
   result = initPath(expandTildeImpl(path.data))

--- a/tests/nimony/stdlib/tappdirs.nim
+++ b/tests/nimony/stdlib/tappdirs.nim
@@ -1,0 +1,10 @@
+import std/paths
+import std/appdirs
+
+
+discard getHomeDir()
+discard getDataDir()
+discard getConfigDir()
+discard getCacheDir()
+# discard getCacheDir(initPath("myapp"))
+discard getTempDir()


### PR DESCRIPTION
I got some weird issue. Some seems to be related to importing order somehow, I haven't figured the issue out yet. One is related to `inline`, I will fix it soon.

<del>
```
cycle detected: /Users/blue/Documents/GitHub/nimony/lib/std/appdirs.nim <-> /Users/blue/Documents/GitHub/nimony/lib/std/paths.nim
```
Though I don't know what is this cycle 
</del>