### PR TITLE
fixes `error` doesn't produces a new line

### DIFF
--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -150,7 +150,7 @@ template reportImpl(msg: string; level: string) =
   when defined(debug):
     writeStackTrace()
   write stdout, level
-  write stdout, msg
+  writeLine stdout, msg
   quit 1
 
 proc error*(msg: string; c: Cursor) {.noreturn.} =


### PR DESCRIPTION
before
```
[Error] method `=destroy_SX53tringX53treamX4fbj0fucp3imyt1.0.yug9jhd8` not found in class StringStream.Obj.0.fucp3imyt1Error: execution of an external program failed: '/Users/blue/Documents/GitHub/nimony/bin/hexer c --bits:64 nimcache/yug9jhd8.s.nif'
```
after
```
[Error] method `=destroy_SX53tringX53treamX4fbj0fucp3imyt1.0.yug9jhd8` not found in class StringStream.Obj.0.fucp3imyt1
Error: execution of an external program failed: '/Users/blue/Documents/GitHub/nimony/bin/hexer c --bits:64 nimcache/yug9jhd8.s.nif'
```
