### PR TITLE
Improved constraint enforcement in generic concepts

### DIFF
--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -20,6 +20,23 @@ import ".." / lib / symparser
 proc isConceptType*(a: Cursor): bool {.inline.} =
   a.kind == Symbol and isConceptSym(a.symId)
 
+proc conceptTargetNeedsStrictCheck*(a: Cursor): bool =
+  ## Standalone concepts keep lenient matching for generic typevars and for
+  ## all types except user `distinct` types. Distinct types must satisfy
+  ## requirements structurally so they cannot inherit base-type operators
+  ## silently; other types (including `string` objects and ranges) keep the
+  ## legacy acceptance until full requirement matching is complete.
+  if a.kind == DotToken:
+    return false
+  if a.kind == Symbol:
+    let res = tryLoadSym(a.symId)
+    if res.status == LacksNothing and res.decl.symKind == TypevarY:
+      return false
+  var t = a
+  if t.kind == Symbol:
+    t = typeImpl(t.symId)
+  t.typeKind == DistinctT
+
 proc conceptRoutineBasename*(routine: Cursor): StrId =
   var prc = routine
   assert prc.symKind in RoutineKinds

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -621,7 +621,8 @@ proc collectMissingConceptRequirements(m: var Match; conceptSym: SymId; body: Cu
       if parentMissing.len > 0:
         return parentMissing
   if not actualIsConcept and not hasParents:
-    return @[]
+    if not conceptTargetNeedsStrictCheck(a):
+      return @[]
   result = @[]
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
@@ -673,14 +674,9 @@ proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor):
     for parent in conceptParentSyms(parents):
       if not matchConceptSym(m, parent, a):
         return false
-  # Until concrete-type requirement matching is complete, standalone concepts
-  # match any concrete type (legacy stub behaviour). Concept-to-concept
-  # subsumption always checks requirements structurally.
   if not actualIsConcept and not hasParents:
-    # An unconstrained typevar reaches us as an empty (`.`) constraint: it
-    # provably fulfils no requirement, so it must not satisfy the concept
-    # (issue #755). Genuine concrete types stay leniently accepted.
-    return a.kind != DotToken
+    if not conceptTargetNeedsStrictCheck(a):
+      return a.kind != DotToken
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
       return false

--- a/tests/nimony/concepts/tconceptstandalonebad.msgs
+++ b/tests/nimony/concepts/tconceptstandalonebad.msgs
@@ -1,0 +1,1 @@
+tests/nimony/concepts/tconceptstandalonebad.nim(17, 12) Error: type Foo does not match constraint: Comparable; missing required proc: func >(a: Self, b: Self)

--- a/tests/nimony/concepts/tconceptstandalonebad.nim
+++ b/tests/nimony/concepts/tconceptstandalonebad.nim
@@ -1,0 +1,17 @@
+## Standalone concepts (no `of` parent) must check requirements on
+## user `distinct` types.
+
+type
+  Comparable = concept
+    func `==`(a, b: Self): bool
+    func `<`(a, b: Self): bool
+    func `>`(a, b: Self): bool
+
+  Foo = distinct int
+
+func `==`(a, b: Foo): bool = true
+
+type Box[T: Comparable] = object
+  v: T
+
+var x: Box[Foo]


### PR DESCRIPTION
Fixes https://github.com/nim-lang/nimony/issues/755

Strict standalone-concept checking is now limited to `distinct` types via `conceptTargetNeedsStrictCheck` in _sigconcepts.nim_:
- Generic typevars: still lenient (needed for _stdlib_ generics like `T: Arithmetic`)
- Builtin/prelude types (`string`, `int`, `ranges`, etc.): still lenient (_boot/stdlib_)
- `distinct` types (e.g. `Foo`): strict requirement checking