### PR TITLE
disable `runnableExamples` semchecking arguments

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -5258,7 +5258,7 @@ proc semcheck*(infile, outfile: string; config: sink NifConfig; moduleFlags: set
     canSelfExec: canSelfExec,
     pending: createTokenBuf())
 
-  for magic in ["typeof", "compiles", "defined", "declared"]:
+  for magic in ["typeof", "compiles", "defined", "declared", "runnableExamples"]:
     c.unoverloadableMagics.incl(pool.strings.getOrIncl(magic))
 
   while true:

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -952,6 +952,12 @@ proc semCall(c: var SemContext; it: var Item; flags: set[SemFlag]; source: Trans
     semExpr(c, cs.fn, {KeepMagics, AllowUndeclared, AllowOverloads})
     cs.fnName = getFnIdent(c)
     it.n = cs.fn.n
+
+    if pool.strings[cs.fnName] == "runnableExamples":
+      skipToEnd it.n
+      swap c.dest, cs.dest
+      return
+
   if c.g.config.compat and cs.fnName in c.unoverloadableMagics:
     # transform call early before semchecking arguments
     let syms = beginRead(c.dest)


### PR DESCRIPTION
Semchecking  arguments of `runnableExamples` because it may contain imports, that is resolved by `semImport` but should not

e.g.

```nim
# test1.nim
runnableExamples:
  import test2
```

```nim
# test2.nim
import test1
```

which causes cyclic imports. But the imports in the `runnableExamples` should be semchecked. Not sure how to handle it more properly