### PR TITLE
Fix some silly typos in Nimony's documentation

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -30,7 +30,7 @@ A constant is a symbol that is bound to the value of a constant expression. Cons
 * previously declared constants
 * the call of a routine as long as the passed arguments could be evaluated at compile-time.
 
-Nimony offers a complex evalution engine for arbitrary compile-time computations. The restrictions for this mechanism are currently undocumented.
+Nimony offers a complex evaluation engine for arbitrary compile-time computations. The restrictions for this mechanism are currently undocumented.
 
 
 
@@ -431,7 +431,7 @@ template concat(): string {.varargs.} =
   res
 ```
 
-Nimony's `echo` is also uses `varargs`:
+Nimony's `echo` also uses `varargs`:
 
 ```nim
 template echo*() {.varargs} =

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -50,8 +50,8 @@ There are different files that manage different aspects of the configuration:
 
 1. `nimony.args` is a text file that contains command line arguments that are processed as if they were passed on the command line.
 2. `nimony.paths` is a text file where every line is an entry to the search `--path`. This is so important for tooling that it became a separate file.
-3. `$cc.args` is a text file that contains command line arguments that are passed to the used C compiler. `$cc` here stands for a general C compiler key. This key is extraced from the `--cc` command line option.
-4. `$linker.args` is a text file that contains command line arguments that are passed to the used linker. `$linker` here stands for a general linker key. This key is extraced from the `--linker` command line option. If `--linker` is not used the C compiler command is used for linking.
+3. `$cc.args` is a text file that contains command line arguments that are passed to the used C compiler. `$cc` here stands for a general C compiler key. This key is extracted from the `--cc` command line option.
+4. `$linker.args` is a text file that contains command line arguments that are passed to the used linker. `$linker` here stands for a general linker key. This key is extracted from the `--linker` command line option. If `--linker` is not used the C compiler command is used for linking.
 
 `.args` files are processed before the real command line arguments are processed so that they can be overridden. An `.args` file can contain newlines as whitespace. Lines starting with `#` are comments. The POSIX command line parsing rules are used: Whitespace enclosed within single or double quotes is kept as is and the quotes are removed.
 


### PR DESCRIPTION
I found some silly typos as I was reading Nimony's documentation.