### PR TITLE
Added minimally invasive LRU cache for concept matching

### DIFF
--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -56,34 +56,6 @@ type
     candidatesCacheOrder*: seq[CandidatesCacheKey]
     metadata*: Table[SymId, ConceptMetadata]
 
-when defined(nimonyProfileConcepts):
-  var
-    conceptBodyChecks* = 0
-    conceptBodyCacheHits* = 0
-    conceptRoutineAvailableCalls* = 0
-    conceptRoutineImplCacheHits* = 0
-    conceptCandidateScans* = 0
-    conceptCandidateCacheHits* = 0
-    matchConceptRoutineSigCalls* = 0
-
-  proc printConceptProfile*() =
-    echo "concept profile:"
-    echo "  body_checks=", conceptBodyChecks, " body_cache_hits=", conceptBodyCacheHits
-    echo "  routine_available=", conceptRoutineAvailableCalls,
-         " routine_impl_hits=", conceptRoutineImplCacheHits
-    echo "  candidate_scans=", conceptCandidateScans,
-         " candidate_cache_hits=", conceptCandidateCacheHits
-    echo "  sig_match_calls=", matchConceptRoutineSigCalls
-else:
-  template conceptBodyChecks*() = discard
-  template conceptBodyCacheHits*() = discard
-  template conceptRoutineAvailableCalls*() = discard
-  template conceptRoutineImplCacheHits*() = discard
-  template conceptCandidateScans*() = discard
-  template conceptCandidateCacheHits*() = discard
-  template matchConceptRoutineSigCalls*() = discard
-  template printConceptProfile*() = discard
-
 proc `==`*(a, b: ConceptTypeKey): bool {.inline, noSideEffect.} =
   a.root == b.root and a.aux == b.aux
 
@@ -376,7 +348,6 @@ proc tryBodyCheckFromCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor): (b
   let key = bodyCacheKey(conceptSym, a)
   if not cache.bodyCache.hasKey(key):
     return (false, default(ConceptBodyResult))
-  conceptBodyCacheHits()
   lruTouchBody(cache.bodyCacheOrder, key)
   (true, cache.bodyCache.getOrDefault(key))
 
@@ -395,7 +366,6 @@ proc tryRoutineImplFromCache*(c: ptr SemContext; conceptSym, reqSym: SymId; a: C
   let key = routineImplCacheKey(conceptSym, reqSym, a)
   if not cache.routineImplCache.hasKey(key):
     return (false, default(ConceptRoutineImplResult))
-  conceptRoutineImplCacheHits()
   lruTouchRoutine(cache.routineImplCacheOrder, key)
   (true, cache.routineImplCache.getOrDefault(key))
 
@@ -421,7 +391,6 @@ proc tryMissingFromBodyCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
   let key = bodyCacheKey(conceptSym, a)
   if not cache.bodyCache.hasKey(key):
     return false
-  conceptBodyCacheHits()
   lruTouchBody(cache.bodyCacheOrder, key)
   let cached = cache.bodyCache.getOrDefault(key)
   if not cached.satisfied and cached.missing.len == 0:
@@ -449,6 +418,5 @@ proc tryCandidatesFromCache*(c: ptr SemContext; conceptSym: SymId; basename: Str
   let key = CandidatesCacheKey(conceptSym: conceptSym, basename: basename)
   if not cache.candidatesCache.hasKey(key):
     return (false, default(seq[SymId]))
-  conceptCandidateCacheHits()
   lruTouchCandidates(cache.candidatesCacheOrder, key)
   (true, cache.candidatesCache.getOrDefault(key))

--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -22,6 +22,19 @@ type
     root*: SymId
     aux*: Hash
 
+  BodyCacheKey* = object
+    conceptSym*: SymId
+    typeKey*: ConceptTypeKey
+
+  RoutineImplCacheKey* = object
+    conceptSym*: SymId
+    reqSym*: SymId
+    typeKey*: ConceptTypeKey
+
+  CandidatesCacheKey* = object
+    conceptSym*: SymId
+    basename*: StrId
+
   ConceptBodyResult* = object
     satisfied*: bool
     missing*: seq[SymId]
@@ -33,15 +46,17 @@ type
   ConceptMetadata* = object
     parents*: seq[SymId]
 
-  ConceptCacheImpl* = ref object of ConceptCache
+  ConceptCacheImpl* = ref object of RootObj
     capacity*: int
-    bodyCache*: Table[(SymId, ConceptTypeKey), ConceptBodyResult]
-    bodyCacheOrder*: seq[(SymId, ConceptTypeKey)]
-    routineImplCache*: Table[(SymId, SymId, ConceptTypeKey), ConceptRoutineImplResult]
-    routineImplCacheOrder*: seq[(SymId, SymId, ConceptTypeKey)]
-    candidatesCache*: Table[(SymId, StrId), seq[SymId]]
-    candidatesCacheOrder*: seq[(SymId, StrId)]
+    bodyCache*: Table[BodyCacheKey, ConceptBodyResult]
+    bodyCacheOrder*: seq[BodyCacheKey]
+    routineImplCache*: Table[RoutineImplCacheKey, ConceptRoutineImplResult]
+    routineImplCacheOrder*: seq[RoutineImplCacheKey]
+    candidatesCache*: Table[CandidatesCacheKey, seq[SymId]]
+    candidatesCacheOrder*: seq[CandidatesCacheKey]
     metadata*: Table[SymId, ConceptMetadata]
+
+var fallbackConceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
 
 when defined(nimonyProfileConcepts):
   var
@@ -71,29 +86,51 @@ else:
   template matchConceptRoutineSigCalls*() = discard
   template printConceptProfile*() = discard
 
-proc `==`*(a, b: ConceptTypeKey): bool {.inline.} =
+proc `==`*(a, b: ConceptTypeKey): bool {.inline, noSideEffect.} =
   a.root == b.root and a.aux == b.aux
 
-proc hash*(k: ConceptTypeKey): Hash =
+proc hash*(k: ConceptTypeKey): Hash {.noSideEffect.} =
   result = Hash(k.root.int) xor k.aux
 
+proc `==`*(a, b: BodyCacheKey): bool {.inline, noSideEffect.} =
+  a.conceptSym == b.conceptSym and a.typeKey == b.typeKey
+
+proc hash*(k: BodyCacheKey): Hash {.noSideEffect.} =
+  result = Hash(k.conceptSym.int) !& hash(k.typeKey)
+
+proc `==`*(a, b: RoutineImplCacheKey): bool {.inline, noSideEffect.} =
+  a.conceptSym == b.conceptSym and a.reqSym == b.reqSym and a.typeKey == b.typeKey
+
+proc hash*(k: RoutineImplCacheKey): Hash {.noSideEffect.} =
+  result = Hash(k.conceptSym.int) !& Hash(k.reqSym.int) !& hash(k.typeKey)
+
+proc `==`*(a, b: CandidatesCacheKey): bool {.inline, noSideEffect.} =
+  a.conceptSym == b.conceptSym and a.basename == b.basename
+
+proc hash*(k: CandidatesCacheKey): Hash {.noSideEffect.} =
+  result = Hash(k.conceptSym.int) !& Hash(k.basename.int)
+
 proc initConceptCache*(c: var SemContext) =
-  if c.conceptCache.isNil:
+  if c.conceptCache == nil:
     c.conceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
 
 proc initConceptCache*(c: ptr SemContext) =
-  if c != nil and c.conceptCache.isNil:
+  if c != nil and c.conceptCache == nil:
     c.conceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
 
+proc asConceptCacheImpl(cache: RootRef): ConceptCacheImpl {.inline.} =
+  cast[ConceptCacheImpl](cache)
+
 proc ensureConceptCache(c: ptr SemContext): ConceptCacheImpl =
-  if c != nil and c.conceptCache.isNil:
-    initConceptCache(c)
-  ConceptCacheImpl(c.conceptCache)
+  if c != nil and c.conceptCache != nil:
+    asConceptCacheImpl(c.conceptCache)
+  else:
+    fallbackConceptCache
 
 proc onConceptImportsChanged*(c: var SemContext) =
-  if c.conceptCache.isNil:
+  if c.conceptCache == nil:
     return
-  let cache = ConceptCacheImpl(c.conceptCache)
+  let cache = asConceptCacheImpl(c.conceptCache)
   cache.bodyCache.clear()
   cache.bodyCacheOrder.setLen(0)
   cache.routineImplCache.clear()
@@ -103,50 +140,49 @@ proc onConceptImportsChanged*(c: var SemContext) =
 
 proc invalidateConceptSymCache(cache: ConceptCacheImpl; conceptSym: SymId) =
   block body:
-    var remove: seq[(SymId, ConceptTypeKey)] = @[]
+    var remove: seq[BodyCacheKey] = @[]
     for k in cache.bodyCache.keys:
-      if k[0] == conceptSym:
+      if k.conceptSym == conceptSym:
         remove.add k
     for k in remove:
       cache.bodyCache.del k
     var i = 0
     while i < cache.bodyCacheOrder.len:
-      if cache.bodyCacheOrder[i][0] == conceptSym:
+      if cache.bodyCacheOrder[i].conceptSym == conceptSym:
         cache.bodyCacheOrder.delete(i)
       else:
         inc i
   block routine:
-    var remove: seq[(SymId, SymId, ConceptTypeKey)] = @[]
+    var remove: seq[RoutineImplCacheKey] = @[]
     for k in cache.routineImplCache.keys:
-      if k[0] == conceptSym:
+      if k.conceptSym == conceptSym:
         remove.add k
     for k in remove:
       cache.routineImplCache.del k
     var i = 0
     while i < cache.routineImplCacheOrder.len:
-      if cache.routineImplCacheOrder[i][0] == conceptSym:
+      if cache.routineImplCacheOrder[i].conceptSym == conceptSym:
         cache.routineImplCacheOrder.delete(i)
       else:
         inc i
   block candidates:
-    var remove: seq[(SymId, StrId)] = @[]
+    var remove: seq[CandidatesCacheKey] = @[]
     for k in cache.candidatesCache.keys:
-      if k[0] == conceptSym:
+      if k.conceptSym == conceptSym:
         remove.add k
     for k in remove:
       cache.candidatesCache.del k
     var i = 0
     while i < cache.candidatesCacheOrder.len:
-      if cache.candidatesCacheOrder[i][0] == conceptSym:
+      if cache.candidatesCacheOrder[i].conceptSym == conceptSym:
         cache.candidatesCacheOrder.delete(i)
       else:
         inc i
 
 proc onConceptDeclSem*(c: var SemContext; ownerSym: SymId; dest: var TokenBuf; conceptStart: int) =
-  if ownerSym == SymId(0):
+  if ownerSym == SymId(0) or c.conceptCache == nil:
     return
-  initConceptCache(c)
-  let cache = ConceptCacheImpl(c.conceptCache)
+  let cache = asConceptCacheImpl(c.conceptCache)
   invalidateConceptSymCache(cache, ownerSym)
   let body = cursorAt(dest, conceptStart)
   let parents = conceptParentsSlot(body)
@@ -195,6 +231,12 @@ proc conceptTypeKey*(a: Cursor): ConceptTypeKey =
   else:
     result = ConceptTypeKey(root: SymId(0), aux: hashTypeCursor(a))
 
+proc bodyCacheKey(conceptSym: SymId; a: Cursor): BodyCacheKey =
+  BodyCacheKey(conceptSym: conceptSym, typeKey: conceptTypeKey(a))
+
+proc routineImplCacheKey(conceptSym, reqSym: SymId; a: Cursor): RoutineImplCacheKey =
+  RoutineImplCacheKey(conceptSym: conceptSym, reqSym: reqSym, typeKey: conceptTypeKey(a))
+
 proc isOpenTypevar*(a: Cursor): bool =
   if a.kind == Symbol:
     let res = tryLoadSym(a.symId)
@@ -242,11 +284,10 @@ proc collectConceptMetadata(body: Cursor): ConceptMetadata =
       result.parents.add p
 
 proc getConceptMetadata*(c: ptr SemContext; conceptSym: SymId; body: Cursor): ConceptMetadata =
-  if c != nil and conceptSym != SymId(0):
-    initConceptCache(c)
-    let cache = ConceptCacheImpl(c.conceptCache)
+  if c != nil and conceptSym != SymId(0) and c.conceptCache != nil:
+    let cache = asConceptCacheImpl(c.conceptCache)
     if cache.metadata.hasKey(conceptSym):
-      return cache.metadata[conceptSym]
+      return cache.metadata.getOrDefault(conceptSym)
   collectConceptMetadata(body)
 
 proc loadConceptRequirement*(reqSym: SymId): Cursor =
@@ -256,7 +297,7 @@ proc loadConceptRequirement*(reqSym: SymId): Cursor =
   else:
     default(Cursor)
 
-proc lruTouch[K](order: var seq[K]; key: K) =
+proc lruTouchBody(order: var seq[BodyCacheKey]; key: BodyCacheKey) =
   for i, k in order:
     if k == key:
       if i < order.high:
@@ -265,14 +306,61 @@ proc lruTouch[K](order: var seq[K]; key: K) =
       return
   order.add key
 
-proc lruPut[K, V](table: var Table[K, V]; order: var seq[K];
-                  capacity: int; key: K; val: sink V) =
-  let isNew = key notin table
+proc lruPutBody(table: var Table[BodyCacheKey, ConceptBodyResult];
+                order: var seq[BodyCacheKey]; capacity: int;
+                key: BodyCacheKey; val: sink ConceptBodyResult) =
+  let isNew = not table.hasKey(key)
   table[key] = val
   if isNew:
     order.add key
   else:
-    lruTouch(order, key)
+    lruTouchBody(order, key)
+  while order.len > capacity:
+    let oldKey = order[0]
+    order.delete(0)
+    table.del oldKey
+
+proc lruTouchRoutine(order: var seq[RoutineImplCacheKey]; key: RoutineImplCacheKey) =
+  for i, k in order:
+    if k == key:
+      if i < order.high:
+        order.delete(i)
+        order.add key
+      return
+  order.add key
+
+proc lruPutRoutine(table: var Table[RoutineImplCacheKey, ConceptRoutineImplResult];
+                   order: var seq[RoutineImplCacheKey]; capacity: int;
+                   key: RoutineImplCacheKey; val: sink ConceptRoutineImplResult) =
+  let isNew = not table.hasKey(key)
+  table[key] = val
+  if isNew:
+    order.add key
+  else:
+    lruTouchRoutine(order, key)
+  while order.len > capacity:
+    let oldKey = order[0]
+    order.delete(0)
+    table.del oldKey
+
+proc lruTouchCandidates(order: var seq[CandidatesCacheKey]; key: CandidatesCacheKey) =
+  for i, k in order:
+    if k == key:
+      if i < order.high:
+        order.delete(i)
+        order.add key
+      return
+  order.add key
+
+proc lruPutCandidates(table: var Table[CandidatesCacheKey, seq[SymId]];
+                      order: var seq[CandidatesCacheKey]; capacity: int;
+                      key: CandidatesCacheKey; val: sink seq[SymId]) =
+  let isNew = not table.hasKey(key)
+  table[key] = val
+  if isNew:
+    order.add key
+  else:
+    lruTouchCandidates(order, key)
   while order.len > capacity:
     let oldKey = order[0]
     order.delete(0)
@@ -284,38 +372,35 @@ proc isConceptTypeArg(a: Cursor): bool {.inline.} =
 proc cacheCapacity(cache: ConceptCacheImpl): int =
   if cache.capacity > 0: cache.capacity else: DefaultConceptCacheCapacity
 
-template rememberBodyCheck*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
-                             compute: untyped): untyped =
-  if c != nil and conceptSym != SymId(0) and isCacheableConcreteType(a) and not isConceptTypeArg(a):
-    let cache = ensureConceptCache(c)
-    let key = (conceptSym, conceptTypeKey(a))
-    if key in cache.bodyCache:
-      conceptBodyCacheHits()
-      lruTouch(cache.bodyCacheOrder, key)
-      cache.bodyCache[key]
-    else:
-      conceptBodyChecks()
-      let res = compute
-      lruPut(cache.bodyCache, cache.bodyCacheOrder, cacheCapacity(cache), key, res)
-      res
-  else:
-    compute
+proc tryBodyCheckFromCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor): (bool, ConceptBodyResult) =
+  if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
+    return (false, default(ConceptBodyResult))
+  let cache = ensureConceptCache(c)
+  let key = bodyCacheKey(conceptSym, a)
+  if not cache.bodyCache.hasKey(key):
+    return (false, default(ConceptBodyResult))
+  conceptBodyCacheHits()
+  lruTouchBody(cache.bodyCacheOrder, key)
+  (true, cache.bodyCache.getOrDefault(key))
 
-template rememberRoutineImpl*(c: ptr SemContext; conceptSym, reqSym: SymId; a: Cursor;
-                              compute: untyped): untyped =
-  if c != nil and conceptSym != SymId(0) and reqSym != SymId(0) and isCacheableConcreteType(a):
-    let cache = ensureConceptCache(c)
-    let key = (conceptSym, reqSym, conceptTypeKey(a))
-    if key in cache.routineImplCache:
-      conceptRoutineImplCacheHits()
-      lruTouch(cache.routineImplCacheOrder, key)
-      cache.routineImplCache[key].found
-    else:
-      let res = compute
-      lruPut(cache.routineImplCache, cache.routineImplCacheOrder, cacheCapacity(cache), key, res)
-      res.found
-  else:
-    (compute).found
+proc storeRoutineImpl*(c: ptr SemContext; conceptSym, reqSym: SymId; a: Cursor;
+                        res: sink ConceptRoutineImplResult) =
+  if c == nil or conceptSym == SymId(0) or reqSym == SymId(0) or not isCacheableConcreteType(a):
+    return
+  let cache = ensureConceptCache(c)
+  let key = routineImplCacheKey(conceptSym, reqSym, a)
+  lruPutRoutine(cache.routineImplCache, cache.routineImplCacheOrder, cacheCapacity(cache), key, res)
+
+proc tryRoutineImplFromCache*(c: ptr SemContext; conceptSym, reqSym: SymId; a: Cursor): (bool, ConceptRoutineImplResult) =
+  if c == nil or conceptSym == SymId(0) or reqSym == SymId(0) or not isCacheableConcreteType(a):
+    return (false, default(ConceptRoutineImplResult))
+  let cache = ensureConceptCache(c)
+  let key = routineImplCacheKey(conceptSym, reqSym, a)
+  if not cache.routineImplCache.hasKey(key):
+    return (false, default(ConceptRoutineImplResult))
+  conceptRoutineImplCacheHits()
+  lruTouchRoutine(cache.routineImplCacheOrder, key)
+  (true, cache.routineImplCache.getOrDefault(key))
 
 proc bodyResultFromMissing*(missing: openArray[Cursor]): ConceptBodyResult =
   result = ConceptBodyResult(satisfied: missing.len == 0)
@@ -328,20 +413,20 @@ proc storeBodyCheck*(c: ptr SemContext; conceptSym: SymId; a: Cursor; res: sink 
   if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
     return
   let cache = ensureConceptCache(c)
-  let key = (conceptSym, conceptTypeKey(a))
-  lruPut(cache.bodyCache, cache.bodyCacheOrder, cacheCapacity(cache), key, res)
+  let key = bodyCacheKey(conceptSym, a)
+  lruPutBody(cache.bodyCache, cache.bodyCacheOrder, cacheCapacity(cache), key, res)
 
 proc tryMissingFromBodyCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
                               missing: var seq[Cursor]): bool =
   if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
     return false
   let cache = ensureConceptCache(c)
-  let key = (conceptSym, conceptTypeKey(a))
-  if key notin cache.bodyCache:
+  let key = bodyCacheKey(conceptSym, a)
+  if not cache.bodyCache.hasKey(key):
     return false
   conceptBodyCacheHits()
-  lruTouch(cache.bodyCacheOrder, key)
-  let cached = cache.bodyCache[key]
+  lruTouchBody(cache.bodyCacheOrder, key)
+  let cached = cache.bodyCache.getOrDefault(key)
   if not cached.satisfied and cached.missing.len == 0:
     return false
   if cached.satisfied:
@@ -352,19 +437,21 @@ proc tryMissingFromBodyCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
       missing.add loadConceptRequirement(reqSym)
   true
 
-template rememberCandidates*(c: ptr SemContext; conceptSym: SymId; basename: StrId;
-                             compute: untyped): untyped =
-  if c != nil:
-    let cache = ensureConceptCache(c)
-    let key = (conceptSym, basename)
-    if key in cache.candidatesCache:
-      conceptCandidateCacheHits()
-      lruTouch(cache.candidatesCacheOrder, key)
-      cache.candidatesCache[key]
-    else:
-      conceptCandidateScans()
-      let res = compute
-      lruPut(cache.candidatesCache, cache.candidatesCacheOrder, cacheCapacity(cache), key, res)
-      res
-  else:
-    compute
+proc storeCandidates*(c: ptr SemContext; conceptSym: SymId; basename: StrId;
+                      res: sink seq[SymId]) =
+  if c == nil:
+    return
+  let cache = ensureConceptCache(c)
+  let key = CandidatesCacheKey(conceptSym: conceptSym, basename: basename)
+  lruPutCandidates(cache.candidatesCache, cache.candidatesCacheOrder, cacheCapacity(cache), key, res)
+
+proc tryCandidatesFromCache*(c: ptr SemContext; conceptSym: SymId; basename: StrId): (bool, seq[SymId]) =
+  if c == nil:
+    return (false, default(seq[SymId]))
+  let cache = ensureConceptCache(c)
+  let key = CandidatesCacheKey(conceptSym: conceptSym, basename: basename)
+  if not cache.candidatesCache.hasKey(key):
+    return (false, default(seq[SymId]))
+  conceptCandidateCacheHits()
+  lruTouchCandidates(cache.candidatesCacheOrder, key)
+  (true, cache.candidatesCache.getOrDefault(key))

--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -46,7 +46,7 @@ type
   ConceptMetadata* = object
     parents*: seq[SymId]
 
-  ConceptCacheImpl* = ref object of RootObj
+  ConceptCacheImpl* = ref object of ConceptCache
     capacity*: int
     bodyCache*: Table[BodyCacheKey, ConceptBodyResult]
     bodyCacheOrder*: seq[BodyCacheKey]
@@ -55,8 +55,6 @@ type
     candidatesCache*: Table[CandidatesCacheKey, seq[SymId]]
     candidatesCacheOrder*: seq[CandidatesCacheKey]
     metadata*: Table[SymId, ConceptMetadata]
-
-var fallbackConceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
 
 when defined(nimonyProfileConcepts):
   var
@@ -118,19 +116,15 @@ proc initConceptCache*(c: ptr SemContext) =
   if c != nil and c.conceptCache == nil:
     c.conceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
 
-proc asConceptCacheImpl(cache: RootRef): ConceptCacheImpl {.inline.} =
-  cast[ConceptCacheImpl](cache)
-
 proc ensureConceptCache(c: ptr SemContext): ConceptCacheImpl =
-  if c != nil and c.conceptCache != nil:
-    asConceptCacheImpl(c.conceptCache)
-  else:
-    fallbackConceptCache
+  if c != nil and c.conceptCache == nil:
+    initConceptCache(c)
+  ConceptCacheImpl(c.conceptCache)
 
 proc onConceptImportsChanged*(c: var SemContext) =
   if c.conceptCache == nil:
     return
-  let cache = asConceptCacheImpl(c.conceptCache)
+  let cache = ConceptCacheImpl(c.conceptCache)
   cache.bodyCache.clear()
   cache.bodyCacheOrder.setLen(0)
   cache.routineImplCache.clear()
@@ -182,7 +176,7 @@ proc invalidateConceptSymCache(cache: ConceptCacheImpl; conceptSym: SymId) =
 proc onConceptDeclSem*(c: var SemContext; ownerSym: SymId; dest: var TokenBuf; conceptStart: int) =
   if ownerSym == SymId(0) or c.conceptCache == nil:
     return
-  let cache = asConceptCacheImpl(c.conceptCache)
+  let cache = ConceptCacheImpl(c.conceptCache)
   invalidateConceptSymCache(cache, ownerSym)
   let body = cursorAt(dest, conceptStart)
   let parents = conceptParentsSlot(body)
@@ -285,7 +279,7 @@ proc collectConceptMetadata(body: Cursor): ConceptMetadata =
 
 proc getConceptMetadata*(c: ptr SemContext; conceptSym: SymId; body: Cursor): ConceptMetadata =
   if c != nil and conceptSym != SymId(0) and c.conceptCache != nil:
-    let cache = asConceptCacheImpl(c.conceptCache)
+    let cache = ConceptCacheImpl(c.conceptCache)
     if cache.metadata.hasKey(conceptSym):
       return cache.metadata.getOrDefault(conceptSym)
   collectConceptMetadata(body)

--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -163,34 +163,23 @@ proc onConceptDeclSem*(c: var SemContext; ownerSym: SymId; dest: var TokenBuf; c
 
 proc hashTypeCursor(n: Cursor): Hash =
   var h: Hash = 0
-  var nested = 0
-  var c = n
-  while nested >= 0:
-    case c.kind
-    of Symbol:
-      h = h !& Hash(c.symId.int)
-      inc c
-    of ParLe:
-      h = h !& Hash(c.tagId.int)
-      inc nested
-      inc c
-    of ParRi:
-      inc c
-      dec nested
-    of Ident, StringLit:
-      h = h !& Hash(c.litId.int)
-      inc c
-    of IntLit, InlineInt:
-      h = h !& Hash(c.intId.int)
-      inc c
-    of FloatLit:
-      h = h !& Hash(c.floatId.int)
-      inc c
-    else:
-      h = h !& Hash(ord(c.kind))
-      inc c
-    if nested == 0:
-      break
+  case n.kind
+  of Symbol:
+    h = h !& Hash(n.symId.int)
+  of ParLe:
+    h = h !& Hash(n.tagId.int)
+    var child = sub(n)
+    while hasMore(child):
+      h = h !& hashTypeCursor(child)
+      skip child
+  of Ident, StringLit:
+    h = h !& Hash(n.litId.int)
+  of IntLit, InlineInt:
+    h = h !& Hash(n.intId.int)
+  of FloatLit:
+    h = h !& Hash(n.floatId.int)
+  else:
+    h = h !& Hash(ord(n.kind))
   result = h
 
 proc conceptTypeKey*(a: Cursor): ConceptTypeKey =
@@ -214,25 +203,18 @@ proc isOpenTypevar*(a: Cursor): bool =
   false
 
 proc hasOpenTypevarDeep(a: Cursor): bool =
-  var nested = 0
-  var c = a
-  while nested >= 0:
-    if c.kind == Symbol:
-      let res = tryLoadSym(c.symId)
-      if res.status == LacksNothing and res.decl.symKind == TypevarY:
+  case a.kind
+  of Symbol:
+    isOpenTypevar(a)
+  of ParLe:
+    var child = sub(a)
+    while hasMore(child):
+      if hasOpenTypevarDeep(child):
         return true
-      inc c
-    elif c.kind == ParLe:
-      inc nested
-      inc c
-    elif c.kind == ParRi:
-      dec nested
-      inc c
-    else:
-      inc c
-    if nested == 0:
-      break
-  false
+      skip child
+    false
+  else:
+    false
 
 proc isCacheableConcreteType*(a: Cursor): bool =
   not hasOpenTypevarDeep(a)

--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -1,0 +1,370 @@
+#       Nimony
+# (c) Copyright 2026 Andreas Rumpf
+#
+# See the file "license.txt", included in this
+# distribution, for details about the copyright.
+
+## Self-contained concept-match cache. The rest of the compiler only needs
+## the lifecycle hooks (`initConceptCache`, `onConceptDeclSem`,
+## `onConceptImportsChanged`) and the `remember*` templates used from
+## `sigmatch.nim`.
+
+import std / [tables, hashes]
+include ".." / lib / nifprelude
+include ".." / lib / compat2
+import ".." / lib / symparser
+import nimony_model, decls, programs, semdata, typeprops, symtabs
+
+const DefaultConceptCacheCapacity* = 1024
+
+type
+  ConceptTypeKey* = object
+    root*: SymId
+    aux*: Hash
+
+  ConceptBodyResult* = object
+    satisfied*: bool
+    missing*: seq[SymId]
+
+  ConceptRoutineImplResult* = object
+    found*: bool
+    impl*: SymId
+
+  ConceptMetadata* = object
+    parents*: seq[SymId]
+
+  ConceptCacheImpl* = ref object of ConceptCache
+    capacity*: int
+    bodyCache*: Table[(SymId, ConceptTypeKey), ConceptBodyResult]
+    bodyCacheOrder*: seq[(SymId, ConceptTypeKey)]
+    routineImplCache*: Table[(SymId, SymId, ConceptTypeKey), ConceptRoutineImplResult]
+    routineImplCacheOrder*: seq[(SymId, SymId, ConceptTypeKey)]
+    candidatesCache*: Table[(SymId, StrId), seq[SymId]]
+    candidatesCacheOrder*: seq[(SymId, StrId)]
+    metadata*: Table[SymId, ConceptMetadata]
+
+when defined(nimonyProfileConcepts):
+  var
+    conceptBodyChecks* = 0
+    conceptBodyCacheHits* = 0
+    conceptRoutineAvailableCalls* = 0
+    conceptRoutineImplCacheHits* = 0
+    conceptCandidateScans* = 0
+    conceptCandidateCacheHits* = 0
+    matchConceptRoutineSigCalls* = 0
+
+  proc printConceptProfile*() =
+    echo "concept profile:"
+    echo "  body_checks=", conceptBodyChecks, " body_cache_hits=", conceptBodyCacheHits
+    echo "  routine_available=", conceptRoutineAvailableCalls,
+         " routine_impl_hits=", conceptRoutineImplCacheHits
+    echo "  candidate_scans=", conceptCandidateScans,
+         " candidate_cache_hits=", conceptCandidateCacheHits
+    echo "  sig_match_calls=", matchConceptRoutineSigCalls
+else:
+  template conceptBodyChecks*() = discard
+  template conceptBodyCacheHits*() = discard
+  template conceptRoutineAvailableCalls*() = discard
+  template conceptRoutineImplCacheHits*() = discard
+  template conceptCandidateScans*() = discard
+  template conceptCandidateCacheHits*() = discard
+  template matchConceptRoutineSigCalls*() = discard
+  template printConceptProfile*() = discard
+
+proc `==`*(a, b: ConceptTypeKey): bool {.inline.} =
+  a.root == b.root and a.aux == b.aux
+
+proc hash*(k: ConceptTypeKey): Hash =
+  result = Hash(k.root.int) xor k.aux
+
+proc initConceptCache*(c: var SemContext) =
+  if c.conceptCache.isNil:
+    c.conceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
+
+proc initConceptCache*(c: ptr SemContext) =
+  if c != nil and c.conceptCache.isNil:
+    c.conceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
+
+proc ensureConceptCache(c: ptr SemContext): ConceptCacheImpl =
+  if c != nil and c.conceptCache.isNil:
+    initConceptCache(c)
+  ConceptCacheImpl(c.conceptCache)
+
+proc onConceptImportsChanged*(c: var SemContext) =
+  if c.conceptCache.isNil:
+    return
+  let cache = ConceptCacheImpl(c.conceptCache)
+  cache.bodyCache.clear()
+  cache.bodyCacheOrder.setLen(0)
+  cache.routineImplCache.clear()
+  cache.routineImplCacheOrder.setLen(0)
+  cache.candidatesCache.clear()
+  cache.candidatesCacheOrder.setLen(0)
+
+proc invalidateConceptSymCache(cache: ConceptCacheImpl; conceptSym: SymId) =
+  block body:
+    var remove: seq[(SymId, ConceptTypeKey)] = @[]
+    for k in cache.bodyCache.keys:
+      if k[0] == conceptSym:
+        remove.add k
+    for k in remove:
+      cache.bodyCache.del k
+    var i = 0
+    while i < cache.bodyCacheOrder.len:
+      if cache.bodyCacheOrder[i][0] == conceptSym:
+        cache.bodyCacheOrder.delete(i)
+      else:
+        inc i
+  block routine:
+    var remove: seq[(SymId, SymId, ConceptTypeKey)] = @[]
+    for k in cache.routineImplCache.keys:
+      if k[0] == conceptSym:
+        remove.add k
+    for k in remove:
+      cache.routineImplCache.del k
+    var i = 0
+    while i < cache.routineImplCacheOrder.len:
+      if cache.routineImplCacheOrder[i][0] == conceptSym:
+        cache.routineImplCacheOrder.delete(i)
+      else:
+        inc i
+  block candidates:
+    var remove: seq[(SymId, StrId)] = @[]
+    for k in cache.candidatesCache.keys:
+      if k[0] == conceptSym:
+        remove.add k
+    for k in remove:
+      cache.candidatesCache.del k
+    var i = 0
+    while i < cache.candidatesCacheOrder.len:
+      if cache.candidatesCacheOrder[i][0] == conceptSym:
+        cache.candidatesCacheOrder.delete(i)
+      else:
+        inc i
+
+proc onConceptDeclSem*(c: var SemContext; ownerSym: SymId; dest: var TokenBuf; conceptStart: int) =
+  if ownerSym == SymId(0):
+    return
+  initConceptCache(c)
+  let cache = ConceptCacheImpl(c.conceptCache)
+  invalidateConceptSymCache(cache, ownerSym)
+  let body = cursorAt(dest, conceptStart)
+  let parents = conceptParentsSlot(body)
+  if conceptParentsWellFormed(parents):
+    var meta = ConceptMetadata()
+    for p in conceptParentSyms(parents):
+      meta.parents.add p
+    cache.metadata[ownerSym] = meta
+
+proc hashTypeCursor(n: Cursor): Hash =
+  var h: Hash = 0
+  var nested = 0
+  var c = n
+  while nested >= 0:
+    case c.kind
+    of Symbol:
+      h = h !& Hash(c.symId.int)
+      inc c
+    of ParLe:
+      h = h !& Hash(c.tagId.int)
+      inc nested
+      inc c
+    of ParRi:
+      inc c
+      dec nested
+    of Ident, StringLit:
+      h = h !& Hash(c.litId.int)
+      inc c
+    of IntLit, InlineInt:
+      h = h !& Hash(c.intId.int)
+      inc c
+    of FloatLit:
+      h = h !& Hash(c.floatId.int)
+      inc c
+    else:
+      h = h !& Hash(ord(c.kind))
+      inc c
+    if nested == 0:
+      break
+  result = h
+
+proc conceptTypeKey*(a: Cursor): ConceptTypeKey =
+  let root = nominalRoot(a, allowTypevar = true)
+  if root != SymId(0):
+    result = ConceptTypeKey(root: root)
+  else:
+    result = ConceptTypeKey(root: SymId(0), aux: hashTypeCursor(a))
+
+proc isOpenTypevar*(a: Cursor): bool =
+  if a.kind == Symbol:
+    let res = tryLoadSym(a.symId)
+    if res.status == LacksNothing and res.decl.symKind == TypevarY:
+      return true
+  false
+
+proc hasOpenTypevarDeep(a: Cursor): bool =
+  var nested = 0
+  var c = a
+  while nested >= 0:
+    if c.kind == Symbol:
+      let res = tryLoadSym(c.symId)
+      if res.status == LacksNothing and res.decl.symKind == TypevarY:
+        return true
+      inc c
+    elif c.kind == ParLe:
+      inc nested
+      inc c
+    elif c.kind == ParRi:
+      dec nested
+      inc c
+    else:
+      inc c
+    if nested == 0:
+      break
+  false
+
+proc isCacheableConcreteType*(a: Cursor): bool =
+  not hasOpenTypevarDeep(a)
+
+proc conceptRequirementSym*(routine: Cursor): SymId =
+  var prc = routine
+  if prc.symKind in RoutineKinds:
+    inc prc
+    if prc.kind == SymbolDef:
+      return prc.symId
+  SymId(0)
+
+proc collectConceptMetadata(body: Cursor): ConceptMetadata =
+  result = ConceptMetadata()
+  let parents = conceptParentsSlot(body)
+  if conceptParentsWellFormed(parents):
+    for p in conceptParentSyms(parents):
+      result.parents.add p
+
+proc getConceptMetadata*(c: ptr SemContext; conceptSym: SymId; body: Cursor): ConceptMetadata =
+  if c != nil and conceptSym != SymId(0):
+    initConceptCache(c)
+    let cache = ConceptCacheImpl(c.conceptCache)
+    if cache.metadata.hasKey(conceptSym):
+      return cache.metadata[conceptSym]
+  collectConceptMetadata(body)
+
+proc loadConceptRequirement*(reqSym: SymId): Cursor =
+  let res = tryLoadSym(reqSym)
+  if res.status == LacksNothing:
+    res.decl
+  else:
+    default(Cursor)
+
+proc lruTouch[K](order: var seq[K]; key: K) =
+  for i, k in order:
+    if k == key:
+      if i < order.high:
+        order.delete(i)
+        order.add key
+      return
+  order.add key
+
+proc lruPut[K, V](table: var Table[K, V]; order: var seq[K];
+                  capacity: int; key: K; val: sink V) =
+  let isNew = key notin table
+  table[key] = val
+  if isNew:
+    order.add key
+  else:
+    lruTouch(order, key)
+  while order.len > capacity:
+    let oldKey = order[0]
+    order.delete(0)
+    table.del oldKey
+
+proc isConceptTypeArg(a: Cursor): bool {.inline.} =
+  a.kind == Symbol and isConceptSym(a.symId)
+
+proc cacheCapacity(cache: ConceptCacheImpl): int =
+  if cache.capacity > 0: cache.capacity else: DefaultConceptCacheCapacity
+
+template rememberBodyCheck*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
+                             compute: untyped): untyped =
+  if c != nil and conceptSym != SymId(0) and isCacheableConcreteType(a) and not isConceptTypeArg(a):
+    let cache = ensureConceptCache(c)
+    let key = (conceptSym, conceptTypeKey(a))
+    if key in cache.bodyCache:
+      conceptBodyCacheHits()
+      lruTouch(cache.bodyCacheOrder, key)
+      cache.bodyCache[key]
+    else:
+      conceptBodyChecks()
+      let res = compute
+      lruPut(cache.bodyCache, cache.bodyCacheOrder, cacheCapacity(cache), key, res)
+      res
+  else:
+    compute
+
+template rememberRoutineImpl*(c: ptr SemContext; conceptSym, reqSym: SymId; a: Cursor;
+                              compute: untyped): untyped =
+  if c != nil and conceptSym != SymId(0) and reqSym != SymId(0) and isCacheableConcreteType(a):
+    let cache = ensureConceptCache(c)
+    let key = (conceptSym, reqSym, conceptTypeKey(a))
+    if key in cache.routineImplCache:
+      conceptRoutineImplCacheHits()
+      lruTouch(cache.routineImplCacheOrder, key)
+      cache.routineImplCache[key].found
+    else:
+      let res = compute
+      lruPut(cache.routineImplCache, cache.routineImplCacheOrder, cacheCapacity(cache), key, res)
+      res.found
+  else:
+    (compute).found
+
+proc bodyResultFromMissing*(missing: openArray[Cursor]): ConceptBodyResult =
+  result = ConceptBodyResult(satisfied: missing.len == 0)
+  for routine in missing:
+    let rs = conceptRequirementSym(routine)
+    if rs != SymId(0):
+      result.missing.add rs
+
+proc storeBodyCheck*(c: ptr SemContext; conceptSym: SymId; a: Cursor; res: sink ConceptBodyResult) =
+  if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
+    return
+  let cache = ensureConceptCache(c)
+  let key = (conceptSym, conceptTypeKey(a))
+  lruPut(cache.bodyCache, cache.bodyCacheOrder, cacheCapacity(cache), key, res)
+
+proc tryMissingFromBodyCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
+                              missing: var seq[Cursor]): bool =
+  if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
+    return false
+  let cache = ensureConceptCache(c)
+  let key = (conceptSym, conceptTypeKey(a))
+  if key notin cache.bodyCache:
+    return false
+  conceptBodyCacheHits()
+  lruTouch(cache.bodyCacheOrder, key)
+  let cached = cache.bodyCache[key]
+  if not cached.satisfied and cached.missing.len == 0:
+    return false
+  if cached.satisfied:
+    missing = @[]
+  else:
+    missing = @[]
+    for reqSym in cached.missing:
+      missing.add loadConceptRequirement(reqSym)
+  true
+
+template rememberCandidates*(c: ptr SemContext; conceptSym: SymId; basename: StrId;
+                             compute: untyped): untyped =
+  if c != nil:
+    let cache = ensureConceptCache(c)
+    let key = (conceptSym, basename)
+    if key in cache.candidatesCache:
+      conceptCandidateCacheHits()
+      lruTouch(cache.candidatesCacheOrder, key)
+      cache.candidatesCache[key]
+    else:
+      conceptCandidateScans()
+      let res = compute
+      lruPut(cache.candidatesCache, cache.candidatesCacheOrder, cacheCapacity(cache), key, res)
+      res
+  else:
+    compute

--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -46,7 +46,7 @@ type
   ConceptMetadata* = object
     parents*: seq[SymId]
 
-  ConceptCacheImpl* = ref object of ConceptCache
+  ConceptCacheImpl* = ref object of RootObj
     capacity*: int
     bodyCache*: Table[BodyCacheKey, ConceptBodyResult]
     bodyCacheOrder*: seq[BodyCacheKey]
@@ -116,15 +116,18 @@ proc initConceptCache*(c: ptr SemContext) =
   if c != nil and c.conceptCache == nil:
     c.conceptCache = ConceptCacheImpl(capacity: DefaultConceptCacheCapacity)
 
+proc asConceptCacheImpl(cache: RootRef): ConceptCacheImpl {.inline.} =
+  cast[ConceptCacheImpl](cache)
+
 proc ensureConceptCache(c: ptr SemContext): ConceptCacheImpl =
   if c != nil and c.conceptCache == nil:
     initConceptCache(c)
-  ConceptCacheImpl(c.conceptCache)
+  asConceptCacheImpl(c.conceptCache)
 
 proc onConceptImportsChanged*(c: var SemContext) =
   if c.conceptCache == nil:
     return
-  let cache = ConceptCacheImpl(c.conceptCache)
+  let cache = asConceptCacheImpl(c.conceptCache)
   cache.bodyCache.clear()
   cache.bodyCacheOrder.setLen(0)
   cache.routineImplCache.clear()
@@ -176,7 +179,7 @@ proc invalidateConceptSymCache(cache: ConceptCacheImpl; conceptSym: SymId) =
 proc onConceptDeclSem*(c: var SemContext; ownerSym: SymId; dest: var TokenBuf; conceptStart: int) =
   if ownerSym == SymId(0) or c.conceptCache == nil:
     return
-  let cache = ConceptCacheImpl(c.conceptCache)
+  let cache = asConceptCacheImpl(c.conceptCache)
   invalidateConceptSymCache(cache, ownerSym)
   let body = cursorAt(dest, conceptStart)
   let parents = conceptParentsSlot(body)
@@ -279,7 +282,7 @@ proc collectConceptMetadata(body: Cursor): ConceptMetadata =
 
 proc getConceptMetadata*(c: ptr SemContext; conceptSym: SymId; body: Cursor): ConceptMetadata =
   if c != nil and conceptSym != SymId(0) and c.conceptCache != nil:
-    let cache = ConceptCacheImpl(c.conceptCache)
+    let cache = asConceptCacheImpl(c.conceptCache)
     if cache.metadata.hasKey(conceptSym):
       return cache.metadata.getOrDefault(conceptSym)
   collectConceptMetadata(body)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -17,8 +17,8 @@ include ".." / lib / nifprelude
 include ".." / lib / compat2
 import ".." / lib / [symparser, nifindexes, docpaths]
 import nimony_model, symtabs, builtintypes, decls, asthelpers,
-  programs, sigmatch, magics, reporters, nifconfig,
-  intervals, xints, typeprops,
+  programs, sigconcepts, sigmatch, magics, reporters, nifconfig,
+  intervals, xints, typeprops, conceptcache,
   semdata, sembasics, semchecks, semconst, semmagics, semimport, templates, sempragmas, semos, expreval, semborrow, enumtostr, derefs, sizeof, renderer,
   semuntyped, vtables_frontend, module_plugins, deferstmts, pragmacanon, exprexec, langmodes,
   features, identstyle, macro_plugin

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -23,6 +23,8 @@ import nimony_model, symtabs, builtintypes, decls, asthelpers,
   semuntyped, vtables_frontend, module_plugins, deferstmts, pragmacanon, exprexec, langmodes,
   features, identstyle, macro_plugin
 
+import conceptcache
+  
 import ".." / gear2 / modnames
 import ".." / models / [tags, nifindex_tags]
 when not defined(nimony):

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -17,14 +17,12 @@ include ".." / lib / nifprelude
 include ".." / lib / compat2
 import ".." / lib / [symparser, nifindexes, docpaths]
 import nimony_model, symtabs, builtintypes, decls, asthelpers,
-  programs, sigconcepts, sigmatch, magics, reporters, nifconfig,
+  programs, sigmatch, magics, reporters, nifconfig,
   intervals, xints, typeprops,
   semdata, sembasics, semchecks, semconst, semmagics, semimport, templates, sempragmas, semos, expreval, semborrow, enumtostr, derefs, sizeof, renderer,
   semuntyped, vtables_frontend, module_plugins, deferstmts, pragmacanon, exprexec, langmodes,
   features, identstyle, macro_plugin
 
-import conceptcache
-  
 import ".." / gear2 / modnames
 import ".." / models / [tags, nifindex_tags]
 when not defined(nimony):

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1,7 +1,5 @@
 # included in sem.nim
 
-import sigconcepts
-
 proc fetchCallableType(c: var SemContext; dest: var TokenBuf; n: Cursor; s: Sym): TypeCursor =
   if s.kind == NoSym:
     let s = getIdent(n)

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1,5 +1,7 @@
 # included in sem.nim
 
+import sigconcepts
+
 proc fetchCallableType(c: var SemContext; dest: var TokenBuf; n: Cursor; s: Sym): TypeCursor =
   if s.kind == NoSym:
     let s = getIdent(n)

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -137,6 +137,9 @@ type
 
   Classes* = Table[SymId, ClassEntry]
 
+  ConceptCache* = ref object of RootObj
+    ## Opaque concept-match cache; implementation in conceptcache.nim.
+
   SemContext* = object
     #dest*: TokenBuf
     routine*: SemRoutine
@@ -195,8 +198,7 @@ type
     pendingModulePlugins*: seq[PluginObj]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
     cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
-    conceptCache*: RootRef
-      ## Opaque concept-match cache; implementation in conceptcache.nim.
+    conceptCache*: ConceptCache
     userPragmas*: Table[StrId, TokenBuf]
     customPragmaTemplates*: HashSet[StrId]
       ## Names of templates declared with `{.pragma.}`. Such templates can

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -137,9 +137,6 @@ type
 
   Classes* = Table[SymId, ClassEntry]
 
-  ConceptCache* = ref object of RootObj
-    ## Opaque concept-match cache; implementation in conceptcache.nim.
-
   SemContext* = object
     #dest*: TokenBuf
     routine*: SemRoutine
@@ -198,7 +195,8 @@ type
     pendingModulePlugins*: seq[PluginObj]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
     cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
-    conceptCache*: ConceptCache
+    conceptCache*: RootRef
+      ## Opaque concept-match cache; implementation in conceptcache.nim.
     userPragmas*: Table[StrId, TokenBuf]
     customPragmaTemplates*: HashSet[StrId]
       ## Names of templates declared with `{.pragma.}`. Such templates can

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -137,6 +137,9 @@ type
 
   Classes* = Table[SymId, ClassEntry]
 
+  ConceptCache* = ref object of RootObj
+    ## Opaque concept-match cache; implementation in conceptcache.nim.
+
   SemContext* = object
     #dest*: TokenBuf
     routine*: SemRoutine
@@ -195,6 +198,7 @@ type
     pendingModulePlugins*: seq[PluginObj]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
     cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
+    conceptCache*: ConceptCache
     userPragmas*: Table[StrId, TokenBuf]
     customPragmaTemplates*: HashSet[StrId]
       ## Names of templates declared with `{.pragma.}`. Such templates can

--- a/src/nimony/semimport.nim
+++ b/src/nimony/semimport.nim
@@ -20,7 +20,7 @@ include ".." / lib / compat2
 import ".." / lib / symparser
 import ".." / gear2 / modnames
 import nimony_model, symtabs, builtintypes, decls, asthelpers, programs,
-  reporters, nifconfig, semdata, sembasics, semchecks, semos
+  reporters, nifconfig, semdata, sembasics, semchecks, semos, conceptcache
 
 # --- thin shims forwarding into the sem core via SemContext callbacks ---
 
@@ -192,6 +192,8 @@ proc doImports(c: var SemContext; dest: var TokenBuf; files: seq[ImportedFilenam
   let origin = getFile(info)
   for f in files:
     importSingleFileConsiderExports c, dest, f, origin, mode, info
+  if files.len > 0:
+    onConceptImportsChanged(c)
 
 template maybeCyclic(c: var SemContext; dest: var TokenBuf; x: var Cursor) =
   if x.kind == ParLe and x.exprKind == PragmaxX:

--- a/src/nimony/semmain.nim
+++ b/src/nimony/semmain.nim
@@ -697,7 +697,6 @@ proc semcheckCycleGroup(infiles, outfiles: seq[string]; config: sink NifConfig;
       writeOutput modules[i].c, modules[i].dest, modules[i].outfile
     else:
       quit 1
-  printConceptProfile()
 
 proc semcheck*(infiles, outfiles: seq[string]; config: sink NifConfig; moduleFlags: set[ModuleFlag];
                commandLineArgs: sink string; canSelfExec: bool) =
@@ -734,4 +733,3 @@ proc semcheck*(infiles, outfiles: seq[string]; config: sink NifConfig; moduleFla
     writeOutput c, dest, outfile
   else:
     quit 1
-  printConceptProfile()

--- a/src/nimony/semmain.nim
+++ b/src/nimony/semmain.nim
@@ -23,7 +23,7 @@ include ".." / lib / compat2
 import ".." / lib / [symparser, nifindexes, docpaths]
 import ".." / gear2 / modnames
 import ".." / models / nifindex_tags
-import nimony_model, symtabs, builtintypes, decls, programs, sigmatch,
+import nimony_model, symtabs, builtintypes, decls, programs, sigmatch, conceptcache,
   reporters, nifconfig, xints, semdata, sembasics,
   semos, langmodes, derefs, vtables_frontend,
   contracts_fir, exprexec, semimport, module_plugins, sem
@@ -568,6 +568,7 @@ proc initSemContext(suffix: string; config: ProgramContext; moduleFlags: set[Mod
     semLocalTypeImplCB: semLocalTypeImpl,
     declareResultCB: declareResult,
     semEmitCB: semEmit)
+  initConceptCache(result)
   for magic in ["typeof", "compiles", "defined", "declared"]:
     result.unoverloadableMagics.incl(pool.strings.getOrIncl(magic))
 
@@ -696,6 +697,7 @@ proc semcheckCycleGroup(infiles, outfiles: seq[string]; config: sink NifConfig;
       writeOutput modules[i].c, modules[i].dest, modules[i].outfile
     else:
       quit 1
+  printConceptProfile()
 
 proc semcheck*(infiles, outfiles: seq[string]; config: sink NifConfig; moduleFlags: set[ModuleFlag];
                commandLineArgs: sink string; canSelfExec: bool) =
@@ -732,3 +734,4 @@ proc semcheck*(infiles, outfiles: seq[string]; config: sink NifConfig; moduleFla
     writeOutput c, dest, outfile
   else:
     quit 1
+  printConceptProfile()

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -1,7 +1,5 @@
 # included in sem.nim
 
-import conceptcache
-
 proc semObjectComponent(c: var SemContext; dest: var TokenBuf; n: var Cursor;
                         state: var SemObjectState) =
   case n.substructureKind

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -257,6 +257,7 @@ proc semConceptParents(c: var SemContext; dest: var TokenBuf; n: var Cursor;
   result = parents.len > 0
 
 proc semConceptType(c: var SemContext; dest: var TokenBuf; n: var Cursor; ownerSym: SymId) =
+  let conceptStart = dest.len
   dest.takeInto n:
     # Nifler layout: `(concept S0 S1 Parents Body)` with two reserved slots.
     wantDot c, dest, n
@@ -298,6 +299,7 @@ proc semConceptType(c: var SemContext; dest: var TokenBuf; n: var Cursor; ownerS
     else:
       bug "(stmts) or empty body expected, but got: ", n
       skip n
+  onConceptDeclSem(c, ownerSym, dest, conceptStart)
 
 proc copyPragmasWithoutHooks(dest: var TokenBuf; pragmas: Cursor) =
   var n = pragmas

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -1,5 +1,7 @@
 # included in sem.nim
 
+import conceptcache
+
 proc semObjectComponent(c: var SemContext; dest: var TokenBuf; n: var Cursor;
                         state: var SemObjectState) =
   case n.substructureKind

--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -15,11 +15,6 @@ include ".." / lib / nifprelude
 include ".." / lib / compat2
 
 import nimony_model, decls, programs, semdata, typeprops, features, symtabs, conceptcache
-
-export conceptcache.tryBodyCheckFromCache, tryRoutineImplFromCache, tryCandidatesFromCache,
-  tryMissingFromBodyCache, getConceptMetadata, conceptRequirementSym, isOpenTypevar,
-  ConceptBodyResult, ConceptRoutineImplResult, storeBodyCheck, storeRoutineImpl,
-  storeCandidates, bodyResultFromMissing
 import ".." / lib / symparser
 
 proc isConceptType*(a: Cursor): bool {.inline.} =

--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -14,7 +14,12 @@ import std / [sets, tables, assertions]
 include ".." / lib / nifprelude
 include ".." / lib / compat2
 
-import nimony_model, decls, programs, semdata, typeprops, features, symtabs
+import nimony_model, decls, programs, semdata, typeprops, features, symtabs, conceptcache
+
+export conceptcache.rememberBodyCheck, rememberRoutineImpl, tryMissingFromBodyCache,
+  getConceptMetadata, conceptRequirementSym, isOpenTypevar, ConceptBodyResult,
+  ConceptRoutineImplResult, matchConceptRoutineSigCalls, conceptRoutineAvailableCalls,
+  storeBodyCheck, bodyResultFromMissing
 import ".." / lib / symparser
 
 proc isConceptType*(a: Cursor): bool {.inline.} =
@@ -128,6 +133,13 @@ iterator conceptRoutineCandidates*(c: ptr SemContext; conceptSym: SymId; basenam
     for cand in visibleNamedSyms(c, basename):
       if not seen.containsOrIncl(cand):
         yield cand
+
+proc collectConceptRoutineCandidates*(c: ptr SemContext; conceptSym: SymId; basename: StrId): seq[SymId] =
+  rememberCandidates(c, conceptSym, basename):
+    var result = default(seq[SymId])
+    for cand in conceptRoutineCandidates(c, conceptSym, basename):
+      result.add cand
+    result
 
 proc routineHasNoSideEffect*(routine: Cursor): bool {.inline.} =
   let r = asRoutine(routine)

--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -16,10 +16,11 @@ include ".." / lib / compat2
 
 import nimony_model, decls, programs, semdata, typeprops, features, symtabs, conceptcache
 
-export conceptcache.rememberBodyCheck, rememberRoutineImpl, tryMissingFromBodyCache,
-  getConceptMetadata, conceptRequirementSym, isOpenTypevar, ConceptBodyResult,
-  ConceptRoutineImplResult, matchConceptRoutineSigCalls, conceptRoutineAvailableCalls,
-  storeBodyCheck, bodyResultFromMissing
+export conceptcache.tryBodyCheckFromCache, tryRoutineImplFromCache, tryCandidatesFromCache,
+  tryMissingFromBodyCache, getConceptMetadata, conceptRequirementSym, isOpenTypevar,
+  ConceptBodyResult, ConceptRoutineImplResult, matchConceptRoutineSigCalls,
+  conceptRoutineAvailableCalls, storeBodyCheck, storeRoutineImpl, storeCandidates,
+  bodyResultFromMissing, conceptBodyChecks
 import ".." / lib / symparser
 
 proc isConceptType*(a: Cursor): bool {.inline.} =
@@ -135,11 +136,14 @@ iterator conceptRoutineCandidates*(c: ptr SemContext; conceptSym: SymId; basenam
         yield cand
 
 proc collectConceptRoutineCandidates*(c: ptr SemContext; conceptSym: SymId; basename: StrId): seq[SymId] =
-  rememberCandidates(c, conceptSym, basename):
-    var result = default(seq[SymId])
-    for cand in conceptRoutineCandidates(c, conceptSym, basename):
-      result.add cand
-    result
+  let (hit, cached) = tryCandidatesFromCache(c, conceptSym, basename)
+  if hit:
+    return cached
+  conceptCandidateScans()
+  result = default(seq[SymId])
+  for cand in conceptRoutineCandidates(c, conceptSym, basename):
+    result.add cand
+  storeCandidates(c, conceptSym, basename, result)
 
 proc routineHasNoSideEffect*(routine: Cursor): bool {.inline.} =
   let r = asRoutine(routine)

--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -18,9 +18,8 @@ import nimony_model, decls, programs, semdata, typeprops, features, symtabs, con
 
 export conceptcache.tryBodyCheckFromCache, tryRoutineImplFromCache, tryCandidatesFromCache,
   tryMissingFromBodyCache, getConceptMetadata, conceptRequirementSym, isOpenTypevar,
-  ConceptBodyResult, ConceptRoutineImplResult, matchConceptRoutineSigCalls,
-  conceptRoutineAvailableCalls, storeBodyCheck, storeRoutineImpl, storeCandidates,
-  bodyResultFromMissing, conceptBodyChecks
+  ConceptBodyResult, ConceptRoutineImplResult, storeBodyCheck, storeRoutineImpl,
+  storeCandidates, bodyResultFromMissing
 import ".." / lib / symparser
 
 proc isConceptType*(a: Cursor): bool {.inline.} =
@@ -139,7 +138,6 @@ proc collectConceptRoutineCandidates*(c: ptr SemContext; conceptSym: SymId; base
   let (hit, cached) = tryCandidatesFromCache(c, conceptSym, basename)
   if hit:
     return cached
-  conceptCandidateScans()
   result = default(seq[SymId])
   for cand in conceptRoutineCandidates(c, conceptSym, basename):
     result.add cand

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -881,15 +881,15 @@ proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor):
       let satisfied = a.kind != DotToken
       storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: satisfied))
       return satisfied
-  var result = ConceptBodyResult(satisfied: true)
+  var bodyResult = ConceptBodyResult(satisfied: true)
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
-      result.satisfied = false
+      bodyResult.satisfied = false
       let rs = conceptRequirementSym(routine)
       if rs != SymId(0):
-        result.missing.add rs
-  storeBodyCheck(m.context, conceptSym, a, result)
-  result.satisfied
+        bodyResult.missing.add rs
+  storeBodyCheck(m.context, conceptSym, a, bodyResult)
+  bodyResult.satisfied
 
 proc isTypevar(s: SymId): bool =
   let res = tryLoadSym(s)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -10,7 +10,7 @@ include ".." / lib / nifprelude
 include ".." / lib / compat2
 
 import nimony_model, decls, programs, semdata, typeprops, xints, builtintypes, renderer, asthelpers,
-  features, symtabs, sigconcepts, expreval, staticmatches
+  features, symtabs, sigconcepts, conceptcache, expreval, staticmatches
 import ".." / lib / symparser
 import ".." / models / tags
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -712,6 +712,7 @@ proc matchConceptParamTypes(m: var Match; conceptTyp, implTyp: Cursor): bool =
   false
 
 proc matchConceptRoutineSig(m: var Match; conceptR, implR: Cursor): bool =
+  matchConceptRoutineSigCalls()
   if not conceptRoutineKindsCompatible(conceptR.symKind, implR.symKind, implR):
     return false
   var cf = conceptR
@@ -754,11 +755,7 @@ proc restoreConceptSelfInference(m: var Match; selfSyms: seq[SymId];
     if selfSym notin restored:
       m.inferred.del(selfSym)
 
-proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): bool =
-  if m.context == nil:
-    return true
-  if isConceptType(a):
-    return conceptRequirementInBody(routine, actualBody)
+proc conceptRoutineAvailableCore(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): ConceptRoutineImplResult =
   let selfSyms = conceptSelfSyms(body, routine)
   var savedSelf: seq[(SymId, Cursor)] = @[]
   for selfSym in selfSyms:
@@ -767,7 +764,7 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
     m.inferred[selfSym] = a
   let basename = conceptRoutineBasename(routine)
   let inferenceBase = m.inferred
-  for cand in conceptRoutineCandidates(m.context, conceptSym, basename):
+  for cand in collectConceptRoutineCandidates(m.context, conceptSym, basename):
     let res = tryLoadSym(cand)
     if res.status != LacksNothing:
       continue
@@ -785,28 +782,41 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
     m.hasError = oldHasError
     if sigMatch:
       restoreConceptSelfInference(m, selfSyms, savedSelf)
-      return true
+      return ConceptRoutineImplResult(found: true, impl: cand)
   restoreConceptSelfInference(m, selfSyms, savedSelf)
-  false
+  ConceptRoutineImplResult(found: false)
+
+proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): bool =
+  conceptRoutineAvailableCalls()
+  if m.context == nil:
+    return true
+  if isConceptType(a):
+    return conceptRequirementInBody(routine, actualBody)
+  rememberRoutineImpl(m.context, conceptSym, conceptRequirementSym(routine), a):
+    conceptRoutineAvailableCore(m, conceptSym, body, routine, a, actualBody)
 
 proc collectMissingConceptRequirements(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): seq[Cursor] =
+  var cachedMissing = default(seq[Cursor])
+  if tryMissingFromBodyCache(m.context, conceptSym, a, cachedMissing):
+    return cachedMissing
   let actualIsConcept = isConceptType(a)
   let actualBody = if actualIsConcept: getTypeSection(a.symId).body else: default(Cursor)
-  let parents = conceptParentsSlot(body)
-  let hasParents = conceptHasParents(parents)
-  if hasParents:
-    for parent in conceptParentSyms(parents):
-      let parentBody = getTypeSection(parent).body
-      let parentMissing = collectMissingConceptRequirements(m, parent, parentBody, a)
-      if parentMissing.len > 0:
-        return parentMissing
-  if not actualIsConcept and not hasParents:
+  let meta = getConceptMetadata(m.context, conceptSym, body)
+  for parent in meta.parents:
+    let parentBody = getTypeSection(parent).body
+    let parentMissing = collectMissingConceptRequirements(m, parent, parentBody, a)
+    if parentMissing.len > 0:
+      storeBodyCheck(m.context, conceptSym, a, bodyResultFromMissing(parentMissing))
+      return parentMissing
+  if not actualIsConcept and meta.parents.len == 0:
     if not conceptTargetNeedsStrictCheck(a):
+      storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: true))
       return @[]
   result = @[]
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
       result.add routine
+  storeBodyCheck(m.context, conceptSym, a, bodyResultFromMissing(result))
 
 proc collectMissingConceptRequirementsFromConstraint(m: var Match; f: Cursor; a: Cursor): seq[Cursor] =
   var f = f
@@ -845,22 +855,34 @@ proc constraintMismatchMsg*(m: var Match; constraint, arg: Cursor): string =
         result.add ", "
       result.add asNimCode(routine, {renderNoBody})
 
-proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): bool =
+proc matchConceptBodyCore(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): ConceptBodyResult =
+  if isOpenTypevar(a):
+    return ConceptBodyResult(satisfied: true)
   let actualIsConcept = isConceptType(a)
   let actualBody = if actualIsConcept: getTypeSection(a.symId).body else: default(Cursor)
-  let parents = conceptParentsSlot(body)
-  let hasParents = conceptHasParents(parents)
-  if hasParents:
-    for parent in conceptParentSyms(parents):
-      if not matchConceptSym(m, parent, a):
-        return false
-  if not actualIsConcept and not hasParents:
+  let meta = getConceptMetadata(m.context, conceptSym, body)
+  for parent in meta.parents:
+    if not matchConceptSym(m, parent, a):
+      return ConceptBodyResult(satisfied: false)
+  # Until concrete-type requirement matching is complete, standalone concepts
+  # match any concrete type (legacy stub behaviour). Concept-to-concept
+  # subsumption always checks requirements structurally.
+  if not actualIsConcept and meta.parents.len == 0:
     if not conceptTargetNeedsStrictCheck(a):
-      return a.kind != DotToken
+      # An unconstrained typevar reaches us as an empty (`.`) constraint: it
+      # provably fulfils no requirement, so it must not satisfy the concept
+      # (issue #755). Genuine concrete types stay leniently accepted.
+      return ConceptBodyResult(satisfied: a.kind != DotToken)
+  result = ConceptBodyResult(satisfied: true)
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
-      return false
-  true
+      result.satisfied = false
+      let rs = conceptRequirementSym(routine)
+      if rs != SymId(0):
+        result.missing.add rs
+
+proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): bool =
+  rememberBodyCheck(m.context, conceptSym, a, matchConceptBodyCore(m, conceptSym, body, a)).satisfied
 
 proc isTypevar(s: SymId): bool =
   let res = tryLoadSym(s)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -754,7 +754,15 @@ proc restoreConceptSelfInference(m: var Match; selfSyms: seq[SymId];
     if selfSym notin restored:
       m.inferred.del(selfSym)
 
-proc findConceptRoutineImpl(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): ConceptRoutineImplResult =
+proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): bool =
+  if m.context == nil:
+    return true
+  if isConceptType(a):
+    return conceptRequirementInBody(routine, actualBody)
+  let reqSym = conceptRequirementSym(routine)
+  let (hit, cachedImpl) = tryRoutineImplFromCache(m.context, conceptSym, reqSym, a)
+  if hit:
+    return cachedImpl.found
   let selfSyms = conceptSelfSyms(body, routine)
   var savedSelf: seq[(SymId, Cursor)] = @[]
   for selfSym in selfSyms:
@@ -781,22 +789,12 @@ proc findConceptRoutineImpl(m: var Match; conceptSym: SymId; body: Cursor; routi
     m.hasError = oldHasError
     if sigMatch:
       restoreConceptSelfInference(m, selfSyms, savedSelf)
-      return ConceptRoutineImplResult(found: true, impl: cand)
+      storeRoutineImpl(m.context, conceptSym, reqSym, a,
+                       ConceptRoutineImplResult(found: true, impl: cand))
+      return true
   restoreConceptSelfInference(m, selfSyms, savedSelf)
-  ConceptRoutineImplResult(found: false)
-
-proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): bool =
-  if m.context == nil:
-    return true
-  if isConceptType(a):
-    return conceptRequirementInBody(routine, actualBody)
-  let reqSym = conceptRequirementSym(routine)
-  let (hit, cachedImpl) = tryRoutineImplFromCache(m.context, conceptSym, reqSym, a)
-  if hit:
-    return cachedImpl.found
-  let implRes = findConceptRoutineImpl(m, conceptSym, body, routine, a, actualBody)
-  storeRoutineImpl(m.context, conceptSym, reqSym, a, implRes)
-  implRes.found
+  storeRoutineImpl(m.context, conceptSym, reqSym, a, ConceptRoutineImplResult(found: false))
+  false
 
 proc collectMissingConceptRequirements(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): seq[Cursor] =
   var cachedMissing = default(seq[Cursor])
@@ -858,15 +856,20 @@ proc constraintMismatchMsg*(m: var Match; constraint, arg: Cursor): string =
         result.add ", "
       result.add asNimCode(routine, {renderNoBody})
 
-proc checkConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): ConceptBodyResult =
+proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): bool =
+  let (hit, cached) = tryBodyCheckFromCache(m.context, conceptSym, a)
+  if hit:
+    return cached.satisfied
   if isOpenTypevar(a):
-    return ConceptBodyResult(satisfied: true)
+    storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: true))
+    return true
   let actualIsConcept = isConceptType(a)
   let actualBody = if actualIsConcept: getTypeSection(a.symId).body else: default(Cursor)
   let meta = getConceptMetadata(m.context, conceptSym, body)
   for parent in meta.parents:
     if not matchConceptSym(m, parent, a):
-      return ConceptBodyResult(satisfied: false)
+      storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: false))
+      return false
   # Until concrete-type requirement matching is complete, standalone concepts
   # match any concrete type (legacy stub behaviour). Concept-to-concept
   # subsumption always checks requirements structurally.
@@ -875,22 +878,18 @@ proc checkConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor):
       # An unconstrained typevar reaches us as an empty (`.`) constraint: it
       # provably fulfils no requirement, so it must not satisfy the concept
       # (issue #755). Genuine concrete types stay leniently accepted.
-      return ConceptBodyResult(satisfied: a.kind != DotToken)
-  result = ConceptBodyResult(satisfied: true)
+      let satisfied = a.kind != DotToken
+      storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: satisfied))
+      return satisfied
+  var result = ConceptBodyResult(satisfied: true)
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
       result.satisfied = false
       let rs = conceptRequirementSym(routine)
       if rs != SymId(0):
         result.missing.add rs
-
-proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): bool =
-  let (hit, cached) = tryBodyCheckFromCache(m.context, conceptSym, a)
-  if hit:
-    return cached.satisfied
-  let res = checkConceptBody(m, conceptSym, body, a)
-  storeBodyCheck(m.context, conceptSym, a, res)
-  res.satisfied
+  storeBodyCheck(m.context, conceptSym, a, result)
+  result.satisfied
 
 proc isTypevar(s: SymId): bool =
   let res = tryLoadSym(s)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -754,7 +754,7 @@ proc restoreConceptSelfInference(m: var Match; selfSyms: seq[SymId];
     if selfSym notin restored:
       m.inferred.del(selfSym)
 
-proc conceptRoutineAvailableCore(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): ConceptRoutineImplResult =
+proc findConceptRoutineImpl(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): ConceptRoutineImplResult =
   let selfSyms = conceptSelfSyms(body, routine)
   var savedSelf: seq[(SymId, Cursor)] = @[]
   for selfSym in selfSyms:
@@ -794,7 +794,7 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
   let (hit, cachedImpl) = tryRoutineImplFromCache(m.context, conceptSym, reqSym, a)
   if hit:
     return cachedImpl.found
-  let implRes = conceptRoutineAvailableCore(m, conceptSym, body, routine, a, actualBody)
+  let implRes = findConceptRoutineImpl(m, conceptSym, body, routine, a, actualBody)
   storeRoutineImpl(m.context, conceptSym, reqSym, a, implRes)
   implRes.found
 
@@ -858,7 +858,7 @@ proc constraintMismatchMsg*(m: var Match; constraint, arg: Cursor): string =
         result.add ", "
       result.add asNimCode(routine, {renderNoBody})
 
-proc matchConceptBodyCore(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): ConceptBodyResult =
+proc checkConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): ConceptBodyResult =
   if isOpenTypevar(a):
     return ConceptBodyResult(satisfied: true)
   let actualIsConcept = isConceptType(a)
@@ -888,7 +888,7 @@ proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor):
   let (hit, cached) = tryBodyCheckFromCache(m.context, conceptSym, a)
   if hit:
     return cached.satisfied
-  let res = matchConceptBodyCore(m, conceptSym, body, a)
+  let res = checkConceptBody(m, conceptSym, body, a)
   storeBodyCheck(m.context, conceptSym, a, res)
   res.satisfied
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -792,8 +792,13 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
     return true
   if isConceptType(a):
     return conceptRequirementInBody(routine, actualBody)
-  rememberRoutineImpl(m.context, conceptSym, conceptRequirementSym(routine), a):
-    conceptRoutineAvailableCore(m, conceptSym, body, routine, a, actualBody)
+  let reqSym = conceptRequirementSym(routine)
+  let (hit, cachedImpl) = tryRoutineImplFromCache(m.context, conceptSym, reqSym, a)
+  if hit:
+    return cachedImpl.found
+  let implRes = conceptRoutineAvailableCore(m, conceptSym, body, routine, a, actualBody)
+  storeRoutineImpl(m.context, conceptSym, reqSym, a, implRes)
+  implRes.found
 
 proc collectMissingConceptRequirements(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): seq[Cursor] =
   var cachedMissing = default(seq[Cursor])
@@ -882,7 +887,13 @@ proc matchConceptBodyCore(m: var Match; conceptSym: SymId; body: Cursor; a: Curs
         result.missing.add rs
 
 proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): bool =
-  rememberBodyCheck(m.context, conceptSym, a, matchConceptBodyCore(m, conceptSym, body, a)).satisfied
+  let (hit, cached) = tryBodyCheckFromCache(m.context, conceptSym, a)
+  if hit:
+    return cached.satisfied
+  conceptBodyChecks()
+  let res = matchConceptBodyCore(m, conceptSym, body, a)
+  storeBodyCheck(m.context, conceptSym, a, res)
+  res.satisfied
 
 proc isTypevar(s: SymId): bool =
   let res = tryLoadSym(s)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -712,7 +712,6 @@ proc matchConceptParamTypes(m: var Match; conceptTyp, implTyp: Cursor): bool =
   false
 
 proc matchConceptRoutineSig(m: var Match; conceptR, implR: Cursor): bool =
-  matchConceptRoutineSigCalls()
   if not conceptRoutineKindsCompatible(conceptR.symKind, implR.symKind, implR):
     return false
   var cf = conceptR
@@ -787,7 +786,6 @@ proc conceptRoutineAvailableCore(m: var Match; conceptSym: SymId; body: Cursor; 
   ConceptRoutineImplResult(found: false)
 
 proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; routine: Cursor; a: Cursor; actualBody: Cursor): bool =
-  conceptRoutineAvailableCalls()
   if m.context == nil:
     return true
   if isConceptType(a):
@@ -890,7 +888,6 @@ proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor):
   let (hit, cached) = tryBodyCheckFromCache(m.context, conceptSym, a)
   if hit:
     return cached.satisfied
-  conceptBodyChecks()
   let res = matchConceptBodyCore(m, conceptSym, body, a)
   storeBodyCheck(m.context, conceptSym, a, res)
   res.satisfied

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -648,19 +648,18 @@ proc conceptHasParents*(parents: Cursor): bool =
 
 iterator conceptParentSyms*(parents: Cursor): SymId {.sideEffect.} =
   var p = parents
-  if conceptParentsWellFormed(p):
-    if p.kind == DotToken:
-      discard
-    elif p.kind == Symbol:
-      yield p.symId
-    elif p.typeKind == AndT or p.exprKind == ParX:
-      p.into:
-        while p.hasMore:
-          if p.kind == Symbol:
-            yield p.symId
-          skip p
-    else:
-      bug "illformed concept parents: ", p
+  if not conceptParentsWellFormed(p):
+    bug "illformed concept parents: ", p
+  if p.kind == DotToken:
+    discard
+  elif p.kind == Symbol:
+    yield p.symId
+  elif p.typeKind == AndT or p.exprKind == ParX:
+    p.into:
+      while p.hasMore:
+        if p.kind == Symbol:
+          yield p.symId
+        skip p
 
 proc conceptSelfSlot*(body: Cursor): Cursor =
   result = conceptParentsSlot(body)

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -638,23 +638,29 @@ proc conceptParentsSlot*(body: Cursor): Cursor =
   skip result
   skip result
 
+proc conceptParentsWellFormed*(parents: Cursor): bool =
+  ## False when parent sem produced an `(err ...)` node or other garbage.
+  parents.kind == DotToken or parents.kind == Symbol or
+    parents.typeKind == AndT or parents.exprKind == ParX
+
 proc conceptHasParents*(parents: Cursor): bool =
-  parents.kind != DotToken
+  conceptParentsWellFormed(parents) and parents.kind != DotToken
 
 iterator conceptParentSyms*(parents: Cursor): SymId {.sideEffect.} =
   var p = parents
-  if p.kind == DotToken:
-    discard
-  elif p.kind == Symbol:
-    yield p.symId
-  elif p.typeKind == AndT or p.exprKind == ParX:
-    p.into:
-      while p.hasMore:
-        if p.kind == Symbol:
-          yield p.symId
-        skip p
-  else:
-    bug "illformed concept parents: ", p
+  if conceptParentsWellFormed(p):
+    if p.kind == DotToken:
+      discard
+    elif p.kind == Symbol:
+      yield p.symId
+    elif p.typeKind == AndT or p.exprKind == ParX:
+      p.into:
+        while p.hasMore:
+          if p.kind == Symbol:
+            yield p.symId
+          skip p
+    else:
+      bug "illformed concept parents: ", p
 
 proc conceptSelfSlot*(body: Cursor): Cursor =
   result = conceptParentsSlot(body)

--- a/tests/nimony/concepts/deps/mconceptblowup_lib.nim
+++ b/tests/nimony/concepts/deps/mconceptblowup_lib.nim
@@ -1,0 +1,171 @@
+## Minimal generic dual-style library for concept-check / overload-resolution blowup.
+##
+## Pattern: a compound concept with many `std/math` requirements, generic
+## operators on a wrapper type, and bodies that call unqualified `sin`/`exp`
+## so `import std/math` competes with generic overloads during instantiation.
+
+import std/math
+
+export math
+
+type
+  Comparable* = concept
+    func `==`(a, b: Self): bool
+    func `<`(a, b: Self): bool
+
+  Field* = concept of Comparable
+    func `+`(a, b: Self): Self
+    func `-`(a: Self): Self
+    func `-`(a, b: Self): Self
+    func `*`(a, b: Self): Self
+    func `/`(a, b: Self): Self
+
+  Scalar* = concept
+    func high(t: typedesc[Self]): Self
+    func low(t: typedesc[Self]): Self
+
+  RealScalar* = concept of Scalar
+    func e(t: typedesc[Self]): Self
+    func epsilon(t: typedesc[Self]): Self
+    func identity(t: typedesc[Self]): Self
+    func pi(t: typedesc[Self]): Self
+    func tau(t: typedesc[Self]): Self
+
+  FatPart* = concept of Comparable, Field, RealScalar
+    func arccos(x: Self): Self
+    func arccosh(x: Self): Self
+    func arccot(x: Self): Self
+    func arccoth(x: Self): Self
+    func arccsc(x: Self): Self
+    func arccsch(x: Self): Self
+    func arcsec(x: Self): Self
+    func arcsech(x: Self): Self
+    func arcsin(x: Self): Self
+    func arcsinh(x: Self): Self
+    func arctan(x: Self): Self
+    func arctanh(x: Self): Self
+    func cos(x: Self): Self
+    func cosh(x: Self): Self
+    func cot(x: Self): Self
+    func coth(x: Self): Self
+    func csc(x: Self): Self
+    func csch(x: Self): Self
+    func exp(x: Self): Self
+    func ln(x: Self): Self
+    func sec(x: Self): Self
+    func sech(x: Self): Self
+    func sin(x: Self): Self
+    func sinh(x: Self): Self
+    func sqrt(x: Self): Self
+    func tan(x: Self): Self
+    func tanh(x: Self): Self
+
+
+## Scalar traits required by `FatPart` (mirrors frehmwoerk numerictraits)
+## -----------------------------------------------------------------------
+
+func e*(x: typedesc[float32]): float32 = 2.7182818'f32
+func epsilon*(x: typedesc[float32]): float32 = 1.1920929e-7'f32
+func identity*(x: typedesc[float32]): float32 = 1.0'f32
+func high*(x: typedesc[float32]): float32 = 3.4028235e38'f32
+func low*(x: typedesc[float32]): float32 = -3.4028235e38'f32
+func pi*(x: typedesc[float32]): float32 = 3.1415927'f32
+func tau*(x: typedesc[float32]): float32 = 6.2831855'f32
+
+func e*(x: typedesc[float64]): float64 = 2.718281828459045
+func epsilon*(x: typedesc[float64]): float64 = 2.220446049250313e-16
+func identity*(x: typedesc[float64]): float64 = 1.0
+func high*(x: typedesc[float64]): float64 = Inf
+func low*(x: typedesc[float64]): float64 = -Inf
+func pi*(x: typedesc[float64]): float64 = PI
+func tau*(x: typedesc[float64]): float64 = 6.283185307179586
+
+
+type
+  Box*[T: FatPart] = object
+    re, du: T
+
+func newBox*[T: FatPart](re, du: T): Box[T] =
+  Box[T](re: re, du: du)
+
+func real*[T: FatPart](a: Box[T]): T = a.re
+func dual*[T: FatPart](a: Box[T]): T = a.du
+
+func `==`*[T: FatPart](a, b: Box[T]): bool =
+  a.re == b.re and a.du == b.du
+
+func `+`*[T: FatPart](a, b: Box[T]): Box[T] =
+  Box[T](re: a.re + b.re, du: a.du + b.du)
+
+func `*`*[T: FatPart](a, b: Box[T]): Box[T] =
+  Box[T](re: a.re * b.re, du: a.du * b.re + a.re * b.du)
+
+func `/`*[T: FatPart](a, b: Box[T]): Box[T] =
+  Box[T](re: a.re / b.re, du: (a.du * b.re - a.re * b.du) / (b.re * b.re))
+
+func exp*[T: FatPart](a: Box[T]): Box[T] =
+  let re = exp(a.re)
+  Box[T](re: re, du: a.du * re)
+
+func ln*[T: FatPart](a: Box[T]): Box[T] =
+  let re = ln(a.re)
+  Box[T](re: re, du: a.du / a.re)
+
+func sqrt*[T: FatPart](a: Box[T]): Box[T] =
+  let t = sqrt(a.re)
+  let two = T.identity + T.identity
+  Box[T](re: t, du: a.du * t / two)
+
+func sin*[T: FatPart](a: Box[T]): Box[T] =
+  let re = sin(a.re)
+  Box[T](re: re, du: a.du * cos(a.re))
+
+func cos*[T: FatPart](a: Box[T]): Box[T] =
+  let re = cos(a.re)
+  Box[T](re: re, du: -a.du * sin(a.re))
+
+func tan*[T: FatPart](a: Box[T]): Box[T] =
+  let ca = cos(a.re)
+  let re = tan(a.re)
+  Box[T](re: re, du: a.du / (ca * ca))
+
+func cot*[T: FatPart](a: Box[T]): Box[T] =
+  let ct = cot(a.re)
+  let one = T.identity
+  Box[T](re: ct, du: -a.du * (one + ct * ct))
+
+func sec*[T: FatPart](a: Box[T]): Box[T] =
+  let re = sec(a.re)
+  Box[T](re: re, du: a.du * tan(a.re) * sec(a.re))
+
+func csc*[T: FatPart](a: Box[T]): Box[T] =
+  let re = csc(a.re)
+  Box[T](re: re, du: -a.du * csc(a.re) * cot(a.re))
+
+func sinh*[T: FatPart](a: Box[T]): Box[T] =
+  let re = sinh(a.re)
+  Box[T](re: re, du: a.du * cosh(a.re))
+
+func cosh*[T: FatPart](a: Box[T]): Box[T] =
+  let re = cosh(a.re)
+  Box[T](re: re, du: a.du * sinh(a.re))
+
+func tanh*[T: FatPart](a: Box[T]): Box[T] =
+  let t = tanh(a.re)
+  let one = T.identity
+  Box[T](re: t, du: a.du * (one - t * t))
+
+func arcsin*[T: FatPart](a: Box[T]): Box[T] =
+  let re = arcsin(a.re)
+  let one = T.identity
+  Box[T](re: re, du: a.du / sqrt(one - a.re * a.re))
+
+func arccos*[T: FatPart](a: Box[T]): Box[T] =
+  let re = arccos(a.re)
+  let one = T.identity
+  Box[T](re: re, du: -a.du / sqrt(one - a.re * a.re))
+
+func arctan*[T: FatPart](a: Box[T]): Box[T] =
+  let re = arctan(a.re)
+  let one = T.identity
+  Box[T](re: re, du: a.du / (one + a.re * a.re))

--- a/tests/nimony/concepts/deps/mconceptblowup_wrap.nim
+++ b/tests/nimony/concepts/deps/mconceptblowup_wrap.nim
@@ -1,0 +1,24 @@
+## Thin wrappers that force generic `Box[float32]` instantiation (dualfloat32 pattern).
+
+import std/math
+
+import ./mconceptblowup_lib as lib
+
+func wrapPlus*(a, b: lib.Box[float32]): lib.Box[float32] = lib.`+`(a, b)
+func wrapMul*(a, b: lib.Box[float32]): lib.Box[float32] = lib.`*`(a, b)
+func wrapDiv*(a, b: lib.Box[float32]): lib.Box[float32] = lib.`/`(a, b)
+func wrapExp*(a: lib.Box[float32]): lib.Box[float32] = lib.exp(a)
+func wrapLn*(a: lib.Box[float32]): lib.Box[float32] = lib.ln(a)
+func wrapSqrt*(a: lib.Box[float32]): lib.Box[float32] = lib.sqrt(a)
+func wrapSin*(a: lib.Box[float32]): lib.Box[float32] = lib.sin(a)
+func wrapCos*(a: lib.Box[float32]): lib.Box[float32] = lib.cos(a)
+func wrapTan*(a: lib.Box[float32]): lib.Box[float32] = lib.tan(a)
+func wrapCot*(a: lib.Box[float32]): lib.Box[float32] = lib.cot(a)
+func wrapSec*(a: lib.Box[float32]): lib.Box[float32] = lib.sec(a)
+func wrapCsc*(a: lib.Box[float32]): lib.Box[float32] = lib.csc(a)
+func wrapSinh*(a: lib.Box[float32]): lib.Box[float32] = lib.sinh(a)
+func wrapCosh*(a: lib.Box[float32]): lib.Box[float32] = lib.cosh(a)
+func wrapTanh*(a: lib.Box[float32]): lib.Box[float32] = lib.tanh(a)
+func wrapArcsin*(a: lib.Box[float32]): lib.Box[float32] = lib.arcsin(a)
+func wrapArccos*(a: lib.Box[float32]): lib.Box[float32] = lib.arccos(a)
+func wrapArctan*(a: lib.Box[float32]): lib.Box[float32] = lib.arctan(a)

--- a/tests/nimony/concepts/tconceptblowup.nim
+++ b/tests/nimony/concepts/tconceptblowup.nim
@@ -1,0 +1,38 @@
+## Regression for concept-check blowup when instantiating generic math wrappers.
+##
+## Before the fix, compiling the wrapper module took tens of seconds because
+## each thin wrapper forces `Box[float32]` instantiation and expensive `FatPart`
+## checking plus `std/math` overload resolution inside generic bodies.
+##
+## After the fix, semantics for this test should finish in well under a second.
+
+import std/[assertions, math]
+
+import deps/mconceptblowup_lib as lib
+import deps/mconceptblowup_wrap
+
+let a = lib.newBox(1.0'f32, 2.0'f32)
+let b = lib.newBox(3.0'f32, 4.0'f32)
+
+# Instantiate every generic wrapper (the compile-time stressor).
+discard wrapPlus(a, b)
+discard wrapMul(a, b)
+discard wrapDiv(a, b)
+discard wrapExp(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapLn(lib.newBox(2.0'f32, 1.0'f32))
+discard wrapSqrt(lib.newBox(4.0'f32, 4.0'f32))
+discard wrapSin(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapCos(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapTan(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapCot(lib.newBox(1.0'f32, 0.0'f32))
+discard wrapSec(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapCsc(lib.newBox(1.0'f32, 0.0'f32))
+discard wrapSinh(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapCosh(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapTanh(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapArcsin(lib.newBox(0.0'f32, 1.0'f32))
+discard wrapArccos(lib.newBox(0.5'f32, 1.0'f32))
+discard wrapArctan(lib.newBox(0.0'f32, 1.0'f32))
+
+assert lib.real(wrapPlus(a, b)) == 4.0'f32
+assert lib.dual(wrapPlus(a, b)) == 6.0'f32

--- a/tests/nimony/concepts/tconceptcacheparent.msgs
+++ b/tests/nimony/concepts/tconceptcacheparent.msgs
@@ -1,0 +1,1 @@
+tests/nimony/concepts/tconceptcacheparent.nim(19, 12) Error: type X does not match constraint: C; missing required procs: proc bar(x: Self), proc foo(x: Self)

--- a/tests/nimony/concepts/tconceptcacheparent.nim
+++ b/tests/nimony/concepts/tconceptcacheparent.nim
@@ -1,0 +1,19 @@
+# Regression: inherited concept errors must list missing procs even when
+# matchConceptBody cached a parent failure with an empty missing list.
+
+type
+  Q = concept
+    proc foo(x: Self)
+
+  P = concept of Q
+    proc bar(x: Self)
+
+  C = concept of P
+
+type X = object
+  y: int
+
+type Box[T: C] = object
+  v: T
+
+var x: Box[X]


### PR DESCRIPTION
The cache is currently being used for:
- Body cache: whole concept body check for concrete types
- Routine Impl cache: Per-requirement overload resolution
- Candidates cache: Name lookup across modules/scopes

The bulk of the implementation is in _conceptcache.nim_. The rest of the compiler only calls a small hook surface. Some minor refactoring was necessary in _sigmatch.nim_

Profile counters are available with `-d:nimonyProfileConcepts` for measuring cache hit rates on real workloads.