### PR TITLE
fixes #1544; explicit proc type conversion crashes the compiler

### DIFF
--- a/src/nimony/contracts.nim
+++ b/src/nimony/contracts.nim
@@ -378,6 +378,11 @@ proc analyseExpr(c: var Context; pc: var Cursor) =
         analyseArrayConstr c, pc
       of TupconstrX:
         analyseTupConstr c, pc
+      of CastX, ConvX, HconvX:
+        inc pc
+        skip pc # skips type
+        analyseExpr c, pc
+        skipParRi pc
       else:
         inc nested
         inc pc

--- a/tests/nimony/sysbasics/tbasics2.nim
+++ b/tests/nimony/sysbasics/tbasics2.nim
@@ -211,3 +211,10 @@ block:
   type
     Foo = object
       cFileName: array[0..MAX_PATH - 1, int]
+
+type
+  ProcType = proc (x: int) {.nimcall.}
+
+var call: ProcType = ProcType(nil)
+call = proc (x: int) = discard x
+call(1)


### PR DESCRIPTION
fixes #1544

```
[Bug] symbol definition in single path
```

because there is a symbol def in the type of conv

```
(conv
 (proctype . . . .
  (params
   (param :x.0 . .
    (i -1) .)) .
  (pragmas
   (nimcall)) . .)
 (nil))
```