### PR TITLE
dirs: fix createDir for nested paths — create parents root-first

### DIFF
--- a/lib/std/dirs.nim
+++ b/lib/std/dirs.nim
@@ -50,7 +50,9 @@ proc tryCreateFinalDir*(dir: Path): ErrorCode =
 proc createDir*(dir: Path) {.raises.} =
   ## Creates a new directory `dir`. If the directory already exists, no error is raised.
   ## This can be used to create a nested directory structure directly.
-  for d in parentDirs(dir, fromRoot=false, inclusive=true):
+  # fromRoot=true: parents must be created root-first; the default leaf-first
+  # order makes the first mkdir fail with ENOENT for any nested path.
+  for d in parentDirs(dir, fromRoot=true, inclusive=true):
     let res = tryCreateFinalDir(d)
     if res == Success or res == NameExists:
       discard "fine"

--- a/tests/nimony/stdlib/tcreatedir_nested.nim
+++ b/tests/nimony/stdlib/tcreatedir_nested.nim
@@ -1,0 +1,36 @@
+import std/[dirs, paths, syncio, assertions]
+
+# Regression test: createDir must create a NESTED directory structure in one
+# call (its documented behaviour). It used to walk parentDirs leaf-first, so
+# the first mkdir hit ENOENT and raised before any parent was created.
+
+proc main {.raises.} =
+  let base = path("tcreatedir_nested_dir")
+  removeDir(base)        # clean up a stale run; ignore "does not exist"
+
+  let nested = base / path("a") / path("b")
+  createDir(nested)      # must create base, base/a and base/a/b
+
+  # prove the leaf exists by creating a file inside it
+  writeFile($(nested / path("probe.txt")), "ok")
+  var found = 0
+  for kind, p in walkDir(nested, relative = true):
+    if kind == pcFile: inc found
+  assert found == 1
+
+  # relative nested creation below an existing dir also works
+  createDir(base / path("x") / path("y"))
+
+  # leaf-up cleanup (removeDir removes a single, empty directory)
+  removeFile(nested / path("probe.txt"))
+  removeDir(nested)
+  removeDir(base / path("a"))
+  removeDir(base / path("x") / path("y"))
+  removeDir(base / path("x"))
+  removeDir(base)
+  echo "ok"
+
+try:
+  main()
+except:
+  quit "createDir nested test failed"


### PR DESCRIPTION
createDir's parentDirs walk used fromRoot=false (leaf-first), so for any nested path the first mkdir failed with ENOENT and raised before any parent had been attempted — contradicting its own doc ('can be used to create a nested directory structure directly'). Single-level creation masked the bug.

Iterate fromRoot=true so parents are created root-first; existing components report NameExists and are skipped as before.

Adds tests/nimony/stdlib/tcreatedir_nested.nim (nested create in one call, file probe in the leaf, idempotent re-run, leaf-up cleanup).

Found porting a production server: the session recorder creates ~/.config/<app>/sessions/<id>/ in one call.