### PR TITLE
hexer/coro_transform: treat ParRi as missing else in IteV lowering

### DIFF
--- a/src/hexer/coro_transform.nim
+++ b/src/hexer/coro_transform.nim
@@ -1215,7 +1215,12 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
       skip n
       var elseCur = n
       skip n
-      if elseCur.kind != DotToken:
+      # Else-branch presence: in NJVL the missing-else case can present as
+      # either a `DotToken` placeholder *or* the parent's closing `ParRi`
+      # (when the `ite` was emitted with the else slot elided rather than
+      # explicitly filled with `.`). Treating ParRi as "no else" prevents
+      # `elseCur.into:` from asserting on a non-ParLe cursor.
+      if elseCur.kind == ParLe:
         emitJump dest, lelse, info
         emitLabel dest, lelse, info
         elseCur.into:


### PR DESCRIPTION
The IteV handler in `trGoto` calls `elseCur.into:` to descend into the else branch when one is present. The presence check was

  if elseCur.kind != DotToken:
    ...
    elseCur.into:                            # asserts ParLe

but the missing-else case in NJVL can present as *either* a `DotToken` placeholder *or* the parent's closing `ParRi` (when the `ite` was emitted with the else slot elided rather than explicitly filled with `.`). `into` then asserts because `ParRi` is not `ParLe`.

Triggered by the natural request/response shape:

  proc waitOp(): int {.passive.} =
    result = 0
    let c = delay()
    suspend()

  proc handler() {.passive.} =
    while true:
      if waitOp() <= 0: break
      if waitOp() <= 0: break

  handler()

Fix: gate the descent on `elseCur.kind == ParLe` directly.

All 22 `tests/nimony/cps/*.nim` tests still pass. The patch unblocks the assertion but exposes a downstream "could not find symbol: handler.0.s2.<modid>" coming from the state-machine generation when this NJVL shape is processed — that's a separate bug in the lab/jmp final-pass walker; not addressed here.