### PR TITLE
Show considered proc overloads in error for ambiguous call

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1013,6 +1013,14 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
       if cs.fnName != StrId(0):
         errorMsg.add pool.strings[cs.fnName]
       errorMsg.add "'"
+      # Add proc signatures and location for each match
+      for i in 0..<m.len:
+        errorMsg.add "\n"
+        errorMsg.add typeToString(m[i].fn.typ, {renderNoBody})
+        if m[i].fn.sym != NoSymId:
+          let res = tryLoadSym(m[i].fn.sym)
+          if res.status == LacksNothing:
+            errorMsg.add " (declared in " & res.decl.info.infoToStr & ")"
     elif cs.source in {DotCall, DotAsgnCall} and cs.fnName != StrId(0):
       errorMsg = "undeclared field: '"
       if cs.fnName != StrId(0):

--- a/tests/nimony/overload/tvartoverloads_off.msgs
+++ b/tests/nimony/overload/tvartoverloads_off.msgs
@@ -1,1 +1,3 @@
 tests/nimony/overload/tvartoverloads_off.nim(8, 12) Error: ambiguous call: 'foo'
+proc (x: int64): string (declared in tests/nimony/overload/tvartoverloads_off.nim(4, 1))
+proc (x: var int64): string (declared in tests/nimony/overload/tvartoverloads_off.nim(5, 1))


### PR DESCRIPTION
Show which overloads were considered in an ambiguous call error

Example:

```nim
proc foo(x: int): string = "T"
proc foo(x: var int): string = "varT"

var v = 0
discard foo(v)

# Output
# tests/nimony/overload/tvartoverloads_off.nim(8, 12) Error: ambiguous call: 'foo'
# proc (x: int64): string (declared in tests/nimony/overload/tvartoverloads_off.nim(4, 1))
# proc (x: var int64): string (declared in tests/nimony/overload/tvartoverloads_off.nim(5, 1))
```