### PR TITLE
Compiler fixes

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -987,7 +987,14 @@ proc robustMoveFile(src, dest: string) =
 var release = false
 
 proc nimcPrefix(): string =
-  (if release: "nim c -d:release " else: "nim c ")
+  # `--warningAsError:ProveInit:off` and `--warningAsError:Uninit:off`:
+  # Nimony's `src/config.nims` promotes these warnings to errors, but Nim
+  # 2.2.10's host stdlib (typedthreads.nim, deques.nim) trips them on
+  # patterns that aren't actionable from our side. Without these overrides,
+  # any tool using `createThread` (hastur itself) or `initDeque` (pnak)
+  # fails to build on Nim 2.2.10.
+  (if release: "nim c -d:release " else: "nim c ") &
+    "--warningAsError:ProveInit:off --warningAsError:Uninit:off "
 
 proc validatePassesFlag(): string =
   ## Enable the phase-aware IR validator only when running on CI. GitHub Actions

--- a/src/nifc/llvmgenstmts.nim
+++ b/src/nifc/llvmgenstmts.nim
@@ -10,6 +10,15 @@
 # included from llvmcodegen.nim
 # Generates LLVM IR for statements.
 
+type
+  CaseBranch = object
+    ## Used by genSwitchLLVM. Declared at module scope rather than inside
+    ## the proc's `n.into:` block so the type isn't re-instantiated each
+    ## time the template expands — two distinct types from the same
+    ## source location confuse later type-equality checks.
+    values: seq[string]
+    label: string
+
 proc getVirtualGuardLLVM(c: var LLVMCode; n: Cursor): (SymId, bool) =
   result = (SymId(0), false)
   var n = n
@@ -182,10 +191,6 @@ proc genSwitchLLVM(c: var LLVMCode; n: var Cursor) =
     let endLabel = c.label()
     var defaultLabel = c.str(endLabel)
 
-    # First pass: collect all case branches
-    type CaseBranch = object
-      values: seq[string]
-      label: string
 
     var branches: seq[CaseBranch] = @[]
     var defaultBranch: string = ""


### PR DESCRIPTION
Two compiler build fixes for Linux (Debian 13 amd64):
- treat two compiler warnings as warnings (arise in 2.2.10 stdlib code) rather than erroring out of nimony build
- move `CaseBranch` definition out of template to prevent incompatible types being generated each time the template is expanded.

AI disclosure: Writen with Claude Opus 4.8 but reivewed and functionally tested.