### PR TITLE
std/json: tolerate out-of-range integer literals

### DIFF
--- a/lib/std/json.nim
+++ b/lib/std/json.nim
@@ -218,14 +218,43 @@ proc parseArray(p: var JsonParser; t: var JsonTree; mode: LineInfoMode; file: Fi
     emitError(p, t, mode, file, errBracketRiExpected)    # mark truncation in-tree
   t.buf.closeTag()
 
+proc fitsInt64(s: string): bool =
+  ## True if the decimal integer literal `s` is representable as `int64`.
+  ## JSON forbids leading zeros, so a pure digit-count + overflow-guarded
+  ## accumulation is exact. Used to fall back to a float for out-of-range
+  ## integers (e.g. C's `UINT64_MAX` in libclang/opir output) instead of
+  ## aborting the whole parse.
+  var i = 0
+  var neg = false
+  if i < s.len and (s[i] == '-' or s[i] == '+'):
+    neg = s[i] == '-'; inc i
+  var acc: uint64 = 0
+  let limit = if neg: uint64(high(int64)) + 1'u64 else: uint64(high(int64))
+  while i < s.len:
+    let c = s[i]
+    if c < '0' or c > '9': return true   # non-digit: leave to the int parser
+    let d = uint64(ord(c) - ord('0'))
+    if acc > (limit - d) div 10'u64: return false
+    acc = acc * 10'u64 + d
+    inc i
+  return true
+
 proc parseValue(p: var JsonParser; t: var JsonTree; mode: LineInfoMode; file: FileId) =
   case p.tok
   of tkString:
     t.buf.addStrLit p.a; emitInfo(p, t, mode, file); discard getTok(p)
   of tkInt:
-    var v: BiggestInt = 0
-    discard parseBiggestInt(p.a, v)
-    t.buf.addIntLit int64(v); emitInfo(p, t, mode, file); discard getTok(p)
+    if fitsInt64(p.a):
+      var v: BiggestInt = 0
+      discard parseBiggestInt(p.a, v)
+      t.buf.addIntLit int64(v)
+    else:
+      # Out-of-range for int64 (e.g. UINT64_MAX): store as float rather than
+      # abort. Lossy for magnitudes > 2^53, but never aborts the parse.
+      var f: BiggestFloat = 0.0
+      discard parseBiggestFloat(p.a, f)
+      t.buf.addFloatLit float64(f)
+    emitInfo(p, t, mode, file); discard getTok(p)
   of tkFloat:
     var v: BiggestFloat = 0.0
     discard parseBiggestFloat(p.a, v)

--- a/tests/nimony/stdlib/tjson.nim
+++ b/tests/nimony/stdlib/tjson.nim
@@ -106,6 +106,20 @@ proc main() =
     check kind(t.root), JObject
     check hasError(t), true
 
+  block int_out_of_range:
+    # Integers outside int64 must not abort the parse (libclang/opir emit C's
+    # UINT64_MAX etc.); they fall back to a float atom instead.
+    var hi = parseJson("[9223372036854775807]")    # int64.high
+    for v in items(hi.root): check kind(v), JInt
+    var lo = parseJson("[-9223372036854775808]")   # int64.low
+    for v in items(lo.root): check kind(v), JInt
+    var over = parseJson("[9223372036854775808]")  # int64.high + 1
+    for v in items(over.root): check kind(v), JFloat
+    var under = parseJson("[-9223372036854775809]")# int64.low - 1
+    for v in items(under.root): check kind(v), JFloat
+    var umax = parseJson("[18446744073709551615]") # uint64.max
+    for v in items(umax.root): check kind(v), JFloat
+
   echo "json self-tests passed"
 
 main()


### PR DESCRIPTION
parseValue aborted the whole parse via parseBiggestInt's `quit` when an integer literal exceeded int64 (e.g. C's UINT64_MAX in libclang/opir header dumps). Add fitsInt64 to range-check the literal first and fall back to a float atom for out-of-range values — the standard JSON approach — instead of aborting.

Lossy for magnitudes > 2^53, but the parse never aborts. Boundary cases (int64.high/low fit; ±1 and uint64.max become floats) covered in tests/nimony/stdlib/tjson.nim.