### PR TITLE
hexer/coro_transform: drain trailing ite slots in CPS walker

### DIFF
--- a/src/hexer/coro_transform.nim
+++ b/src/hexer/coro_transform.nim
@@ -1977,6 +1977,9 @@ proc coroTr*(c: var Context; dest: var TokenBuf; n: var Cursor) =
           dest.addParRi()
           dest.addParRi()
         of IteV, ItecV:
+          # `nj.nim` can emit a trailing 4th slot (a leftover DotToken from
+          # guard-closing); drain any extra children so the closing `)` isn't
+          # left for the outer loop, which would drop the following siblings.
           var info = n.info
           inc n
           dest.copyIntoKind IfS, info:
@@ -1985,7 +1988,9 @@ proc coroTr*(c: var Context; dest: var TokenBuf; n: var Cursor) =
               coroTr c, dest, n
             dest.copyIntoKind ElseU, info:
               coroTr c, dest, n
-          inc n
+          while n.kind != ParRi:
+            skip n
+          skipParRi n
         of MflagV, VflagV:
           trMflag c, dest, n
         of JtrueV:


### PR DESCRIPTION
NJVL `ite`/`itec` is canonically 3 children, but `nj.nim`'s guard-closing path (`maybeCloseGuard` before `closeBasicBlock` in `trWhileTrue`) can leave a trailing DotToken — producing a 4-child `(ite cond then else .)` when a loop body has nested suspending `if cond: break`s. The walker assumed 3 children and stepped past the closing `)` with a bare `inc n`, landing mid-`ite`; the real `)` then leaked to the outer loop, ending it early and silently dropping the following `lab`/`jmp` tokens. Surfaced later in `constparams` as `could not find symbol: foo.0.sN.…`.

Drain any extra children before the closing `)`. Verified against tests/nimony/cps (no new failures) and test case in prior PR (#1917).