### PR TITLE
Fix duplicate C labels for anonymous block with try/except

### DIFF
--- a/src/hexer/lengcgen.nim
+++ b/src/hexer/lengcgen.nim
@@ -1916,7 +1916,10 @@ proc trTry(c: var EContext; dest: var TokenBuf; n: var Cursor) =
   var hasExcept = false
   var tryLab: SymId = NoSymId
   if nn.substructureKind == ExceptU:
-    tryLab = pool.syms.getOrIncl("`lab." & $getTmpId(c))
+    # Use a distinct prefix from iterinliner's anonymous block break labels
+    # (`lab.N` via elimForLoops) so try/except lowering does not reuse the
+    # same C label as the enclosing block's break target.
+    tryLab = pool.syms.getOrIncl("`exlab." & $getTmpId(c))
     c.exceptLabels.add tryLab
     hasExcept = true
   trStmt c, dest, n

--- a/tests/nimony/exceptions/tanonblock_try.nim
+++ b/tests/nimony/exceptions/tanonblock_try.nim
@@ -1,0 +1,14 @@
+## Regression for https://github.com/nim-lang/nimony/issues/1977
+## Anonymous `block:` containing `try/except` must not generate duplicate C labels.
+
+proc test() {.raises.} =
+  block:
+    try:
+      discard
+    except ErrorCode:
+      discard
+
+try:
+  test()
+except ErrorCode:
+  discard


### PR DESCRIPTION
Anonymous blocks get break labels (`lab.N`) from elimForLoops, but try/except lowering reused the same prefix and tmp-id counter, so an enclosing `block: try/except` emitted two C labels with the same name. Use a separate `exlab.` prefix for except-handler labels.

https://github.com/nim-lang/nimony/issues/1977