### PR TITLE
hexer/coro_transform: keep the rotated loop prelude inside the loop

### DIFF
--- a/src/hexer/coro_transform.nim
+++ b/src/hexer/coro_transform.nim
@@ -1172,23 +1172,27 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
       inc c.currentProc.labelCounter
   of LoopV:
     if containsSuspensionPoint(c, n):
+      var beforeLoopState = c.currentProc.labelCounter
+      inc c.currentProc.labelCounter
+      var afterLoopState = c.currentProc.labelCounter
+      inc c.currentProc.labelCounter
       n.into:                                       # (loop ...)
         assert n.stmtKind == StmtsS
+        var preludeBuf = createTokenBuf(16)
         n.into:                                     # stmts_before
-          while n.hasMore:
-            dest.takeTree n # copy all mflags, it will be handled later
-        var beforeLoopState = c.currentProc.labelCounter
-        inc c.currentProc.labelCounter
-        var afterLoopState = c.currentProc.labelCounter
-        inc c.currentProc.labelCounter
+          while n.hasMore and n.njvlKind in {MflagV, VflagV}:
+            dest.takeTree n                         # flag decls: once, above the loop
+          while n.hasMore:                          # rotated prelude: lowered, spliced below
+            trGoto c, preludeBuf, n
         emitJump dest, beforeLoopState, info
         emitLabel dest, beforeLoopState, info
-        dest.copyIntoKind IfS, info:
+        dest.copyIntoKind IfS, info:                # loop-continue test (cond first)
           dest.copyIntoKind ElifU, info:
             dest.copyIntoKind NotX, info:
               dest.takeTree n
             dest.copyIntoKind StmtsS, info:
               emitJump dest, afterLoopState, info
+        dest.add preludeBuf                         # prelude: each iteration, after the test
         assert n.stmtKind == StmtsS
         n.into:                                     # stmts_body
           while n.hasMore:


### PR DESCRIPTION
trGoto's LoopV lowering emitted the loop's whole NJVL "before" section above the loop-top label and jumped the back-edge there. That is correct only when "before" holds nothing but mflag/vflag decls — but NJVL also rotates the first iteration's condition computation into "before", and in a .passive proc that prelude can be a suspending call. Placing it above the label made the back-edge skip it: the prelude ran once and the loop then spun on the stale value.

Mirror coroTr's LoopV reconstruction `(while cond (stmts before body))`: hoist the flag decls once above the label, lower the rest of "before" into a side buffer (via trGoto, so a passive call keeps its resume label), and splice it in after the continue-test, ahead of the body.

Reproducer — a() should run every iteration; before this fix it ran once and the loop spun on b() (prints ABBBB… instead of ABABA):

    import std/syncio
    var parked = Continuation(fn: nil, env: nil)
    var order = ""
    var aLeft = 2
    proc a(): int {.passive.} =
      order.add 'A'; result = aLeft; aLeft = aLeft - 1
      parked = delay(); suspend()
    proc b(): int {.passive.} =
      order.add 'B'; result = 1
      parked = delay(); suspend()
    proc loop() {.passive.} =
      while true:
        if a() <= 0: break
        if b() <= 0: break
    proc main() =
      complete(delay(loop()))
      var steps = 0
      while parked.fn != nil and steps < 12:
        let c = parked; parked = Continuation(fn: nil, env: nil)
        complete(c); steps = steps + 1
      echo order            # ABABA
    main()