### PR TITLE
Fixed compile-time `is` for union types and generic bodies

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6292,7 +6292,7 @@ proc semIs(c: var SemContext; dest: var TokenBuf; it: var Item) =
     rhs = semLocalType(c, dest, it.n)
   skipParRi it.n
   dest.shrink beforeExpr # delete LHS and RHS
-  if c.routine.inGeneric > 0 or containsGenericParams(lhs.typ) or containsGenericParams(rhs):
+  if containsGenericParams(lhs.typ) or containsGenericParams(rhs):
     # Keep the unpreprocessed operand expressions so template/generic
     # instantiation can substitute formals and re-run `semIs`. Defer whenever
     # `inGeneric > 0` too: in template bodies operands can still be `untyped`,

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6270,6 +6270,10 @@ proc semIs(c: var SemContext; dest: var TokenBuf; it: var Item) =
   let beforeExpr = dest.len
   let info = it.n.info
   let orig = it.n
+  var lhsExpr = orig
+  inc lhsExpr
+  var rhsExpr = lhsExpr
+  skip rhsExpr
   inc it.n
   var lhs = Item(n: it.n, typ: c.types.autoType)
   semExpr c, dest, lhs
@@ -6288,15 +6292,19 @@ proc semIs(c: var SemContext; dest: var TokenBuf; it: var Item) =
     rhs = semLocalType(c, dest, it.n)
   skipParRi it.n
   dest.shrink beforeExpr # delete LHS and RHS
-  if containsGenericParams(lhs.typ) or containsGenericParams(rhs):
+  if c.routine.inGeneric > 0 or containsGenericParams(lhs.typ) or containsGenericParams(rhs):
+    # Keep the unpreprocessed operand expressions so template/generic
+    # instantiation can substitute formals and re-run `semIs`. Defer whenever
+    # `inGeneric > 0` too: in template bodies operands can still be `untyped`,
+    # which would make `containsGenericParams` false and wrongly fold to `false`.
     dest.add orig
-    dest.addSubtree lhs.typ
-    dest.addSubtree rhs
+    dest.addSubtree lhsExpr
+    dest.addSubtree rhsExpr
     dest.addParRi()
   else:
     var m = createMatch(addr c)
     typematch m, rhs, lhs
-    if classifyMatch(m) >= SubtypeMatch:
+    if isMatchForIs(m, rhs):
       dest.addParPair(TrueX, info)
     else:
       dest.addParPair(FalseX, info)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -6303,8 +6303,14 @@ proc semIs(c: var SemContext; dest: var TokenBuf; it: var Item) =
     dest.addParRi()
   else:
     var m = createMatch(addr c)
-    typematch m, rhs, lhs
-    if isMatchForIs(m, rhs):
+    let matched =
+      if isTypeclassConstraint(rhs):
+        var formal = rhs
+        matchesConstraint(m, formal, lhs.typ)
+      else:
+        typematch m, rhs, lhs
+        isMatchForIs(m, rhs)
+    if matched:
       dest.addParPair(TrueX, info)
     else:
       dest.addParPair(FalseX, info)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -1397,16 +1397,8 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: CallArg) =
         if not matched:
           m.error InvalidMatch, f, arg.typ
         skip f
-    of TypekindT, OrdinalT, ConceptT, SymkindT:
-      let fOrig = f
-      var f2 = f
-      let a = skipModifier(arg.typ)
-      if matchTypeConstraint(m, f2, a):
-        f = f2
-      else:
-        m.error InvalidMatch, fOrig, a
     of NoType, ErrT, ObjectT, EnumT, HoleyEnumT, AnumT, NiltT, AndT, NotT,
-        DistinctT, StaticT, AutoT:
+        DistinctT, StaticT, AutoT, TypekindT, OrdinalT, ConceptT, SymkindT:
       m.error UnhandledTypeBug, f, f
   else:
     m.error MismatchBug, f, arg.typ
@@ -1651,7 +1643,7 @@ proc classifyMatch*(m: Match): TypeRelation {.inline.} =
     return GenericMatch
   result = EqualMatch
 
-proc isTypeclassConstraint(f: TypeCursor): bool =
+proc isTypeclassConstraint*(f: TypeCursor): bool =
   var f = f
   if f.kind == Symbol:
     f = typeImpl(f.symId)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -1397,8 +1397,16 @@ proc singleArgImpl(m: var Match; f: var Cursor; arg: CallArg) =
         if not matched:
           m.error InvalidMatch, f, arg.typ
         skip f
+    of TypekindT, OrdinalT, ConceptT, SymkindT:
+      let fOrig = f
+      var f2 = f
+      let a = skipModifier(arg.typ)
+      if matchTypeConstraint(m, f2, a):
+        f = f2
+      else:
+        m.error InvalidMatch, fOrig, a
     of NoType, ErrT, ObjectT, EnumT, HoleyEnumT, AnumT, NiltT, AndT, NotT,
-        ConceptT, DistinctT, StaticT, AutoT, SymkindT, TypekindT, OrdinalT:
+        DistinctT, StaticT, AutoT:
       m.error UnhandledTypeBug, f, f
   else:
     m.error MismatchBug, f, arg.typ
@@ -1642,6 +1650,26 @@ proc classifyMatch*(m: Match): TypeRelation {.inline.} =
     # maybe a better way to track this
     return GenericMatch
   result = EqualMatch
+
+proc isTypeclassConstraint(f: TypeCursor): bool =
+  var f = f
+  if f.kind == Symbol:
+    f = typeImpl(f.symId)
+  result = f.typeKind in TypeclassKinds
+
+proc isMatchForIs*(m: Match; formal: TypeCursor): bool =
+  ## Whether `typematch(formal, arg)` should make `arg is formal` true.
+  ## Unlike overload resolution, `is` requires exact types unless the
+  ## formal is a typeclass / union constraint.
+  if m.err:
+    return false
+  case classifyMatch(m)
+  of NoMatch:
+    return false
+  of EqualMatch, GenericMatch, SubtypeMatch:
+    return true
+  of IntLitMatch, IntConvMatch, ConvertibleMatch:
+    return isTypeclassConstraint(formal)
 
 proc sigmatchLoop(m: var Match; f: var Cursor; args: openArray[CallArg]) =
   var i = 0

--- a/tests/nimony/stdlib/system/tuniontypes.nim
+++ b/tests/nimony/stdlib/system/tuniontypes.nim
@@ -42,17 +42,26 @@ testFloat float
 testFloat float32
 testFloat float64
 
-# `enum` union from `system/basic_types` (OrdinalEnum | HoleyEnum)
+assert bool isnot SomeSignedInt
+assert bool isnot SomeUnsignedInt
+assert bool isnot SomeInteger
+assert bool isnot SomeFloat
+assert bool isnot SomeNumber
+assert bool is SomeOrdinal
+
+
+# `enum` union from `system/basic_types`
 
 type
-  NormalEnum = enum
+  EnumWithoutHoles = enum
     e0, e1, e2
-  HoleyEnumType = enum
+
+  EnumWithHoles = enum
     a = 0
     b = 2
     c = 3
 
-template testNormalEnum(T: typedesc) =
+template testOrdinalEnum(T: typedesc) =
   assert T is enum
   assert T is OrdinalEnum
   assert T isnot HoleyEnum
@@ -68,11 +77,11 @@ template testHoleyEnum(T: typedesc) =
   assert T isnot int
   assert T isnot bool
 
-testNormalEnum NormalEnum
-testHoleyEnum HoleyEnumType
+testOrdinalEnum EnumWithoutHoles
+testHoleyEnum EnumWithHoles
 
-# Non-enum ordinals: in SomeOrdinal but not in the `enum` union
-assert bool is SomeOrdinal
+
+# Non-enum ordinals (in SomeOrdinal but not in the `enum` union)
+
 assert bool isnot enum
-assert int is SomeOrdinal
 assert int isnot enum

--- a/tests/nimony/stdlib/system/tuniontypes.nim
+++ b/tests/nimony/stdlib/system/tuniontypes.nim
@@ -61,6 +61,19 @@ type
     b = 2
     c = 3
 
+  DenseEnum = enum
+    x = 0
+    y = 1
+    z = 2
+
+  SmallEnum {.size: 1.} = enum
+    p, q, r
+
+  SizeEnum {.size: sizeof(cint).} = enum
+    a = 0
+    b = 1
+    c = 2
+
 template testOrdinalEnum(T: typedesc) =
   assert T is enum
   assert T is OrdinalEnum
@@ -78,6 +91,9 @@ template testHoleyEnum(T: typedesc) =
   assert T isnot bool
 
 testOrdinalEnum EnumWithoutHoles
+testOrdinalEnum DenseEnum
+testOrdinalEnum SmallEnum
+testOrdinalEnum SizeEnum
 testHoleyEnum EnumWithHoles
 
 

--- a/tests/nimony/stdlib/system/tuniontypes.nim
+++ b/tests/nimony/stdlib/system/tuniontypes.nim
@@ -1,0 +1,78 @@
+import std/assertions
+
+# Numeric union types from `system/basic_types`
+
+template testSignedInt(T: typedesc) =
+  assert T is SomeSignedInt
+  assert T isnot SomeUnsignedInt
+  assert T is SomeInteger
+  assert T isnot SomeFloat
+  assert T is SomeNumber
+  assert T is SomeOrdinal
+
+template testUnsignedInt(T: typedesc) =
+  assert T isnot SomeSignedInt
+  assert T is SomeUnsignedInt
+  assert T is SomeInteger
+  assert T isnot SomeFloat
+  assert T is SomeNumber
+  assert T is SomeOrdinal
+
+template testFloat(T: typedesc) =
+  assert T isnot SomeSignedInt
+  assert T isnot SomeUnsignedInt
+  assert T isnot SomeInteger
+  assert T is SomeFloat
+  assert T is SomeNumber
+  assert T isnot SomeOrdinal
+
+testSignedInt int
+testSignedInt int8
+testSignedInt int16
+testSignedInt int32
+testSignedInt int64
+
+testUnsignedInt uint
+testUnsignedInt uint8
+testUnsignedInt uint16
+testUnsignedInt uint32
+testUnsignedInt uint64
+
+testFloat float
+testFloat float32
+testFloat float64
+
+# `enum` union from `system/basic_types` (OrdinalEnum | HoleyEnum)
+
+type
+  NormalEnum = enum
+    e0, e1, e2
+  HoleyEnumType = enum
+    a = 0
+    b = 2
+    c = 3
+
+template testNormalEnum(T: typedesc) =
+  assert T is enum
+  assert T is OrdinalEnum
+  assert T isnot HoleyEnum
+  assert T is SomeOrdinal
+  assert T isnot int
+  assert T isnot bool
+
+template testHoleyEnum(T: typedesc) =
+  assert T is enum
+  assert T is HoleyEnum
+  assert T isnot OrdinalEnum
+  assert T is SomeOrdinal
+  assert T isnot int
+  assert T isnot bool
+
+testNormalEnum NormalEnum
+testHoleyEnum HoleyEnumType
+
+# Non-enum ordinals: in SomeOrdinal but not in the `enum` union
+assert bool is SomeOrdinal
+assert bool isnot enum
+assert int is SomeOrdinal
+assert int isnot enum


### PR DESCRIPTION
While union-type matching in `sigmath.nim` was largely fine, there were issues with `semIs` that rejected successful matches, causing tests like `int8 is SomeInteger` to fail. I added unit tests that also cover various types of enums.

More details in https://github.com/nim-lang/nimony/pull/1909/changes/aa6c9ddc39db77c5285b396a2b2efcd4dc4011df