### PR TITLE
Sem ptr[T] and ref[T]

### DIFF
--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -694,7 +694,13 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
       if tryTypeClass(c, n):
         return
       takeToken c, n
-      semLocalTypeImpl c, n, InLocalDecl
+      if exprKind(n) == BracketX:
+        # ptr[T] or ref[T], extract T
+        inc n
+        semLocalTypeImpl c, n, InLocalDecl
+        skipParRi n
+      else:
+        semLocalTypeImpl c, n, InLocalDecl
       if n.kind != ParRi:
         takeTree c, n # notnil, nil
       takeParRi c, n


### PR DESCRIPTION
Makes `ptr[T]` and `ref[T]` work, like in
```nim
let x: ptr[int]
```

I assumed it should be fixed in sem as the original parser preserves `[]`