### PR TITLE
fix --nimcache with nimonyplugins

### DIFF
--- a/src/nimony/cli.nim
+++ b/src/nimony/cli.nim
@@ -103,7 +103,7 @@ proc parseCommonOption*(key, val: string; config: var NifConfig;
     config.baseDir = val
   of "nimcache":
     config.nifcachePath = val
-    forwardArgNifc = true
+    forwardArgNifc = false
   of "usages":
     if config.toTrack.mode == TrackNone:
       config.toTrack = parseTrack(val, TrackUsages)

--- a/src/nimony/nimsem.nim
+++ b/src/nimony/nimsem.nim
@@ -69,7 +69,8 @@ proc executeNif(files: seq[string]; config: sink NifConfig) =
     return
 
   # little hack: prepare our writenif dependency
-  exec quoteShell(findTool("nimony")) & " c " & quoteShell(stdlibFile("std/writenif.nim"))
+  exec quoteShell(findTool("nimony")) & " --nimcache:" & quoteShell(config.nifcachePath) &
+    " c " & quoteShell(stdlibFile("std/writenif.nim"))
 
   let dependencyFiles = files[1..^1]
 

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -303,7 +303,10 @@ proc selfExec*(c: var SemContext; file: string; moreArgs: string) =
 
 proc compilePlugin(c: var SemContext; info: PackedLineInfo; nf, exefile: string) =
   let pluginDir = nimonyDir() / "src/nimony/lib"
-  let cmd = "nim c -d:nimonyPlugin -o:" & quoteShell(exefile) & " -p:" & quoteShell(pluginDir) &
+  let pluginCache = exefile & "_d"
+  createDir(pluginCache)
+  let cmd = "nim c -d:nimonyPlugin --nimcache:" & quoteShell(pluginCache) &
+    " -o:" & quoteShell(exefile) & " -p:" & quoteShell(pluginDir) &
     " " & quoteShell(nf)
   exec cmd
 
@@ -344,10 +347,11 @@ proc runPlugin*(c: var SemContext; dest: var TokenBuf; info: PackedLineInfo; plu
   finally:
     close s
 
-proc runProgram(file: string; usedModules: HashSet[string]): tuple[output: string, exitCode: int] =
+proc runProgram(file: string; nimcachePath: string; usedModules: HashSet[string]): tuple[output: string, exitCode: int] =
   # Use nimony s to compile and run the .p.nif file through the full pipeline
   let nimonyExe = findTool("nimony")
-  var cmd = quoteShell(nimonyExe) & " s -r " & quoteShell(file)
+  var cmd = quoteShell(nimonyExe) & " --nimcache:" & quoteShell(nimcachePath) &
+    " s -r " & quoteShell(file)
   result = execCmdEx(cmd)
 
 const
@@ -359,7 +363,8 @@ proc prepareEval*(c: var SemContext): string =
     if not fileExists(c.g.config.nifcachePath / writeNifModuleSuffix & ".s.nif"):
       # precompile the module
       let nimonyExe = findTool("nimony")
-      var cmd = quoteShell(nimonyExe) & " c " & quoteShell(stdlibFile("std/writenif.nim"))
+      var cmd = quoteShell(nimonyExe) & " --nimcache:" & quoteShell(c.g.config.nifcachePath) &
+        " c " & quoteShell(stdlibFile("std/writenif.nim"))
       let (output, exitCode) = execCmdEx(cmd)
       if exitCode != 0:
         return ensureMove(output)
@@ -379,7 +384,7 @@ proc runEval*(c: var SemContext; dest: var TokenBuf; srcName: string; src: Token
     let depsFile = c.g.config.nifcachePath / srcName & ".p.deps.nif"
     writeFile deps, depsFile
 
-  let (output, exitCode) = runProgram(progfile, usedModules)
+  let (output, exitCode) = runProgram(progfile, c.g.config.nifcachePath, usedModules)
   if exitCode != 0:
     result = ensureMove(output)
   else:


### PR DESCRIPTION
Fix --nimcache handling for nested Nimony/NIFC builds

  This change fixes custom --nimcache: paths in the full Nimony pipeline.

  What changed:

  - Stop forwarding top-level --nimcache into nifc command-line passthrough.
  - Keep backend-specific --nimcache:<main-subdir> generated by the final build graph as the effective nifc cache path.
  - Forward --nimcache when nimsem bootstraps std/writenif.nim via a nested nimony invocation.

  Root cause:

  - The final build graph already emits a per-backend nifc --nimcache:<cache>/<main> argument.
  - We were also forwarding the top-level --nimcache:<cache> through commandLineArgsNifc.
  - Because the forwarded flag came later, it overrode the backend-specific one.
  - Result: nifc wrote generated .c files into the root cache dir instead of the backend subdir, and nifmake later failed looking for <cache>/<main>/<main>.c.

  Files changed:

  - src/nimony/cli.nim
  - src/nimony/nimsem.nim

