### PR TITLE
fixes #1523; Custom destructor not run with `finally` existing

### DIFF
--- a/src/hexer/destroyer.nim
+++ b/src/hexer/destroyer.nim
@@ -134,8 +134,8 @@ proc createFreshVars(c: var Context; n: Cursor): TokenBuf =
       result.add n
       inc n
 
-proc leaveScope(c: var Context; s: var Scope) =
-  if s.finallySection != default(Cursor):
+proc leaveScope(c: var Context; s: var Scope; kind = Other) =
+  if kind != OtherPreventFinally and s.finallySection != default(Cursor):
     var freshVars = createFreshVars(c, s.finallySection)
     var n = beginRead(freshVars)
     tr c, n
@@ -201,8 +201,7 @@ proc trRaise(c: var Context; n: var Cursor) =
   ]#
   var it = addr(c.currentScope)
   while it != nil:
-    if it.kind != OtherPreventFinally:
-      leaveScope(c, it[])
+    leaveScope(c, it[], it.kind)
     it = it.parent
   takeTree c.dest, n
 
@@ -231,8 +230,7 @@ proc trScope(c: var Context; body: var Cursor; kind = Other) =
       inc body
     else:
       tr c, body
-    if kind != OtherPreventFinally:
-      leaveScope(c, c.currentScope)
+    leaveScope(c, c.currentScope, kind)
 
 proc registerSinkParameters(c: var Context; params: Cursor) =
   var p = params

--- a/tests/nimony/exceptions/tfinally.nim
+++ b/tests/nimony/exceptions/tfinally.nim
@@ -19,3 +19,22 @@ except:
   echo "you are not supposed to see this"
 finally:
   echo "B finally"
+
+
+type
+  MyObj = object
+    value: int
+
+# Custom destructor
+proc `=destroy`(x: var MyObj) =
+  echo "Destructor called for MyObj(value=", x.value, ")"
+
+proc main() =
+  try:
+    var o = MyObj(value: 123)
+    echo "Object initialized"
+  finally:
+    echo "Inside finally block"
+
+main()
+echo "Program end"

--- a/tests/nimony/exceptions/tfinally.output
+++ b/tests/nimony/exceptions/tfinally.output
@@ -3,3 +3,7 @@ caught
 A finally
 hi
 B finally
+Object initialized
+Destructor called for MyObj(value=123)
+Inside finally block
+Program end


### PR DESCRIPTION
fixes #1523

ensures that `destructors` are called before leaving scopes regardless of `finally`