### PR TITLE
LLVM backend stub wrappers for C macros

### DIFF
--- a/src/nifc/llvmcodegen.nim
+++ b/src/nifc/llvmcodegen.nim
@@ -124,6 +124,7 @@ type
     symName: string
     wrapperName: string
     header: string
+    cType: string
 
   LLVMGenFlag* = enum
     gfMainModule
@@ -189,6 +190,36 @@ proc error(m: MainModule; msg: string; n: Cursor) {.noreturn.} =
   when defined(debug):
     echo getStackTrace()
   quit 1
+
+proc computeCType(c: var LLVMCode; typ: Cursor): string =
+  var t = typ
+  case t.typeKind
+  of PtrT, AptrT:
+    inc t
+    if t.typeKind == VoidT:
+      return "void*"
+    if t.kind == Symbol:
+      let decl = c.m.getDeclOrNil(t.symId)
+      if decl != nil and decl.extern != StrId(0):
+        return pool.strings[decl.extern] & "*"
+    return "void*"
+  of IT, UT, FT:
+    result = case t.typeKind
+             of IT: "int"
+             of UT: "unsigned int"
+             else: "double"
+    inc t
+    if t.kind == IntLit: inc t
+    while t.kind != ParRi:
+      if t.pragmaKind == ImportcP:
+        inc t
+        if t.kind == StringLit:
+          result = pool.strings[t.litId]
+          break
+        skip t
+      else: skip t
+  else:
+    return "void*"
 
 # ---- Token helpers ----
 
@@ -504,15 +535,16 @@ proc genGlobalVarDeclLLVM(c: var LLVMCode; n: var Cursor; vk: VarKindLLVM; toExt
       # C macros (e.g. stderr, stdout) cannot be referenced as LLVM symbols;
       # generate a wrapper function that returns the macro's value.
       let wrapperName = c.stubModuleName & "_get_" & name
-      c.stubWrappers.add StubWrapper(
-        symName: name,
-        wrapperName: wrapperName,
-        header: headerStr
-      )
       c.wrappedSyms[lit] = wrapperName
       if wrapperName notin c.declaredExterns:
         c.declaredExterns.incl wrapperName
         c.addTo(c.externs, "declare " & typ & " @" & wrapperName & "()\n")
+        c.stubWrappers.add StubWrapper(
+          symName: name,
+          wrapperName: wrapperName,
+          header: headerStr,
+          cType: computeCType(c, d.typ)
+        )
     elif toExtern or isImport:
       c.addTo(c.globals, "@" & name & " = external " & tls & "global " & typ & alignSuffix & "\n")
     else:
@@ -907,8 +939,11 @@ proc generateStubFile(c: var LLVMCode; stubPath: string) =
       content.add "#include \"" & h & "\"\n"
   content.add "\n"
   for w in c.stubWrappers:
-    content.add "void* " & w.wrapperName & "(void) {\n"
-    content.add "  return (void*)" & w.symName & ";\n"
+    content.add w.cType & " " & w.wrapperName & "(void) {\n"
+    if w.cType == "void*":
+      content.add "  return (void*)" & w.symName & ";\n"
+    else:
+      content.add "  return " & w.symName & ";\n"
     content.add "}\n\n"
   let contentStr = content
   if vfsExists(stubPath) and vfsRead(stubPath) == contentStr:

--- a/src/nifc/llvmcodegen.nim
+++ b/src/nifc/llvmcodegen.nim
@@ -120,6 +120,11 @@ proc fillTokenTable(tab: var BiTable[LToken, string]) =
     assert id == LToken(e), $(id, " ", ord(e))
 
 type
+  StubWrapper = object
+    symName: string
+    wrapperName: string
+    header: string
+
   LLVMGenFlag* = enum
     gfMainModule
 
@@ -162,6 +167,9 @@ type
     currentProc: LLVMCurrentProc
     strLitCounter*: int       # global counter for string literal names
     debug*: DebugInfo
+    stubWrappers*: seq[StubWrapper]
+    wrappedSyms*: Table[SymId, string] # symId -> wrapper function name
+    stubModuleName*: string
 
 proc initLLVMCode*(m: sink MainModule; flags: set[LLVMGenFlag]; bits: int): LLVMCode =
   result = LLVMCode(m: m, flags: flags, bits: bits, inToplevel: true,
@@ -388,6 +396,8 @@ include llvmgentypes
 
 # ---- Expression generation ----
 
+proc genImportedSymsLLVM(c: var LLVMCode)  # forward declaration
+
 include llvmgenexprs
 
 # ---- Forward declarations ----
@@ -437,6 +447,7 @@ proc genGlobalVarDeclLLVM(c: var LLVMCode; n: var Cursor; vk: VarKindLLVM; toExt
     var externName = StrId(0)
     var isImport = false
     var isNodecl = false
+    var headerStr = ""
     let alignVal = extractAlignValue(d.pragmas)
     if d.pragmas.substructureKind == PragmasU:
       var p = d.pragmas.firstSon
@@ -450,7 +461,9 @@ proc genGlobalVarDeclLLVM(c: var LLVMCode; n: var Cursor; vk: VarKindLLVM; toExt
         of NodeclP:
           isNodecl = true
         of HeaderP:
-          discard # ignored for LLVM backend
+          let hp = p.firstSon
+          if hp.kind == StringLit:
+            headerStr = pool.strings[hp.litId]
         else: discard
         skip p
 
@@ -487,7 +500,20 @@ proc genGlobalVarDeclLLVM(c: var LLVMCode; n: var Cursor; vk: VarKindLLVM; toExt
 
     let alignSuffix = if alignVal > 0: ", align " & $alignVal else: ""
     let tls = if vk == IsThreadlocal: "thread_local " else: ""
-    if toExtern or isImport:
+    if isImport and headerStr.len > 0:
+      # C macros (e.g. stderr, stdout) cannot be referenced as LLVM symbols;
+      # generate a wrapper function that returns the macro's value.
+      let wrapperName = c.stubModuleName & "_get_" & name
+      c.stubWrappers.add StubWrapper(
+        symName: name,
+        wrapperName: wrapperName,
+        header: headerStr
+      )
+      c.wrappedSyms[lit] = wrapperName
+      if wrapperName notin c.declaredExterns:
+        c.declaredExterns.incl wrapperName
+        c.addTo(c.externs, "declare " & typ & " @" & wrapperName & "()\n")
+    elif toExtern or isImport:
       c.addTo(c.globals, "@" & name & " = external " & tls & "global " & typ & alignSuffix & "\n")
     else:
       if d.value.kind != DotToken:
@@ -869,11 +895,35 @@ proc generateLLVMTypes(c: var LLVMCode) =
         if typeDef != "":
           c.addTo(c.types, typeDef)
 
+proc generateStubFile(c: var LLVMCode; stubPath: string) =
+  var content = "// Auto-generated stub wrappers for C macros\n"
+  var headers = initHashSet[string]()
+  for w in c.stubWrappers:
+    headers.incl w.header
+  for h in headers:
+    if h[0] == '<' or h[0] == '"':
+      content.add "#include " & h & "\n"
+    else:
+      content.add "#include \"" & h & "\"\n"
+  content.add "\n"
+  for w in c.stubWrappers:
+    content.add "void* " & w.wrapperName & "(void) {\n"
+    content.add "  return (void*)" & w.symName & ";\n"
+    content.add "}\n\n"
+  let contentStr = content
+  if vfsExists(stubPath) and vfsRead(stubPath) == contentStr:
+    discard "unchanged"
+  else:
+    vfsWrite stubPath, contentStr
+
 proc generateLLVMCode*(s: var State, inp, outp: string; flags: set[LLVMGenFlag]) =
   var m = load(inp)
   m.config = s.config
   var c = initLLVMCode(m, flags, s.bits)
   c.m.openScope()
+
+  let (_, moduleName, _) = splitFile(outp)
+  c.stubModuleName = moduleName
 
   # Initialize debug info
   initDebugInfo(c, inp)
@@ -942,5 +992,8 @@ proc generateLLVMCode*(s: var State, inp, outp: string; flags: set[LLVMGenFlag])
     discard "unchanged, keep mtime for incremental builds"
   else:
     vfsWrite outp, f
+
+  let stubPath = changeFileExt(outp, ".wrap.c")
+  generateStubFile(c, stubPath)
 
   c.m.closeScope()

--- a/src/nifc/llvmgenexprs.nim
+++ b/src/nifc/llvmgenexprs.nim
@@ -694,6 +694,7 @@ proc genExprLLVM(c: var LLVMCode; n: var Cursor; result: var LLValue) =
       # Look up the type from the scope before advancing
       let symType = getType(c.m, n)
       let decl = c.m.getDeclOrNil(s)
+      genImportedSymsLLVM(c)
       inc n
       # Check if this is an enum field — resolve to its integer constant
       if symType.typeKind == EnumT:
@@ -730,8 +731,13 @@ proc genExprLLVM(c: var LLVMCode; n: var Cursor; result: var LLValue) =
       let typ = genTypeLLVMReadOnly(c, symType)
       let prefix = if isGlobalSym(c, s): "@" else: "%"
       let t = c.temp()
-      c.emitLine "  " & c.str(t) & " = load " & typ & ", ptr " & prefix & name
-      result = LLValue(name: t, typ: c.tok(typ))
+      if s in c.wrappedSyms:
+        let wrapperName = c.wrappedSyms[s]
+        c.emitLine "  " & c.str(t) & " = call " & typ & " @" & wrapperName & "()"
+        result = LLValue(name: t, typ: c.tok(typ))
+      else:
+        c.emitLine "  " & c.str(t) & " = load " & typ & ", ptr " & prefix & name
+        result = LLValue(name: t, typ: c.tok(typ))
     else:
       let exprType = getType(c.m, n)
       let typ = genTypeLLVMReadOnly(c, exprType)

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -58,6 +58,12 @@ proc genFile(config: NifConfig; f: FilePair; backendDir: string = ""): string =
 proc objFile(config: NifConfig; f: FilePair; backendDir: string = ""): string =
   let base = if backendDir.len > 0: config.nifcachePath / backendDir else: config.nifcachePath
   base / f.modname & ".o"
+proc wrapCFile(config: NifConfig; f: FilePair; backendDir: string = ""): string =
+  let base = if backendDir.len > 0: config.nifcachePath / backendDir else: config.nifcachePath
+  base / f.modname & ".wrap.c"
+proc wrapObjFile(config: NifConfig; f: FilePair; backendDir: string = ""): string =
+  let base = if backendDir.len > 0: config.nifcachePath / backendDir else: config.nifcachePath
+  base / f.modname & ".wrap.o"
 
 # It turned out to be too annoying in practice to have the exe file in
 # the current directory per default so we now put it into the nifcache too:
@@ -732,6 +738,11 @@ proc generateFinalBuildFile(c: DepContext; commandLineArgsNifc: string; passC, p
           if not objFiles.containsOrIncl(obj):
             b.withTree "input":
               b.addStrLit obj
+          if c.config.backend == backendLLVM:
+            let wrapObj = c.config.wrapObjFile(v.files[0], backend)
+            if not objFiles.containsOrIncl(wrapObj):
+              b.withTree "input":
+                b.addStrLit wrapObj
         b.withTree "output":
           b.addStrLit c.config.exeFile(c.rootNode.files[0], backend)
 
@@ -759,6 +770,16 @@ proc generateFinalBuildFile(c: DepContext; commandLineArgsNifc: string; passC, p
             b.withTree "output":
               b.addStrLit obj
 
+        if c.config.backend == backendLLVM:
+          let wrapObj = c.config.wrapObjFile(v.files[0], backend)
+          if not objFiles.containsOrIncl(wrapObj):
+            b.withTree "do":
+              b.addIdent "cc"
+              b.withTree "input":
+                b.addStrLit c.config.wrapCFile(v.files[0], backend)
+              b.withTree "output":
+                b.addStrLit wrapObj
+
         # Build C/LLVM IR files from .c.nif files
         b.withTree "do":
           b.addIdent "nifc"
@@ -771,6 +792,9 @@ proc generateFinalBuildFile(c: DepContext; commandLineArgsNifc: string; passC, p
             b.addStrLit c.config.nifcFile(v.files[0], backend)
           b.withTree "output":
             b.addStrLit c.config.genFile(v.files[0], backend)
+          if c.config.backend == backendLLVM:
+            b.withTree "output":
+              b.addStrLit c.config.wrapCFile(v.files[0], backend)
 
         # Build .x.nif files from .s.nif files via hexer.
         # For the root module (i==0) the output is backend-specific so that


### PR DESCRIPTION
## Summary

The LLVM backend cannot directly reference C macros as symbols. C macros include but are not limited to: variable-like macros (e.g. `stderr`, `stdout`, which on some platforms expand to internal symbols like     
 `__stderrp` rather than linkable global variables) and constant-like macros (e.g. `_IOFBF`, `EOF`). Referencing `@stderr` directly in LLVM IR produces undefined symbols.                                               
                                                                               
 nifc LLVM codegen now detects `importc + header` global variable declarations and generates a C wrapper function for each (e.g. `module_get_stderr()`), compiled into `module.wrap.o` and linked into the final binary.

## Implementation

### Why this lives in nifc

 C macros being non-representable as LLVM symbols is a backend compatibility issue. nifc, as the backend code generator, encapsulates this platform difference — it only exposes the `module.wrap.c` artifact filename
 to the upper nifler layer (deps.nim / nifmake), without leaking any C FFI semantics.

### Why empty .wrap.c files exist

 This minimizes the surface area of the change. `generateStubFile` function is called for every module and always writes a file. `deps.nim` unconditionally generates cc rules and link inputs for `module.wrap.c`. (Maybe could parse at nif's metadata? I will check it :)

## Changes

 `src/nifc/llvmcodegen.nim` — Detects importc + header global variables, collects StubWrapper entries, generates .wrap.c. Emits `declare ptr @module_get_xxx()` for wrapped symbols.

 `src/nifc/llvmgenexprs.nim` — In genExprLLVM Symbol branch: if symbol is in wrappedSyms, generates `call ptr @wrapper()` instead of `load ptr, ptr @symbol`.

 `src/nimony/deps.nim` — Unconditionally generates cc rules for .wrap.c, adds .wrap.o to link inputs, declares .wrap.c as an additional output of the nifc step.

### Example generated files

 .ll diff (using stderr as example):

```llvm
 -@stderr = external global ptr
 +declare ptr @module_get_stderr()
  ...
 -  %t1 = load ptr, ptr @stderr
 +  %t1 = call ptr @module_get_stderr()
```

 module.wrap.c:

```c
 // Auto-generated stub wrappers for C macros
 #include <stdio.h>

 FILE* module_get_stderr(void) {
   return stderr;
 }
```

 final.build.nif diff:

```lisp
  (do cc
    (input "nimcache/module.c")
    (output "nimcache/module.o"))
 +(do cc
 +  (input "nimcache/module.wrap.c")
 +  (output "nimcache/module.wrap.o"))
  (do nifc
    (input "nimcache/module.c.nif")
    (output "nimcache/module.ll")
 +  (output "nimcache/module.wrap.c"))
```

 Link step gains .wrap.o input:

```lisp
  (do link
    (input "nimcache/module.o")
 +  (input "nimcache/module.wrap.o")
    (output "nimcache/module"))
```