### PR TITLE
Add missing strutils and parseutils helpers

### DIFF
--- a/lib/std/parseutils.nim
+++ b/lib/std/parseutils.nim
@@ -383,3 +383,27 @@ func skipIgnoreCase*(s, token: openArray[char]): int =
   while result < s.len and result < token.len and
       toLower(s[result]) == toLower(token[result]): inc(result)
   if result != token.len: result = 0
+
+func skipUntil*(s: openArray[char], until: set[char]): int {.inline.} =
+  ## Skips all characters until one char from the set `until` is found
+  ## or the end is reached.
+  ## Returns number of characters skipped.
+  result = 0
+  while result < s.len and s[result] notin until: inc(result)
+
+func skipUntil*(s: openArray[char], until: char): int {.inline.} =
+  ## Skips all characters until the char `until` is found or the end is reached.
+  ## Returns number of characters skipped.
+  result = 0
+  while result < s.len and s[result] != until: inc(result)
+
+func skipUntil*(s: string, until: set[char], start = 0): int {.inline.} =
+  ## Skips all characters until one char from the set `until` is found
+  ## or the end is reached.
+  ## Returns number of characters skipped.
+  skipUntil(s.toOpenArray(start, s.high), until)
+
+func skipUntil*(s: string, until: char, start = 0): int {.inline.} =
+  ## Skips all characters until the char `until` is found or the end is reached.
+  ## Returns number of characters skipped.
+  skipUntil(s.toOpenArray(start, s.high), until)

--- a/lib/std/strutils.nim
+++ b/lib/std/strutils.nim
@@ -174,11 +174,24 @@ func `$`*(x: char): string =
   result = newString(1)
   result[0] = x
 
+func substrEq(s: string, pos: int, substr: string): bool =
+  var length = substr.len
+  if length > 0:
+    var i = 0
+    while i < length and pos + i < s.len and s[pos + i] == substr[i]:
+      inc i
+    i == length
+  else:
+    false
+
 template stringHasSep(s: string, index: int, seps: set[char]): bool =
   s[index] in seps
 
 template stringHasSep(s: string, index: int, sep: char): bool =
   s[index] == sep
+
+template stringHasSep(s: string, index: int, sep: string): bool =
+  s.substrEq(index, sep)
 
 template splitCommon(s, sep, maxsplit, sepLen) {.untyped.} =
   ## Common code for split procs
@@ -194,6 +207,11 @@ template splitCommon(s, sep, maxsplit, sepLen) {.untyped.} =
     if splits == 0: break
     dec(splits)
     inc(last, sepLen)
+
+template accResult(iter: untyped) {.untyped.} =
+  result = @[]
+  for x in iter:
+    result.add x
 
 iterator split*(s: string; seps: set[char] = Whitespace;
                 maxsplit: int = -1): string =
@@ -252,6 +270,37 @@ iterator split*(s: string; sep: char; maxsplit: int = -1): string =
   ## Substrings are separated by the character `sep`.
   splitCommon(s, sep, maxsplit, 1)
 
+iterator split*(s: string; sep: string; maxsplit: int = -1): string =
+  ## Splits the string `s` into substrings using the separator `sep`.
+  let sepLen = if sep.len == 0: 1 else: sep.len
+  splitCommon(s, sep, maxsplit, sepLen)
+
+iterator splitLines*(s: string; keepEol = false): string =
+  ## Splits the string `s` into its containing lines.
+  ## Supports LF, CR, and CR-LF line endings.
+  var first = 0
+  var last = 0
+  var eolpos = 0
+  while true:
+    while last < s.len and s[last] notin {'\c', '\l'}:
+      inc last
+
+    eolpos = last
+    if last < s.len:
+      if s[last] == '\l':
+        inc last
+      elif s[last] == '\c':
+        inc last
+        if last < s.len and s[last] == '\l':
+          inc last
+
+    yield substr(s, first, if keepEol: last - 1 else: eolpos - 1)
+
+    if eolpos == last:
+      break
+
+    first = last
+
 iterator splitWhitespace*(s: string; maxsplit: int = -1): string =
   ## Splits the string `s` at whitespace, stripping leading and trailing
   ## whitespace and collapsing runs of whitespace (no empty substrings are
@@ -274,6 +323,26 @@ iterator splitWhitespace*(s: string; maxsplit: int = -1): string =
       yield substr(s, first, last-1)
       if splits == 0: break
       dec(splits)
+
+func split*(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[string] =
+  ## The same as the `split` iterator, but returns a sequence of substrings.
+  accResult(split(s, seps, maxsplit))
+
+func split*(s: string; sep: char; maxsplit: int = -1): seq[string] =
+  ## The same as the `split` iterator, but returns a sequence of substrings.
+  accResult(split(s, sep, maxsplit))
+
+func split*(s: string; sep: string; maxsplit: int = -1): seq[string] =
+  ## The same as the `split` iterator, but returns a sequence of substrings.
+  accResult(split(s, sep, maxsplit))
+
+func splitLines*(s: string; keepEol = false): seq[string] =
+  ## The same as the `splitLines` iterator, but returns a sequence of substrings.
+  accResult(splitLines(s, keepEol))
+
+func splitWhitespace*(s: string; maxsplit: int = -1): seq[string] =
+  ## The same as the `splitWhitespace` iterator, but returns a sequence of substrings.
+  accResult(splitWhitespace(s, maxsplit))
 
 func delete*(s: var string, slice: Slice[int]) =
   ## Deletes the items `s[slice]`.

--- a/tests/nimony/stdlib/tparseutils.nim
+++ b/tests/nimony/stdlib/tparseutils.nim
@@ -31,6 +31,15 @@ block: # parseHex
   assert parseHex("123def", num, start = 2, maxLen = 2) == 2
   assert num == 0x3d
 
+block: # skipUntil
+  assert skipUntil("Hello World", {'W', 'e'}) == 1
+  assert skipUntil("Hello World", {'W'}) == 6
+  assert skipUntil("Hello World", {'W', 'd'}) == 6
+  assert skipUntil("Hello World", 'o') == 4
+  assert skipUntil("Hello World", 'o', 4) == 0
+  assert skipUntil("Hello World", 'W') == 6
+  assert skipUntil("Hello World", 'w') == 11
+
 block:
   var ret: int64 = 3'i64
   assert parseBiggestInt("0", ret) == 1

--- a/tests/nimony/stdlib/tstrutils.nim
+++ b/tests/nimony/stdlib/tstrutils.nim
@@ -112,6 +112,20 @@ block: # split iterator
   assert testSplit(s1, Digits, 3) == @["foo", "bar", "", "baz456"]
   assert testSplit(s1, Digits, 4) == @["foo", "bar", "", "baz", "56"]
 
+block: # split funcs
+  assert split("a,b,c", ',') == @["a", "b", "c"]
+  assert split("a,b;c", {',', ';'}) == @["a", "b", "c"]
+  assert split("a--b--c", "--") == @["a", "b", "c"]
+  assert split("empty seps return unsplit s", {}) == @["empty seps return unsplit s"]
+  assert split("empty sep returns unsplit s", "") == @["empty sep returns unsplit s"]
+  assert splitWhitespace("  foo \t bar  baz  ") == @["foo", "bar", "baz"]
+
+block: # splitLines
+  assert splitLines("\nthis\nis\nan\n\nexample\n") ==
+    @["", "this", "is", "an", "", "example", ""]
+  assert splitLines("a\r\nb\nc\r") == @["a", "b", "c", ""]
+  assert splitLines("a\r\nb\n", keepEol = true) == @["a\r\n", "b\n", ""]
+
 block: # delete
   try:
     block:


### PR DESCRIPTION
## Summary

Adds several stdlib helpers that exist in Nim's stdlib but were missing from Nimony:

- `parseutils.skipUntil` overloads for `openArray[char]` and `string`
- `strutils.splitLines` iterator and sequence-returning overload
- sequence-returning `strutils.split` overloads for `char`, `set[char]`, and `string`
- sequence-returning `strutils.splitWhitespace`
- string-separator support for `strutils.split`

The `strutils` implementation follows the Nim stdlib shape, including the private `substrEq` helper used by string-separator splitting.

## Motivation

Nimony-compiled plugins now compile against Nimony's own stdlib. Code that previously compiled through Nim can depend on common Nim stdlib APIs such as `skipUntil`, `splitLines`, and sequence-returning `split`. Missing these APIs causes otherwise portable plugin code to fail during plugin compilation.

## Validation

Ran:

```sh
nimony c -r tests/nimony/stdlib/tstrutils.nim
nimony c -r tests/nimony/stdlib/tparseutils.nim
nimony c -r /tmp/nimony_std_missing_probe.nim
```

Also verified in a downstream `smartcli` compile that the previous stdlib-related errors for `skipUntil`, `split`, `splitLines`, and `isEmptyOrWhitespace` are gone. The remaining downstream errors are separate plugin API/compiler issues.