### PR TITLE
fix: accept a pragma on a for-loop variable (for x {.inject.} in s)

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -635,9 +635,25 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
         else:
           c.b.addTree(LetL)
 
-          toNif(n[i], n, c) # name
+          # A loop variable may carry a pragma (e.g. `for x {.inject.} in s`,
+          # as used by `mapIt` & friends). Split it out like a regular ident-def
+          # so the pragma lands in the `let`'s pragmas slot rather than staying
+          # wrapped as a `pragmax` in the name slot.
+          let split = splitIdentDefName(n[i])
 
-          c.b.addEmpty 4 # export marker, pragmas, type, value
+          toNif(split.name, n, c) # name
+
+          if split.visibility != nil:
+            c.b.addRaw " x"
+          else:
+            c.b.addEmpty # export marker
+
+          if split.pragma != nil:
+            toNif(split.pragma, n, c)
+          else:
+            c.b.addEmpty # pragmas
+
+          c.b.addEmpty 2 # type, value
           c.b.endTree() # LetDecl
       c.b.endTree() # UnpackIntoFlat
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2694,7 +2694,9 @@ proc semForLoopVar(c: var SemContext; dest: var TokenBuf; it: var Item; loopvarT
     let delayed = handleSymDef(c, dest, it.n, LetY)
     c.addSym dest, delayed
     wantDot c, dest, it.n # export marker must be empty
-    wantDot c, dest, it.n # pragmas
+    # The loop variable may carry pragmas (e.g. `{.inject.}` from a template, as
+    # `mapIt`/`toSeq` use); copy the slot through rather than requiring it empty.
+    takeTree dest, it.n # pragmas
     if loopvarTypeMod != NoType and loopvarType.typeKind notin TypeModifiers:
       dest.buildTree loopvarTypeMod, it.n.info:
         copyTree dest, loopvarType

--- a/tests/nimony/templates/tforloopinject.nim
+++ b/tests/nimony/templates/tforloopinject.nim
@@ -1,0 +1,29 @@
+import std/[assertions]
+
+# A loop variable may carry a pragma. `{.inject.}` on a template's loop variable
+# (as `mapIt`/`toSeq` use) must expose `it` to the substituted predicate/body.
+
+template anyItF(s, pred: untyped): bool {.untyped.} =
+  var res = false
+  for it {.inject.} in s:
+    if pred: res = true
+  res
+
+template mapItF(s, op: untyped): untyped {.untyped.} =
+  var res: seq[int] = @[]
+  for it {.inject.} in s:
+    res.add(op)
+  res
+
+proc main =
+  assert anyItF(@[1, 2, 3], it == 2)
+  assert not anyItF(@[1, 3, 5], it == 2)
+  assert mapItF(@[1, 2, 3], it + 10) == @[11, 12, 13]
+
+  # A pragma on a plain (non-template) loop variable must also be accepted.
+  var total = 0
+  for x {.inject.} in @[1, 2, 3]:
+    total += x
+  assert total == 6
+
+main()


### PR DESCRIPTION
## Bug

`for x {.inject.} in s` crashed the compiler with an internal
`[Bug] expected ')'`. This is the form `mapIt`/`toSeq` and other `*It`-style
templates rely on (`for it {.inject.} in s`).

## Fix (two halves)

**nifler (`bridge.nim`)** — the for-loop's `unpackflat` emission wrote the loop
variable verbatim, so a pragma'd var became
`(let (pragmax x (pragmas inject)) . . . .)` with the pragma stuck in the *name*
slot. It now uses `splitIdentDefName` like the regular ident-def path, producing
`(let x . (pragmas inject) . .)`.

**sem (`semForLoopVar`)** — the loop-var reader did `wantDot` on the pragmas
slot (i.e. required it empty), so a real pragma derailed the cursor and tripped
`takeParRi`. It now copies the slot through with `takeTree`, accepting either an
empty slot or a `(pragmas …)` node.

## Test

`tests/nimony/templates/tforloopinject.nim` covers `{.inject.}` loop variables
in any-/map-style `{.untyped.}` templates and on a plain top-level loop.
`tests/nimony/iter` (10/10) and `tests/nimony/stdlib` (32/32) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
