### PR TITLE
system/cps: free heap coroutine frames invoked with a nil caller

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -479,9 +479,7 @@ proc allocFrame*(size: int): ptr CoroutineBase =
 
 proc deallocFrame*(frame: ptr CoroutineBase) =
   ## Frees a coroutine frame previously allocated by `allocFrame`.
-  ## Stack-allocated frames (called from non-passive context with nil caller)
-  ## have `callee == nil` or `caller.fn == nil` and are not freed.
-  if frame.callee != nil and frame.caller.fn != nil:
+  if frame.callee != nil:
     dealloc(frame)
 
 type

--- a/src/hexer/cps.nim
+++ b/src/hexer/cps.nim
@@ -145,7 +145,8 @@ proc trPassiveCall(c: var Context; dest: var TokenBuf; n: var Cursor; target: Cu
         dest.addSymUse contVar, info
     else:
       # Stack-allocate the callee's frame (statically known callee).
-      # Tag callee.callee with bit 0 so deallocFrame is a nop.
+      # Null callee.callee (see emitStackFrameTag) so deallocFrame is a
+      # nop — `callee == nil` marks the frame as stack-allocated.
       let coroVar = pool.syms.getOrIncl("`coroVar." & $c.currentProc.counter)
       inc c.currentProc.counter
       var sym = n.firstSon.symId

--- a/tests/nimony/valgrind/tpassivespawn.nim
+++ b/tests/nimony/valgrind/tpassivespawn.nim
@@ -1,0 +1,20 @@
+# Regression test for the deallocFrame heap-frame leak.
+#
+# A `.passive` proc spawned via `delay(call)` + `complete()` is
+# heap-allocated (allocFrame) but handed a nil (Stop) continuation as its
+# caller — it resumes no one when it finishes. deallocFrame must still
+# free such a frame on completion.
+
+var total = 0
+
+proc worker(x: int) {.passive.} =
+  total = total + x
+
+proc driver(n: int) {.passive.} =
+  var i = 0
+  while i < n:
+    let child = delay(worker(i))
+    complete(child)
+    i = i + 1
+
+driver(8)


### PR DESCRIPTION
deallocFrame only reclaimed a heap frame when both `callee != nil` and `caller.fn != nil`. The second condition leaked every heap-allocated frame invoked with a Stop continuation (nil caller):

- `delay(call)` spawns — the detached-task pattern from passive_procs.md;
- passive method / closure / proctype calls made from non-passive code, which must allocate on the heap because dynamic dispatch defeats the stack-frame inlining used for statically-known calls.

The CPS transform sets `callee = self` for heap frames and explicitly nulls it for stack frames (the non-passive static-call path, via `emitStackFrameTag`). Stack frames are therefore already excluded by `callee == nil`, making the `caller.fn != nil` check redundant for the case it guarded while leaking the nil-caller heap frames. Free on `callee != nil` alone.

Also corrects a stale comment in cps.nim that described the stack-frame tag as setting bit 0; it nulls callee.