### PR TITLE
expreval: fold a parenthesised when/if in a const initialiser

### DIFF
--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -760,11 +760,24 @@ proc eval*(c: var EvalContext; n: var Cursor): Cursor =
     of ExprX:
       let orig = n
       inc n # tag
-      result = eval(c, n)
-      if n.kind == ParRi:
-        inc n
+      var foldable = true
+      while n.stmtKind == StmtsS:
+        var inner = n
+        inc inner
+        if inner.kind == ParRi:   # empty `(stmts)` → skip it
+          skip n
+        else:
+          foldable = false
+          break
+      if foldable and n.kind != ParRi:
+        result = propagateError eval(c, n)   # the trailing value
+        if n.kind == ParRi:
+          inc n
+        else:
+          foldable = false
       else:
-        # was not a trivial ExprX, so we could not evaluate it
+        foldable = false
+      if not foldable:
         cannotEval orig
     of NegX:
       evalUnOp(c, n, `-`)

--- a/tests/nimony/const/tparenwhenconst.nim
+++ b/tests/nimony/const/tparenwhenconst.nim
@@ -1,0 +1,26 @@
+import std/assertions
+
+# Regression: a *parenthesised* `when` expression in a const initialiser lowers
+# to `(expr (stmts) <value>)` — an empty leading statement list, then the
+# selected branch. The compile-time evaluator (expreval) must skip the empty
+# leading stmts and fold the trailing value; it previously evaluated the first
+# child and failed with `cannot evaluate expression at compile time:
+# (; <value>)`. (Bare `when`, and parens around a plain expr, already folded.)
+
+const B = (when false: 10 else: 20)
+const C = (when true: 30 else: 40)
+const F = (when defined(linux): 1'i32 else: 2'i32)   # the std/ioring SOL_SOCKET shape
+
+# parens around a nested when, and a leading-blank-stmt grouping, still fold:
+const G = (when true: (when false: 1 else: 2) else: 3)
+
+assert B == 20
+assert C == 30
+assert F == (when defined(linux): 1'i32 else: 2'i32)
+assert G == 2
+
+# guards: the forms that already worked must keep working
+const bare = when true: 5 else: 6
+const paren = (7)
+assert bare == 5
+assert paren == 7


### PR DESCRIPTION
A parenthesised when/if value lowers to `(expr (stmts) <value>)` (empty leading stmts, then the selected branch). The ExprX arm in the compile-time evaluator evaluated the first child — the empty stmts — instead of the trailing value, so it bailed with "cannot evaluate expression at compile time". Skip empty leading statement lists and fold the trailing value.

Repro (from std/ioring):
```  
const SOL_SOCKET = (when defined(macosx): 0xFFFF.cint else: 1.cint)
  # Error: cannot evaluate expression at compile time: (; int32(1))
```
Test: tests/nimony/const/tparenwhenconst.nim