### PR TITLE
fixes for i386 nightlies

### DIFF
--- a/src/lib/nifstreams.nim
+++ b/src/lib/nifstreams.nim
@@ -260,7 +260,7 @@ proc tag*(n: PackedToken): TagId {.inline.} =
 
 proc typebits*(n: PackedToken): int =
   if n.kind == IntLit:
-    result = pool.integers[n.intId]
+    result = int pool.integers[n.intId]
   elif n.kind == InlineInt:
     result = n.soperand
   else:


### PR DESCRIPTION
ref https://github.com/nim-lang/nightlies/actions/runs/19351726390/job/55364732743

```
/home/runner/work/nightlies/nightlies/nim/dist/nimony/src/lib/nifstreams.nim(263, 27) Error: type mismatch: got 'int64' for 'pool.integers[intId(n)]' but expected 'int'
Error: call to nim compiler failed
```