### PR TITLE
Git ignore Linux build products and test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 bin/
+bin0/
+bin1/
+bin2/
+bin3/
 nimcache/
 nimblecache/
+nimcache_static/
 htmldocs/
-*.exe
+src/hastur
 src/nifc/nifc_grammar.nim
+src/nifgram/nifgram
+src/lib/nifindexes
+tests/tester
+*.exe


### PR DESCRIPTION
Masks various run-time generated files and folders generated during compiling with Nimony and testing with Hastur on Linux.