### PR TITLE
 fixes #1539; prepareMutationAt: cannot pass prepareMutation(s) to var/out T parameter

### DIFF
--- a/doc/stdlib.dgn.md
+++ b/doc/stdlib.dgn.md
@@ -327,6 +327,10 @@ Converts a Nim string to a C string.
 
 Prepares a string for mutation. String literals are "copy on write", so you need to call `prepareMutation` before modifying strings via `addr`.
 
+####prepareMutationAt
+
+Prepares the given string for mutation and returns an addressable
+reference to the character at index `i`.
 
 ####&
 

--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -287,6 +287,10 @@ proc prepareMutation*(s: var string) =
       s.i = EmptyI
     s.a = a # also do this for `a == nil`
 
+proc prepareMutationAt*(s: var string; i: int): var char {.requires: (i < len(s) and i >= 0), inline.} =
+  prepareMutation(s)
+  result = s.a[i]
+
 proc newString*(len: int): string =
   let a = cast[StrData](alloc(len))
   if a != nil:

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -383,7 +383,7 @@ proc trProcDecl(c: var Context; n: var Cursor) =
     takeParRi c, n
   else:
     var body = n
-    trSons c, n, c.r.returnExpects
+    tr c, n, c.r.returnExpects
     if c.r.dangerousLocations.len > 0:
       checkForDangerousLocations c, body
     takeParRi c, n

--- a/tests/nimony/sysbasics/tstrings.nim
+++ b/tests/nimony/sysbasics/tstrings.nim
@@ -143,3 +143,8 @@ block: # issue #1444
   assert substr("abc", 3, 1) == ""
   assert substr("abc", 3, 2) == ""
   assert substr("abc", 3, 3) == ""
+
+block:
+  var s = "12234"
+  var m = prepareMutationAt(s, 1)
+  assert m == '2'


### PR DESCRIPTION
 fixes #1539
ref https://github.com/nim-lang/nimony/pull/1536