### PR TITLE
Move relative line info from (ranges) to (of) node to fix error message locations

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -437,8 +437,8 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
       c.b.endTree()
   of nkOfBranch:
     c.b.addTree(OfL)
-    c.b.addTree(RangesL)
     relLineInfo(n, parent, c)
+    c.b.addTree(RangesL)
     for i in 0..<n.len-1:
       toNif(n[i], n, c)
     c.b.endTree()

--- a/tests/nimony/errmsgs/tcaseerrors.msgs
+++ b/tests/nimony/errmsgs/tcaseerrors.msgs
@@ -5,3 +5,4 @@ tests/nimony/errmsgs/tcaseerrors.nim(12, 19) Error: cannot evaluate symbol at co
 tests/nimony/errmsgs/tcaseerrors.nim(13, 4) Error: value already handled
 tests/nimony/errmsgs/tcaseerrors.nim(20, 32) Error: cannot evaluate symbol at compile time: c.0.tcagl87gf1
 tests/nimony/errmsgs/tcaseerrors.nim(21, 25) Error: value already handled
+tests/nimony/errmsgs/tcaseerrors.nim(26, 6) Error: undeclared identifier: 'foo'

--- a/tests/nimony/errmsgs/tcaseerrors.nim
+++ b/tests/nimony/errmsgs/tcaseerrors.nim
@@ -19,3 +19,9 @@ case c
 of cstring"abc", cstring"def": discard
 of cstring"ghi", cstring"jkl", c: discard
 of cstring"mno", cstring"abc": discard
+
+case b
+of 123: discard
+of 456:
+  foo()
+else: discard


### PR DESCRIPTION
In the output of nifler, the (of) node in a (case) didn't have relative line info, but the first child (ranges) had it instead. This caused the body of a branch to have line info relative to the (case) node instead of the (of) node (because it's a sibling of the (ranges) node, not a child). This moves the relative line info from (ranges) to (of) so the body of a an (of) node has correct line info.

Before:
```lisp
(case@,2 a@5
  (of
   (ranges@,1 "abc"@3 "def"@A)
   (stmts@H
    (discard .))))
```

After:
```lisp
(case@,2 a@5
  (of@,1
   (ranges "abc"@3 "def"@A)
   (stmts@H
    (discard .))))
```

```nim
# use of undeclared identifier 'foo'
case b
of 123: discard # before: error here (relative to case instead of "of")
of 456:
  foo() # after: error here
else: discard

```