### PR TITLE
Simplify nifcore plugin helpers

### DIFF
--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -118,11 +118,9 @@ proc tag*(n: NifCursor): TagId {.inline.} =
 
 proc rawTag(n: NifCursor): TagEnum {.inline.} =
   if n.kind != TagLit or n.tags != pluginTags:
-    result = InvalidTagId
-  else:
-    let id = uint32(n.cursorTagId)
-    result = if id <= uint32(high(TagEnum)): cast[TagEnum](id)
-             else: result = InvalidTagId
+    return InvalidTagId
+  let id = uint32(n.cursorTagId)
+  if id <= uint32(high(TagEnum)): cast[TagEnum](id) else: InvalidTagId
 
 proc stmtKind*(n: NifCursor): NimonyStmt {.inline.} =
   ## Returns the current statement tag, or `NoStmt`.

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -197,15 +197,21 @@ proc takeTree*(t: var NifBuilder; n: var NifCursor) =
   t.addSubtree(n)
   n.skip()
 
+proc enterPluginScope(n: var NifCursor): nifcore.CursorScope =
+  nifcore.enterScope(n)
+
+proc leavePluginScope(n: var NifCursor; scope: nifcore.CursorScope) =
+  nifcore.leaveScope(n, scope)
+
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   ## Copies `n`'s tag, transforms its children with `body`, and advances `n`.
   assert n.kind == TagLit, "copyInto requires cursor at TagLit"
   let copiedTag = n.tagId
   let copiedInfo = n.info
   t.openTree(copiedTag, copiedInfo)
-  let inputScope = nifcore.enterScope(n)
+  let inputScope = enterPluginScope(n)
   body
-  nifcore.leaveScope(n, inputScope)
+  leavePluginScope(n, inputScope)
   t.closeTree()
 
 proc addTree*(t: var NifBuilder; child: NifBuilder) =
@@ -656,9 +662,9 @@ template replaceHead*(t: var Replacer;
   ## scopes.
   assert t.src.kind == TagLit, "replaceHead requires cursor at TagLit"
   t.dest.withTree(tag, info):
-    let inputScope = nifcore.enterScope(t.src)
+    let inputScope = enterPluginScope(t.src)
     body
-    nifcore.leaveScope(t.src, inputScope)
+    leavePluginScope(t.src, inputScope)
 
 # ── Cursor access for analysis ────────────────────────────────────────────
 

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -8,7 +8,6 @@
 ##
 ## See `doc/plugins.md` for the full guide.
 
-{.feature: "lenientnils".}
 {.feature: "untyped".}
 
 import std / [assertions, hashes, syncio, cmdline]
@@ -55,7 +54,6 @@ proc appendInfo(buf: var NifBuilder; info: LineInfo) {.inline.} =
   if info.isValid:
     buf.appendLineInfo(info)
 
-proc hasSubtree(n: NifCursor): bool {.inline.} = n.hasMore
 proc isEmpty*(tree: NifBuilder): bool {.inline.} =
   ## Returns whether `tree` contains no NIF values.
   tree.len == 0
@@ -117,7 +115,7 @@ proc tag*(n: NifCursor): TagId {.inline.} =
   if n.hasMore and n.kind == TagLit:
     n.cursorTagId
   else:
-    TagId(uint32(ErrTagId))
+    cast[TagId](ErrTagId)
 
 proc rawTag(n: NifCursor): TagEnum {.inline.} =
   if n.kind != TagLit or n.tags != pluginTags:
@@ -158,9 +156,6 @@ proc pragmaKind*(n: NifCursor): NimonyPragma {.inline.} =
       t = cast[TagEnum](id)
   if rawTagIsNimonyPragma(t): cast[NimonyPragma](t) else: NoPragma
 
-template tagIdFor(kind: untyped): untyped =
-  TagId(uint32(kind))
-
 proc createTree*(): NifBuilder =
   ## Creates an empty plugin builder using the shared plugin pools.
   nifcore.createTokenBuf(sharedPool = pluginPool, sharedTags = pluginTags)
@@ -176,7 +171,7 @@ template withTree*(
     info: LineInfo;
     body: untyped) =
   ## Emits a tagged tree around the values produced by `body`.
-  t.openTag(tagIdFor(kind))
+  t.openTag(cast[TagId](kind))
   appendInfo(t, info)
   body
   t.closeTag()
@@ -202,21 +197,15 @@ proc takeTree*(t: var NifBuilder; n: var NifCursor) =
   t.addSubtree(n)
   n.skip()
 
-proc enterPluginScope(n: var NifCursor): nifcore.CursorScope =
-  nifcore.enterScope(n)
-
-proc leavePluginScope(n: var NifCursor; scope: nifcore.CursorScope) =
-  nifcore.leaveScope(n, scope)
-
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   ## Copies `n`'s tag, transforms its children with `body`, and advances `n`.
   assert n.kind == TagLit, "copyInto requires cursor at TagLit"
   let copiedTag = n.tagId
   let copiedInfo = n.info
   t.openTree(copiedTag, copiedInfo)
-  let inputScope = enterPluginScope(n)
+  let inputScope = nifcore.enterScope(n)
   body
-  leavePluginScope(n, inputScope)
+  nifcore.leaveScope(n, inputScope)
   t.closeTree()
 
 proc addTree*(t: var NifBuilder; child: NifBuilder) =
@@ -263,14 +252,14 @@ proc errorTree*(msg: string; info: LineInfo): NifBuilder =
 
 proc errorTree*(msg: string; at: NifCursor): NifBuilder =
   ## Builds a compiler error tree reported at `at`, attaching `at`.
-  if hasSubtree(at):
+  if at.hasMore:
     buildErrorTree(at.info, msg, at)
   else:
     buildErrorTree(at.info, msg)
 
 proc errorTree*(msg: string; at, orig: NifCursor): NifBuilder =
   ## Builds a compiler error tree reported at `at`, attaching `orig`.
-  if hasSubtree(orig):
+  if orig.hasMore:
     buildErrorTree(at.info, msg, orig)
   else:
     buildErrorTree(at.info, msg)
@@ -294,8 +283,7 @@ proc bindSymHelper*(t: var NifBuilder; nifText: string) =
   ## Runtime helper: parse `nifText` (a NIF source fragment) and append the
   ## resulting tokens to `t`. Called by `bindSym`'s sem rewrite — not intended
   ## for direct use.
-  var parsed = parseNifBuffer(nifText)
-  t.addBuffer(parsed)
+  t.addTree(parseNifBuffer(nifText))
 
 proc bindSym*(t: var NifBuilder; name: string;
               rule: BindSymRule = brClosed) {.magic: BindSymName.}
@@ -325,30 +313,18 @@ proc addEmptyNode*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
 
 proc addEmptyNode2*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends two empty placeholder nodes (`. .`) to `t`.
-  t.addDotToken()
-  appendInfo(t, info)
-  t.addDotToken()
-  appendInfo(t, info)
+  t.addEmptyNode(info)
+  t.addEmptyNode(info)
 
 proc addEmptyNode3*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends three empty placeholder nodes (`. . .`) to `t`.
-  t.addDotToken()
-  appendInfo(t, info)
-  t.addDotToken()
-  appendInfo(t, info)
-  t.addDotToken()
-  appendInfo(t, info)
+  t.addEmptyNode2(info)
+  t.addEmptyNode(info)
 
 proc addEmptyNode4*(t: var NifBuilder; info: LineInfo = NoLineInfo) =
   ## Appends four empty placeholder nodes (`. . . .`) to `t`.
-  t.addDotToken()
-  appendInfo(t, info)
-  t.addDotToken()
-  appendInfo(t, info)
-  t.addDotToken()
-  appendInfo(t, info)
-  t.addDotToken()
-  appendInfo(t, info)
+  t.addEmptyNode2(info)
+  t.addEmptyNode2(info)
 
 proc firstChild*(n: NifCursor): NifCursor {.inline.} =
   ## Returns a cursor positioned at the first child of `n`. `n` must be at
@@ -680,9 +656,9 @@ template replaceHead*(t: var Replacer;
   ## scopes.
   assert t.src.kind == TagLit, "replaceHead requires cursor at TagLit"
   t.dest.withTree(tag, info):
-    let inputScope = enterPluginScope(t.src)
+    let inputScope = nifcore.enterScope(t.src)
     body
-    leavePluginScope(t.src, inputScope)
+    nifcore.leaveScope(t.src, inputScope)
 
 # ── Cursor access for analysis ────────────────────────────────────────────
 
@@ -848,7 +824,7 @@ proc saveTree*(tree: sink NifBuilder) =
 proc renderNode*(n: NifCursor): string =
   ## Renders the current token or subtree as raw NIF text for debugging.
   ## This omits line info and only covers the subtree rooted at `n`.
-  if not hasSubtree(n):
+  if not n.hasMore:
     result = "<bug: empty>"
   else:
     result = nifcoreparse.toString(n, includeLineInfo = false)

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -51,8 +51,7 @@ let
   pluginTags = createPluginTags()
 
 proc appendInfo(buf: var NifBuilder; info: LineInfo) {.inline.} =
-  if info.isValid:
-    buf.appendLineInfo(info)
+  buf.appendLineInfo(info)
 
 proc isEmpty*(tree: NifBuilder): bool {.inline.} =
   ## Returns whether `tree` contains no NIF values.
@@ -60,7 +59,7 @@ proc isEmpty*(tree: NifBuilder): bool {.inline.} =
 
 proc info*(n: NifCursor): LineInfo {.inline.} =
   ## Returns the current value's source location, or `NoLineInfo` at exhaustion.
-  if n.hasMore: n.rawLineInfo else: NoLineInfo
+  n.rawLineInfo
 
 proc filePath*(info: LineInfo): string {.inline.} =
   ## Returns the source path stored in `info`, or `""` when unavailable.
@@ -119,9 +118,11 @@ proc tag*(n: NifCursor): TagId {.inline.} =
 
 proc rawTag(n: NifCursor): TagEnum {.inline.} =
   if n.kind != TagLit or n.tags != pluginTags:
-    return InvalidTagId
-  let id = uint32(n.cursorTagId)
-  if id <= uint32(high(TagEnum)): cast[TagEnum](id) else: InvalidTagId
+    result = InvalidTagId
+  else:
+    let id = uint32(n.cursorTagId)
+    result = if id <= uint32(high(TagEnum)): cast[TagEnum](id)
+             else: result = InvalidTagId
 
 proc stmtKind*(n: NifCursor): NimonyStmt {.inline.} =
   ## Returns the current statement tag, or `NoStmt`.
@@ -206,9 +207,7 @@ proc leavePluginScope(n: var NifCursor; scope: nifcore.CursorScope) =
 template copyInto*(t: var NifBuilder; n: var NifCursor; body: untyped) =
   ## Copies `n`'s tag, transforms its children with `body`, and advances `n`.
   assert n.kind == TagLit, "copyInto requires cursor at TagLit"
-  let copiedTag = n.tagId
-  let copiedInfo = n.info
-  t.openTree(copiedTag, copiedInfo)
+  t.openTree(n.tagId, n.info)
   let inputScope = enterPluginScope(n)
   body
   leavePluginScope(n, inputScope)

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -720,10 +720,7 @@ proc loadReplacer*(inputFile = paramStr(1)): Replacer =
 proc saveReplacer*(t: var Replacer; filename = paramStr(2)) =
   ## Writes the Replacer's output to `filename` (default: `paramStr(2)`).
   try:
-    if t.dest.isEmpty:
-      writeFile filename, ""
-    else:
-      writeFile filename, nifcoreparse.toString(t.dest)
+    writeFile filename, nifcoreparse.toString(t.dest)
   except:
     quit "FAILURE: cannot write " & filename
 
@@ -808,26 +805,23 @@ proc forLoopBody*(n: NifCursor): NifCursor =
   ## `(forcall <iter-name> (callargs ...) (unpackflat ...) <body>)`.
   ## This proc scans past the iter name, call args, and loop vars to reach
   ## the body subtree.
-  result = forLoopVars(n)
-  if result.hasMore:
-    skip result # skip loop vars
-    # result is now at the body (or exhausted if there is none)
+  result = n
+  if result.otherKind == ForcallU:
+    result = firstChild(result)
+    skip result # iterator name
+    skip result # call arguments
+    skip result # loop variables
+  # result is now at the body (or exhausted if there is none)
 
 proc renderTree*(tree: var NifBuilder): string =
   ## Renders the complete contents of `tree` as raw NIF text for debugging.
   ## Unlike `saveTree`, this omits line info and may contain multiple
   ## top-level fragments when the tree is still under construction.
-  if tree.isEmpty:
-    result = ""
-  else:
-    result = nifcoreparse.toString(tree, includeLineInfo = false)
+  result = nifcoreparse.toString(tree, includeLineInfo = false)
 
 proc writeTree(tree: var NifBuilder; filename: string) =
   try:
-    if tree.isEmpty:
-      writeFile filename, ""
-    else:
-      writeFile filename, nifcoreparse.toString(tree)
+    writeFile filename, nifcoreparse.toString(tree)
   except:
     quit "FAILURE: cannot write " & filename
 

--- a/tests/nimony/nifcore/tnifcoreparse.nim
+++ b/tests/nimony/nifcore/tnifcoreparse.nim
@@ -22,6 +22,9 @@ proc roundTrips(b1: var TokenBuf): bool =
   if not result: echo "round-trip MISMATCH:\n", txt
 
 proc main =
+  var empty = createTokenBuf()
+  assert toString(empty) == ""
+
   for s in [
       "(stmts (call foo 42 \"hi\") (asgn x 3.14) (ret -7))",
       "(proc :myproc.0 . . (params (param x.1 (i +32))) (i +32) (stmts (ret 0)))",


### PR DESCRIPTION
  Includes the two cleanup commits made after #2028 was merged.

  - Removes redundant empty-tree serialization branches.
  - Simplifies for-loop body traversal and small helper implementations.
  - Removes unnecessary aliases and lenientnils.
  - Retains scope adapters required by Nimony template instantiation.
  - Adds empty-buffer serialization coverage.
  
  Tests: 12/12 plugin tests and tnifcoreparse pass.
