### PR TITLE
fixes crossmodule overloading

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -682,11 +682,8 @@ proc resolveOverloads(c: var SemContext; it: var Item; cs: var CallState) =
   var idx = pickBestMatch(c, m, cs.flags)
 
   if idx < 0 and (cs.fn.n.kind == Symbol or cs.fn.n.exprKind == OchoiceX):
-    let idxOffset = m.len
     considerInScopeOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs)
-    idx = pickBestMatch(c, m.toOpenArray(idxOffset, m.high), cs.flags)
-    if idx >= 0:
-      idx += idxOffset
+    idx = pickBestMatch(c, m, cs.flags)
 
   if idx < 0:
     # try converters

--- a/tests/nimony/lookups/deps/mextraoverload.nim
+++ b/tests/nimony/lookups/deps/mextraoverload.nim
@@ -1,0 +1,3 @@
+
+proc contains*(s: HSlice[float, float]; value: char): bool =
+  (value.int.float / 128) >= s.a and (value.int.float / 128) <= s.b

--- a/tests/nimony/lookups/tcrossmoduleoverload2.nim
+++ b/tests/nimony/lookups/tcrossmoduleoverload2.nim
@@ -1,10 +1,7 @@
 import std / syncio
 
-proc write*(f: File; s: cstring) =
+proc write(f: File; s: cstring) =
   discard writeBuffer(f, s, s.len)
 
-proc main =
-  var s90 = cstring "abc"
-  echo s90
-
-main()
+var s = cstring "abc"
+echo s

--- a/tests/nimony/lookups/tcrossmoduleoverload2.nim
+++ b/tests/nimony/lookups/tcrossmoduleoverload2.nim
@@ -1,0 +1,10 @@
+import std / syncio
+
+proc write*(f: File; s: cstring) =
+  discard writeBuffer(f, s, s.len)
+
+proc main =
+  var s90 = cstring "abc"
+  echo s90
+
+main()

--- a/tests/nimony/lookups/tcrossmoduleoverload3.nim
+++ b/tests/nimony/lookups/tcrossmoduleoverload3.nim
@@ -1,0 +1,5 @@
+import std / syncio
+import deps/mextraoverload
+
+echo 'a' in (0.0..1.0)
+


### PR DESCRIPTION
ref #1469

if I understand correctly, type bound operations should only be created if proc is defined in the same module as the type, so they won't help in cases when type is imported and proc is imported from different module or defined in current, but still in scope

This PR tries to solve this by considering procs in-scope if match failed, so
```nim
import std / syncio

proc write(f: File; s: cstring) =
  discard writeBuffer(f, s, s.len)

var s = cstring "abc"
echo s
```
works.

I am not sure if in-scope procs should instead be considered even if match didn't fail, and/or if this may be only needed for template/generic instantiations