### PR TITLE
fixes malformed `import as` etc. statements hang the compiler: improve error messages

### DIFF
--- a/src/nimony/semimport.nim
+++ b/src/nimony/semimport.nim
@@ -169,6 +169,15 @@ template maybeCyclic(c: var SemContext; dest: var TokenBuf; x: var Cursor) =
         cyclicImport(c, dest, x)
         return
 
+proc takeImportedName(x: var Cursor; names: var HashSet[StrId];
+                      hasError: var bool) =
+  let ident = takeIdent(x)
+  if ident == StrId(0):
+    hasError = true
+    skip x, AnyExpr
+  else:
+    names.incl ident
+
 proc semImport(c: var SemContext; dest: var TokenBuf; it: var Item) =
   let info = it.n.info
   var x = it.n
@@ -198,7 +207,7 @@ proc semImportExcept(c: var SemContext; dest: var TokenBuf; it: var Item) =
     filenameVal(x, files, hasError, allowAs = true)
     if not hasError:
       while x.hasMore:
-        excluded.incl takeIdent(x)
+        takeImportedName(x, excluded, hasError)
   if hasError:
     c.buildErr dest, info, "wrong `import except` statement"
   else:
@@ -222,7 +231,7 @@ proc semFromImport(c: var SemContext; dest: var TokenBuf; it: var Item) =
           # from a import nil
           skip x, AnyExpr
         else:
-          included.incl takeIdent(x)
+          takeImportedName(x, included, hasError)
   if hasError:
     c.buildErr dest, info, "wrong `from import` statement"
   else:

--- a/tests/nimony/errmsgs/deps/mfromimportalias.nim
+++ b/tests/nimony/errmsgs/deps/mfromimportalias.nim
@@ -1,0 +1,1 @@
+proc hello*() = discard

--- a/tests/nimony/errmsgs/tfromimportalias.msgs
+++ b/tests/nimony/errmsgs/tfromimportalias.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tfromimportalias.nim(1, 1) Error: wrong `from import` statement

--- a/tests/nimony/errmsgs/tfromimportalias.nim
+++ b/tests/nimony/errmsgs/tfromimportalias.nim
@@ -1,0 +1,1 @@
+from deps / mfromimportalias import hello as sayHello


### PR DESCRIPTION
This pull request refactors the way imported names are handled in the semantic analysis of import statements, particularly for `import except` and `from import` forms. It introduces a helper procedure to centralize name extraction and error handling, and adds new test cases to verify correct error reporting for invalid import statements with aliases.

Improvements to import name handling:

* Added a new procedure `takeImportedName` in `semimport.nim` to extract identifiers from import statements, handle errors consistently, and skip invalid expressions. This refactoring replaces direct calls to `takeIdent` in both `semImportExcept` and `semFromImport` with calls to the new helper, improving maintainability and error handling. [[1]](diffhunk://#diff-47d6faacc7e772cccad62565faffb4693d25e656d60bb3f658d65ff2a0ef5977R172-R180) [[2]](diffhunk://#diff-47d6faacc7e772cccad62565faffb4693d25e656d60bb3f658d65ff2a0ef5977L201-R210) [[3]](diffhunk://#diff-47d6faacc7e772cccad62565faffb4693d25e656d60bb3f658d65ff2a0ef5977L225-R234)

Testing and error reporting:

* Added a new test module `mfromimportalias.nim` and a test case `tfromimportalias.nim` to check error handling when using an alias in a `from import` statement. [[1]](diffhunk://#diff-ca723e7bff2fc3941a791f9ddfcdf06859059d7c7ffc511222390fe03cbb1ec7R1) [[2]](diffhunk://#diff-fd884a4e55cac2e56d16280e735aba63aabc7589fbd1b97768498cb9b272d335R1)
* Added the expected error message to `tfromimportalias.msgs` to ensure the compiler reports "wrong `from import` statement" for invalid syntax.