### PR TITLE
fixes #1360; `importc` makes fields `exportc` by default

### DIFF
--- a/tests/nimony/ffi/bar.h
+++ b/tests/nimony/ffi/bar.h
@@ -1,1 +1,8 @@
 typedef struct {} Bar;
+
+typedef struct {
+    unsigned char r;
+    unsigned char g;
+    unsigned char b;
+    unsigned char a;
+} Color;

--- a/tests/nimony/ffi/theader.nim
+++ b/tests/nimony/ffi/theader.nim
@@ -3,3 +3,15 @@ type Bar1 {.importc: "Bar1", header: "${path}/bar1.h".} = object
 
 const header = "bar.h"
 type Bar2 {.importc: "Bar", header: header.} = object
+
+import std/assertions
+
+type
+  Color* {.bycopy, importc, header: header.} = object
+    r*: uint8
+    g*: uint8
+    b*: uint8
+    a*: uint8
+
+var color = Color(r: 8, g: 8, b: 8, a: 8)
+assert color.r == 8


### PR DESCRIPTION
fixes #1360

ref https://github.com/nim-lang/nimony/issues/1516

As in Nim, the fields of `importc` should be `exportc` by default, which could be convenient without excess `exportc` pragmas on each fields