### PR TITLE
add version with system of setter test

### DIFF
--- a/tests/nimony/sysbasics/tsettersys.nif
+++ b/tests/nimony/sysbasics/tsettersys.nif
@@ -1,0 +1,24 @@
+(.nif24)
+0,1,tests/nimony/sysbasics/tsettersys.nim(stmts 9
+ (type ~4 :Foo.0.tseskwzyg . . . 2
+  (object .)) ,2
+ (proc 5 :bar=.0.tseskwzyg . . . 11
+  (params 1
+   (param :x.0 . . 3 Foo.0.tseskwzyg .) 9
+   (param :y.0 . . 3
+    (i -1) .)) . . . 30
+  (stmts
+   (discard .))) ,3
+ (proc 5 :\5B\5D=.0.tseskwzyg . . . 10
+  (params 1
+   (param :x.1 . . 3 Foo.0.tseskwzyg .) 9
+   (param :y.1 . . 3
+    (i -1) .) 17
+   (param :z.0 . . 3
+    (i -1) .)) . . . 37
+  (stmts
+   (discard .))) 4,5
+ (gvar :foo.0.tseskwzyg . . 5 Foo.0.tseskwzyg .) ,6
+ (call bar=.0.tseskwzyg foo.0.tseskwzyg 10 +123) ,7
+ (call \5B\5D=.0.tseskwzyg foo.0.tseskwzyg 4 +123 11 +456) 23,2
+ (comment int.0.sysvq0asl ~1,1 int.0.sysvq0asl 7,1 int.0.sysvq0asl))

--- a/tests/nimony/sysbasics/tsettersys.nim
+++ b/tests/nimony/sysbasics/tsettersys.nim
@@ -1,0 +1,8 @@
+type Foo = object
+
+proc `bar=`(x: Foo; y: int) = discard
+proc `[]=`(x: Foo; y: int; z: int) = discard
+
+var foo: Foo
+foo.bar = 123
+foo[123] = 456


### PR DESCRIPTION
refs #1478 first list item

`nosystem/tsetter.nim` already exists but this adds the same test to `sysbasics` so that it is tested with system as well. More tests for setters can also be added here.