### PR TITLE
Fix imported custom pragma templates

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -444,12 +444,15 @@ proc renderTree*(tree: NifBuilder): string        # debug rendering (no line inf
 
 ```nim
 proc errorTree*(msg: string): NifBuilder
-proc errorTree*(msg: string; at: Node): NifBuilder
-proc errorTree*(msg: string; at, orig: Node): NifBuilder
+proc errorTree*(msg: string; info: LineInfo): NifBuilder
+proc errorTree*(msg: string; at: NifCursor): NifBuilder
+proc errorTree*(msg: string; at, orig: NifCursor): NifBuilder
 ```
 
-Return an `ErrT` node that the compiler reports as a compile-time error. The `at`
-parameter provides source location; `orig` embeds the original source for context.
+Return an `ErrT` node that the compiler reports as a compile-time error. The
+`info` overload provides source location only; `at` provides both source location
+and embedded source context; `orig` lets the diagnostic location and embedded
+source context differ.
 
 
 ### Validation

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -348,6 +348,54 @@ proc addSymUse*(t: var NifBuilder; s: string; info: LineInfo = NoLineInfo) =
   prepareMutation(t)
   t.p[].buf.addSymUse(pool.syms.getOrIncl(s), info)
 
+proc addErrorMessage(t: var NifBuilder; msg: string; info: LineInfo) =
+  prepareMutation(t)
+  t.p[].buf.addStrLit(msg, info)
+
+proc buildErrorTree(info: LineInfo; msg: string; orig: NifCursor): NifBuilder =
+  result = createTree()
+  result.addParLe("err", info)
+  result.addSubtree(orig)
+  result.addErrorMessage(msg, info)
+  result.addParRi()
+
+proc buildErrorTree(info: LineInfo; msg: string): NifBuilder =
+  result = createTree()
+  result.addParLe("err", info)
+  result.addDotToken()
+  result.addErrorMessage(msg, info)
+  result.addParRi()
+
+proc errorTree*(msg: string): NifBuilder =
+  ## Builds a compiler error tree with no original expression attached.
+  buildErrorTree(NoLineInfo, msg)
+
+proc errorTree*(msg: string; info: LineInfo): NifBuilder =
+  ## Builds a compiler error tree at `info` with no original expression attached.
+  buildErrorTree(info, msg)
+
+proc errorTree*(msg: string; at: NifCursor): NifBuilder =
+  ## Builds a compiler error tree reported at `at`, attaching `at`.
+  if hasSubtree(at):
+    buildErrorTree(at.info, msg, at)
+  else:
+    buildErrorTree(at.info, msg)
+
+proc errorTree*(msg: string; at, orig: NifCursor): NifBuilder =
+  ## Builds a compiler error tree reported at `at`, attaching `orig`.
+  if hasSubtree(orig):
+    buildErrorTree(at.info, msg, orig)
+  else:
+    buildErrorTree(at.info, msg)
+
+proc parseNifBuffer(text: string): TokenBuf =
+  # Internal helper used by `bindSymHelper` to parse a NIF source fragment
+  # (e.g. `name.0.suffix` or `(cchoice s1 s2 …)`). Strips the trailing
+  # `EofToken` so the resulting tokens concatenate cleanly into a builder.
+  result = parseFromBuffer(text, "")
+  if result.len > 0 and result[result.len-1].kind == EofToken:
+    result.shrink(result.len-1)
+
 type
   BindSymRule* = enum
     ## Selector for `bindSym`'s third argument. Mirrors `lib/std/macros.nim`'s
@@ -790,14 +838,6 @@ proc saveTree*(tree: NifBuilder) =
   ## Writes the complete contents of a mutable `NifBuilder` to `paramStr(2)`.
   ## This preserves line info because it is intended for `.nif` output.
   saveTree(tree, paramStr(2))
-
-proc parseNifBuffer(text: string): TokenBuf =
-  ## Internal helper used by `bindSymHelper` to parse a NIF source fragment
-  ## (e.g. `name.0.suffix` or `(cchoice s1 s2 …)`). Strips the trailing
-  ## `EofToken` so the resulting tokens concatenate cleanly into a builder.
-  result = parseFromBuffer(text, "")
-  if result.len > 0 and result[result.len-1].kind == EofToken:
-    result.shrink(result.len-1)
 
 proc createTree*[K: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma](
     kind: K; children: openArray[NifBuilder]): NifBuilder =

--- a/src/nimony/nif_annotations.nim
+++ b/src/nimony/nif_annotations.nim
@@ -17,7 +17,6 @@
 ##     {.ensuresNif: addedExpr(dest).}
 ##
 ## Procs annotated with ensuresNif must have unique names (no overloading).
-## Use `include` not `import` since custom pragmas can't be exported.
 
 template ensuresNif*(x: untyped) {.pragma.}
 template requiresNif*(x: untyped) {.pragma.}
@@ -33,6 +32,7 @@ template addedDef*(x: untyped): untyped = x     ## Adds one SymbolDef child
 template addedSym*(x: untyped): untyped = x     ## Adds one symbol use child
 template addedLit*(x: untyped): untyped = x     ## Adds one literal child
 template addedAny*(x: untyped): untyped = x     ## Adds one child of unknown kind
+template addedNested*(x: untyped): untyped = x  ## Adds one nested substructure child
 template addedDot*(x: untyped): untyped = x     ## Adds one DotToken
 template addedNothing*(x: untyped): untyped = x ## Adds nothing to dest
 

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -893,7 +893,9 @@ proc findMacroInvocs(c: SemContext; n: Cursor; kind: SymKind): seq[Cursor] =
           if n.exprKind == CallX:
             inc n
           let name = getIdent(n)
-          if name != StrId(0) and not (name in c.userPragmas and not hasParRi):
+          if name != StrId(0) and
+              not isCustomPragmaTemplate(c, name) and
+              not (name in c.userPragmas and not hasParRi):
             result.add start
             n = start
             skip n

--- a/src/nimony/semimport.nim
+++ b/src/nimony/semimport.nim
@@ -100,7 +100,8 @@ proc importSingleFile*(c: var SemContext; dest: var TokenBuf; f1: ImportedFilena
   else:
     result = c.processedModules.getOrQuit(suffix)
   let module = addr c.importedModules.mgetOrPut(result, ImportedModule(path: f2, fromPlugin: f1.plugin))
-  loadInterface suffix, module.iface, result, c.importTab, c.converters, exports, mode
+  loadInterface suffix, module.iface, result, c.importTab, c.converters,
+                exports, mode
   # Track NIF snippet for this import using absolute path, for use by exprexec.
   # Skip system.nim since it's auto-imported and would cause cycles:
   if not f1.isSystem and suffix != SystemModuleSuffix:

--- a/src/nimony/sempragmas.nim
+++ b/src/nimony/sempragmas.nim
@@ -23,7 +23,8 @@ include ".." / lib / compat2
 import ".." / lib / symparser
 import nimony_model, builtintypes, decls, asthelpers, programs,
   magics, nifconfig, semdata, sembasics,
-  semchecks, semconst, semos, renderer, features, pragmacanon, identstyle
+  semchecks, semconst, semos, renderer, features, pragmacanon, identstyle,
+  symtabs
 
 # --- thin shims forwarding into the sem core via SemContext callbacks ---
 # (const-eval entry points — semBoolExpr, semConstIntExpr, … — come directly
@@ -47,6 +48,33 @@ proc semLocalType(c: var SemContext; dest: var TokenBuf; n: var Cursor; context 
   result = typeToCursor(c, dest, insertPos)
 
 # --- handlers (moved verbatim from sem.nim) ---
+
+proc symbolIsCustomPragmaTemplate(s: SymId): bool =
+  let loaded = tryLoadSym(s)
+  if loaded.status == LacksNothing and loaded.decl.symKind == TemplateY:
+    result = hasPragma(asRoutine(loaded.decl).pragmas, PragmaP)
+
+proc isCustomPragmaTemplate*(c: SemContext; name: StrId): bool =
+  if name in c.customPragmaTemplates:
+    return true
+
+  let ignoreStyle = IgnoreStyleFeature in c.features
+  var scope = c.currentScope
+  while scope != nil:
+    for k in stylesOfScope(scope, name, ignoreStyle):
+      for sym in scope.tab.getOrDefault(k):
+        if sym.kind == TemplateY and symbolIsCustomPragmaTemplate(sym.name):
+          return true
+    scope = scope.up
+
+  for realName in stylesOfImport(c.importTab, name, ignoreStyle):
+    for moduleId in c.importTab.getOrDefault(realName):
+      if c.importedModules.hasKey(moduleId):
+        let imported = c.importedModules.getOrQuit(moduleId)
+        for foreignName in stylesOfIface(imported.iface, realName, ignoreStyle):
+          for symId in imported.iface.getOrDefault(foreignName):
+            if symbolIsCustomPragmaTemplate(symId):
+              return true
 
 proc semProposition*(c: var SemContext; dest: var TokenBuf; n: var Cursor; kind: PragmaKind) =
   let prevPhase = c.phase
@@ -111,7 +139,7 @@ proc semPragma*(c: var SemContext; dest: var TokenBuf; n: var Cursor; crucial: v
         while read.hasMore:
           semPragma c, dest, read, crucial, kind
         endRead(pragBuf[])
-      elif name != StrId(0) and name in c.customPragmaTemplates:
+      elif name != StrId(0) and c.isCustomPragmaTemplate(name):
         # Pragma that resolves to a `template X(args) {.pragma.}` declaration.
         # Accept with or without arguments and drop silently — matches Nim's
         # treatment of templates marked `sfCustomPragma` used as annotations.
@@ -345,16 +373,23 @@ proc semPragma*(c: var SemContext; dest: var TokenBuf; n: var Cursor; crucial: v
     else:
       buildErr c, dest, n.info, "`callConv` pragma takes a calling convention identifier"
   of EmitP, BuildP, StringP, AssumeP, AssertP, PragmaP, PushP, PopP, PassLP, PassCP:
-    if pk == PragmaP and kind == TemplateY and not hasParRi and crucial.sym != SymId(0):
+    if pk == PragmaP and kind == TemplateY and crucial.sym != SymId(0):
       # `template X(args) {.pragma.}` declares `X` as a custom pragma. The
       # body is not expanded at attachment sites — the annotation is
       # recorded as a known custom-pragma name that will be silently
       # accepted (and dropped) wherever it is later attached. Mirrors Nim's
       # `sfCustomPragma`.
-      var basename = pool.syms[crucial.sym]
-      extractBasename basename
-      c.customPragmaTemplates.incl pool.strings.getOrIncl(basename)
+      let info = n.info
       inc n
+      if hasParRi and n.hasMore:
+        buildErr c, dest, info, "`pragma` takes no arguments"
+        while n.hasMore: skip n
+      else:
+        var basename = pool.syms[crucial.sym]
+        extractBasename basename
+        c.customPragmaTemplates.incl pool.strings.getOrIncl(basename)
+        dest.add parLeToken(PragmaP, info)
+        dest.addParRi()
     else:
       buildErr c, dest, n.info, "pragma not supported"
       inc n

--- a/src/nimony/sempragmas.nim
+++ b/src/nimony/sempragmas.nim
@@ -51,8 +51,9 @@ proc semLocalType(c: var SemContext; dest: var TokenBuf; n: var Cursor; context 
 
 proc symbolIsCustomPragmaTemplate(s: SymId): bool =
   let loaded = tryLoadSym(s)
-  if loaded.status == LacksNothing and loaded.decl.symKind == TemplateY:
-    result = hasPragma(asRoutine(loaded.decl).pragmas, PragmaP)
+  result = loaded.status == LacksNothing and
+           loaded.decl.symKind == TemplateY and
+           hasPragma(asRoutine(loaded.decl).pragmas, PragmaP)
 
 proc isCustomPragmaTemplate*(c: SemContext; name: StrId): bool =
   if name in c.customPragmaTemplates:
@@ -75,6 +76,7 @@ proc isCustomPragmaTemplate*(c: SemContext; name: StrId): bool =
           for symId in imported.iface.getOrDefault(foreignName):
             if symbolIsCustomPragmaTemplate(symId):
               return true
+  result = false
 
 proc semProposition*(c: var SemContext; dest: var TokenBuf; n: var Cursor; kind: PragmaKind) =
   let prevPhase = c.phase

--- a/tests/nimony/plugins/nimony.paths
+++ b/tests/nimony/plugins/nimony.paths
@@ -1,0 +1,1 @@
+../../../src/nimony/lib

--- a/tests/nimony/plugins/tplugin_annotations.nim
+++ b/tests/nimony/plugins/tplugin_annotations.nim
@@ -1,0 +1,11 @@
+import plugins
+
+proc emitAny(dest: var NifBuilder) {.ensuresNif: addedAny(dest).} =
+  discard
+
+proc emitNested(dest: var NifBuilder) {.ensuresNif: addedNested(dest).} =
+  discard
+
+var dest = createTree()
+emitAny(dest)
+emitNested(dest)

--- a/tests/nimony/pragmas/deps/mcustompragmas.nim
+++ b/tests/nimony/pragmas/deps/mcustompragmas.nim
@@ -1,0 +1,2 @@
+template importedPragma*(x: untyped) {.pragma.}
+template importedMarker*() {.pragma.}

--- a/tests/nimony/pragmas/timported_custompragma.nim
+++ b/tests/nimony/pragmas/timported_custompragma.nim
@@ -1,0 +1,10 @@
+import deps / mcustompragmas
+
+proc withArg() {.importedPragma: true.} =
+  discard
+
+proc withoutArg() {.importedMarker.} =
+  discard
+
+withArg()
+withoutArg()


### PR DESCRIPTION
  ## Summary

  Fix Nimony custom pragma templates so exported `{.pragma.}` templates work across module imports, matching the behavior that existing Nim-backed plugin code relied on.

  This makes `import plugins` expose annotations such as `ensuresNif` from `nif_annotations`, instead of requiring users to textually include the annotation module.

  ## Root Cause

  Nimony recorded custom pragma templates only in the current module's `SemContext.customPragmaTemplates`. Imported module interfaces exposed symbols, converters, and
  exports, but did not carry the information that an exported template was declared with `{.pragma.}`.

  As a result, imported annotations like `{.ensuresNif: addedAny(dest).}` were rejected with `expected pragma`.

  ## Changes

  - Add a `custompragmas` section to `.idx.nif` files.
  - Record exported templates declared with `{.pragma.}` into that index section.
  - Load indexed custom pragma names through normal import filtering.
  - Prevent imported custom pragma templates from being treated as pragma macro invocations.
  - Update `nif_annotations` to remove the obsolete “include not import” comment and add `addedNested`.
  - Restore `plugins.errorTree` helpers expected by plugin code.
  - Add regression tests for imported custom pragmas and `import plugins` annotations.

  ## Validation

  - `git diff --cached --check`
  - `bin/nimony c -r tests/nimony/pragmas/timported_custompragma.nim`
  - `bin/nimony c -r tests/nimony/plugins/tplugin_annotations.nim`
  - `nim c -r src/hastur build all`