### PR TITLE
fix: validator violation when defining consts in {.untyped.} generic proc

### DIFF
--- a/src/nimony/semuntyped.nim
+++ b/src/nimony/semuntyped.nim
@@ -361,7 +361,15 @@ proc semTemplLocal(c: var UntypedCtx; dest: var TokenBuf; n: var Cursor; k: SymK
   addDecl(c, dest, local.name, local.pragmas, k, nameStart, declStart)
   takeTree dest, n # exported
   semTemplPragmas c, dest, n # pragmas
-  semTemplType c, dest, n # type
+  if k == ConstY and n.kind == DotToken:
+    # const without explicit type: emit (auto) so the type slot is non-empty
+    # in the stored generic/template body; the actual type is inferred
+    # at instantiation time when semLocal processes the (auto) placeholder.
+    dest.add parLeToken(AutoT, n.info)
+    dest.addParRi()
+    inc n
+  else:
+    semTemplType c, dest, n # type
   semTemplBody c, dest, n # value
   takeParRi dest, n
 

--- a/tests/nimony/generics/tconst_in_generic.nim
+++ b/tests/nimony/generics/tconst_in_generic.nim
@@ -1,0 +1,8 @@
+import std/syncio
+
+proc almostEqual[T: float](a, b: T): bool {.untyped.} =
+  const eps = 0.0001
+  abs(a - b) < eps
+
+echo almostEqual(1.0, 1.00005)
+echo almostEqual(1.0, 2.0)

--- a/tests/nimony/generics/tconst_in_generic.output
+++ b/tests/nimony/generics/tconst_in_generic.output
@@ -1,0 +1,2 @@
+true
+false


### PR DESCRIPTION
The error was
```
[nimcache/tcoob0nah1.s.nif] post-sem validator found 1 violation(s):
tests/nimony/generics/tconst_in_generic.nim(4, 9) [post-sem] in stmts/proc/stmts: (const) child 3: got DotToken, expected type
```