### PR TITLE
nimsem: report bare `typedesc` used as a type instead of crashing

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1312,7 +1312,14 @@ proc exprToType(c: var SemContext; dest: var TokenBuf; exprType: Cursor; start: 
     dest.shrink start
     var base = exprType
     inc base
-    dest.addSubtree base
+    if base.kind == ParRi:
+      # A bare `typedesc` carrying no concrete base type, e.g. a `T: typedesc`
+      # parameter used as a type (`proc f(T: typedesc): Box[T]`). nimony has no
+      # implicit-generic `typedesc` params, so there is nothing to inline here.
+      # Report it instead of tripping the `addSubtree` "cursor at end?" assert.
+      c.buildErr dest, info, "'typedesc' without a concrete type cannot be used as a type; use an explicit generic parameter such as `proc f[T](x: typedesc[T])`"
+    else:
+      dest.addSubtree base
   of ErrT, AutoT:
     # propagate error
     discard

--- a/tests/nimony/errmsgs/ttypedescret.msgs
+++ b/tests/nimony/errmsgs/ttypedescret.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/ttypedescret.nim(8, 20) Error: 'typedesc' without a concrete type cannot be used as a type; use an explicit generic parameter such as `proc f[T](x: typedesc[T])`

--- a/tests/nimony/errmsgs/ttypedescret.nim
+++ b/tests/nimony/errmsgs/ttypedescret.nim
@@ -1,0 +1,8 @@
+# A bare `typedesc` parameter used to build a generic return type
+# (`proc make(T: typedesc): Box[T]`) used to crash nimsem with an
+# `addSubtree` "cursor at end?" assertion in `exprToType`. It must now
+# report a normal error instead.
+type Box[T] = object
+  value: T
+
+proc make(T: typedesc): Box[T] = discard


### PR DESCRIPTION
## Problem

A proc with a bare `typedesc` parameter used to build a generic return type — e.g. `proc make(T: typedesc): Box[T]` — crashed nimsem with an internal assertion:

```
nifcursors.nim(621) `c.kind != ParRi` cursor at end?
```

`exprToType`'s `TypedescT` branch skips the `typedesc` tag and inlines its base type, but a bare `typedesc` (an unsupported implicit-generic parameter) carries no base, so the cursor lands on the closing `ParRi` and `addSubtree` asserts.

## Fix

Guard the empty-base case and emit a normal diagnostic instead of crashing, pointing at the supported explicit form `proc f[T](x: typedesc[T])`. The `typedesc[T]` path is unchanged.

After the fix:

```
Error: 'typedesc' without a concrete type cannot be used as a type; use an explicit generic parameter such as `proc f[T](x: typedesc[T])`
```

## Test

Adds `tests/nimony/errmsgs/ttypedescret.nim` (+ `.msgs`) as a regression test. The full `errmsgs` suite (28 tests) and `generics` suite (25 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
