### PR TITLE
Fixed include path in macros.nim

### DIFF
--- a/lib/std/macros.nim
+++ b/lib/std/macros.nim
@@ -9,7 +9,7 @@
 
 {.feature: "lenientnils".}
 import std/[syncio, assertions, strutils, math, formatfloat, cmdline]
-import nifreader, nifbuilder
+import ../../src/lib/[nifbuilder, nifreader]
 
 type
   NimNodeKind* = enum


### PR DESCRIPTION
Without this change, the compiler is looking for `nifbuilder.nim` and `nifreader.nim` in the `nimony/lib/std/` folder, not the `nimony/src/lib/` folder, which prevents importing macro.nim in external projects compiled with Nimony.

Having a relative path here feels a bit awkward. It's probably a side effect of moving the stdlib over from Nim. I followed the pattern in [`nifply.nim`](https://github.com/gmpreussner/nim-lang.nimony/blob/master/lib/std/nifply.nim#L2)