### PR TITLE
Port plugins to nifcore

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -423,7 +423,7 @@ snapshot transparently detaches its token storage.
 |------|-------------|
 | `takeTree(t, n)` | Copy the current subtree from `n` into `t`, advancing `n` |
 | `addSubtree(t, n)` | Copy subtree from `n` into `t` without advancing |
-| `addTree(t, child)` | Consume and append an entire child builder |
+| `addTree(t, child)` | Append an entire child builder without consuming it |
 
 **Structured building:**
 
@@ -496,7 +496,7 @@ saveReplacer(r)
 The core operations are:
 - `keep r, Kind` — copy one child verbatim, asserting its kind
 - `drop r, Kind` — skip one child without emitting, asserting its kind
-- `replace r, Kind, node` — skip one child of `Kind`, emit a replacement (`NifCursor` or `NifBuilder`)
+- `replace r, Kind, node` — skip one child of `Kind`, emit a replacement (`NifCursor` or borrowed `NifBuilder`)
 - `keepTag r:` — descend into a compound node (copy tag, process children, close)
 - `loopKeepTag r:` — copy tag, iterate all children, close
 - `peek r:` — read-ahead analysis without consuming (cursor is restored)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -7,11 +7,12 @@ compiler through NIF files.
 
 ## Overview
 
-There are four kinds of plugins:
+There are five kinds of plugins:
 
 | Kind | Declaration | Scope |
 |------|-------------|-------|
 | **Template plugin** | `template foo(...) {.plugin: "path".}` | Invoked at each call site |
+| **For-loop plugin** | `iterator foo(...) {.plugin: "path".}` | Rewrites a `for` loop using the iterator |
 | **Module plugin** | `{.plugin: "path".}` as statement | Transforms the entire module |
 | **Type plugin** | `type T {.plugin: "path".} = ...` | Invoked for every module that uses `T` |
 | **Import plugin** | `import (path/foo) {.plugin: "std/v2".}` | Imports the module `path/foo` **from the plugin** `std/v2` |
@@ -43,15 +44,14 @@ And in `deps/mplugin1.nim`:
 ```nim
 import plugins
 
-proc transform(n: Node): NifBuilder =
+proc transform(n: NifCursor): NifBuilder =
   result = createTree()
   let info = n.info
-  var n = n
-  if n.stmtKind == StmtsS: inc n
+  var arg = callArgs(n)
   result.withTree StmtsS, info:
     result.withTree CallS, info:
       result.addIdent "echo"
-      result.takeTree n
+      result.takeTree arg
 
 var inp = loadPluginInput()
 saveTree transform(inp)
@@ -126,16 +126,13 @@ an expression, or a substructure) and only then call the appropriate accessor.
 
 ### Building with the enum classes
 
-`createTree` and `withTree` accept any of the five enum types directly:
+`withTree` accepts any of the five enum types directly:
 
 ```nim
 result.withTree StmtsS, info:                 # NimonyStmt
   result.withTree CallX, info:                # NimonyExpr
     result.addIdent "echo"
     result.addStrLit "hello"
-
-let t = createTree(ObjectT,                    # NimonyType
-  createTree(FldU, nameSym, intType))          # NimonyOther
 ```
 
 Passing the enum rather than a raw string means a typo becomes a compile error
@@ -189,13 +186,13 @@ template generateEcho(s: string) {.plugin: "deps/mplugin1".}
 generateEcho("Hello, world!")
 ```
 
-The input `Node` is wrapped in a `StmtsS` node containing the arguments. A typical
-plugin starts by skipping past this wrapper:
+The input is wrapped in a `StmtsS` node containing the template name and
+arguments. Use `callArgs` to obtain a bounded cursor over the arguments:
 
 ```nim
-var n = loadPluginInput()
-if n.stmtKind == StmtsS: inc n
-# n now points to the first argument
+let input = loadPluginInput()
+var args = callArgs(input)
+# args now points to the first argument
 ```
 
 A template plugin can also accept a code block via `typed` parameters:
@@ -231,17 +228,16 @@ For example, stripping all top-level `block` statements:
 ```nim
 import plugins
 
-proc transform(n: Node): NifBuilder =
+proc transform(n: NifCursor): NifBuilder =
   result = createTree()
   let info = n.info
-  var n = n
-  if n.stmtKind == StmtsS: inc n
+  var body = firstChild(n)
   result.withTree StmtsS, info:
-    while n.kind != ParRi:
-      if n.kind == ParLe and n.stmtKind == BlockS:
-        skip n  # remove it
+    while body.hasMore:
+      if body.kind == TagLit and body.stmtKind == BlockS:
+        skip body  # remove it
       else:
-        result.takeTree n
+        result.takeTree body
 
 var inp = loadPluginInput()
 saveTree transform(inp)
@@ -329,16 +325,25 @@ import plugins
 ### Reading input
 
 ```nim
-proc loadPluginInput*(filename = paramStr(1)): Node
+proc loadPluginInput*(filename = paramStr(1)): NifCursor
 ```
 
-Returns a `Node` positioned at the root of the NIF tree. For type plugins, load
-the type definitions with `loadPluginInput(paramStr(3))`.
+Returns a `NifCursor` positioned at the root of the NIF tree. For type plugins, load
+the type definitions with `loadPluginInput(paramStr(3))`. Plugin inputs are
+densified while loading, so every positioned value carries its effective source
+location rather than only nifcore's sparse line-info changes.
 
 
-### Node — reading NIF trees
+### NifCursor — reading NIF trees
 
-A `Node` is a read-only cursor into a frozen NIF tree. It advances forward only.
+A `NifCursor` is a reference-counted, read-only cursor into a frozen NIF tree.
+It advances forward only. Child cursors are bounded by `nifcore` jump counts;
+there is no closing-token value.
+
+All inputs and builders in one plugin process share a pre-seeded literal and tag
+pool. Consequently, `SymId` values are directly comparable across the main input,
+type-definition input, and generated builders, and Nimony enum ordinals map
+directly to `TagId`.
 
 **Navigation:**
 
@@ -351,14 +356,14 @@ A `Node` is a read-only cursor into a frozen NIF tree. It advances forward only.
 
 | Proc | Returns | Description |
 |------|---------|-------------|
-| `kind(n)` | `NifKind` | Raw token kind (`ParLe`, `ParRi`, `Symbol`, `Ident`, `IntLit`, ...) |
+| `kind(n)` | `NifKind` | Raw token kind (`TagLit`, `Symbol`, `Ident`, `StrLit`, `IntLit`, ...) |
 | `info(n)` | `LineInfo` | Source location |
 | `stmtKind(n)` | `NimonyStmt` | Statement kind (`VarS`, `ProcS`, `CallS`, ...) or `NoStmt` |
 | `exprKind(n)` | `NimonyExpr` | Expression kind (`CallX`, `DotX`, `AddX`, ...) or `NoExpr` |
 | `typeKind(n)` | `NimonyType` | Type kind (`ObjectT`, `ArrayT`, ...) or `NoType` |
 | `otherKind(n)` | `NimonyOther` | Substructure kind or `NoSub` |
 | `pragmaKind(n)` | `NimonyPragma` | Pragma kind or `NoPragma` |
-| `tagId(n)` | `TagId` | Raw NIF tag id for `ParLe` tokens |
+| `tagId(n)` | `TagId` | Raw NIF tag id for `TagLit` tokens |
 | `tagText(n)` | `string` | Textual tag name |
 | `symId(n)` | `SymId` | Opaque symbol handle |
 | `symText(n)` | `string` | Symbol text |
@@ -381,26 +386,25 @@ A `Node` is a read-only cursor into a frozen NIF tree. It advances forward only.
 
 ### NifBuilder — building NIF output
 
-A `NifBuilder` is a mutable builder. Copy-on-write semantics: copying a tree shares
-the buffer until the next mutation detaches it.
+A `NifBuilder` is a move-only alias for `nifcore.TokenBuf`. It cannot be copied.
+`snapshot(tree)` returns a reference-counted cursor; mutating the builder after a
+snapshot transparently detaches its token storage.
 
 **Creating trees:**
 
 | Proc | Description |
 |------|-------------|
 | `createTree()` | Empty mutable tree |
-| `createTree(kind, children...)` | Tree node of `kind` containing `children` |
-| `createTree(kind, info, children...)` | Same, with line info |
-| `snapshot(tree)` | Read-only `Node` into the tree (keeps tree alive) |
+| `snapshot(tree)` | Read-only `NifCursor` into the tree (keeps tree alive) |
 | `isEmpty(tree)` | True when tree has no tokens |
 
 **Appending tokens:**
 
 | Proc | Description |
 |------|-------------|
-| `addParLe(t, tag, info)` | Opening `(tag` with optional line info |
-| `addParLe(t, tagString, info)` | Same, from textual tag name |
-| `addParRi(t)` | Closing `)` |
+| `openTree(t, tag, info)` | Begin a tagged tree with optional line info |
+| `openTree(t, tagString, info)` | Same, from a textual tag name |
+| `closeTree(t)` | Seal the most recently opened tree |
 | `addIdent(t, name)` | Identifier |
 | `addSymUse(t, sym, info)` | Symbol reference (from `SymId` or string) |
 | `addStrLit(t, s)` | String literal |
@@ -417,7 +421,7 @@ the buffer until the next mutation detaches it.
 |------|-------------|
 | `takeTree(t, n)` | Move current subtree from `n` into `t`, advancing `n` |
 | `addSubtree(t, n)` | Copy subtree from `n` into `t` without advancing |
-| `add(t, child)` | Append entire `child` tree to `t` |
+| `addTree(t, child)` | Consume and append an entire child builder |
 
 **Structured building:**
 
@@ -434,9 +438,9 @@ result.withTree StmtsS, info:
 ### Writing output
 
 ```nim
-proc saveTree*(tree: NifBuilder)                  # writes to paramStr(2)
-proc saveTree*(tree: NifBuilder; filename: string)
-proc renderTree*(tree: NifBuilder): string        # debug rendering (no line info)
+proc saveTree*(tree: sink NifBuilder)                  # writes to paramStr(2)
+proc saveTree*(tree: sink NifBuilder; filename: string)
+proc renderTree*(tree: var NifBuilder): string         # debug rendering (no line info)
 ```
 
 
@@ -531,7 +535,7 @@ saveTree transform(inp)
 The key low-level operations are:
 - `takeTree` to pass nodes through unchanged
 - `skip` to remove nodes
-- `withTree`/`addParLe`/`addParRi` to construct new nodes
+- `withTree` or `openTree`/`closeTree` to construct new nodes
 - `addSubtree` to duplicate nodes
 
 ### Traversal and transformation templates
@@ -542,9 +546,9 @@ The `into`/`loopInto` templates are for pure analysis; the
 
 | Template | Type | Purpose |
 |---|---|---|
-| `hasMore(n)` | `NifCursor` | true while there are more children before `)` |
-| `into n:` | `NifCursor` | enter node, run body for children, leave |
+| `hasMore(n)` | `NifCursor` | true while the bounded cursor has more values |
+| `into n:` | `NifCursor` | enter a `TagLit`, run the body for its children, leave |
 | `loopInto n:` | `NifCursor` | enter node, iterate all children, leave |
 | `balancedTokens n:` | `NifCursor` | deep-scan all compound nodes in subtree |
-| `keepTag r:` | `Replacer` | copy tag to output, run body, close + skip `)` |
-| `loopKeepTag r:` | `Replacer` | copy tag, iterate all children, close + skip `)` |
+| `keepTag r:` | `Replacer` | copy tag to output, run body, seal tree and advance |
+| `loopKeepTag r:` | `Replacer` | copy tag, iterate all children, seal tree and advance |

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -330,9 +330,7 @@ proc loadPluginInput*(filename = paramStr(1)): NifCursor
 
 Returns a `NifCursor` positioned at the root of the NIF tree. Type plugins use
 `loadPluginInput()` for the module and `loadTypeDefinitions()` for the
-definitions that triggered the plugin. Plugin inputs are densified while
-loading, so every positioned value carries its effective source location rather
-than only nifcore's sparse line-info changes.
+definitions that triggered the plugin.
 
 
 ### NifCursor — reading NIF trees
@@ -408,7 +406,7 @@ snapshot transparently detaches its token storage.
 |------|-------------|
 | `openTree(t, tag, info)` | Begin a tagged tree with optional line info |
 | `openTree(t, tagString, info)` | Same, from a textual tag name |
-| `closeTree(t)` | Seal the most recently opened tree |
+| `closeTree(t)` | Close the most recently opened tree |
 | `addIdent(t, name)` | Identifier |
 | `addSymUse(t, sym, info)` | Symbol reference (from `SymId` or string) |
 | `addStrLit(t, s)` | String literal |
@@ -555,5 +553,5 @@ The `into`/`loopInto` templates are for pure analysis; the
 | `into n:` | `NifCursor` | enter a `TagLit`, run the body for its children, leave |
 | `loopInto n:` | `NifCursor` | enter node, iterate all children, leave |
 | `balancedTokens n:` | `NifCursor` | scan descendant compound nodes, then advance past the subtree |
-| `keepTag r:` | `Replacer` | copy tag to output, run body, seal tree and advance |
-| `loopKeepTag r:` | `Replacer` | copy tag, iterate all children, seal tree and advance |
+| `keepTag r:` | `Replacer` | copy tag to output, run body, close tree and advance |
+| `loopKeepTag r:` | `Replacer` | copy tag, iterate all children, close tree and advance |

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -345,6 +345,9 @@ pool. Consequently, `SymId` values are directly comparable across the main input
 type-definition input, and generated builders, and Nimony enum ordinals map
 directly to `TagId`.
 
+`SymId` and `TagId` are pool-local numeric handles. Use `symText` and `tagText`
+when textual names are needed; `$id` is intentionally not a text lookup.
+
 **Navigation:**
 
 | Proc | Description |
@@ -549,6 +552,6 @@ The `into`/`loopInto` templates are for pure analysis; the
 | `hasMore(n)` | `NifCursor` | true while the bounded cursor has more values |
 | `into n:` | `NifCursor` | enter a `TagLit`, run the body for its children, leave |
 | `loopInto n:` | `NifCursor` | enter node, iterate all children, leave |
-| `balancedTokens n:` | `NifCursor` | deep-scan all compound nodes in subtree |
+| `balancedTokens n:` | `NifCursor` | scan descendant compound nodes, then advance past the subtree |
 | `keepTag r:` | `Replacer` | copy tag to output, run body, seal tree and advance |
 | `loopKeepTag r:` | `Replacer` | copy tag, iterate all children, seal tree and advance |

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -266,8 +266,8 @@ that uses the type. This enables type-driven code transformations similar to
 Nim 2's term rewriting macros.
 
 The type plugin receives two inputs:
-- `paramStr(1)`: the module AST
-- `paramStr(3)`: the type definition(s) that triggered the plugin
+- `loadPluginInput()`: the module AST
+- `loadTypeDefinitions()`: the type definition(s) that triggered the plugin
 
 ```nim
 # listener.nim
@@ -328,10 +328,11 @@ import plugins
 proc loadPluginInput*(filename = paramStr(1)): NifCursor
 ```
 
-Returns a `NifCursor` positioned at the root of the NIF tree. For type plugins, load
-the type definitions with `loadPluginInput(paramStr(3))`. Plugin inputs are
-densified while loading, so every positioned value carries its effective source
-location rather than only nifcore's sparse line-info changes.
+Returns a `NifCursor` positioned at the root of the NIF tree. Type plugins use
+`loadPluginInput()` for the module and `loadTypeDefinitions()` for the
+definitions that triggered the plugin. Plugin inputs are densified while
+loading, so every positioned value carries its effective source location rather
+than only nifcore's sparse line-info changes.
 
 
 ### NifCursor — reading NIF trees
@@ -422,7 +423,7 @@ snapshot transparently detaches its token storage.
 
 | Proc | Description |
 |------|-------------|
-| `takeTree(t, n)` | Move current subtree from `n` into `t`, advancing `n` |
+| `takeTree(t, n)` | Copy the current subtree from `n` into `t`, advancing `n` |
 | `addSubtree(t, n)` | Copy subtree from `n` into `t` without advancing |
 | `addTree(t, child)` | Consume and append an entire child builder |
 
@@ -497,7 +498,7 @@ saveReplacer(r)
 The core operations are:
 - `keep r, Kind` — copy one child verbatim, asserting its kind
 - `drop r, Kind` — skip one child without emitting, asserting its kind
-- `replace r, node` — skip one child, emit a replacement (NifCursor or NifBuilder)
+- `replace r, Kind, node` — skip one child of `Kind`, emit a replacement (`NifCursor` or `NifBuilder`)
 - `keepTag r:` — descend into a compound node (copy tag, process children, close)
 - `loopKeepTag r:` — copy tag, iterate all children, close
 - `peek r:` — read-ahead analysis without consuming (cursor is restored)
@@ -526,7 +527,8 @@ import plugins
 proc transform(n: NifCursor): NifBuilder =
   result = createTree()
   var n = n
-  if n.stmtKind == StmtsS: inc n
+  if n.stmtKind == StmtsS:
+    n = firstChild(n)
   result.withTree StmtsS, n.info:
     while n.hasMore:
       result.takeTree n

--- a/lib/std/deps/parfor.nim
+++ b/lib/std/deps/parfor.nim
@@ -42,9 +42,9 @@ import plugins
 proc loopVarSym(n: NifCursor): SymId =
   ## The resolved loop-variable symbol, from `(unpackflat (let (symdef i) …))`.
   var vars = forLoopVars(n)
-  if vars.kind == ParLe and vars.otherKind == UnpackflatU:
+  if vars.kind == TagLit and vars.otherKind == UnpackflatU:
     vars = firstChild(vars)          # (let …)
-    if vars.kind == ParLe:
+    if vars.kind == TagLit:
       vars = firstChild(vars)        # (symdef i)
     if vars.kind == SymbolDef:
       return vars.symId
@@ -54,7 +54,7 @@ proc collectArgs(n: NifCursor): seq[NifCursor] =
   result = @[]
   var c = forLoopCallArgs(n)
   c.into:
-    while c.kind != ParRi:
+    while c.hasMore:
       result.add c
       skip c
 
@@ -105,7 +105,7 @@ proc lvalueBase(n: NifCursor): SymId =
   ## Recursive (descent terminates at a leaf) rather than a `while` with a
   ## `firstChild` reassignment, which the termination checker doesn't recognise
   ## as progress.
-  if n.kind == ParLe and n.exprKind in PeelKinds:
+  if n.kind == TagLit and n.exprKind in PeelKinds:
     result = lvalueBase(firstChild(n))
   elif n.kind == Symbol:
     result = n.symId
@@ -116,7 +116,7 @@ proc analyzeIndex(idx: NifCursor; loopSym: SymId): tuple[ok: bool, off: int] =
   ## Accepts `i`, `i + c`, `c + i`, `i - c` (with `c` an integer literal).
   if idx.kind == Symbol and idx.symId == loopSym:
     return (true, 0)
-  if idx.kind == ParLe and (idx.exprKind == AddX or idx.exprKind == SubX):
+  if idx.kind == TagLit and (idx.exprKind == AddX or idx.exprKind == SubX):
     var op1 = firstChild(idx)   # type child
     skip op1                    # → first operand
     var op2 = op1
@@ -145,16 +145,16 @@ proc collectLocals(c: var Ctx; n: var NifCursor) =
   if n.kind == SymbolDef:
     c.locals.add n.symId
     skip n
-  elif n.kind == ParLe:
+  elif n.kind == TagLit:
     n.into:
-      while n.kind != ParRi:
+      while n.hasMore:
         collectLocals(c, n)
   else:
     skip n
 
 proc handleAsgn(c: var Ctx; lhs: NifCursor; depth: int) =
   let base = lvalueBase(lhs)
-  if lhs.kind == ParLe and lhs.exprKind in IndexKinds:
+  if lhs.kind == TagLit and lhs.exprKind in IndexKinds:
     if base != default(SymId) and has(c.locals, base):
       discard "private per-iteration buffer — safe"
     elif base == c.loopSym:
@@ -188,21 +188,21 @@ proc handleAsgn(c: var Ctx; lhs: NifCursor; depth: int) =
 proc checkWrites(c: var Ctx; n: var NifCursor; depth: int) =
   if c.err.len > 0:
     skip n; return
-  if n.kind != ParLe:
+  if n.kind != TagLit:
     skip n; return
   let sk = n.stmtKind
   if sk == AsgnS:
     handleAsgn(c, child(n, 0), depth)
     n.into:
-      while n.kind != ParRi:
+      while n.hasMore:
         checkWrites(c, n, depth)
   elif sk == ForS or sk == WhileS:
     n.into:
-      while n.kind != ParRi:
+      while n.hasMore:
         checkWrites(c, n, depth + 1)
   else:
     n.into:
-      while n.kind != ParRi:
+      while n.hasMore:
         checkWrites(c, n, depth)
 
 proc readErr(s: SymId): string =
@@ -215,10 +215,10 @@ proc checkReads(c: var Ctx; n: var NifCursor)
 proc checkWriteLhs(c: var Ctx; n: var NifCursor) =
   ## Walk an asgn LHS: the output write-base symbol is allowed, but every index
   ## / bound / field sub-expression is a read.
-  if n.kind == ParLe and n.exprKind in IndexKinds:
+  if n.kind == TagLit and n.exprKind in IndexKinds:
     n.into:
       var first = true
-      while n.kind != ParRi:
+      while n.hasMore:
         if first:
           if n.kind == Symbol and has(c.outBases, n.symId):
             skip n
@@ -240,11 +240,11 @@ proc checkReads(c: var Ctx; n: var NifCursor) =
     skip n
   of SymbolDef:
     skip n
-  of ParLe:
+  of TagLit:
     if n.stmtKind == AsgnS:
       n.into:
         var first = true
-        while n.kind != ParRi:
+        while n.hasMore:
           if first:
             checkWriteLhs(c, n)
             first = false
@@ -252,7 +252,7 @@ proc checkReads(c: var Ctx; n: var NifCursor) =
             checkReads(c, n)
     else:
       n.into:
-        while n.kind != ParRi:
+        while n.hasMore:
           checkReads(c, n)
   else:
     skip n
@@ -273,9 +273,9 @@ proc raceCheck(loopSym: SymId; body: NifCursor): string =
 
 proc emitBody(o: var NifBuilder; n: var NifCursor; loopSym: SymId) =
   ## Copy the typed body, replacing each use of `loopSym` with `(ident pforI)`.
-  if n.kind == ParLe:
+  if n.kind == TagLit:
     o.copyInto(n):
-      while n.kind != ParRi:
+      while n.hasMore:
         emitBody(o, n, loopSym)
   elif n.kind == Symbol and n.symId == loopSym:
     o.addIdent("pforI")
@@ -287,34 +287,34 @@ proc emitBody(o: var NifBuilder; n: var NifCursor; loopSym: SymId) =
 # ── builder helpers (nifler "nim-parsed" dialect) ────────────────────────────
 
 proc beginCall(o: var NifBuilder; fn: string) =
-  ## Opens `(call <fn>` — caller emits the args and a matching `addParRi`.
-  o.addParLe("call")
+  ## Opens `(call <fn>`; the caller emits arguments and closes the tree.
+  o.openTree("call")
   o.addIdent(fn)
 
 proc beginVar(o: var NifBuilder; tag, name: string) =
   ## Opens `(<tag> <name> . . .` (a `var`/`let` decl) — caller emits the
-  ## initializer expression and a matching `addParRi`.
-  o.addParLe(tag)
+  ## initializer expression and closes the tree.
+  o.openTree(tag)
   o.addIdent(name)
   o.addEmptyNode3()   # exported, pragmas, type
 
 proc emitInfix(o: var NifBuilder; op, lhs, rhs: string) =
-  o.addParLe("infix")
+  o.openTree("infix")
   o.addIdent(op)
   o.addIdent(lhs)
   o.addIdent(rhs)
-  o.addParRi()
+  o.closeTree()
 
 proc emitIncr(o: var NifBuilder; name: string) =
   ## `(asgn name (infix + name 1))`
-  o.addParLe("asgn")
+  o.openTree("asgn")
   o.addIdent(name)
-  o.addParLe("infix")
+  o.openTree("infix")
   o.addIdent("+")
   o.addIdent(name)
   o.addIntLit(1)
-  o.addParRi()
-  o.addParRi()
+  o.closeTree()
+  o.closeTree()
 
 # ── transform ────────────────────────────────────────────────────────────────
 
@@ -341,97 +341,97 @@ proc transform(n: NifCursor): NifBuilder =
 
   # Wrap in a `block` so the helper locals (pforA, pforJ, pforChunk, …) get a
   # fresh scope -- several `||` loops can then coexist in one routine.
-  result.addParLe("block")
+  result.openTree("block")
   result.addDotToken()
   result.withTree StmtsS, info:
     # ensureParPool()
-    result.beginCall("ensureParPool"); result.addParRi()
+    result.beginCall("ensureParPool"); result.closeTree()
 
     # var pforA = <a>; pforB = <b>; pforStep = <step>; pforChunkSize = <chunkSize>; pforWorkload = <workload>
-    result.beginVar("var", "pforA"); result.addSubtree(args[0]); result.addParRi()
-    result.beginVar("var", "pforB"); result.addSubtree(args[1]); result.addParRi()
-    result.beginVar("var", "pforStep"); result.addSubtree(args[2]); result.addParRi()
-    result.beginVar("var", "pforChunkSize"); result.addSubtree(args[3]); result.addParRi()
-    result.beginVar("var", "pforWorkload"); result.addSubtree(args[4]); result.addParRi()
+    result.beginVar("var", "pforA"); result.addSubtree(args[0]); result.closeTree()
+    result.beginVar("var", "pforB"); result.addSubtree(args[1]); result.closeTree()
+    result.beginVar("var", "pforStep"); result.addSubtree(args[2]); result.closeTree()
+    result.beginVar("var", "pforChunkSize"); result.addSubtree(args[3]); result.closeTree()
+    result.beginVar("var", "pforWorkload"); result.addSubtree(args[4]); result.closeTree()
 
     # var pforJ = default(ParJoin)
     result.beginVar("var", "pforJ")
-    result.beginCall("default"); result.addIdent("ParJoin"); result.addParRi()
-    result.addParRi()
+    result.beginCall("default"); result.addIdent("ParJoin"); result.closeTree()
+    result.closeTree()
 
     # var pforIters = parIterCount(pforA, pforB, pforStep)
     result.beginVar("var", "pforIters")
     result.beginCall("parIterCount")
     result.addIdent("pforA"); result.addIdent("pforB"); result.addIdent("pforStep")
-    result.addParRi()
-    result.addParRi()
+    result.closeTree()
+    result.closeTree()
 
     # var pforGrain = parGrain(pforIters, pforChunkSize)
     result.beginVar("var", "pforGrain")
     result.beginCall("parGrain")
     result.addIdent("pforIters"); result.addIdent("pforChunkSize")
-    result.addParRi()
-    result.addParRi()
+    result.closeTree()
+    result.closeTree()
 
     # var pforTotal = parChunkCount(pforIters, pforGrain)
     result.beginVar("var", "pforTotal")
     result.beginCall("parChunkCount")
     result.addIdent("pforIters"); result.addIdent("pforGrain")
-    result.addParRi()
-    result.addParRi()
+    result.closeTree()
+    result.closeTree()
 
     # parBegin(pforJ, pforTotal)
     result.beginCall("parBegin")
     result.addIdent("pforJ"); result.addIdent("pforTotal")
-    result.addParRi()
+    result.closeTree()
 
     # proc pforChunk(pforLo, pforHi: int) {.passive, closure.} = ...
-    result.addParLe("proc")
+    result.openTree("proc")
     result.addIdent("pforChunk")
     result.addEmptyNode3()              # exported, pattern, generics
-    result.addParLe("params")
+    result.openTree("params")
     block:
-      result.addParLe("param"); result.addIdent("pforLo")
+      result.openTree("param"); result.addIdent("pforLo")
       result.addEmptyNode2(); result.addIdent("int"); result.addDotToken()
-      result.addParRi()
-      result.addParLe("param"); result.addIdent("pforHi")
+      result.closeTree()
+      result.openTree("param"); result.addIdent("pforHi")
       result.addEmptyNode2(); result.addIdent("int"); result.addDotToken()
-      result.addParRi()
-    result.addParRi()                   # /params
+      result.closeTree()
+    result.closeTree()                   # /params
     result.addDotToken()                # return type (void)
-    result.addParLe("pragmas")
+    result.openTree("pragmas")
     result.addIdent("passive"); result.addIdent("closure")
-    result.addParRi()
+    result.closeTree()
     result.addDotToken()                # effects
     result.withTree StmtsS, info:
       # pforLo/pforHi are iteration indices; map each back to `pforA + j*pforStep`.
       # var pforIt = pforLo
-      result.beginVar("var", "pforIt"); result.addIdent("pforLo"); result.addParRi()
+      result.beginVar("var", "pforIt"); result.addIdent("pforLo"); result.closeTree()
       # while pforIt < pforHi:
       #   let pforI = pforA + pforIt * pforStep; <body>; pforIt = pforIt + 1
-      result.addParLe("while")
+      result.openTree("while")
       result.emitInfix("<", "pforIt", "pforHi")
       result.withTree StmtsS, info:
         # let pforI = pforA + pforIt * pforStep
         result.beginVar("let", "pforI")
-        result.addParLe("infix"); result.addIdent("+"); result.addIdent("pforA")
-        result.addParLe("infix"); result.addIdent("*")
+        result.openTree("infix"); result.addIdent("+"); result.addIdent("pforA")
+        result.openTree("infix"); result.addIdent("*")
         result.addIdent("pforIt"); result.addIdent("pforStep")
-        result.addParRi()               # /inner infix
-        result.addParRi()               # /outer infix
-        result.addParRi()               # /let
+        result.closeTree()               # /inner infix
+        result.closeTree()               # /outer infix
+        result.closeTree()               # /let
         var body = forLoopBody(n)
         emitBody(result, body, loopSym)
         result.emitIncr("pforIt")
-      result.addParRi()                 # /while
+      result.closeTree()                 # /while
       # parChunkDone(addr pforJ)
       result.beginCall("parChunkDone")
-      result.beginCall("addr"); result.addIdent("pforJ"); result.addParRi()
-      result.addParRi()
-    result.addParRi()                   # /proc
+      result.beginCall("addr"); result.addIdent("pforJ"); result.closeTree()
+      result.closeTree()
+    result.closeTree()                   # /proc
 
     # var pforK = 0
-    result.beginVar("var", "pforK"); result.addIntLit(0); result.addParRi()
+    result.beginVar("var", "pforK"); result.addIntLit(0); result.closeTree()
 
     # while pforK < pforTotal:
     #   let pforLo2 = parChunkLo(pforGrain, pforK)
@@ -439,33 +439,33 @@ proc transform(n: NifCursor): NifBuilder =
     #   parSubmit(delay(pforChunk(pforLo2, pforHi2)), pforK)   -- pforK spreads
     #     chunks across stripes; submit-all-then-`parWait` is the structured join.
     #   pforK = pforK + 1
-    result.addParLe("while")
+    result.openTree("while")
     result.emitInfix("<", "pforK", "pforTotal")
     result.withTree StmtsS, info:
       result.beginVar("let", "pforLo2")
       result.beginCall("parChunkLo")
       result.addIdent("pforGrain"); result.addIdent("pforK")
-      result.addParRi(); result.addParRi()
+      result.closeTree(); result.closeTree()
       result.beginVar("let", "pforHi2")
       result.beginCall("parChunkHi")
       result.addIdent("pforIters"); result.addIdent("pforGrain"); result.addIdent("pforK")
-      result.addParRi(); result.addParRi()
+      result.closeTree(); result.closeTree()
       result.beginCall("parSubmit")
       result.beginCall("delay")
       result.beginCall("pforChunk")
       result.addIdent("pforLo2"); result.addIdent("pforHi2")
-      result.addParRi()                 # /pforChunk
-      result.addParRi()                 # /delay
+      result.closeTree()                 # /pforChunk
+      result.closeTree()                 # /delay
       result.addIdent("pforK")
-      result.addParRi()                 # /parSubmit
+      result.closeTree()                 # /parSubmit
       result.emitIncr("pforK")
-    result.addParRi()                   # /while
+    result.closeTree()                   # /while
 
     # parWait(pforJ, pforWorkload)
     result.beginCall("parWait")
     result.addIdent("pforJ"); result.addIdent("pforWorkload")
-    result.addParRi()
-  result.addParRi()                     # /block
+    result.closeTree()
+  result.closeTree()                     # /block
 
 let input = loadPluginInput()
 saveTree transform(input)

--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -2025,6 +2025,7 @@ proc handleCmdLine =
       buildNifmake(showProgress)
       buildNj(showProgress)
       buildVl(showProgress)
+      buildValidator(showProgress)
       buildDagon(showProgress)
       buildPnak(showProgress)
     of "nifler":

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -988,6 +988,16 @@ proc beginRead*(b: var TokenBuf): Cursor =
                   p: addr(b.data[0]),
                   rem: b.len)
 
+proc childCursor*(c: Cursor): Cursor =
+  ## Returns a bounded cursor over the children of the `TagLit` at `c`.
+  ## The input cursor is not advanced.
+  assert c.kind == TagLit, "childCursor requires cursor at TagLit"
+  result = c
+  let headWidth = tokenWidth(result)
+  result.p = cast[ptr NifToken](cast[uint](result.p) +
+                                uint(headWidth) * sizeof(NifToken).uint)
+  result.rem = int c.cursorJump
+
 proc endRead*(c: var Cursor) {.inline.} =
   if c.owner != nil: decRcAndFree(c.owner)
   `=wasMoved`(c)

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -374,7 +374,7 @@ proc `=copy`*(dest: var Cursor; src: Cursor) {.inline.} =
     if src.owner != nil: inc src.owner.rc
     dest.owner = src.owner
     dest.p = src.p
-    dest.rem = src.rem
+  dest.rem = src.rem
 
 proc `=dup`*(src: Cursor): Cursor {.nodestroy, inline.} =
   result = Cursor(owner: src.owner, p: src.p, rem: src.rem)

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -1127,6 +1127,27 @@ proc addSubtree*(dest: var TokenBuf; c: Cursor) =
     var c = c
     addAcrossPools(dest, c)
 
+proc addBufferSamePool*(dest: var TokenBuf; src: TokenBuf) =
+  ## Append a closed buffer that shares `dest`'s literal and tag pools.
+  ##
+  ## The source is borrowed and remains usable. Matching pools make the
+  ## append one bulk copy without constructing a read cursor.
+  assert src.openTags.len == 0, "addBufferSamePool with unclosed source tags"
+  assert dest.data != src.data, "cannot append a TokenBuf to itself"
+  assert dest.pool == src.pool and dest.tags == src.tags,
+         "addBufferSamePool requires matching pools"
+  if src.len == 0:
+    return
+  if dest.owner != nil:
+    prepareMutation(dest)
+  if dest.len + src.len > dest.cap:
+    dest.cap = max(dest.cap div 2 + dest.cap, dest.len + src.len)
+    dest.data = cast[Storage](
+      realloc(dest.data, sizeof(NifToken) * dest.cap))
+  copyMem(addr dest.data[dest.len], src.data,
+          src.len * sizeof(NifToken))
+  dest.len += src.len
+
 proc addBuffer*(dest: var TokenBuf; src: var TokenBuf) =
   ## Append all complete top-level values from `src` to `dest`.
   ##
@@ -1137,15 +1158,7 @@ proc addBuffer*(dest: var TokenBuf; src: var TokenBuf) =
   if src.len == 0:
     return
   if dest.pool == src.pool and dest.tags == src.tags:
-    if dest.owner != nil:
-      prepareMutation(dest)
-    if dest.len + src.len > dest.cap:
-      dest.cap = max(dest.cap div 2 + dest.cap, dest.len + src.len)
-      dest.data = cast[Storage](
-        realloc(dest.data, sizeof(NifToken) * dest.cap))
-    copyMem(addr dest.data[dest.len], src.data,
-            src.len * sizeof(NifToken))
-    dest.len += src.len
+    dest.addBufferSamePool(src)
   else:
     var c = src.beginRead()
     while c.hasMore:

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -321,6 +321,11 @@ type
     p: ptr NifToken
     rem: int
 
+  CursorScope* = object ## Saved outer bounds for bounded cursor traversal.
+    savedP: ptr NifToken
+    savedRem: int
+    bodyLen: int
+
 template decRcAndFree(owner: CursorOwner) =
   dec owner.rc
   if owner.rc == 0:
@@ -647,26 +652,35 @@ template hasMore*(c: Cursor): bool =
   ## sentinel: `rem` does all the work.
   c.rem > 0
 
-template into*(c: var Cursor; body: untyped) =
-  ## Enter the current TagLit, iterate its body, then restore the outer
-  ## scope's bound. Body MUST consume exactly the children (leave
-  ## `rem == 0`) — without a ParRi marker, `rem` is the only signal.
-  # `c.load.kind` not `c.kind`: adapters often define their own `kind*` proc
-  # which would shadow nifcore.kind at the template's instantiation site.
+proc enterScope*(c: var Cursor): CursorScope =
+  ## Enters the current `TagLit` body and returns its saved outer bounds.
+  ## Pair with `leaveScope` after consuming every child.
   assert c.load.kind == TagLit, "into requires cursor at TagLit"
-  let savedRem  = c.rem
-  let savedP    = c.p
-  let bodyLen   = int c.cursorJump
+  result = CursorScope(savedP: c.p, savedRem: c.rem,
+                       bodyLen: int(c.cursorJump))
   let headWidth = tokenWidth(c)
   c.p = cast[ptr NifToken](cast[uint](c.p) +
                            uint(headWidth) * sizeof(NifToken).uint)
-  c.rem = bodyLen
-  body
-  assert c.rem == 0, "into: body did not consume all " & $bodyLen &
+  c.rem = result.bodyLen
+
+proc leaveScope*(c: var Cursor; scope: CursorScope) =
+  ## Leaves a scope opened by `enterScope`.
+  ## The cursor must have consumed the complete bounded body.
+  assert c.rem == 0, "into: body did not consume all " & $scope.bodyLen &
                      " children (left " & $c.rem & ")"
-  let consumed = int((cast[uint](c.p) - cast[uint](savedP)) div
+  let consumed = int((cast[uint](c.p) - cast[uint](scope.savedP)) div
                      sizeof(NifToken).uint)
-  c.rem = if savedRem >= consumed: savedRem - consumed else: 0
+  c.rem = if scope.savedRem >= consumed:
+            scope.savedRem - consumed
+          else:
+            0
+
+template into*(c: var Cursor; body: untyped) =
+  ## Enters the current `TagLit`, runs `body`, then restores the outer bounds.
+  ## `body` must consume every child.
+  let cursorScope = enterScope(c)
+  body
+  leaveScope(c, cursorScope)
 
 template loopInto*(c: var Cursor; body: untyped) =
   into c:

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -876,6 +876,17 @@ proc addSymUse*(b: var TokenBuf; s: string) =
 proc addSymDef*(b: var TokenBuf; s: string) =
   addStringLike(b, SymbolDef, s, b.pool.syms)
 
+proc addSymUse*(b: var TokenBuf; id: SymId) =
+  ## Emit a symbol already interned in `b.pool`. Short symbols remain inline;
+  ## longer symbols reuse `id` without a second hash-table lookup.
+  let s = b.pool.syms[id]
+  if s.len <= StrInlineMaxLen:
+    b.add NifToken(toX(Symbol, encodeInlineStr(s)))
+  else:
+    let payload = uint64(uint32(id)) shl 1
+    b.add NifToken(toX(Symbol, lowBits(payload)))
+    addSuffixIfNeeded(b, payload)
+
 template emitChained(b: var TokenBuf; kind: NifKind; bits: uint64) =
   ## Emit a value carrier (kinded token plus 0/1/2 ExtendedSuffix
   ## tokens) holding `bits`. Picks the minimum chain length whose

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -554,6 +554,7 @@ proc floatVal*(c: Cursor): float64 {.inline.} =
   cast[float64](combinedPayload(c))
 
 proc charLit*(c: Cursor): char {.inline.} =
+  ## Returns the character stored in the `CharLit` at `c`.
   assert c.kind == CharLit
   char(c.load.uoperand)
 
@@ -847,8 +848,13 @@ template addSuffixIfNeeded(b: var TokenBuf; payload: uint64) =
 template lowBits(x: uint32): uint32 = x and PayloadMask
 template lowBits(x: uint64): uint32 = uint32(x and uint64(PayloadMask))
 
-proc addDotToken*(b: var TokenBuf) {.inline.} = b.add dotToken()
-proc addCharLit*(b: var TokenBuf; c: char) {.inline.} = b.add charToken(c)
+proc addDotToken*(b: var TokenBuf) {.inline.} =
+  ## Appends an empty dot placeholder.
+  b.add dotToken()
+
+proc addCharLit*(b: var TokenBuf; c: char) {.inline.} =
+  ## Appends a character literal.
+  b.add charToken(c)
 
 proc encodeInlineStr(s: string): uint32 {.inline.} =
   ## Pack up to 3 bytes of `s` into the inline-string layout.
@@ -868,12 +874,19 @@ template addStringLike(b: var TokenBuf; kind: NifKind; s: string; pool: untyped)
     addSuffixIfNeeded(b, payload)
 
 proc addStrLit*(b: var TokenBuf; s: string) =
+  ## Appends a string literal, using inline storage when possible.
   addStringLike(b, StrLit, s, b.pool.strings)
+
 proc addIdent*(b: var TokenBuf; s: string) =
+  ## Appends an identifier, using inline storage when possible.
   addStringLike(b, Ident,  s, b.pool.strings)
+
 proc addSymUse*(b: var TokenBuf; s: string) =
+  ## Appends a symbol use, interning `s` when it does not fit inline.
   addStringLike(b, Symbol, s, b.pool.syms)
+
 proc addSymDef*(b: var TokenBuf; s: string) =
+  ## Appends a symbol definition, interning `s` when it does not fit inline.
   addStringLike(b, SymbolDef, s, b.pool.syms)
 
 proc addSymUse*(b: var TokenBuf; id: SymId) =
@@ -919,9 +932,11 @@ proc addIntLit*(b: var TokenBuf; v: int64) =
     b.add extendedSuffixToken(uint32(bits shr (PayloadBits * 2)))
 
 proc addUIntLit*(b: var TokenBuf; v: uint64) =
+  ## Appends an unsigned integer literal using the shortest token chain.
   emitChained(b, UIntLit, v)
 
 proc addFloatLit*(b: var TokenBuf; v: float64) =
+  ## Appends a floating-point literal using its exact bit representation.
   emitChained(b, FloatLit, cast[uint64](v))
 
 # ── Open / close tags (the only mutations that touch `openTags`) ─────────

--- a/src/lib/nifcore.nim
+++ b/src/lib/nifcore.nim
@@ -1098,6 +1098,31 @@ proc addSubtree*(dest: var TokenBuf; c: Cursor) =
     var c = c
     addAcrossPools(dest, c)
 
+proc addBuffer*(dest: var TokenBuf; src: var TokenBuf) =
+  ## Append all complete top-level values from `src` to `dest`.
+  ##
+  ## Matching pools permit one bulk copy. Otherwise values are re-interned
+  ## through `addSubtree`. `dest` and `src` must be distinct buffers.
+  assert src.openTags.len == 0, "addBuffer with unclosed source tags"
+  assert dest.data != src.data, "cannot append a TokenBuf to itself"
+  if src.len == 0:
+    return
+  if dest.pool == src.pool and dest.tags == src.tags:
+    if dest.owner != nil:
+      prepareMutation(dest)
+    if dest.len + src.len > dest.cap:
+      dest.cap = max(dest.cap div 2 + dest.cap, dest.len + src.len)
+      dest.data = cast[Storage](
+        realloc(dest.data, sizeof(NifToken) * dest.cap))
+    copyMem(addr dest.data[dest.len], src.data,
+            src.len * sizeof(NifToken))
+    dest.len += src.len
+  else:
+    var c = src.beginRead()
+    while c.hasMore:
+      dest.addSubtree(c)
+      c.skip()
+
 # ── Self-test ────────────────────────────────────────────────────────────
 
 when isMainModule:

--- a/src/lib/nifcoreparse.nim
+++ b/src/lib/nifcoreparse.nim
@@ -145,7 +145,8 @@ proc emitRelLineInfo(bld: var Builder; abs, parent: NifLineInfo; pool: Pool;
     bld.attachComment(pool.strings[abs.comment])
 
 proc emitValue(bld: var Builder; c: var Cursor; cur: var NifLineInfo;
-               parents: var seq[NifLineInfo]; tags: TagPool; pool: Pool) =
+               parents: var seq[NifLineInfo]; tags: TagPool; pool: Pool;
+               includeLineInfo: bool) =
   ## Emit one value (atom or whole TagLit subtree), advancing `c` past it.
   ## `cur` is the running absolute line info (a head with no `LineInfoLit`
   ## inherits it); `parents` holds enclosing-tag infos for relative encoding.
@@ -154,45 +155,49 @@ proc emitValue(bld: var Builder; c: var Cursor; cur: var NifLineInfo;
   if li.isValid:
     cur = li
     cur.comment = StrId(0)   # a comment is a one-shot decoration, never inherited
+  template emitInfo() =
+    if includeLineInfo:
+      emitRelLineInfo(bld, abs, parents[^1], pool)
   case c.kind
   of TagLit:
     bld.addTree(tags.tags[c.cursorTagId])
-    emitRelLineInfo(bld, abs, parents[^1], pool)
+    emitInfo()
     parents.add abs
     c.into:
       while c.hasMore:
-        emitValue(bld, c, cur, parents, tags, pool)
+        emitValue(bld, c, cur, parents, tags, pool, includeLineInfo)
     discard parents.pop()
     bld.endTree()
   of DotToken:
-    bld.addEmpty(); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addEmpty(); emitInfo(); c.inc
   of Ident:
-    bld.addIdent(strVal(c, pool)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addIdent(strVal(c, pool)); emitInfo(); c.inc
   of StrLit:
-    bld.addStrLit(strVal(c, pool)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addStrLit(strVal(c, pool)); emitInfo(); c.inc
   of Symbol:
-    bld.addSymbol(symName(c, pool)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addSymbol(symName(c, pool)); emitInfo(); c.inc
   of SymbolDef:
-    bld.addSymbolDef(symName(c, pool)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addSymbolDef(symName(c, pool)); emitInfo(); c.inc
   of CharLit:
-    bld.addCharLit(charLit(c)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addCharLit(charLit(c)); emitInfo(); c.inc
   of IntLit:
-    bld.addIntLit(intVal(c)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addIntLit(intVal(c)); emitInfo(); c.inc
   of UIntLit:
-    bld.addUIntLit(uintVal(c)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addUIntLit(uintVal(c)); emitInfo(); c.inc
   of FloatLit:
-    bld.addFloatLit(floatVal(c)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    bld.addFloatLit(floatVal(c)); emitInfo(); c.inc
   of ExtendedSuffix, LineInfoLit:
     assert false, "suffix token is not a value head"
 
-proc toString*(b: var TokenBuf; sizeHint = 0): string =
+proc toString*(b: var TokenBuf; sizeHint = 0;
+               includeLineInfo = true): string =
   ## Canonical NIF text for the whole buffer (one or more top-level values).
   var bld = nifbuilder.open(if sizeHint > 0: sizeHint else: b.len * 8)
   var c = b.beginRead()
   var cur = NoNifLineInfo
   var parents = @[NoNifLineInfo]
   while c.hasMore:
-    emitValue(bld, c, cur, parents, b.tags, b.pool)
+    emitValue(bld, c, cur, parents, b.tags, b.pool, includeLineInfo)
   result = bld.extract()
 
 # ── toModuleString (full file with embedded index) ─────────────────────────

--- a/src/lib/nifcoreparse.nim
+++ b/src/lib/nifcoreparse.nim
@@ -11,7 +11,8 @@
 ## `openTag`/`closeTag`, and atoms drive the builder. The reader's relative
 ## line positions are resolved to absolute file/line/col (against a parent
 ## stack, exactly like `nifstreams.rawNext`) and emitted as a sparse
-## `LineInfoLit` suffix only where the position changes.
+## `LineInfoLit` suffix only where the position changes. Callers that need
+## random-access effective locations can request dense line info while parsing.
 ##
 ## Note: NIF `#comment#` decorations are not carried into the token buffer —
 ## the codegen path has no use for them.
@@ -49,18 +50,21 @@ proc resolveInfo(b: var TokenBuf; tok: rd.ExpandedToken;
                          comment: comment)
 
 proc parse*(r: var rd.Reader; b: var TokenBuf;
-            parentSeed: NifLineInfo = NoNifLineInfo) =
+            parentSeed: NifLineInfo = NoNifLineInfo;
+            denseLineInfo = false) =
   ## Read one complete NIF tree (or until EOF) from `r` into `b`. `parentSeed`
   ## seeds the parent line-info stack so the first token's relative position
   ## resolves against the right origin (index-jumped reads pass the indexed
   ## compound's parent info; whole-file reads pass `NoNifLineInfo`).
+  ## With `denseLineInfo`, every positioned value receives its effective
+  ## location instead of only changes in the location stream.
   var parents = @[(file: parentSeed.file, line: parentSeed.line,
                    col: parentSeed.col)]
   var last = NoNifLineInfo
   var nested = 0
   var tok = default(rd.ExpandedToken)
   template emit(info: NifLineInfo) =
-    if info.isValid and info != last:
+    if info.isValid and (denseLineInfo or info != last):
       b.appendLineInfo info
       last = info
   while true:
@@ -107,18 +111,20 @@ proc parse*(r: var rd.Reader; b: var TokenBuf;
 
 proc parseFromBuffer*(input: string; thisModule: sink string;
                       sizeHint = 100; sharedPool: Pool = nil;
-                      sharedTags: TagPool = nil): TokenBuf =
+                      sharedTags: TagPool = nil;
+                      denseLineInfo = false): TokenBuf =
   var r = rd.openFromBuffer(input, thisModule)
   result = createTokenBuf(sizeHint, sharedPool, sharedTags)
-  parse(r, result)
+  parse(r, result, denseLineInfo = denseLineInfo)
 
 proc parseFromFile*(filename: string; sizeHint = 100;
                     sharedPool: Pool = nil;
-                    sharedTags: TagPool = nil): TokenBuf =
+                    sharedTags: TagPool = nil;
+                    denseLineInfo = false): TokenBuf =
   var r = rd.open(filename)
   discard rd.processDirectives(r)
   result = createTokenBuf(sizeHint, sharedPool, sharedTags)
-  parse(r, result)
+  parse(r, result, denseLineInfo = denseLineInfo)
 
 # ── toString ─────────────────────────────────────────────────────────────
 
@@ -192,12 +198,26 @@ proc emitValue(bld: var Builder; c: var Cursor; cur: var NifLineInfo;
 proc toString*(b: var TokenBuf; sizeHint = 0;
                includeLineInfo = true): string =
   ## Canonical NIF text for the whole buffer (one or more top-level values).
+  ## Set `includeLineInfo` to false for location-free diagnostic rendering.
   var bld = nifbuilder.open(if sizeHint > 0: sizeHint else: b.len * 8)
   var c = b.beginRead()
   var cur = NoNifLineInfo
   var parents = @[NoNifLineInfo]
   while c.hasMore:
     emitValue(bld, c, cur, parents, b.tags, b.pool, includeLineInfo)
+  result = bld.extract()
+
+proc toString*(node: Cursor; sizeHint = 0;
+               includeLineInfo = true): string =
+  ## Canonical NIF text for the value or subtree at `node`.
+  if not node.hasMore:
+    return ""
+  var bld = nifbuilder.open(
+    if sizeHint > 0: sizeHint else: subtreeWidth(node) * 8)
+  var c = node
+  var cur = NoNifLineInfo
+  var parents = @[NoNifLineInfo]
+  emitValue(bld, c, cur, parents, node.tags, node.pool, includeLineInfo)
   result = bld.extract()
 
 # ── toModuleString (full file with embedded index) ─────────────────────────

--- a/src/lib/nifcoreparse.nim
+++ b/src/lib/nifcoreparse.nim
@@ -150,9 +150,10 @@ proc emitRelLineInfo(bld: var Builder; abs, parent: NifLineInfo; pool: Pool;
   if emitComment and uint32(abs.comment) != 0'u32:
     bld.attachComment(pool.strings[abs.comment])
 
-proc emitValue(bld: var Builder; c: var Cursor; cur: var NifLineInfo;
-               parents: var seq[NifLineInfo]; tags: TagPool; pool: Pool;
-               includeLineInfo: bool) =
+proc emitValueWithLineInfo(bld: var Builder; c: var Cursor;
+                           cur: var NifLineInfo;
+                           parents: var seq[NifLineInfo];
+                           tags: TagPool; pool: Pool) =
   ## Emit one value (atom or whole TagLit subtree), advancing `c` past it.
   ## `cur` is the running absolute line info (a head with no `LineInfoLit`
   ## inherits it); `parents` holds enclosing-tag infos for relative encoding.
@@ -161,37 +162,81 @@ proc emitValue(bld: var Builder; c: var Cursor; cur: var NifLineInfo;
   if li.isValid:
     cur = li
     cur.comment = StrId(0)   # a comment is a one-shot decoration, never inherited
-  template emitInfo() =
-    if includeLineInfo:
-      emitRelLineInfo(bld, abs, parents[^1], pool)
   case c.kind
   of TagLit:
     bld.addTree(tags.tags[c.cursorTagId])
-    emitInfo()
+    emitRelLineInfo(bld, abs, parents[^1], pool)
     parents.add abs
     c.into:
       while c.hasMore:
-        emitValue(bld, c, cur, parents, tags, pool, includeLineInfo)
+        emitValueWithLineInfo(bld, c, cur, parents, tags, pool)
     discard parents.pop()
     bld.endTree()
   of DotToken:
-    bld.addEmpty(); emitInfo(); c.inc
+    bld.addEmpty(); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
   of Ident:
-    bld.addIdent(strVal(c, pool)); emitInfo(); c.inc
+    bld.addIdent(strVal(c, pool))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of StrLit:
-    bld.addStrLit(strVal(c, pool)); emitInfo(); c.inc
+    bld.addStrLit(strVal(c, pool))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of Symbol:
-    bld.addSymbol(symName(c, pool)); emitInfo(); c.inc
+    bld.addSymbol(symName(c, pool))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of SymbolDef:
-    bld.addSymbolDef(symName(c, pool)); emitInfo(); c.inc
+    bld.addSymbolDef(symName(c, pool))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of CharLit:
-    bld.addCharLit(charLit(c)); emitInfo(); c.inc
+    bld.addCharLit(charLit(c))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of IntLit:
-    bld.addIntLit(intVal(c)); emitInfo(); c.inc
+    bld.addIntLit(intVal(c))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of UIntLit:
-    bld.addUIntLit(uintVal(c)); emitInfo(); c.inc
+    bld.addUIntLit(uintVal(c))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
   of FloatLit:
-    bld.addFloatLit(floatVal(c)); emitInfo(); c.inc
+    bld.addFloatLit(floatVal(c))
+    emitRelLineInfo(bld, abs, parents[^1], pool)
+    c.inc
+  of ExtendedSuffix, LineInfoLit:
+    assert false, "suffix token is not a value head"
+
+proc emitValueWithoutLineInfo(bld: var Builder; c: var Cursor;
+                              tags: TagPool; pool: Pool) =
+  ## Fast diagnostic serializer: no location decoding or parent stack.
+  case c.kind
+  of TagLit:
+    bld.addTree(tags.tags[c.cursorTagId])
+    c.into:
+      while c.hasMore:
+        emitValueWithoutLineInfo(bld, c, tags, pool)
+    bld.endTree()
+  of DotToken:
+    bld.addEmpty(); c.inc
+  of Ident:
+    bld.addIdent(strVal(c, pool)); c.inc
+  of StrLit:
+    bld.addStrLit(strVal(c, pool)); c.inc
+  of Symbol:
+    bld.addSymbol(symName(c, pool)); c.inc
+  of SymbolDef:
+    bld.addSymbolDef(symName(c, pool)); c.inc
+  of CharLit:
+    bld.addCharLit(charLit(c)); c.inc
+  of IntLit:
+    bld.addIntLit(intVal(c)); c.inc
+  of UIntLit:
+    bld.addUIntLit(uintVal(c)); c.inc
+  of FloatLit:
+    bld.addFloatLit(floatVal(c)); c.inc
   of ExtendedSuffix, LineInfoLit:
     assert false, "suffix token is not a value head"
 
@@ -201,10 +246,14 @@ proc toString*(b: var TokenBuf; sizeHint = 0;
   ## Set `includeLineInfo` to false for location-free diagnostic rendering.
   var bld = nifbuilder.open(if sizeHint > 0: sizeHint else: b.len * 8)
   var c = b.beginRead()
-  var cur = NoNifLineInfo
-  var parents = @[NoNifLineInfo]
-  while c.hasMore:
-    emitValue(bld, c, cur, parents, b.tags, b.pool, includeLineInfo)
+  if includeLineInfo:
+    var cur = NoNifLineInfo
+    var parents = @[NoNifLineInfo]
+    while c.hasMore:
+      emitValueWithLineInfo(bld, c, cur, parents, b.tags, b.pool)
+  else:
+    while c.hasMore:
+      emitValueWithoutLineInfo(bld, c, b.tags, b.pool)
   result = bld.extract()
 
 proc toString*(node: Cursor; sizeHint = 0;
@@ -215,9 +264,12 @@ proc toString*(node: Cursor; sizeHint = 0;
   var bld = nifbuilder.open(
     if sizeHint > 0: sizeHint else: subtreeWidth(node) * 8)
   var c = node
-  var cur = NoNifLineInfo
-  var parents = @[NoNifLineInfo]
-  emitValue(bld, c, cur, parents, node.tags, node.pool, includeLineInfo)
+  if includeLineInfo:
+    var cur = NoNifLineInfo
+    var parents = @[NoNifLineInfo]
+    emitValueWithLineInfo(bld, c, cur, parents, node.tags, node.pool)
+  else:
+    emitValueWithoutLineInfo(bld, c, node.tags, node.pool)
   result = bld.extract()
 
 # ── toModuleString (full file with embedded index) ─────────────────────────

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -219,9 +219,9 @@ template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   leavePluginScope(n, inputScope)
   t.closeTree()
 
-proc addTree*(t: var NifBuilder; child: sink NifBuilder) =
-  ## Consumes and appends every complete top-level value from `child`.
-  t.addBuffer(child)
+proc addTree*(t: var NifBuilder; child: NifBuilder) =
+  ## Appends every complete top-level value from `child`.
+  t.addBufferSamePool(child)
 
 proc addSymUse*(t: var NifBuilder; s: SymId;
                 info: LineInfo = NoLineInfo) =
@@ -612,11 +612,11 @@ proc replace*(t: var Replacer; expected: ChildKind; replacement: NifCursor) =
   t.dest.addSubtree(replacement)
 
 proc replace*(t: var Replacer; expected: ChildKind;
-              replacement: sink NifBuilder) =
+              replacement: NifBuilder) =
   ## Skip one child from input, emit replacement builder tree instead.
   assertChild(t.src, expected)
   t.src.skip()
-  t.dest.addTree(ensureMove(replacement))
+  t.dest.addTree(replacement)
 
 proc replace*(t: var Replacer; expected: NimonyStmt; replacement: NifCursor) =
   ## Skip one child, asserting a specific statement tag, emit replacement.
@@ -625,11 +625,11 @@ proc replace*(t: var Replacer; expected: NimonyStmt; replacement: NifCursor) =
   t.dest.addSubtree(replacement)
 
 proc replace*(t: var Replacer; expected: NimonyStmt;
-              replacement: sink NifBuilder) =
+              replacement: NifBuilder) =
   ## Skip one child, asserting a specific statement tag, emit replacement.
   assertTag(t.src, expected)
   t.src.skip()
-  t.dest.addTree(ensureMove(replacement))
+  t.dest.addTree(replacement)
 
 proc replace*(t: var Replacer; expected: NimonyExpr; replacement: NifCursor) =
   ## Skip one child, asserting a specific expression tag, emit replacement.
@@ -638,11 +638,11 @@ proc replace*(t: var Replacer; expected: NimonyExpr; replacement: NifCursor) =
   t.dest.addSubtree(replacement)
 
 proc replace*(t: var Replacer; expected: NimonyExpr;
-              replacement: sink NifBuilder) =
+              replacement: NifBuilder) =
   ## Skip one child, asserting a specific expression tag, emit replacement.
   assertTag(t.src, expected)
   t.src.skip()
-  t.dest.addTree(ensureMove(replacement))
+  t.dest.addTree(replacement)
 
 proc replace*(t: var Replacer; expected: NimonyType; replacement: NifCursor) =
   ## Skip one child, asserting a specific type tag, emit replacement.
@@ -651,11 +651,11 @@ proc replace*(t: var Replacer; expected: NimonyType; replacement: NifCursor) =
   t.dest.addSubtree(replacement)
 
 proc replace*(t: var Replacer; expected: NimonyType;
-              replacement: sink NifBuilder) =
+              replacement: NifBuilder) =
   ## Skip one child, asserting a specific type tag, emit replacement.
   assertTag(t.src, expected)
   t.src.skip()
-  t.dest.addTree(ensureMove(replacement))
+  t.dest.addTree(replacement)
 
 template keepTag*(t: var Replacer; body: untyped) =
   ## Copy the opening tag from input to output, run `body` for children,

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -158,8 +158,8 @@ proc addTree*(t: var NifBuilder; child: sink NifBuilder) =
       c.skip()
 
 proc addSymUse*(t: var NifBuilder; s: SymId;
-                info: LineInfo = NoLineInfo) =
-  nifcore.addSymUse(t, pluginPool.syms[s])
+                info: LineInfo) =
+  nifcore.addSymUse(t, s)
   appendInfo(t, info)
 
 proc addSymUse*(t: var NifBuilder; s: string;
@@ -592,54 +592,14 @@ template peek*(t: var Replacer; body: untyped) =
 
 # ── Entry points ──────────────────────────────────────────────────────────
 
-proc densify(dest: var NifBuilder; n: var NifCursor; cur: var LineInfo) =
-  let raw = n.rawLineInfo
-  if raw.isValid:
-    cur = raw
-  let effective = cur
-  cur.comment = StrId(0)
-  case n.kind
-  of TagLit:
-    dest.openTag(n.cursorTagId)
-    appendInfo(dest, effective)
-    n.into:
-      while n.hasMore:
-        densify(dest, n, cur)
-    dest.closeTag()
-  of DotToken:
-    dest.addDotToken(); appendInfo(dest, effective); n.inc()
-  of Ident:
-    dest.addIdent(n.strVal); appendInfo(dest, effective); n.inc()
-  of Symbol:
-    dest.addSymUse(n.symName); appendInfo(dest, effective); n.inc()
-  of SymbolDef:
-    dest.addSymDef(n.symName); appendInfo(dest, effective); n.inc()
-  of StrLit:
-    dest.addStrLit(n.strVal); appendInfo(dest, effective); n.inc()
-  of CharLit:
-    dest.addCharLit(n.charLit); appendInfo(dest, effective); n.inc()
-  of IntLit:
-    dest.addIntLit(n.intVal); appendInfo(dest, effective); n.inc()
-  of UIntLit:
-    dest.addUIntLit(n.uintVal); appendInfo(dest, effective); n.inc()
-  of FloatLit:
-    dest.addFloatLit(n.floatVal); appendInfo(dest, effective); n.inc()
-  of ExtendedSuffix, LineInfoLit:
-    assert false, "NIF suffix cannot be a value head"
-
-proc loadDenseTree(filename: string): NifBuilder =
-  var sparse = parseFromFile(filename, sharedPool = pluginPool,
-                             sharedTags = pluginTags)
-  result = createTree()
-  var n = sparse.beginRead()
-  var cur = NoLineInfo
-  while n.hasMore:
-    densify(result, n, cur)
+proc loadPluginTree(filename: string): NifBuilder =
+  parseFromFile(filename, sharedPool = pluginPool, sharedTags = pluginTags,
+                denseLineInfo = true)
 
 proc loadReplacer*(inputFile = paramStr(1)): Replacer =
   ## Loads the input NIF file and returns a `Replacer` ready for
   ## transformation. The cursor is positioned at the root of the input tree.
-  var tree = loadDenseTree(inputFile)
+  var tree = loadPluginTree(inputFile)
   result = Replacer(dest: createTree(), src: snapshot(tree))
 
 proc saveReplacer*(t: var Replacer; filename = paramStr(2)) =
@@ -659,7 +619,7 @@ proc loadPluginInput*(filename = paramStr(1)): NifCursor =
   ##
   ## For type plugins, use `loadTypeDefinitions()` to read the second input
   ## file (`paramStr(3)`) that carries the triggering type definitions.
-  var tree = loadDenseTree(filename)
+  var tree = loadPluginTree(filename)
   result = snapshot(tree)
 
 proc loadTypeDefinitions*(): NifCursor =
@@ -800,6 +760,4 @@ proc renderNode*(n: NifCursor): string =
   if not hasSubtree(n):
     result = "<bug: empty>"
   else:
-    var tree = createTree()
-    tree.addSubtree(n)
-    result = nifcoreparse.toString(tree, includeLineInfo = false)
+    result = nifcoreparse.toString(n, includeLineInfo = false)

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -11,12 +11,21 @@
 {.feature: "lenientnils".}
 {.feature: "untyped".}
 
-import std / [assertions, syncio, cmdline]
-import ".." / ".." / "lib" / [nifcore, nifcoreparse, bitabs]
+import std / [assertions, hashes, syncio, cmdline]
+import ".." / ".." / "lib" / nifcore except symId, `$`, addSymUse
+import ".." / ".." / "lib" / nifcoreparse except symId, `$`, addSymUse
+import ".." / ".." / "lib" / bitabs
 import ".." / ".." / "models" / [tags, nimony_tags]
 import ".." / nif_annotations
 export NimonyType, NimonyExpr, NimonyStmt, NimonyPragma, NimonyOther
-export nifcore
+export NifKind, SymId, TagId
+export DotToken, CharLit, StrLit, IntLit, UIntLit, FloatLit
+export Symbol, SymbolDef, Ident, TagLit
+export isValid, hash
+export skip, hasMore, into, loopInto
+export addSubtree, addDotToken, addStrLit, addIntLit, addUIntLit
+export addIdent, addCharLit, addFloatLit, addSymDef
+export charLit
 export nif_annotations
 
 type
@@ -48,7 +57,9 @@ proc appendInfo(buf: var NifBuilder; info: LineInfo) {.inline.} =
 
 proc hasSubtree(n: NifCursor): bool {.inline.} = n.hasMore
 proc isEmpty*(tree: NifBuilder): bool {.inline.} = tree.len == 0
-proc info*(n: NifCursor): LineInfo {.inline.} = n.rawLineInfo
+proc info*(n: NifCursor): LineInfo {.inline.} =
+  ## Returns no line info for an exhausted bounded cursor.
+  if n.hasMore: n.rawLineInfo else: NoLineInfo
 proc filePath*(info: LineInfo): string {.inline.} =
   if info.file.isValid: pluginPool.filenames[info.file] else: ""
 proc lineCol*(info: LineInfo): SourcePos {.inline.} =
@@ -67,12 +78,18 @@ proc floatValue*(n: NifCursor): BiggestFloat {.inline.} =
 
 proc tagId*(n: NifCursor): TagId {.inline.} = n.cursorTagId
 proc tagText*(n: NifCursor): string {.inline.} =
-  pluginTags.tags[n.cursorTagId]
+  n.tags.tags[n.cursorTagId]
 proc tagText*(tag: TagId): string {.inline.} = pluginTags.tags[tag]
-proc tag*(n: NifCursor): TagId {.inline.} = n.cursorTagId
+proc tag*(n: NifCursor): TagId {.inline.} =
+  ## Returns the error tag for atoms and exhausted cursors.
+  if n.hasMore and n.kind == TagLit:
+    n.cursorTagId
+  else:
+    TagId(uint32(ErrTagId))
 
 proc rawTag(n: NifCursor): TagEnum {.inline.} =
-  if n.kind != TagLit: return InvalidTagId
+  if n.kind != TagLit or n.tags != pluginTags:
+    return InvalidTagId
   let id = uint32(n.cursorTagId)
   if id <= uint32(high(TagEnum)): cast[TagEnum](id) else: InvalidTagId
 
@@ -95,12 +112,13 @@ proc pragmaKind*(n: NifCursor): NimonyPragma {.inline.} =
   if n.kind == TagLit:
     t = rawTag(n)
   elif n.kind == Ident:
-    let id = uint32(pluginTags.tags.getOrIncl(n.identText))
+    let id = uint32(pluginTags.tags.getKeyId(n.identText))
     if id <= uint32(high(TagEnum)):
       t = cast[TagEnum](id)
   if rawTagIsNimonyPragma(t): cast[NimonyPragma](t) else: NoPragma
 
-template tagIdFor(kind: untyped): untyped = TagId(uint32(kind))
+template tagIdFor(kind: untyped): untyped =
+  TagId(uint32(kind))
 
 proc createTree*(): NifBuilder =
   nifcore.createTokenBuf(sharedPool = pluginPool, sharedTags = pluginTags)
@@ -109,7 +127,11 @@ proc snapshot*(tree: var NifBuilder): NifCursor =
   assert not tree.isEmpty, "cannot snapshot empty NifBuilder"
   tree.beginRead()
 
-template withTree*(t: var NifBuilder; kind, info, body: untyped) =
+template withTree*(
+    t: var NifBuilder;
+    kind: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma;
+    info: LineInfo;
+    body: untyped) =
   t.openTag(tagIdFor(kind))
   appendInfo(t, info)
   body
@@ -131,34 +153,20 @@ proc takeTree*(t: var NifBuilder; n: var NifCursor) =
   t.addSubtree(n)
   n.skip()
 
-proc enterPluginScope(n: var NifCursor): NifCursor =
-  result = n
-  n = nifcore.childCursor(n)
-
-proc leavePluginScope(n: var NifCursor; outer: NifCursor) =
-  assert not n.hasMore, "scope body did not consume all children"
-  n = outer
-  n.skip()
-
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   assert n.kind == TagLit, "copyInto requires cursor at TagLit"
   let copiedTag = n.tagId
   let copiedInfo = n.info
   t.openTree(copiedTag, copiedInfo)
-  let outerCursor = enterPluginScope(n)
-  body
-  leavePluginScope(n, outerCursor)
+  nifcore.into n:
+    body
   t.closeTree()
 
 proc addTree*(t: var NifBuilder; child: sink NifBuilder) =
-  if child.len != 0:
-    var c = child.beginRead()
-    while c.hasMore:
-      t.addSubtree(c)
-      c.skip()
+  t.addBuffer(child)
 
 proc addSymUse*(t: var NifBuilder; s: SymId;
-                info: LineInfo) =
+                info: LineInfo = NoLineInfo) =
   nifcore.addSymUse(t, s)
   appendInfo(t, info)
 
@@ -229,10 +237,7 @@ proc bindSymHelper*(t: var NifBuilder; nifText: string) =
   ## resulting tokens to `t`. Called by `bindSym`'s sem rewrite — not intended
   ## for direct use.
   var parsed = parseNifBuffer(nifText)
-  var c = parsed.beginRead()
-  while c.hasMore:
-    t.addSubtree(c)
-    c.skip()
+  t.addBuffer(parsed)
 
 proc bindSym*(t: var NifBuilder; name: string;
               rule: BindSymRule = brClosed) {.magic: BindSymName.}
@@ -307,16 +312,16 @@ template balancedTokens*(n: var NifCursor; body: untyped) =
   ##   n.balancedTokens:
   ##     if n.stmtKind == IfS:
   ##       foundIf = true
-  proc walkBalanced(cursor: NifCursor) =
-    var it = cursor
-    if it.kind == TagLit:
-      n = it
-      body
-      it = firstChild(it)
-      while it.hasMore:
-        walkBalanced(it)
-        skip it
-  walkBalanced(n)
+  let outerCursor = n
+  if n.hasMore and n.kind == TagLit:
+    var scan = firstChild(n)
+    while scan.hasMore:
+      if scan.kind == TagLit:
+        n = scan
+        body
+      scan.inc()
+    n = outerCursor
+    n.skip()
 
 proc eqIdent*(n: NifCursor; name: string): bool =
   ## Returns true when `n` matches `name` exactly.
@@ -565,9 +570,8 @@ template replaceHead*(t: var Replacer;
   ## scopes.
   assert t.src.kind == TagLit, "replaceHead requires cursor at TagLit"
   t.dest.withTree(tag, info):
-    let outerCursor = enterPluginScope(t.src)
-    body
-    leavePluginScope(t.src, outerCursor)
+    nifcore.into t.src:
+      body
 
 # ── Cursor access for analysis ────────────────────────────────────────────
 
@@ -735,24 +739,6 @@ proc saveTree*(tree: sink NifBuilder) =
   ## directly replaces the module body.
   var output = ensureMove(tree)
   writeTree(output, paramStr(2))
-
-proc createTree*[K: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma](
-    kind: K; children: openArray[NifCursor]): NifBuilder =
-  ## Produces a new tree node of `kind` containing `children`.
-  result = createTree()
-  result.openTree(tagIdFor(kind))
-  for child in children:
-    result.addSubtree(child)
-  result.closeTree()
-
-proc createTree*[K: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma](
-    kind: K; info: LineInfo; children: openArray[NifCursor]): NifBuilder =
-  ## Produces a new tree node of `kind` and line info `info` containing `children`.
-  result = createTree()
-  result.openTree(tagIdFor(kind), info)
-  for child in children:
-    result.addSubtree(child)
-  result.closeTree()
 
 proc renderNode*(n: NifCursor): string =
   ## Renders the current token or subtree as raw NIF text for debugging.

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -9,362 +9,181 @@
 ## See `doc/plugins.md` for the full guide.
 
 {.feature: "lenientnils".}
+{.feature: "untyped".}
 
-import std / [assertions, hashes, syncio, cmdline, formatfloat]
-import ".." / ".." / "lib" / [nifcursors, nifstreams, lineinfos, bitabs]
-
-import ".." / [nimony_model, nif_annotations]
-export NimonyType, NimonyExpr, NimonyStmt, NimonyPragma, NimonyOther, NifKind, NoLineInfo
+import std / [assertions, syncio, cmdline]
+import ".." / ".." / "lib" / [nifcore, nifcoreparse, bitabs]
+import ".." / ".." / "models" / [tags, nimony_tags]
+import ".." / nif_annotations
+export NimonyType, NimonyExpr, NimonyStmt, NimonyPragma, NimonyOther
+export nifcore
 export nif_annotations
 
 type
-  NifBuilderObj = object
-    rc: int
-    buf: TokenBuf
+  NifBuilder* = nifcore.TokenBuf
+  NifCursor* = nifcore.Cursor
+  LineInfo* = nifcore.NifLineInfo
 
-  NifBuilderOwner = ptr NifBuilderObj
-
-  NifBuilder* = object ## Mutable NIF builder used by plugins to assemble output.
-                 ## Copying a tree shares the underlying payload until the next
-                 ## mutation detaches it.
-    p: NifBuilderOwner
-
-  LineInfo* = PackedLineInfo ## Packed source location metadata attached to NIF
-                             ## tokens. Use `NoLineInfo` for synthetic output.
-
-  SourcePos* = object ## Decoded source position for plugin-facing APIs.
+  SourcePos* = object
     line*: int
     col*: int
 
-  NifCursor* = object ## Read handle into a frozen NIF tree.
-                 ## A `NifCursor` behaves like a cursor positioned at one token or
-                 ## subtree. Copying a `NifCursor` retains the underlying tree
-                 ## snapshot automatically.
-    cursor: Cursor
+const NoLineInfo* = NoNifLineInfo
 
-  SymId* = object ## Symbol identifier. Use with `addSymUse` / `addSymDef` to
-                  ## emit symbol references and definitions in the output.
-    raw: nifstreams.SymId
+proc createPluginTags(): TagPool =
+  result = newTagPool()
+  for tag in low(TagEnum)..high(TagEnum):
+    if tag != InvalidTagId:
+      let id = result.registerTag(TagData[tag][0])
+      assert uint32(id) == uint32(tag),
+        "Nimony tag pool is not ordinal-aligned for " & TagData[tag][0]
 
-  TagId* = object ## Tag identifier for NIF tree nodes (e.g. `Stmt`, `Expr`).
-                  ## Use with `parLeToken` to open a tagged subtree.
-    raw: nifstreams.TagId
+let
+  pluginPool = newPool()
+  pluginTags = createPluginTags()
 
-proc `=destroy`*(x: NifBuilder) =
-  if x.p != nil:
-    dec x.p.rc
-    if x.p.rc == 0:
-      `=destroy`(x.p[].buf)
-      dealloc(x.p)
+proc appendInfo(buf: var NifBuilder; info: LineInfo) {.inline.} =
+  if info.isValid:
+    buf.appendLineInfo(info)
 
-proc `=wasMoved`*(x: var NifBuilder) =
-  x.p = nil
+proc hasSubtree(n: NifCursor): bool {.inline.} = n.hasMore
+proc isEmpty*(tree: NifBuilder): bool {.inline.} = tree.len == 0
+proc info*(n: NifCursor): LineInfo {.inline.} = n.rawLineInfo
+proc filePath*(info: LineInfo): string {.inline.} =
+  if info.file.isValid: pluginPool.filenames[info.file] else: ""
+proc lineCol*(info: LineInfo): SourcePos {.inline.} =
+  SourcePos(line: int(info.line), col: int(info.col))
 
-proc `=copy`*(dest: var NifBuilder; src: NifBuilder) =
-  if dest.p != src.p:
-    `=destroy`(dest)
-    if src.p != nil:
-      inc src.p.rc
-    dest.p = src.p
-
-proc `=dup`*(x: NifBuilder): NifBuilder {.nodestroy.} =
-  result = NifBuilder(p: x.p)
-  if result.p != nil:
-    inc result.p.rc
-
-proc initNifBuilderObj(buf: sink TokenBuf): NifBuilderOwner =
-  result = cast[NifBuilderOwner](alloc0(sizeof(NifBuilderObj)))
-  result.rc = 1
-  result.buf = ensureMove(buf)
-
-proc copyBuffer(buf: TokenBuf): TokenBuf =
-  result = createTokenBuf(max(buf.len, 4))
-  result.add buf
-
-proc hasSubtree(n: NifCursor): bool {.inline.} =
-  n.cursor.hasMore
-
-proc createTree(buf: sink TokenBuf): NifBuilder =
-  result = NifBuilder(p: initNifBuilderObj(buf))
-
-proc prepareMutation(t: var NifBuilder) =
-  if t.p == nil:
-    t = createTree(createTokenBuf())
-  elif t.p.rc > 1:
-    let oldP = t.p
-    t.p = initNifBuilderObj(copyBuffer(oldP.buf))
-    dec oldP.rc
-
-proc isEmpty*(tree: NifBuilder): bool {.inline.} =
-  ## Returns true when `tree` does not currently contain any tokens.
-  tree.p == nil or tree.p[].buf.len == 0
-
-proc kind*(n: NifCursor): NifKind {.inline.} =
-  ## Returns the raw NIF token kind at the current position.
-  n.cursor.kind
-
-proc info*(n: NifCursor): LineInfo {.inline.} =
-  ## Returns the packed line info stored on the current token.
-  n.cursor.info
-
-proc isValid*(info: LineInfo): bool {.inline.} =
-  ## Returns true when `info` refers to a real source location.
-  lineinfos.isValid(info)
-
-proc filePath*(info: LineInfo): string =
-  ## Returns the source path stored in `info`, or `""` when unavailable.
-  if lineinfos.isValid(info):
-    let rawInfo = unpack(pool.man, info)
-    if rawInfo.file.isValid:
-      result = pool.files[rawInfo.file]
-    else:
-      result = ""
-  else:
-    result = ""
-
-proc lineCol*(info: LineInfo): SourcePos =
-  ## Returns the 1-based `(line, col)` stored in `info`, or `(0, 0)` when
-  ## unavailable.
-  if lineinfos.isValid(info):
-    let rawInfo = unpack(pool.man, info)
-    result = SourcePos(line: int(rawInfo.line), col: int(rawInfo.col))
-  else:
-    result = SourcePos(line: 0, col: 0)
-
-func `==`*(a, b: SymId): bool {.inline.} =
-  a.raw == b.raw
-
-func hash*(x: SymId): Hash {.inline.} =
-  hash(x.raw)
-
-proc `$`*(x: SymId): string {.inline.} =
-  pool.syms[x.raw]
-
-proc `$`*(x: TagId): string {.inline.} =
-  ## Renders `x` as its textual NIF tag name.
-  pool.tags[x.raw]
-
-proc symText*(s: SymId): string {.inline.} =
-  ## Returns the symbol text stored in the plugin-facing symbol handle.
-  pool.syms[s.raw]
-
-proc tagText*(t: TagId): string {.inline.} =
-  ## Returns the textual NIF tag name for `t`.
-  pool.tags[t.raw]
-
-proc symId*(n: NifCursor): SymId {.inline.} =
-  ## Returns the symbol id of the current token as an opaque handle.
-  ## The current token must be a `Symbol` or `SymbolDef`.
-  SymId(raw: n.cursor.symId)
-
-proc symText*(n: NifCursor): string {.inline.} =
-  ## Returns the symbol text of the current `Symbol` or `SymbolDef` token.
-  pool.syms[n.cursor.symId]
-
-proc identText*(n: NifCursor): string {.inline.} =
-  ## Returns the identifier text of the current `Ident` token.
-  pool.strings[n.cursor.litId]
-
-proc stringValue*(n: NifCursor): string {.inline.} =
-  ## Returns the string contents of the current `StringLit` token.
-  pool.strings[n.cursor.litId]
-
-proc charLit*(n: NifCursor): char {.inline.} =
-  ## Returns the character stored in the current `CharLit` token.
-  n.cursor.charLit
-
+proc symText*(n: NifCursor): string {.inline.} = n.symName
+proc symText*(s: SymId): string {.inline.} = pluginPool.syms[s]
+proc identText*(n: NifCursor): string {.inline.} = n.strVal
+proc stringValue*(n: NifCursor): string {.inline.} = n.strVal
 proc intValue*(n: NifCursor): BiggestInt {.inline.} =
-  ## Returns the integer value stored in the current `IntLit` token.
-  pool.integers[n.cursor.intId]
-
+  BiggestInt(n.intVal)
 proc uintValue*(n: NifCursor): BiggestUInt {.inline.} =
-  ## Returns the unsigned integer value stored in the current `UIntLit` token.
-  pool.uintegers[n.cursor.uintId]
-
+  BiggestUInt(n.uintVal)
 proc floatValue*(n: NifCursor): BiggestFloat {.inline.} =
-  ## Returns the floating-point value stored in the current `FloatLit` token.
-  pool.floats[n.cursor.floatId]
+  BiggestFloat(n.floatVal)
+
+proc tagId*(n: NifCursor): TagId {.inline.} = n.cursorTagId
+proc tagText*(n: NifCursor): string {.inline.} =
+  pluginTags.tags[n.cursorTagId]
+proc tagText*(tag: TagId): string {.inline.} = pluginTags.tags[tag]
+proc tag*(n: NifCursor): TagId {.inline.} = n.cursorTagId
+
+proc rawTag(n: NifCursor): TagEnum {.inline.} =
+  if n.kind != TagLit: return InvalidTagId
+  let id = uint32(n.cursorTagId)
+  if id <= uint32(high(TagEnum)): cast[TagEnum](id) else: InvalidTagId
 
 proc stmtKind*(n: NifCursor): NimonyStmt {.inline.} =
-  ## Returns the current statement kind, or `NoStmt` when the current token is
-  ## not a statement node.
-  n.cursor.stmtKind
-
+  let t = rawTag(n)
+  if rawTagIsNimonyStmt(t): cast[NimonyStmt](t) else: NoStmt
 proc exprKind*(n: NifCursor): NimonyExpr {.inline.} =
-  ## Returns the current expression kind, or `NoExpr` when the current token is
-  ## not an expression node.
-  n.cursor.exprKind
-
+  let t = rawTag(n)
+  if rawTagIsNimonyExpr(t): cast[NimonyExpr](t) else: NoExpr
 proc typeKind*(n: NifCursor): NimonyType {.inline.} =
-  ## Returns the current type kind.
-  ## `DotToken` is treated as `VoidT`; non-type nodes return `NoType`.
-  n.cursor.typeKind
-
+  if n.kind == DotToken: VoidT
+  else:
+    let t = rawTag(n)
+    if rawTagIsNimonyType(t): cast[NimonyType](t) else: NoType
 proc otherKind*(n: NifCursor): NimonyOther {.inline.} =
-  ## Returns the current "other/substructure" kind, or `NoSub` for non-matching
-  ## nodes.
-  n.cursor.substructureKind
-
+  let t = rawTag(n)
+  if rawTagIsNimonyOther(t): cast[NimonyOther](t) else: NoSub
 proc pragmaKind*(n: NifCursor): NimonyPragma {.inline.} =
-  ## Returns the current pragma kind, or `NoPragma` for non-matching nodes.
-  n.cursor.pragmaKind
+  var t = InvalidTagId
+  if n.kind == TagLit:
+    t = rawTag(n)
+  elif n.kind == Ident:
+    let id = uint32(pluginTags.tags.getOrIncl(n.identText))
+    if id <= uint32(high(TagEnum)):
+      t = cast[TagEnum](id)
+  if rawTagIsNimonyPragma(t): cast[NimonyPragma](t) else: NoPragma
+
+template tagIdFor(kind: untyped): untyped = TagId(uint32(kind))
 
 proc createTree*(): NifBuilder =
-  ## Creates an empty mutable `NifBuilder`.
-  createTree(createTokenBuf())
+  nifcore.createTokenBuf(sharedPool = pluginPool, sharedTags = pluginTags)
 
 proc snapshot*(tree: var NifBuilder): NifCursor =
-  ## Returns a read-only snapshot positioned at the first top-level token of
-  ## `tree`.
-  ##
-  ## The returned `NifCursor` keeps the underlying data alive automatically via
-  ## the Cursor's COW mechanism. The original tree remains writable and
-  ## detaches on the next mutation.
-  ##
-  ## `tree` must not be empty; use `isEmpty` first when that is expected.
   assert not tree.isEmpty, "cannot snapshot empty NifBuilder"
-  result = NifCursor(cursor: beginRead(tree.p[].buf))
+  tree.beginRead()
 
-template withTree*(t: var NifBuilder; kind: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma; info: LineInfo; body: untyped) =
-  ## Appends a tree node of `kind` to `t`, runs `body` to emit its children, and
-  ## closes the node afterwards.
-  prepareMutation(t)
-  # Use the generic parLeToken overload from nimony_model that does the
-  # TagId conversion via `cast[TagId](kind)` inside its body — nimony's
-  # cast rule allows it there.
-  t.p[].buf.add parLeToken(kind, info)
+template withTree*(t: var NifBuilder; kind, info, body: untyped) =
+  t.openTag(tagIdFor(kind))
+  appendInfo(t, info)
   body
-  t.p[].buf.addParRi()
+  t.closeTag()
 
-proc tagId*(n: NifCursor): TagId {.inline.} =
-  ## Returns the raw tag id of the current token.
-  ## The current token must be a `ParLe`.
-  TagId(raw: n.cursor.tagId)
+proc openTree*(t: var NifBuilder; tag: TagId;
+               info: LineInfo = NoLineInfo) =
+  t.openTag(tag)
+  appendInfo(t, info)
 
-proc tagText*(n: NifCursor): string {.inline.} =
-  ## Returns the tag text of the current `ParLe` token.
-  pool.tags[n.cursor.tagId]
+proc openTree*(t: var NifBuilder; tag: string;
+               info: LineInfo = NoLineInfo) =
+  t.openTag(pluginTags.tags.getOrIncl(tag))
+  appendInfo(t, info)
 
-proc tag*(n: NifCursor): TagId {.inline.} =
-  ## Returns the raw tag id for the current tree node, or `ErrT` if the
-  ## current token is not a `ParLe`.
-  TagId(raw: n.cursor.tag)
-
-proc addParLe*(t: var NifBuilder; tag: TagId; info: LineInfo = NoLineInfo) =
-  ## Appends an opening tree token with raw tag id `tag` to `t`.
-  ## Use `addParLe(tagText, ...)` when constructing nodes from textual tag
-  ## names instead of existing ids.
-  prepareMutation(t)
-  t.p[].buf.addParLe(tag.raw, info)
-
-proc addParLe*(t: var NifBuilder; tag: string; info: LineInfo = NoLineInfo) =
-  ## Appends an opening tree token with textual tag `tag` to `t`.
-  prepareMutation(t)
-  t.p[].buf.addParLe(pool.tags.getOrIncl(tag), info)
-
-proc addParRi*(t: var NifBuilder) =
-  ## Appends a closing tree token (`)`) to `t`.
-  prepareMutation(t)
-  t.p[].buf.addParRi()
+proc closeTree*(t: var NifBuilder) = t.closeTag()
 
 proc takeTree*(t: var NifBuilder; n: var NifCursor) =
-  ## Copies the current token or subtree from `n` into `t` and advances `n`
-  ## past the copied fragment.
-  prepareMutation(t)
-  t.p[].buf.takeTree(n.cursor)
+  t.addSubtree(n)
+  n.skip()
+
+proc enterPluginScope(n: var NifCursor): NifCursor =
+  result = n
+  n = nifcore.childCursor(n)
+
+proc leavePluginScope(n: var NifCursor; outer: NifCursor) =
+  assert not n.hasMore, "scope body did not consume all children"
+  n = outer
+  n.skip()
 
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
-  ## Copies the opening tag from `n` into `t`, processes children via `body`
-  ## (which must consume them through `take*` / `skip` / nested `copyInto`),
-  ## then closes the node in `t` and advances `n` past the matching `)`.
-  ##
-  ## Delegates to nifprims's `into`, so it remains correct under virtual
-  ## ParRi (sealed-jump) and overflow scopes.
-  ##
-  ## .. code-block:: nim
-  ##   o.copyInto(n):
-  ##     while n.hasMore:
-  ##       transform(n, o)
-  assert n.kind == ParLe, "copyInto requires cursor at ParLe"
-  prepareMutation(t)
-  t.p[].buf.add n.cursor
-  nifcursors.into n.cursor:
-    body
-  t.p[].buf.addParRi()
+  assert n.kind == TagLit, "copyInto requires cursor at TagLit"
+  let copiedTag = n.tagId
+  let copiedInfo = n.info
+  t.openTree(copiedTag, copiedInfo)
+  let outerCursor = enterPluginScope(n)
+  body
+  leavePluginScope(n, outerCursor)
+  t.closeTree()
 
-proc addSubtree*(t: var NifBuilder; n: NifCursor) =
-  ## Copies the current token or subtree from `n` into `t` without advancing it.
-  prepareMutation(t)
-  t.p[].buf.addSubtree(n.cursor)
+proc addTree*(t: var NifBuilder; child: sink NifBuilder) =
+  if child.len != 0:
+    var c = child.beginRead()
+    while c.hasMore:
+      t.addSubtree(c)
+      c.skip()
 
-proc add*(t: var NifBuilder; child: NifBuilder) =
-  ## Appends the complete contents of `child` to `t`.
-  if not child.isEmpty:
-    prepareMutation(t)
-    t.p[].buf.add child.p[].buf
+proc addSymUse*(t: var NifBuilder; s: SymId;
+                info: LineInfo = NoLineInfo) =
+  nifcore.addSymUse(t, pluginPool.syms[s])
+  appendInfo(t, info)
 
-proc addDotToken*(t: var NifBuilder) =
-  ## Appends a dot placeholder token (`.`) to `t`.
-  prepareMutation(t)
-  t.p[].buf.addDotToken()
-
-proc addStrLit*(t: var NifBuilder; s: string) =
-  ## Appends a string literal atom to `t`.
-  prepareMutation(t)
-  t.p[].buf.addStrLit(s)
-
-proc addIntLit*(t: var NifBuilder; i: BiggestInt) =
-  ## Appends a signed integer literal atom to `t`.
-  prepareMutation(t)
-  t.p[].buf.addIntLit(i)
-
-proc addUIntLit*(t: var NifBuilder; i: BiggestUInt) =
-  ## Appends an unsigned integer literal atom to `t`.
-  prepareMutation(t)
-  t.p[].buf.addUIntLit(i)
-
-proc addIdent*(t: var NifBuilder; ident: string) =
-  ## Appends an identifier atom to `t`.
-  prepareMutation(t)
-  t.p[].buf.addIdent(ident)
-
-proc addCharLit*(t: var NifBuilder; c: char) =
-  ## Appends a character literal atom to `t`.
-  prepareMutation(t)
-  t.p[].buf.addCharLit(c)
-
-proc addFloatLit*(t: var NifBuilder; f: BiggestFloat) =
-  ## Appends a floating-point literal atom to `t`.
-  prepareMutation(t)
-  t.p[].buf.addFloatLit(f)
-
-proc addSymUse*(t: var NifBuilder; s: SymId; info: LineInfo = NoLineInfo) =
-  ## Appends a symbol-use atom named by the opaque handle `s` to `t`.
-  prepareMutation(t)
-  t.p[].buf.addSymUse(s.raw, info)
-
-proc addSymUse*(t: var NifBuilder; s: string; info: LineInfo = NoLineInfo) =
-  ## Appends a symbol-use atom named `s` to `t`.
-  prepareMutation(t)
-  t.p[].buf.addSymUse(pool.syms.getOrIncl(s), info)
+proc addSymUse*(t: var NifBuilder; s: string;
+                info: LineInfo) =
+  nifcore.addSymUse(t, s)
+  appendInfo(t, info)
 
 proc addErrorMessage(t: var NifBuilder; msg: string; info: LineInfo) =
-  prepareMutation(t)
-  t.p[].buf.addStrLit(msg, info)
+  t.addStrLit(msg)
+  appendInfo(t, info)
 
 proc buildErrorTree(info: LineInfo; msg: string; orig: NifCursor): NifBuilder =
   result = createTree()
-  result.addParLe("err", info)
+  result.openTree("err", info)
   result.addSubtree(orig)
   result.addErrorMessage(msg, info)
-  result.addParRi()
+  result.closeTree()
 
 proc buildErrorTree(info: LineInfo; msg: string): NifBuilder =
   result = createTree()
-  result.addParLe("err", info)
+  result.openTree("err", info)
   result.addDotToken()
   result.addErrorMessage(msg, info)
-  result.addParRi()
+  result.closeTree()
 
 proc errorTree*(msg: string): NifBuilder =
   ## Builds a compiler error tree with no original expression attached.
@@ -388,13 +207,11 @@ proc errorTree*(msg: string; at, orig: NifCursor): NifBuilder =
   else:
     buildErrorTree(at.info, msg)
 
-proc parseNifBuffer(text: string): TokenBuf =
+proc parseNifBuffer(text: string): nifcore.TokenBuf =
   # Internal helper used by `bindSymHelper` to parse a NIF source fragment
-  # (e.g. `name.0.suffix` or `(cchoice s1 s2 …)`). Strips the trailing
-  # `EofToken` so the resulting tokens concatenate cleanly into a builder.
-  result = parseFromBuffer(text, "")
-  if result.len > 0 and result[result.len-1].kind == EofToken:
-    result.shrink(result.len-1)
+  # (e.g. `name.0.suffix` or `(cchoice s1 s2 …)`).
+  result = parseFromBuffer(text, "", sharedPool = pluginPool,
+                           sharedTags = pluginTags)
 
 type
   BindSymRule* = enum
@@ -411,8 +228,11 @@ proc bindSymHelper*(t: var NifBuilder; nifText: string) =
   ## Runtime helper: parse `nifText` (a NIF source fragment) and append the
   ## resulting tokens to `t`. Called by `bindSym`'s sem rewrite — not intended
   ## for direct use.
-  prepareMutation(t)
-  t.p[].buf.add parseNifBuffer(nifText)
+  var parsed = parseNifBuffer(nifText)
+  var c = parsed.beginRead()
+  while c.hasMore:
+    t.addSubtree(c)
+    c.skip()
 
 proc bindSym*(t: var NifBuilder; name: string;
               rule: BindSymRule = brClosed) {.magic: BindSymName.}
@@ -437,81 +257,66 @@ proc bindSym*(t: var NifBuilder; name: string;
 
 proc addEmptyNode*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends a single empty placeholder node (`.`) to `t`.
-  prepareMutation(t)
-  t.p[].buf.addEmpty(info)
+  t.addDotToken()
+  appendInfo(t, info)
 
 proc addEmptyNode2*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends two empty placeholder nodes (`. .`) to `t`.
-  prepareMutation(t)
-  t.p[].buf.addEmpty2(info)
+  t.addDotToken()
+  appendInfo(t, info)
+  t.addDotToken()
+  appendInfo(t, info)
 
 proc addEmptyNode3*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends three empty placeholder nodes (`. . .`) to `t`.
-  prepareMutation(t)
-  t.p[].buf.addEmpty3(info)
+  t.addDotToken()
+  appendInfo(t, info)
+  t.addDotToken()
+  appendInfo(t, info)
+  t.addDotToken()
+  appendInfo(t, info)
 
 proc addEmptyNode4*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends four empty placeholder nodes (`. . . .`) to `t`.
-  prepareMutation(t)
-  t.p[].buf.addEmpty3(info)
-  t.p[].buf.addEmpty(info)
-
-proc skip*(n: var NifCursor) =
-  ## Skips the current token or, if positioned on `ParLe`, the entire subtree.
-  skip n.cursor
+  t.addDotToken()
+  appendInfo(t, info)
+  t.addDotToken()
+  appendInfo(t, info)
+  t.addDotToken()
+  appendInfo(t, info)
+  t.addDotToken()
+  appendInfo(t, info)
 
 proc firstChild*(n: NifCursor): NifCursor {.inline.} =
   ## Returns a cursor positioned at the first child of `n`. `n` must be at
-  ## a `ParLe`. The returned cursor's bounded `rem` is set to the sub-scope's
+  ## a `TagLit`. The returned cursor's bounded `rem` is set to the sub-scope's
   ## body count so it can be used both for read-only `~` / `takeTree`
   ## extraction *and* for bounded iteration (`while c.hasMore: …`). `n`
   ## itself is unchanged.
-  ## a `ParLe`.
-  result = NifCursor(cursor: firstSon(n.cursor))
+  result = nifcore.childCursor(n)
 
 # ── Traversal templates ──────────────────────────────────────────────────
 # Pure traversal helpers for reading/analyzing a tree without producing output.
 
-template hasMore*(n: NifCursor): bool =
-  ## True while there are more children before the closing `)`.
-  n.cursor.hasMore
-
-template into*(n: var NifCursor; body: untyped) =
-  ## Enters the current node, runs `body` to process the children, then
-  ## advances past the (real or virtual) closing `)`. Delegates to nifprims
-  ## so the bounded-scope and overflow paths are handled correctly.
-  ##
-  ## .. code-block:: nim
-  ##   n.into:
-  ##     while n.hasMore:
-  ##       analyze(n)
-  ##       skip n
-  nifcursors.into n.cursor:
-    body
-
-template loopInto*(n: var NifCursor; body: untyped) =
-  ## Enters a node, iterates all children, then advances past `)`.
-  ## The body must advance `n` on every iteration.
-  ##
-  ## .. code-block:: nim
-  ##   n.loopInto:
-  ##     analyze(n)
-  ##     skip n
-  into n:
-    while n.hasMore:
-      body
-
 template balancedTokens*(n: var NifCursor; body: untyped) =
-  ## Deep-scans all `ParLe` nodes in the subtree rooted at `n`.
-  ## Inside `body`, `n` is positioned at each `ParLe` node in turn.
+  ## Deep-scans all `TagLit` nodes in the subtree rooted at `n`.
+  ## Inside `body`, `n` is positioned at each `TagLit` node in turn.
   ## `body` must **not** advance `n` — the template handles traversal.
   ##
   ## .. code-block:: nim
   ##   n.balancedTokens:
   ##     if n.stmtKind == IfS:
   ##       foundIf = true
-  nifcursors.balancedTokens n.cursor:
-    body
+  proc walkBalanced(cursor: NifCursor) =
+    var it = cursor
+    if it.kind == TagLit:
+      n = it
+      body
+      it = firstChild(it)
+      while it.hasMore:
+        walkBalanced(it)
+        skip it
+  walkBalanced(n)
 
 proc eqIdent*(n: NifCursor; name: string): bool =
   ## Returns true when `n` matches `name` exactly.
@@ -531,13 +336,13 @@ type
   ChildKind* = enum
     ## Category of a NIF child for `keep`/`drop` assertions.
     Any       ## matches any token or subtree
-    Expr      ## value expression (ParLe with expr tag, or Symbol/literal)
-    Type      ## type expression (ParLe with type tag, or DotToken for void)
-    Stmt      ## statement (ParLe with stmt tag)
+    Expr      ## value expression (TagLit with expr tag, or Symbol/literal)
+    Type      ## type expression (TagLit with type tag, or DotToken for void)
+    Stmt      ## statement (TagLit with stmt tag)
     Def       ## SymbolDef
     Sym       ## Symbol use
     Dot       ## DotToken (empty placeholder)
-    Lit       ## literal (IntLit, UIntLit, FloatLit, StringLit, CharLit)
+    Lit       ## literal (IntLit, UIntLit, FloatLit, StrLit, CharLit)
     Nested    ## nested substructure (params, pragmas, etc.)
 
   Replacer* = object
@@ -548,9 +353,9 @@ type
     src: NifCursor      ## Input cursor — use getCursor/setCursor for raw access.
 
 proc isAtom*(t: Replacer): bool {.inline.} =
-  ## True when the cursor is at a leaf token (not ParLe). Atoms cannot be
+  ## True when the cursor is at a leaf token (not TagLit). Atoms cannot be
   ## entered with `keepTag`.
-  t.src.kind != ParLe
+  t.src.kind != TagLit
 
 # Delegated cursor accessors:
 proc kind*(t: Replacer): NifKind {.inline.} = t.src.kind
@@ -580,13 +385,13 @@ proc matchesChildKind(n: NifCursor; k: ChildKind): bool =
   of Any: true
   of Expr:
     case n.kind
-    of ParLe: n.exprKind != NoExpr
-    of Symbol, Ident, IntLit, UIntLit, FloatLit, StringLit, CharLit: true
+    of TagLit: n.exprKind != NoExpr
+    of Symbol, Ident, IntLit, UIntLit, FloatLit, StrLit, CharLit: true
     else: false
   of Type:
-    n.kind == DotToken or (n.kind == ParLe and n.typeKind != NoType)
+    n.kind == DotToken or (n.kind == TagLit and n.typeKind != NoType)
   of Stmt:
-    n.kind == ParLe and n.stmtKind != NoStmt
+    n.kind == TagLit and n.stmtKind != NoStmt
   of Def:
     n.kind == SymbolDef
   of Sym:
@@ -594,9 +399,9 @@ proc matchesChildKind(n: NifCursor; k: ChildKind): bool =
   of Dot:
     n.kind == DotToken
   of Lit:
-    n.kind in {IntLit, UIntLit, FloatLit, StringLit, CharLit}
+    n.kind in {IntLit, UIntLit, FloatLit, StrLit, CharLit}
   of Nested:
-    n.kind == ParLe and n.exprKind == NoExpr and n.stmtKind == NoStmt and
+    n.kind == TagLit and n.exprKind == NoExpr and n.stmtKind == NoStmt and
         n.typeKind == NoType
 
 proc assertChild(n: NifCursor; k: ChildKind) {.inline.} =
@@ -691,11 +496,12 @@ proc replace*(t: var Replacer; expected: ChildKind; replacement: NifCursor) =
   t.src.skip()
   t.dest.addSubtree(replacement)
 
-proc replace*(t: var Replacer; expected: ChildKind; replacement: NifBuilder) =
+proc replace*(t: var Replacer; expected: ChildKind;
+              replacement: sink NifBuilder) =
   ## Skip one child from input, emit replacement builder tree instead.
   assertChild(t.src, expected)
   t.src.skip()
-  t.dest.add(replacement)
+  t.dest.addTree(ensureMove(replacement))
 
 proc replace*(t: var Replacer; expected: NimonyStmt; replacement: NifCursor) =
   ## Skip one child, asserting a specific statement tag, emit replacement.
@@ -703,11 +509,12 @@ proc replace*(t: var Replacer; expected: NimonyStmt; replacement: NifCursor) =
   t.src.skip()
   t.dest.addSubtree(replacement)
 
-proc replace*(t: var Replacer; expected: NimonyStmt; replacement: NifBuilder) =
+proc replace*(t: var Replacer; expected: NimonyStmt;
+              replacement: sink NifBuilder) =
   ## Skip one child, asserting a specific statement tag, emit replacement.
   assertTag(t.src, expected)
   t.src.skip()
-  t.dest.add(replacement)
+  t.dest.addTree(ensureMove(replacement))
 
 proc replace*(t: var Replacer; expected: NimonyExpr; replacement: NifCursor) =
   ## Skip one child, asserting a specific expression tag, emit replacement.
@@ -715,11 +522,12 @@ proc replace*(t: var Replacer; expected: NimonyExpr; replacement: NifCursor) =
   t.src.skip()
   t.dest.addSubtree(replacement)
 
-proc replace*(t: var Replacer; expected: NimonyExpr; replacement: NifBuilder) =
+proc replace*(t: var Replacer; expected: NimonyExpr;
+              replacement: sink NifBuilder) =
   ## Skip one child, asserting a specific expression tag, emit replacement.
   assertTag(t.src, expected)
   t.src.skip()
-  t.dest.add(replacement)
+  t.dest.addTree(ensureMove(replacement))
 
 proc replace*(t: var Replacer; expected: NimonyType; replacement: NifCursor) =
   ## Skip one child, asserting a specific type tag, emit replacement.
@@ -727,16 +535,17 @@ proc replace*(t: var Replacer; expected: NimonyType; replacement: NifCursor) =
   t.src.skip()
   t.dest.addSubtree(replacement)
 
-proc replace*(t: var Replacer; expected: NimonyType; replacement: NifBuilder) =
+proc replace*(t: var Replacer; expected: NimonyType;
+              replacement: sink NifBuilder) =
   ## Skip one child, asserting a specific type tag, emit replacement.
   assertTag(t.src, expected)
   t.src.skip()
-  t.dest.add(replacement)
+  t.dest.addTree(ensureMove(replacement))
 
 template keepTag*(t: var Replacer; body: untyped) =
   ## Copy the opening tag from input to output, run `body` for children,
-  ## close the node and advance past the input's closing `)`.
-  assert t.src.kind == ParLe, "keepTag requires cursor at ParLe"
+  ## seal the output node and advance past the input subtree.
+  assert t.src.kind == TagLit, "keepTag requires cursor at TagLit"
   t.dest.copyInto(t.src):
     body
 
@@ -754,10 +563,11 @@ template replaceHead*(t: var Replacer;
   ## Enters the input tree via `into`, runs `body`
   ## (which must consume the children), then closes both input and output
   ## scopes.
-  assert t.src.kind == ParLe, "replaceHead requires cursor at ParLe"
+  assert t.src.kind == TagLit, "replaceHead requires cursor at TagLit"
   t.dest.withTree(tag, info):
-    nifcursors.into t.src.cursor:
-      body
+    let outerCursor = enterPluginScope(t.src)
+    body
+    leavePluginScope(t.src, outerCursor)
 
 # ── Cursor access for analysis ────────────────────────────────────────────
 
@@ -782,40 +592,75 @@ template peek*(t: var Replacer; body: untyped) =
 
 # ── Entry points ──────────────────────────────────────────────────────────
 
+proc densify(dest: var NifBuilder; n: var NifCursor; cur: var LineInfo) =
+  let raw = n.rawLineInfo
+  if raw.isValid:
+    cur = raw
+  let effective = cur
+  cur.comment = StrId(0)
+  case n.kind
+  of TagLit:
+    dest.openTag(n.cursorTagId)
+    appendInfo(dest, effective)
+    n.into:
+      while n.hasMore:
+        densify(dest, n, cur)
+    dest.closeTag()
+  of DotToken:
+    dest.addDotToken(); appendInfo(dest, effective); n.inc()
+  of Ident:
+    dest.addIdent(n.strVal); appendInfo(dest, effective); n.inc()
+  of Symbol:
+    dest.addSymUse(n.symName); appendInfo(dest, effective); n.inc()
+  of SymbolDef:
+    dest.addSymDef(n.symName); appendInfo(dest, effective); n.inc()
+  of StrLit:
+    dest.addStrLit(n.strVal); appendInfo(dest, effective); n.inc()
+  of CharLit:
+    dest.addCharLit(n.charLit); appendInfo(dest, effective); n.inc()
+  of IntLit:
+    dest.addIntLit(n.intVal); appendInfo(dest, effective); n.inc()
+  of UIntLit:
+    dest.addUIntLit(n.uintVal); appendInfo(dest, effective); n.inc()
+  of FloatLit:
+    dest.addFloatLit(n.floatVal); appendInfo(dest, effective); n.inc()
+  of ExtendedSuffix, LineInfoLit:
+    assert false, "NIF suffix cannot be a value head"
+
+proc loadDenseTree(filename: string): NifBuilder =
+  var sparse = parseFromFile(filename, sharedPool = pluginPool,
+                             sharedTags = pluginTags)
+  result = createTree()
+  var n = sparse.beginRead()
+  var cur = NoLineInfo
+  while n.hasMore:
+    densify(result, n, cur)
+
 proc loadReplacer*(inputFile = paramStr(1)): Replacer =
   ## Loads the input NIF file and returns a `Replacer` ready for
   ## transformation. The cursor is positioned at the root of the input tree.
-  var inp = nifstreams.open(inputFile)
-  try:
-    var tree = createTree(fromStream(inp))
-    result = Replacer(dest: createTree(), src: snapshot(tree))
-  finally:
-    close(inp)
+  var tree = loadDenseTree(inputFile)
+  result = Replacer(dest: createTree(), src: snapshot(tree))
 
-proc saveReplacer*(t: Replacer; filename = paramStr(2)) =
+proc saveReplacer*(t: var Replacer; filename = paramStr(2)) =
   ## Writes the Replacer's output to `filename` (default: `paramStr(2)`).
   try:
-    if t.dest.p == nil:
+    if t.dest.isEmpty:
       writeFile filename, ""
     else:
-      writeFile filename, toString(t.dest.p[].buf)
+      writeFile filename, nifcoreparse.toString(t.dest)
   except:
     quit "FAILURE: cannot write " & filename
 
-# ── Existing API (retained for backwards compatibility) ───────────────────
+# ── Plugin input helpers ───────────────────────────────────────────────────
 
 proc loadPluginInput*(filename = paramStr(1)): NifCursor =
   ## Loads a NIF file and returns a root `NifCursor` for reading it.
   ##
   ## For type plugins, use `loadTypeDefinitions()` to read the second input
   ## file (`paramStr(3)`) that carries the triggering type definitions.
-  var inp = nifstreams.open(filename)
-  try:
-    var tree = createTree(fromStream(inp))
-    result = snapshot(tree)
-    # tree is destroyed here, but NifCursor's cursor keeps data alive via COW
-  finally:
-    close(inp)
+  var tree = loadDenseTree(filename)
+  result = snapshot(tree)
 
 proc loadTypeDefinitions*(): NifCursor =
   ## Loads the type-definitions input for a type plugin (`paramStr(3)`).
@@ -859,7 +704,7 @@ proc forLoopCallArgs*(n: NifCursor): NifCursor =
   ## .. code-block:: nim
   ##   var c = forLoopCallArgs(n)
   ##   c.into:
-  ##     while c.kind != ParRi:
+  ##     while c.hasMore:
   ##       process(c)
   ##       skip c
   result = n
@@ -879,7 +724,7 @@ proc forLoopVars*(n: NifCursor): NifCursor =
     result = firstChild(result) # name
     skip result                  # (callargs ...)
     skip result                  # → (unpackflat ...) or (unpacktup ...)
-  # result is now at the loop vars node, or at ')' if none
+  # result is now at the loop vars node, or exhausted if none
 
 proc forLoopBody*(n: NifCursor): NifCursor =
   ## Returns a cursor at the loop body of a for-loop plugin input.
@@ -889,31 +734,35 @@ proc forLoopBody*(n: NifCursor): NifCursor =
   ## This proc scans past the iter name, call args, and loop vars to reach
   ## the body subtree.
   result = forLoopVars(n)
-  if result.kind != ParRi:
+  if result.hasMore:
     skip result # skip loop vars
-    # result is now at the body (or at ')' if there is none)
+    # result is now at the body (or exhausted if there is none)
 
-proc renderTree*(tree: NifBuilder): string =
+proc renderTree*(tree: var NifBuilder): string =
   ## Renders the complete contents of `tree` as raw NIF text for debugging.
   ## Unlike `saveTree`, this omits line info and may contain multiple
   ## top-level fragments when the tree is still under construction.
-  if tree.p == nil:
+  if tree.isEmpty:
     result = ""
   else:
-    result = toString(tree.p[].buf, false)
+    result = nifcoreparse.toString(tree, includeLineInfo = false)
 
-proc saveTree*(tree: NifBuilder; filename: string) =
-  ## Writes the complete contents of a mutable `NifBuilder` to `filename`.
-  ## This preserves line info because it is intended for `.nif` output.
+proc writeTree(tree: var NifBuilder; filename: string) =
   try:
-    if tree.p == nil:
+    if tree.isEmpty:
       writeFile filename, ""
     else:
-      writeFile filename, toString(tree.p[].buf)
+      writeFile filename, nifcoreparse.toString(tree)
   except:
     quit "FAILURE: cannot write " & filename
 
-proc saveTree*(tree: NifBuilder) =
+proc saveTree*(tree: sink NifBuilder; filename: string) =
+  ## Writes the complete contents of a mutable `NifBuilder` to `filename`.
+  ## This preserves line info because it is intended for `.nif` output.
+  var output = ensureMove(tree)
+  writeTree(output, filename)
+
+proc saveTree*(tree: sink NifBuilder) =
   ## Writes the complete contents of a mutable `NifBuilder` to `paramStr(2)`.
   ## This preserves line info because it is intended for `.nif` output.
   ##
@@ -924,27 +773,26 @@ proc saveTree*(tree: NifBuilder) =
   ## type plugin output is NOT re-semantacked — it must already be fully
   ## semanticked NIF (resolved symbols, typed expressions) because it
   ## directly replaces the module body.
-  saveTree(tree, paramStr(2))
+  var output = ensureMove(tree)
+  writeTree(output, paramStr(2))
 
 proc createTree*[K: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma](
-    kind: K; children: openArray[NifBuilder]): NifBuilder =
+    kind: K; children: openArray[NifCursor]): NifBuilder =
   ## Produces a new tree node of `kind` containing `children`.
   result = createTree()
-  prepareMutation(result)
-  result.p[].buf.add parLeToken(kind, NoLineInfo)
+  result.openTree(tagIdFor(kind))
   for child in children:
-    result.add(child)
-  result.p[].buf.addParRi()
+    result.addSubtree(child)
+  result.closeTree()
 
 proc createTree*[K: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma](
-    kind: K; info: LineInfo; children: openArray[NifBuilder]): NifBuilder =
+    kind: K; info: LineInfo; children: openArray[NifCursor]): NifBuilder =
   ## Produces a new tree node of `kind` and line info `info` containing `children`.
   result = createTree()
-  prepareMutation(result)
-  result.p[].buf.add parLeToken(kind, info)
+  result.openTree(tagIdFor(kind), info)
   for child in children:
-    result.add(child)
-  result.p[].buf.addParRi()
+    result.addSubtree(child)
+  result.closeTree()
 
 proc renderNode*(n: NifCursor): string =
   ## Renders the current token or subtree as raw NIF text for debugging.
@@ -952,4 +800,6 @@ proc renderNode*(n: NifCursor): string =
   if not hasSubtree(n):
     result = "<bug: empty>"
   else:
-    result = toString(n.cursor, false)
+    var tree = createTree()
+    tree.addSubtree(n)
+    result = nifcoreparse.toString(tree, includeLineInfo = false)

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -29,15 +29,15 @@ export charLit
 export nif_annotations
 
 type
-  NifBuilder* = nifcore.TokenBuf
-  NifCursor* = nifcore.Cursor
-  LineInfo* = nifcore.NifLineInfo
+  NifBuilder* = nifcore.TokenBuf ## Move-only builder for generated NIF output.
+  NifCursor* = nifcore.Cursor ## Reference-counted, bounded NIF read cursor.
+  LineInfo* = nifcore.NifLineInfo ## Source location attached to a NIF value.
 
-  SourcePos* = object
-    line*: int
-    col*: int
+  SourcePos* = object ## Decoded source position.
+    line*: int ## One-based source line, or zero when unavailable.
+    col*: int ## One-based source column, or zero when unavailable.
 
-const NoLineInfo* = NoNifLineInfo
+const NoLineInfo* = NoNifLineInfo ## Source location for synthetic output.
 
 proc createPluginTags(): TagPool =
   result = newTagPool()
@@ -56,30 +56,62 @@ proc appendInfo(buf: var NifBuilder; info: LineInfo) {.inline.} =
     buf.appendLineInfo(info)
 
 proc hasSubtree(n: NifCursor): bool {.inline.} = n.hasMore
-proc isEmpty*(tree: NifBuilder): bool {.inline.} = tree.len == 0
+proc isEmpty*(tree: NifBuilder): bool {.inline.} =
+  ## Returns whether `tree` contains no NIF values.
+  tree.len == 0
+
 proc info*(n: NifCursor): LineInfo {.inline.} =
-  ## Returns no line info for an exhausted bounded cursor.
+  ## Returns the current value's source location, or `NoLineInfo` at exhaustion.
   if n.hasMore: n.rawLineInfo else: NoLineInfo
+
 proc filePath*(info: LineInfo): string {.inline.} =
+  ## Returns the source path stored in `info`, or `""` when unavailable.
   if info.file.isValid: pluginPool.filenames[info.file] else: ""
+
 proc lineCol*(info: LineInfo): SourcePos {.inline.} =
+  ## Decodes the one-based line and column stored in `info`.
   SourcePos(line: int(info.line), col: int(info.col))
 
-proc symText*(n: NifCursor): string {.inline.} = n.symName
-proc symText*(s: SymId): string {.inline.} = pluginPool.syms[s]
-proc identText*(n: NifCursor): string {.inline.} = n.strVal
-proc stringValue*(n: NifCursor): string {.inline.} = n.strVal
+proc symText*(n: NifCursor): string {.inline.} =
+  ## Returns the current `Symbol` or `SymbolDef` name.
+  n.symName
+
+proc symText*(s: SymId): string {.inline.} =
+  ## Resolves a plugin-pool symbol handle to its name.
+  pluginPool.syms[s]
+
+proc identText*(n: NifCursor): string {.inline.} =
+  ## Returns the current `Ident` text.
+  n.strVal
+
+proc stringValue*(n: NifCursor): string {.inline.} =
+  ## Returns the current `StrLit` contents.
+  n.strVal
+
 proc intValue*(n: NifCursor): BiggestInt {.inline.} =
+  ## Returns the current signed integer literal.
   BiggestInt(n.intVal)
+
 proc uintValue*(n: NifCursor): BiggestUInt {.inline.} =
+  ## Returns the current unsigned integer literal.
   BiggestUInt(n.uintVal)
+
 proc floatValue*(n: NifCursor): BiggestFloat {.inline.} =
+  ## Returns the current floating-point literal.
   BiggestFloat(n.floatVal)
 
-proc tagId*(n: NifCursor): TagId {.inline.} = n.cursorTagId
+proc tagId*(n: NifCursor): TagId {.inline.} =
+  ## Returns the current `TagLit`'s raw tag handle.
+  n.cursorTagId
+
 proc tagText*(n: NifCursor): string {.inline.} =
+  ## Returns the current `TagLit`'s textual tag name.
   n.tags.tags[n.cursorTagId]
-proc tagText*(tag: TagId): string {.inline.} = pluginTags.tags[tag]
+
+proc tagText*(tag: TagId): string {.inline.} =
+  ## Resolves a plugin-pool tag handle to its textual name.
+  pluginTags.tags[tag]
+
 proc tag*(n: NifCursor): TagId {.inline.} =
   ## Returns the error tag for atoms and exhausted cursors.
   if n.hasMore and n.kind == TagLit:
@@ -94,20 +126,29 @@ proc rawTag(n: NifCursor): TagEnum {.inline.} =
   if id <= uint32(high(TagEnum)): cast[TagEnum](id) else: InvalidTagId
 
 proc stmtKind*(n: NifCursor): NimonyStmt {.inline.} =
+  ## Returns the current statement tag, or `NoStmt`.
   let t = rawTag(n)
   if rawTagIsNimonyStmt(t): cast[NimonyStmt](t) else: NoStmt
+
 proc exprKind*(n: NifCursor): NimonyExpr {.inline.} =
+  ## Returns the current expression tag, or `NoExpr`.
   let t = rawTag(n)
   if rawTagIsNimonyExpr(t): cast[NimonyExpr](t) else: NoExpr
+
 proc typeKind*(n: NifCursor): NimonyType {.inline.} =
+  ## Returns the current type tag; `DotToken` is treated as `VoidT`.
   if n.kind == DotToken: VoidT
   else:
     let t = rawTag(n)
     if rawTagIsNimonyType(t): cast[NimonyType](t) else: NoType
+
 proc otherKind*(n: NifCursor): NimonyOther {.inline.} =
+  ## Returns the current substructure tag, or `NoSub`.
   let t = rawTag(n)
   if rawTagIsNimonyOther(t): cast[NimonyOther](t) else: NoSub
+
 proc pragmaKind*(n: NifCursor): NimonyPragma {.inline.} =
+  ## Returns the current pragma tag or identifier kind, or `NoPragma`.
   var t = InvalidTagId
   if n.kind == TagLit:
     t = rawTag(n)
@@ -121,9 +162,11 @@ template tagIdFor(kind: untyped): untyped =
   TagId(uint32(kind))
 
 proc createTree*(): NifBuilder =
+  ## Creates an empty plugin builder using the shared plugin pools.
   nifcore.createTokenBuf(sharedPool = pluginPool, sharedTags = pluginTags)
 
 proc snapshot*(tree: var NifBuilder): NifCursor =
+  ## Returns a stable read cursor at the first value in non-empty `tree`.
   assert not tree.isEmpty, "cannot snapshot empty NifBuilder"
   tree.beginRead()
 
@@ -132,6 +175,7 @@ template withTree*(
     kind: NimonyType|NimonyExpr|NimonyStmt|NimonyOther|NimonyPragma;
     info: LineInfo;
     body: untyped) =
+  ## Emits a tagged tree around the values produced by `body`.
   t.openTag(tagIdFor(kind))
   appendInfo(t, info)
   body
@@ -139,21 +183,27 @@ template withTree*(
 
 proc openTree*(t: var NifBuilder; tag: TagId;
                info: LineInfo = NoLineInfo) =
+  ## Opens a tree using an existing plugin-pool tag handle.
   t.openTag(tag)
   appendInfo(t, info)
 
 proc openTree*(t: var NifBuilder; tag: string;
                info: LineInfo = NoLineInfo) =
+  ## Opens a tree using a textual tag, interning it when necessary.
   t.openTag(pluginTags.tags.getOrIncl(tag))
   appendInfo(t, info)
 
-proc closeTree*(t: var NifBuilder) = t.closeTag()
+proc closeTree*(t: var NifBuilder) =
+  ## Seals the most recently opened tree.
+  t.closeTag()
 
 proc takeTree*(t: var NifBuilder; n: var NifCursor) =
+  ## Copies the current value or subtree into `t` and advances `n`.
   t.addSubtree(n)
   n.skip()
 
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
+  ## Copies `n`'s tag, transforms its children with `body`, and advances `n`.
   assert n.kind == TagLit, "copyInto requires cursor at TagLit"
   let copiedTag = n.tagId
   let copiedInfo = n.info
@@ -163,15 +213,18 @@ template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   t.closeTree()
 
 proc addTree*(t: var NifBuilder; child: sink NifBuilder) =
+  ## Consumes and appends every complete top-level value from `child`.
   t.addBuffer(child)
 
 proc addSymUse*(t: var NifBuilder; s: SymId;
                 info: LineInfo = NoLineInfo) =
+  ## Appends a symbol use from a plugin-pool symbol handle.
   nifcore.addSymUse(t, s)
   appendInfo(t, info)
 
 proc addSymUse*(t: var NifBuilder; s: string;
                 info: LineInfo) =
+  ## Appends a symbol use from its textual name with source information.
   nifcore.addSymUse(t, s)
   appendInfo(t, info)
 
@@ -222,9 +275,7 @@ proc parseNifBuffer(text: string): nifcore.TokenBuf =
                            sharedTags = pluginTags)
 
 type
-  BindSymRule* = enum
-    ## Selector for `bindSym`'s third argument. Mirrors `lib/std/macros.nim`'s
-    ## enum of the same name so the macro and plugin paths share semantics.
+  BindSymRule* = enum ## Controls call-site lookup for `bindSym`.
     brClosed     ## Default: candidates fixed at the plugin's def-site;
                  ## sem at the call site won't add further overloads.
     brOpen       ## Open: sem at the call site augments the choice with
@@ -338,8 +389,7 @@ proc eqIdent*(n: NifCursor; name: string): bool =
 # single object with balanced operations for tree transformations.
 
 type
-  ChildKind* = enum
-    ## Category of a NIF child for `keep`/`drop` assertions.
+  ChildKind* = enum ## Category asserted by `keep`, `drop`, and `replace`.
     Any       ## matches any token or subtree
     Expr      ## value expression (TagLit with expr tag, or Symbol/literal)
     Type      ## type expression (TagLit with type tag, or DotToken for void)
@@ -350,10 +400,7 @@ type
     Lit       ## literal (IntLit, UIntLit, FloatLit, StrLit, CharLit)
     Nested    ## nested substructure (params, pragmas, etc.)
 
-  Replacer* = object
-    ## Primary abstraction for NIF tree transformations. Bundles an output
-    ## builder and an input cursor with balanced operations that consume
-    ## input and produce output atomically.
+  Replacer* = object ## Input/output state for balanced NIF transformations.
     dest*: NifBuilder   ## Output builder — public for direct emit-only access.
     src: NifCursor      ## Input cursor — use getCursor/setCursor for raw access.
 
@@ -363,25 +410,81 @@ proc isAtom*(t: Replacer): bool {.inline.} =
   t.src.kind != TagLit
 
 # Delegated cursor accessors:
-proc kind*(t: Replacer): NifKind {.inline.} = t.src.kind
-proc info*(t: Replacer): LineInfo {.inline.} = t.src.info
-proc stmtKind*(t: Replacer): NimonyStmt {.inline.} = t.src.stmtKind
-proc exprKind*(t: Replacer): NimonyExpr {.inline.} = t.src.exprKind
-proc typeKind*(t: Replacer): NimonyType {.inline.} = t.src.typeKind
-proc otherKind*(t: Replacer): NimonyOther {.inline.} = t.src.otherKind
-proc pragmaKind*(t: Replacer): NimonyPragma {.inline.} = t.src.pragmaKind
-proc symId*(t: Replacer): SymId {.inline.} = t.src.symId
-proc symText*(t: Replacer): string {.inline.} = t.src.symText
-proc identText*(t: Replacer): string {.inline.} = t.src.identText
-proc stringValue*(t: Replacer): string {.inline.} = t.src.stringValue
-proc charLit*(t: Replacer): char {.inline.} = t.src.charLit
-proc intValue*(t: Replacer): BiggestInt {.inline.} = t.src.intValue
-proc uintValue*(t: Replacer): BiggestUInt {.inline.} = t.src.uintValue
-proc floatValue*(t: Replacer): BiggestFloat {.inline.} = t.src.floatValue
-proc tagId*(t: Replacer): TagId {.inline.} = t.src.tagId
-proc tagText*(t: Replacer): string {.inline.} = t.src.tagText
-proc tag*(t: Replacer): TagId {.inline.} = t.src.tag
-proc eqIdent*(t: Replacer; name: string): bool {.inline.} = t.src.eqIdent(name)
+proc kind*(t: Replacer): NifKind {.inline.} =
+  ## Returns the source cursor's raw NIF kind.
+  t.src.kind
+
+proc info*(t: Replacer): LineInfo {.inline.} =
+  ## Returns the source cursor's location.
+  t.src.info
+
+proc stmtKind*(t: Replacer): NimonyStmt {.inline.} =
+  ## Returns the source cursor's statement kind.
+  t.src.stmtKind
+
+proc exprKind*(t: Replacer): NimonyExpr {.inline.} =
+  ## Returns the source cursor's expression kind.
+  t.src.exprKind
+
+proc typeKind*(t: Replacer): NimonyType {.inline.} =
+  ## Returns the source cursor's type kind.
+  t.src.typeKind
+
+proc otherKind*(t: Replacer): NimonyOther {.inline.} =
+  ## Returns the source cursor's substructure kind.
+  t.src.otherKind
+
+proc pragmaKind*(t: Replacer): NimonyPragma {.inline.} =
+  ## Returns the source cursor's pragma kind.
+  t.src.pragmaKind
+
+proc symId*(t: Replacer): SymId {.inline.} =
+  ## Returns the source cursor's symbol handle.
+  t.src.symId
+
+proc symText*(t: Replacer): string {.inline.} =
+  ## Returns the source cursor's symbol text.
+  t.src.symText
+
+proc identText*(t: Replacer): string {.inline.} =
+  ## Returns the source cursor's identifier text.
+  t.src.identText
+
+proc stringValue*(t: Replacer): string {.inline.} =
+  ## Returns the source cursor's string literal.
+  t.src.stringValue
+
+proc charLit*(t: Replacer): char {.inline.} =
+  ## Returns the source cursor's character literal.
+  t.src.charLit
+
+proc intValue*(t: Replacer): BiggestInt {.inline.} =
+  ## Returns the source cursor's signed integer literal.
+  t.src.intValue
+
+proc uintValue*(t: Replacer): BiggestUInt {.inline.} =
+  ## Returns the source cursor's unsigned integer literal.
+  t.src.uintValue
+
+proc floatValue*(t: Replacer): BiggestFloat {.inline.} =
+  ## Returns the source cursor's floating-point literal.
+  t.src.floatValue
+
+proc tagId*(t: Replacer): TagId {.inline.} =
+  ## Returns the source cursor's raw tag handle.
+  t.src.tagId
+
+proc tagText*(t: Replacer): string {.inline.} =
+  ## Returns the source cursor's textual tag.
+  t.src.tagText
+
+proc tag*(t: Replacer): TagId {.inline.} =
+  ## Returns the source cursor's tag or the error tag for an atom.
+  t.src.tag
+
+proc eqIdent*(t: Replacer; name: string): bool {.inline.} =
+  ## Returns whether the source cursor names `name`.
+  t.src.eqIdent(name)
 
 # ── Kind checking ─────────────────────────────────────────────────────────
 

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -659,7 +659,7 @@ proc replace*(t: var Replacer; expected: NimonyType;
 
 template keepTag*(t: var Replacer; body: untyped) =
   ## Copy the opening tag from input to output, run `body` for children,
-  ## seal the output node and advance past the input subtree.
+  ## close the output node and advance past the input subtree.
   assert t.src.kind == TagLit, "keepTag requires cursor at TagLit"
   t.dest.copyInto(t.src):
     body

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -202,14 +202,21 @@ proc takeTree*(t: var NifBuilder; n: var NifCursor) =
   t.addSubtree(n)
   n.skip()
 
+proc enterPluginScope(n: var NifCursor): nifcore.CursorScope =
+  nifcore.enterScope(n)
+
+proc leavePluginScope(n: var NifCursor; scope: nifcore.CursorScope) =
+  nifcore.leaveScope(n, scope)
+
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   ## Copies `n`'s tag, transforms its children with `body`, and advances `n`.
   assert n.kind == TagLit, "copyInto requires cursor at TagLit"
   let copiedTag = n.tagId
   let copiedInfo = n.info
   t.openTree(copiedTag, copiedInfo)
-  nifcore.into n:
-    body
+  let inputScope = enterPluginScope(n)
+  body
+  leavePluginScope(n, inputScope)
   t.closeTree()
 
 proc addTree*(t: var NifBuilder; child: sink NifBuilder) =
@@ -673,8 +680,9 @@ template replaceHead*(t: var Replacer;
   ## scopes.
   assert t.src.kind == TagLit, "replaceHead requires cursor at TagLit"
   t.dest.withTree(tag, info):
-    nifcore.into t.src:
-      body
+    let inputScope = enterPluginScope(t.src)
+    body
+    leavePluginScope(t.src, inputScope)
 
 # ── Cursor access for analysis ────────────────────────────────────────────
 

--- a/src/validator/validator.nim
+++ b/src/validator/validator.nim
@@ -482,10 +482,6 @@ proc scanForNonExhaustiveCases(ctx: var CheckContext; buf: var TokenBuf) =
 # Step 3: Obligation tracking — scan procs for unmatched skip/emit
 # ---------------------------------------------------------------------------
 
-const
-  ## Procs that skip the ParRi after a while-kind-ParRi loop
-  ParRiSkipProcs = ["inc", "skipParRi", "takeParRi", "takeToken"]
-
 proc scanCallsForCursorArg(bc: Cursor; endNested: int; cursorParams: seq[Cursor];
                            consumeCounts: var seq[int]) =
   ## Scan a subtree for any call/cmd that passes one of the cursor params
@@ -548,8 +544,8 @@ proc scanObligations(ctx: var CheckContext; procs: openArray[ProcMeta]) =
 # Proc classification for cursor-buffer balance analysis
 # ---------------------------------------------------------------------------
 # Base categories — every tracked proc belongs to exactly one.
-# Composite sets (TrustedCursorAdvanceProcs, DestContributingProcs, etc.)
-# are derived from these base categories plus edge-case additions.
+# Derived sets such as `TrustedCursorAdvanceProcs` combine these categories
+# with a small number of structured API operations.
 
 const
   ## Advance cursor without emitting — creates debt; needs SkipIntent justification.
@@ -889,7 +885,7 @@ proc scanUnsafeCursorOps(ctx: var CheckContext; reg: TypeRegistry; procs: openAr
         inc bc
 
 # ---------------------------------------------------------------------------
-# Step 5: while-ParRi completion — ensure ParRi is consumed after the loop
+# Step 5: while-loop termination proofs
 # ---------------------------------------------------------------------------
 
 proc extractLvalue(n: Cursor): Cursor =
@@ -897,43 +893,6 @@ proc extractLvalue(n: Cursor): Cursor =
   ## Returns nil Cursor if not an analyzable lvalue.
   if n.kind == Ident: return n
   if n.kind == ParLe and pool.tags[n.tag] == "dot": return n
-  default(Cursor)
-
-proc extractWhileParRiVar(n: Cursor): Cursor =
-  ## If `n` is at a `(while COND BODY)` where COND is `(infix != (dot VAR kind) ParRi)`,
-  ## return VAR as an lvalue Cursor. VAR can be a bare ident (`n`) or a nested dot (`it.n`).
-  ## Otherwise return nil Cursor.
-  var c = n
-  if c.kind != ParLe or pool.tags[c.tag] != "while": return default(Cursor)
-  inc c # skip (while
-  # Condition should be (infix != (dot VAR kind) ParRi)
-  if c.kind != ParLe: return default(Cursor)
-  let condTag = pool.tags[c.tag]
-  var infixCur = c
-  if condTag == "infix":
-    inc infixCur # skip (infix
-    if infixCur.kind != Ident: return default(Cursor)
-    let op = pool.strings[infixCur.litId]
-    if op != "!=": return default(Cursor)
-    skip infixCur # skip op name
-    # LHS should be (dot EXPR kind) where EXPR is a bare ident or dot-chain
-    if infixCur.kind != ParLe: return default(Cursor)
-    if pool.tags[infixCur.tag] != "dot": return default(Cursor)
-    var dotCur = infixCur
-    inc dotCur # skip (dot
-    let varLv = extractLvalue(dotCur)
-    if cursorIsNil(varLv): return default(Cursor)
-    skip dotCur # skip receiver
-    if dotCur.kind != Ident: return default(Cursor)
-    let fieldName = pool.strings[dotCur.litId]
-    if fieldName != "kind": return default(Cursor)
-    skip dotCur # skip field name
-    # RHS should be ParRi
-    skip infixCur # skip dot expr
-    if infixCur.kind != Ident: return default(Cursor)
-    let rhsName = pool.strings[infixCur.litId]
-    if rhsName != "ParRi": return default(Cursor)
-    return varLv
   default(Cursor)
 
 proc extractWhileHasMoreVar(n: Cursor): Cursor =
@@ -954,53 +913,7 @@ proc extractWhileHasMoreVar(n: Cursor): Cursor =
     return default(Cursor)
   result = varLv
 
-proc isParRiSkipCall(n: Cursor; lv: Cursor): bool =
-  ## Check if `n` is at a call/cmd that skips the ParRi for the given lvalue.
-  ## Matches: (cmd inc N lv), (cmd skipParRi N lv), etc.
-  if n.kind != ParLe: return false
-  let tag = pool.tags[n.tag]
-  if tag notin CallTags: return false
-  var c = n
-  inc c # skip (cmd/(call
-  var callName = ""
-  if c.kind == Ident:
-    callName = pool.strings[c.litId]
-    skip c
-  elif c.kind == ParLe:
-    callName = extractDotCallName(c)
-    skip c
-  if callName notin ParRiSkipProcs: return false
-  # Check if lvalue appears as any argument
-  while c.hasMore:
-    if equalLvalues(c, lv):
-      return true
-    skip c
-  false
-
-const
-  ## WrapProcs + {withTree, peek} — handle ParRi internally, exempting inner while loops.
-  CopyIntoProcs = @WrapProcs & @["withTree", "peek"]
-
-  ## BalancedProcs + WrapProcs + EmitOnlyProcs + DelegateProcs + {withTree} —
-  ## any call that contributes output to the dest buffer.
-  DestContributingProcs = @BalancedProcs & @WrapProcs & @EmitOnlyProcs & @DelegateProcs & @["withTree"]
-
-proc whileBodyContributesDest(whileNode: Cursor): bool =
-  ## Check if the while loop body contains any call that writes to a dest buffer.
-  ## Only loops that contribute to dest need the ParRi consumed — scan-only loops
-  ## can break early without issue.
-  var c = whileNode
-  inc c  # skip (while
-  skip c # skip condition
-  if c.kind != ParLe: return false
-  c.balancedTokens:
-    let tag = pool.tags[c.tag]
-    if tag in CallTags:
-      if extractCalleeName(c) in DestContributingProcs:
-        return true
-  false
-
-proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: bool;
+proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor;
                       varCursorCallees: HashSet[string])
 proc whileBodyHasProgressCall(whileNode: Cursor; lv: Cursor;
                               acceptedCalls: openArray[string]): bool
@@ -1124,7 +1037,7 @@ proc whileBodyMustAdvanceCursor(whileNode: Cursor; lv: Cursor;
     return stmtsMustAdvanceCursor(c, lv, varCursorCallees)
   false
 
-proc scanWhileRecurse(ctx: var CheckContext; n: Cursor; insideCopyInto: bool;
+proc scanWhileRecurse(ctx: var CheckContext; n: Cursor;
                       varCursorCallees: HashSet[string]) =
   ## Recurse into a subtree, delegating to `scanWhileInStmts` for every stmts node.
   ## Does NOT re-enter stmts nodes on its own — only `scanWhileInStmts` processes
@@ -1134,17 +1047,15 @@ proc scanWhileRecurse(ctx: var CheckContext; n: Cursor; insideCopyInto: bool;
   inc n # skip the opening tag
   while n.hasMore:
     if n.kind == ParLe and pool.tags[n.tag] == "stmts":
-      scanWhileInStmts(ctx, n, insideCopyInto, varCursorCallees)
+      scanWhileInStmts(ctx, n, varCursorCallees)
     elif n.kind == ParLe:
-      scanWhileRecurse(ctx, n, insideCopyInto, varCursorCallees)
+      scanWhileRecurse(ctx, n, varCursorCallees)
     skip n
 
-proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: bool;
+proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor;
                       varCursorCallees: HashSet[string]) =
   ## Scan children of a stmts node. For each child:
-  ## - If it is a cursor loop, prove that every body path advances the cursor
-  ## - For a while-ParRi loop, also check that ParRi is consumed after it
-  ## - If it's a copyInto call, recurse into its body with insideCopyInto=true
+  ## - If it is a bounded cursor loop, prove every body path advances the cursor
   ## - Otherwise recurse normally
   var child = stmtsNode
   inc child # skip (stmts
@@ -1152,43 +1063,13 @@ proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: 
     if child.kind == ParLe:
       let childTag = pool.tags[child.tag]
       if childTag == "while":
-        let parRiLv = extractWhileParRiVar(child)
-        var varLv = parRiLv
-        if cursorIsNil(varLv):
-          varLv = extractWhileHasMoreVar(child)
+        let varLv = extractWhileHasMoreVar(child)
         if not cursorIsNil(varLv):
           let varStr = lvalueToStr(varLv)
-          let loopLabel =
-            if cursorIsNil(parRiLv):
-              "while " & varStr & ".hasMore"
-            else:
-              "while " & varStr & ".kind != ParRi"
-          # Termination proof for bounded cursor loops:
-          # every iteration path in the body must advance/delegate `n`.
           if not whileBodyMustAdvanceCursor(child, varLv, varCursorCallees):
-            addWarning(ctx, child.info, loopLabel,
+            addWarning(ctx, child.info, "while " & varStr & ".hasMore",
               "cursor progress is not guaranteed on all body paths (expected guaranteed `inc/skip " &
               varStr & "` or guaranteed delegated advancement via calls that take `" & varStr & "`)")
-
-          # Existing structural safety check: if loop contributes to dest, ensure the
-          # trailing ParRi gets consumed after the loop.
-          if not cursorIsNil(parRiLv) and not insideCopyInto and
-              whileBodyContributesDest(child):
-            let whileInfo = child.info
-            var afterWhile = child
-            skip afterWhile
-            var found = false
-            var lookAhead = 0
-            var peek = afterWhile
-            while peek.kind != ParRi and lookAhead < 3:
-              if isParRiSkipCall(peek, varLv):
-                found = true
-                break
-              skip peek
-              inc lookAhead
-            if not found:
-              addWarning(ctx, whileInfo, "while " & varStr & ".kind != ParRi",
-                "ParRi not consumed after loop for `" & varStr & "`")
         else:
           let counterLv = extractWhileCounterVar(child)
           if not cursorIsNil(counterLv):
@@ -1200,24 +1081,11 @@ proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: 
             discard # accepted scanner loop with nested counting + progress + break
           else:
             addWarning(ctx, child.info, "while",
-              "termination proof not recognized: expected `while n.hasMore` or `while n.kind != ParRi` with progress/delegation, `while x > 0 and ...` with `dec x`, or common `while true` scanner form")
+              "termination proof not recognized: expected `while n.hasMore` with progress/delegation, `while x > 0 and ...` with `dec x`, or common `while true` scanner form")
         # Recurse into the while body to find nested patterns
-        scanWhileRecurse(ctx, child, insideCopyInto, varCursorCallees)
-      elif childTag in CallTags:
-        let callName = extractCalleeName(child)
-        if callName in CopyIntoProcs:
-          # copyInto handles the ParRi — recurse with insideCopyInto=true
-          var peek = child
-          inc peek  # skip (cmd/call
-          skip peek # skip callee
-          while peek.hasMore:
-            if peek.kind == ParLe and pool.tags[peek.tag] == "stmts":
-              scanWhileInStmts(ctx, peek, true, varCursorCallees)
-            skip peek
-        else:
-          scanWhileRecurse(ctx, child, insideCopyInto, varCursorCallees)
+        scanWhileRecurse(ctx, child, varCursorCallees)
       else:
-        scanWhileRecurse(ctx, child, insideCopyInto, varCursorCallees)
+        scanWhileRecurse(ctx, child, varCursorCallees)
     skip child
 
 proc buildVarCursorCalleeSet(procs: openArray[ProcMeta]): HashSet[string] =
@@ -1227,12 +1095,12 @@ proc buildVarCursorCalleeSet(procs: openArray[ProcMeta]): HashSet[string] =
     if p.hasCursor:
       result.incl p.name
 
-proc scanWhileParRiCompletion(ctx: var CheckContext; procs: openArray[ProcMeta]; buf: var TokenBuf) =
-  ## Prove cursor progress in bounded and ParRi loops. For ParRi loops, also
-  ## check that the trailing token is consumed; copyInto handles it internally.
+proc scanWhileTermination(ctx: var CheckContext; procs: openArray[ProcMeta];
+                          buf: var TokenBuf) =
+  ## Prove progress in bounded cursor loops.
   let varCursorCallees = buildVarCursorCalleeSet(procs)
   var n = beginRead(buf)
-  scanWhileRecurse(ctx, n, false, varCursorCallees)
+  scanWhileRecurse(ctx, n, varCursorCallees)
   endRead buf
 
 # ---------------------------------------------------------------------------
@@ -1443,8 +1311,7 @@ proc main() =
   # Cursor-buffer balance: tie traversal and emission together
   scanCursorBufferBalance(ctx, reg, procMetas)
 
-  # While-ParRi completion: termination proofs for while loops
-  scanWhileParRiCompletion(ctx, procMetas, buf)
+  scanWhileTermination(ctx, procMetas, buf)
 
   # The remaining checks enforce strict compiler-pass discipline:
   # - Bare skip/inc justification (redundant with balance check, noisy for plugins)

--- a/src/validator/validator.nim
+++ b/src/validator/validator.nim
@@ -936,6 +936,24 @@ proc extractWhileParRiVar(n: Cursor): Cursor =
     return varLv
   default(Cursor)
 
+proc extractWhileHasMoreVar(n: Cursor): Cursor =
+  ## If `n` is at `(while CURSOR.hasMore BODY)`, return `CURSOR`.
+  ## CURSOR can be a bare ident (`n`) or a nested dot (`it.n`).
+  var c = n
+  if c.kind != ParLe or pool.tags[c.tag] != "while":
+    return default(Cursor)
+  inc c # skip (while
+  if c.kind != ParLe or pool.tags[c.tag] != "dot":
+    return default(Cursor)
+  inc c # skip (dot
+  let varLv = extractLvalue(c)
+  if cursorIsNil(varLv):
+    return default(Cursor)
+  skip c # skip receiver
+  if c.kind != Ident or pool.strings[c.litId] != "hasMore":
+    return default(Cursor)
+  result = varLv
+
 proc isParRiSkipCall(n: Cursor; lv: Cursor): bool =
   ## Check if `n` is at a call/cmd that skips the ParRi for the given lvalue.
   ## Matches: (cmd inc N lv), (cmd skipParRi N lv), etc.
@@ -1097,7 +1115,7 @@ proc stmtMustAdvanceCursor(n: Cursor; lv: Cursor;
 
 proc whileBodyMustAdvanceCursor(whileNode: Cursor; lv: Cursor;
                                 varCursorCallees: HashSet[string]): bool =
-  ## For `while n.kind != ParRi`, require body-level guaranteed progress.
+  ## For cursor-bounded loops, require body-level guaranteed progress.
   var c = whileNode
   if c.kind != ParLe or pool.tags[c.tag] != "while": return false
   inc c, SkipTag
@@ -1124,7 +1142,8 @@ proc scanWhileRecurse(ctx: var CheckContext; n: Cursor; insideCopyInto: bool;
 proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: bool;
                       varCursorCallees: HashSet[string]) =
   ## Scan children of a stmts node. For each child:
-  ## - If it's a while-ParRi loop, check that ParRi is consumed after it
+  ## - If it is a cursor loop, prove that every body path advances the cursor
+  ## - For a while-ParRi loop, also check that ParRi is consumed after it
   ## - If it's a copyInto call, recurse into its body with insideCopyInto=true
   ## - Otherwise recurse normally
   var child = stmtsNode
@@ -1133,19 +1152,28 @@ proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: 
     if child.kind == ParLe:
       let childTag = pool.tags[child.tag]
       if childTag == "while":
-        let varLv = extractWhileParRiVar(child)
+        let parRiLv = extractWhileParRiVar(child)
+        var varLv = parRiLv
+        if cursorIsNil(varLv):
+          varLv = extractWhileHasMoreVar(child)
         if not cursorIsNil(varLv):
           let varStr = lvalueToStr(varLv)
-          # Termination proof for while n.hasMore:
+          let loopLabel =
+            if cursorIsNil(parRiLv):
+              "while " & varStr & ".hasMore"
+            else:
+              "while " & varStr & ".kind != ParRi"
+          # Termination proof for bounded cursor loops:
           # every iteration path in the body must advance/delegate `n`.
           if not whileBodyMustAdvanceCursor(child, varLv, varCursorCallees):
-            addWarning(ctx, child.info, "while " & varStr & ".kind != ParRi",
+            addWarning(ctx, child.info, loopLabel,
               "cursor progress is not guaranteed on all body paths (expected guaranteed `inc/skip " &
               varStr & "` or guaranteed delegated advancement via calls that take `" & varStr & "`)")
 
           # Existing structural safety check: if loop contributes to dest, ensure the
           # trailing ParRi gets consumed after the loop.
-          if not insideCopyInto and whileBodyContributesDest(child):
+          if not cursorIsNil(parRiLv) and not insideCopyInto and
+              whileBodyContributesDest(child):
             let whileInfo = child.info
             var afterWhile = child
             skip afterWhile
@@ -1172,7 +1200,7 @@ proc scanWhileInStmts(ctx: var CheckContext; stmtsNode: Cursor; insideCopyInto: 
             discard # accepted scanner loop with nested counting + progress + break
           else:
             addWarning(ctx, child.info, "while",
-              "termination proof not recognized: expected `while n.kind != ParRi` with progress/delegation, `while x > 0 and ...` with `dec x`, or common `while true` scanner form")
+              "termination proof not recognized: expected `while n.hasMore` or `while n.kind != ParRi` with progress/delegation, `while x > 0 and ...` with `dec x`, or common `while true` scanner form")
         # Recurse into the while body to find nested patterns
         scanWhileRecurse(ctx, child, insideCopyInto, varCursorCallees)
       elif childTag in CallTags:
@@ -1200,8 +1228,8 @@ proc buildVarCursorCalleeSet(procs: openArray[ProcMeta]): HashSet[string] =
       result.incl p.name
 
 proc scanWhileParRiCompletion(ctx: var CheckContext; procs: openArray[ProcMeta]; buf: var TokenBuf) =
-  ## Scan for `while n.kind != ParRi` loops and check that the ParRi is consumed.
-  ## Loops inside `copyInto` bodies are exempted (the template handles the ParRi).
+  ## Prove cursor progress in bounded and ParRi loops. For ParRi loops, also
+  ## check that the trailing token is consumed; copyInto handles it internally.
   let varCursorCallees = buildVarCursorCalleeSet(procs)
   var n = beginRead(buf)
   scanWhileRecurse(ctx, n, false, varCursorCallees)

--- a/tests/check_tags/fake_pass.nim
+++ b/tests/check_tags/fake_pass.nim
@@ -27,3 +27,8 @@ proc wrongKind(dest: var TokenBuf; info: PackedLineInfo; s: SymId) =
     dest.addSymDef s, info  # BUG: SymDef where expr expected
     dest.addDotToken()      # BUG: DotToken where expr expected (no dot prefix)
 
+proc boundedCursorLoop(n: var Cursor) =
+  # Canonical bounded-cursor traversal: the validator must recognize `hasMore`
+  # and prove progress from the unconditional `skip`.
+  while n.hasMore:
+    skip n

--- a/tests/nimony/nifcore/tnifcore.nim
+++ b/tests/nimony/nifcore/tnifcore.nim
@@ -35,6 +35,13 @@ proc main =
   c.inc
 
   c.endRead()
+
+  var syms = createTokenBuf()
+  let sym = syms.pool.syms.getOrIncl("already.interned")
+  syms.addSymUse(sym)
+  var symCursor = syms.beginRead()
+  assert symCursor.symId == sym
+  assert symCursor.symName == "already.interned"
   echo "ok"
 
 main()

--- a/tests/nimony/nifcore/tnifcore.nim
+++ b/tests/nimony/nifcore/tnifcore.nim
@@ -60,6 +60,20 @@ proc main =
   appendedCursor.skip()
   assert not appendedCursor.hasMore
 
+  # Assignment must copy the cursor's bound even when both cursors point at
+  # the same token in the same owner.
+  var boundedSource = createTokenBuf(sharedPool = syms.pool,
+                                     sharedTags = syms.tags)
+  boundedSource.buildTree tStmts:
+    boundedSource.addIdent("inside")
+  boundedSource.addIdent("outside")
+  var boundedRoot = boundedSource.beginRead()
+  var bounded = boundedRoot.childCursor()
+  var unbounded = boundedSource.cursorAt(1)
+  unbounded = bounded
+  unbounded.skip()
+  assert not unbounded.hasMore
+
   var foreign = createTokenBuf()
   foreign.addIdent("foreign")
   appended.addBuffer(foreign)

--- a/tests/nimony/nifcore/tnifcore.nim
+++ b/tests/nimony/nifcore/tnifcore.nim
@@ -51,6 +51,10 @@ proc main =
                                 sharedTags = syms.tags)
   appended.addIdent("prefix")
   appended.addBuffer(source)
+  var sourceCursor = source.beginRead()
+  assert sourceCursor.strVal == "first"
+  sourceCursor.skip()
+  assert sourceCursor.strVal == "second"
   var appendedCursor = appended.beginRead()
   assert appendedCursor.strVal == "prefix"
   appendedCursor.skip()

--- a/tests/nimony/nifcore/tnifcore.nim
+++ b/tests/nimony/nifcore/tnifcore.nim
@@ -42,6 +42,32 @@ proc main =
   var symCursor = syms.beginRead()
   assert symCursor.symId == sym
   assert symCursor.symName == "already.interned"
+
+  var source = createTokenBuf(sharedPool = syms.pool,
+                              sharedTags = syms.tags)
+  source.addIdent("first")
+  source.addIdent("second")
+  var appended = createTokenBuf(sharedPool = syms.pool,
+                                sharedTags = syms.tags)
+  appended.addIdent("prefix")
+  appended.addBuffer(source)
+  var appendedCursor = appended.beginRead()
+  assert appendedCursor.strVal == "prefix"
+  appendedCursor.skip()
+  assert appendedCursor.strVal == "first"
+  appendedCursor.skip()
+  assert appendedCursor.strVal == "second"
+  appendedCursor.skip()
+  assert not appendedCursor.hasMore
+
+  var foreign = createTokenBuf()
+  foreign.addIdent("foreign")
+  appended.addBuffer(foreign)
+  appendedCursor = appended.beginRead()
+  appendedCursor.skip()
+  appendedCursor.skip()
+  appendedCursor.skip()
+  assert appendedCursor.strVal == "foreign"
   echo "ok"
 
 main()

--- a/tests/nimony/nifcore/tnifcoreparse.nim
+++ b/tests/nimony/nifcore/tnifcoreparse.nim
@@ -29,6 +29,13 @@ proc main =
       "(nested (a (b (c (d .)))))"]:
     var b1 = parseFromBuffer(s, "t")
     assert roundTrips(b1)
+
+  var positioned = createTokenBuf()
+  positioned.addIdent("hello")
+  let file = positioned.pool.filenames.getOrIncl("source.nim")
+  positioned.appendLineInfo(file, 12, 3)
+  assert toString(positioned, includeLineInfo = false) == "hello"
+  assert toString(positioned).len > "hello".len
   echo "ok"
 
 main()

--- a/tests/nimony/nifcore/tnifcoreparse.nim
+++ b/tests/nimony/nifcore/tnifcoreparse.nim
@@ -36,6 +36,24 @@ proc main =
   positioned.appendLineInfo(file, 12, 3)
   assert toString(positioned, includeLineInfo = false) == "hello"
   assert toString(positioned).len > "hello".len
+  let positionedCursor = positioned.beginRead()
+  assert toString(positionedCursor, includeLineInfo = false) == "hello"
+
+  var sparse = createTokenBuf()
+  let tag = sparse.tags.registerTag("pair")
+  sparse.openTag(tag)
+  let sparseFile = sparse.pool.filenames.getOrIncl("dense.nim")
+  sparse.appendLineInfo(sparseFile, 7, 2)
+  sparse.addIdent("left")
+  sparse.addIdent("right")
+  sparse.closeTag()
+  var dense = parseFromBuffer(toString(sparse), "dense",
+                              denseLineInfo = true)
+  var child = dense.beginRead()
+  child = child.childCursor
+  while child.hasMore:
+    assert child.rawLineInfo.isValid
+    child.skip()
   echo "ok"
 
 main()

--- a/tests/nimony/plugins/deps/mforloop.nim
+++ b/tests/nimony/plugins/deps/mforloop.nim
@@ -12,9 +12,9 @@ import plugins
 
 proc emitSubst(o: var NifBuilder; n: var NifCursor; loopSym: SymId; val: int) =
   ## Copies `n` to `o`, replacing every use of `loopSym` with the literal `val`.
-  if n.kind == ParLe:
+  if n.kind == TagLit:
     o.copyInto(n):
-      while n.kind != ParRi:
+      while n.hasMore:
         emitSubst(o, n, loopSym, val)
   elif n.kind == Symbol and n.symId == loopSym:
     o.addIntLit(val)
@@ -27,9 +27,9 @@ proc loopVarSym(n: NifCursor): SymId =
   ## Extracts the loop variable's symbol from the for-loop plugin input.
   ## Input shape: `(forcall <iter> (callargs ...) (unpackflat ...) <body>)`.
   var vars = forLoopVars(n)
-  if vars.kind == ParLe and vars.otherKind == UnpackflatU:
+  if vars.kind == TagLit and vars.otherKind == UnpackflatU:
     vars = firstChild(vars)        # (let …)
-    if vars.kind == ParLe:
+    if vars.kind == TagLit:
       vars = firstChild(vars)      # (symdef x)
     if vars.kind == SymbolDef:
       return vars.symId

--- a/tests/nimony/plugins/deps/mmoduleplugin.nim
+++ b/tests/nimony/plugins/deps/mmoduleplugin.nim
@@ -12,6 +12,7 @@ proc trAux(t: var Replacer) =
         trAux t
 
 var t = loadReplacer()
-loopKeepTag t:
-  trAux t
+replaceHead t, StmtsS, t.info:
+  while t.getCursor.hasMore:
+    trAux t
 saveReplacer(t)

--- a/tests/nimony/plugins/deps/mplugin1.nim
+++ b/tests/nimony/plugins/deps/mplugin1.nim
@@ -2,6 +2,41 @@ import plugins
 import std / assertions
 
 proc tr(n: NifCursor): NifBuilder =
+  assert n.tagText == "stmts"
+
+  var sample = createTree()
+  sample.withTree StmtsS, NoLineInfo:
+    sample.withTree CallS, NoLineInfo:
+      sample.addIdent "echo"
+  var scan = snapshot(sample)
+  var nestedTags = 0
+  scan.balancedTokens:
+    inc nestedTags
+    assert scan.stmtKind == CallS
+  assert nestedTags == 1
+  assert not scan.hasMore
+  assert scan.tag.tagText == "err"
+
+  var safeError = errorTree("exhausted cursor", scan)
+  assert renderTree(safeError) == "(err . \"exhausted cursor\")"
+
+  var symbols = createTree()
+  symbols.addSymUse("plugin.symbol")
+  let symbolCursor = snapshot(symbols)
+  assert symbolCursor.symId.symText == "plugin.symbol"
+
+  var unknownPragmas = createTree()
+  for i in 0 ..< 600:
+    unknownPragmas.addIdent("unknownPragma" & $i)
+  var unknown = snapshot(unknownPragmas)
+  while unknown.hasMore:
+    assert unknown.pragmaKind == NoPragma
+    unknown.skip()
+  var customTag = createTree()
+  customTag.openTree("customAfterPragmaLookups")
+  customTag.closeTree()
+  assert renderTree(customTag) == "(customAfterPragmaLookups)"
+
   result = createTree()
   let info = n.info
   var head = callArgs(n)

--- a/tests/nimony/plugins/deps/mplugin1.nim
+++ b/tests/nimony/plugins/deps/mplugin1.nim
@@ -1,8 +1,21 @@
 import plugins
 import std / assertions
 
+proc replaceBorrows(t: var Replacer; replacement: NifBuilder) =
+  ## Compile-time regression: builder replacement must remain usable.
+  replace(t, Expr, replacement)
+  assert not replacement.isEmpty
+
 proc tr(n: NifCursor): NifBuilder =
   assert n.tagText == "stmts"
+
+  var child = createTree()
+  child.addIntLit 7
+  var children = createTree()
+  children.addTree(child)
+  children.addTree(child)
+  assert renderTree(children) == "7 7"
+  assert renderTree(child) == "7"
 
   var sample = createTree()
   sample.withTree StmtsS, NoLineInfo:

--- a/tests/nimony/plugins/deps/mplugin1.nim
+++ b/tests/nimony/plugins/deps/mplugin1.nim
@@ -1,9 +1,12 @@
 import plugins
+import std / assertions
 
 proc tr(n: NifCursor): NifBuilder =
   result = createTree()
   let info = n.info
   var head = callArgs(n)
+  assert head.kind == StrLit
+  assert head.info.isValid
   result.withTree StmtsS, info:
     result.withTree CallS, info:
       result.addIdent "echo"

--- a/tests/nimony/plugins/deps/mtypeplugin.nim
+++ b/tests/nimony/plugins/deps/mtypeplugin.nim
@@ -34,7 +34,7 @@ proc trAsgn(n: var NifCursor, o: var NifBuilder) =
     emitOnChanged = false
   traverse n:
     n.into:                              # descend past `(asgn`
-      if n.kind == ParLe and n.exprKind == DotX:
+      if n.kind == TagLit and n.exprKind == DotX:
         access = n                       # snapshot at the dot expression
         # Inspect the receiver/field inside the (dot ...) without consuming
         # `n` — the outer loop's `skip` below handles that.
@@ -79,7 +79,7 @@ proc trTemplate(n: var NifCursor, o: var NifBuilder) =
         n.into:                          # descend into `(params`
           n.into:                        # descend into the first `(param`
             skip n, 3                    # skip first three param children
-            if n.kind == ParLe and n.typeKind == MutT:
+            if n.kind == TagLit and n.typeKind == MutT:
               n.into:                    # descend into `(mut`
                 if n.kind == Symbol:
                   knownOnChanged[n.symId] = nameSym
@@ -94,7 +94,7 @@ proc trTemplate(n: var NifCursor, o: var NifBuilder) =
 
 proc trAux(n: var NifCursor, o: var NifBuilder) =
   case n.kind
-  of ParLe:
+  of TagLit:
     if n.stmtKind == AsgnS:
       trAsgn n, o
     elif n.stmtKind == GvarS:


### PR DESCRIPTION
  ## Summary

  - Port the Nimony plugin API from `nifcursors`/`nifstreams` to `nifcore`.
  - Use native `TagLit`, bounded cursors, and move-only `TokenBuf` builders.
  - Share pre-seeded pools across plugin inputs and generated output.
  - Densify plugin input locations to preserve effective source information.
  - Add optional line-info omission to `nifcoreparse.toString`.
  - Update plugin documentation and tests for the native API.

  ## API changes

  - `ParLe` becomes `TagLit`; `ParRi` checks become `hasMore`.
  - `StringLit` becomes `StrLit`.
  - `addParLe`/`addParRi` become `openTree`/`closeTree`.
  - `NifBuilder` is now move-only.
  - `addTree` consumes child builders.

  ## Validation

  - Plugin tests: 12/12 passed.
  - Plugin-path tests: 1/1 passed.
  - Nifcore tests: 2/2 passed.
  - Host Nim compilation and execution of `tnifcoreparse` passed.
  - `git diff --check` passed.
