### PR TITLE
makes string indexing addressable

### DIFF
--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -214,7 +214,7 @@ proc `[]=`*(s: var string; i: int; c: char) {.requires: (i < len(s) and i >= 0),
     makeAllocated s, s.len
   s.a[i] = c
 
-proc `[]`*(s: string; i: int): char {.requires: (i < len(s) and i >= 0), inline.} = s.a[i]
+proc `[]`*(s: string; i: int): var char {.requires: (i < len(s) and i >= 0), inline.} = s.a[i]
 
 proc substr*(s: string; first, last: int): string =
   let len = s.len

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -211,3 +211,12 @@ block:
   type
     Foo = object
       cFileName: array[0..MAX_PATH - 1, int]
+
+block:
+  proc foo(x: var string) =
+    var m = 2
+    var s = addr x[1]
+
+
+  var ss = "dsjfhg"
+  foo(ss)


### PR DESCRIPTION
so that it is consistent with `seqs`

```nim
proc `[]`*[T](s: seq[T]; i: int): var T {.requires: (i < s.len and i >= 0), inline.} = s.data[i]
```