### PR TITLE
threadpool: pass worker index by value, not via a dangling stack pointer

### DIFF
--- a/lib/std/threadpool.nim
+++ b/lib/std/threadpool.nim
@@ -246,7 +246,7 @@ proc unregisterFd*(fd: cint) =
 # --- Worker loop ---
 
 proc workerLoop(arg: pointer) {.nimcall.} =
-  let threadIdx = cast[ptr int](arg)[]
+  let threadIdx = cast[int](arg)   # index passed by value via the pointer slot (see initPool)
   var taskBuf {.noinit.}: array[BulkSize, Task]
   when hasEpoll:
     var ioEvents {.noinit.}: array[MaxIoEvents, EpollEvent]
@@ -309,11 +309,15 @@ proc initPool*() =
   elif hasKqueue:
     gIoFd = kqueue()
     assert gIoFd >= 0, "kqueue failed"
-  var indexes = default array[WorkerCount, int]
   for i in 0 ..< WorkerCount:
-    indexes[i] = i
     try:
-      create workers[i], workerLoop, addr indexes[i]
+      # Pass the worker index BY VALUE through the pointer slot. It used to be
+      # `addr indexes[i]` into a stack-local array that dangled the moment
+      # initPool returned — run()'s sleep frame then reused that memory and the
+      # workers read garbage thread indices (valgrind: uninitialised value in
+      # tryBulkDequeue/workerLoop, origin the reused frame). No storage, no
+      # lifetime, no race.
+      create workers[i], workerLoop, cast[pointer](i)
     except:
       discard
 


### PR DESCRIPTION
initPool stored `addr indexes[i]` (a stack-local array) as each worker thread's arg; once initPool returned, run()'s sleep frame reused that stack memory and the workers read garbage thread indices. Consequent wrong stripe selection in tryBulkDequeue/workerLoop, so submitted tasks were left undrained.

Pass the index by value through the pointer slot (cast[pointer](i) / cast[int](arg)). `int` is pointer-width so the round-trip is lossless.

Found via valgrind --track-origins: "uninitialised value of size 8 in tryBulkDequeue, created by a stack allocation" (origin: the reused clock_nanosleep frame from run()).