### PR TITLE
fixes #1558; call gcc built-in function for C int type

### DIFF
--- a/src/nifc/genstmts.nim
+++ b/src/nifc/genstmts.nim
@@ -323,8 +323,6 @@ proc genKeepOverflow(c: var GeneratedCode; n: var Cursor) =
     if bits == 64 or (bits == -1 and c.bits == 64):
       gcc.add "ll"
       isLongLong = true
-    else:
-      gcc.add "l"
     inc n
   else:
     error c.m, "expected integer literal but got: ", n

--- a/tests/nimony/basicarith/toverflowflag.nim
+++ b/tests/nimony/basicarith/toverflowflag.nim
@@ -6,4 +6,10 @@ proc main(a, b: int) =
     let x = a + b
     echo overflowFlag()
 
+proc main32(a, b: int32) =
+  {.keepOverflowFlag.}:
+    let x = a + b
+    echo overflowFlag()
+
 main(1, high(int))
+main32(1'i32, high(int32))

--- a/tests/nimony/basicarith/toverflowflag.output
+++ b/tests/nimony/basicarith/toverflowflag.output
@@ -1,1 +1,2 @@
 true
+true


### PR DESCRIPTION
Calling `__builtin_sadd_overflow` instead of `__builtin_saddl_overflow` fixes the compile error from gcc.