### PR TITLE
fixes #1542; proc type doesn't match generic constraints proc

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -405,6 +405,11 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
     else:
       c.b.addTree(ItertypeL)
 
+    if n.len == 0:
+      # it's a type class
+      c.b.endTree()
+      return
+
     c.b.addEmpty 4 # 0: name
     # 1: export marker
     # 2: pattern

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -496,25 +496,6 @@ proc tryTypeClass(c: var SemContext; n: var Cursor): bool =
   else:
     result = false
 
-proc tryRoutineTypeClass(c: var SemContext; n: var Cursor): bool =
-  # if the routine type tree has no non-empty children, interpret it as a type kind typeclass
-  var op = n
-  inc op
-  while op.kind == DotToken:
-    inc op
-
-  if op.kind == ParRi:
-    c.dest.addParLe(TypeKindT, n.info)
-
-    c.dest.add n
-    c.dest.addParRi()
-    skip n
-
-    c.dest.addParRi()
-    result = true
-  else:
-    result = false
-
 proc isOrExpr(n: Cursor): bool =
   # old nim special cases `|` infixes in type contexts
   result = n.exprKind == InfixX
@@ -802,7 +783,7 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
         semLocalTypeImpl c, n, InLocalDecl
         takeParRi c, n
     of RoutineTypes:
-      if tryRoutineTypeClass(c, n):
+      if tryTypeClass(c, n):
         return
       takeToken c, n
       wantDot c, n # name


### PR DESCRIPTION
fixes #1542

Unlike other types classes, `proc` type class is parsed as `(proctype . . . . . . . . .)`. It needs to skip `DotToken` in order to identify whether it is a type class