### PR TITLE
system: add a Stringable concept

### DIFF
--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -119,6 +119,12 @@ func `$`*(b: bool): string =
 func `$`*[T: enum](x: T): string {.magic: "EnumToStr", noSideEffect.}
   ## Converts an enum value to a string.
 
+type Stringable* = concept
+  ## A type that can be rendered as a `string` via the `$` operator. Generic
+  ## code that stringifies an abstract type parameter `T` should constrain it
+  ## with `[T: Stringable]`, since nimony binds generic bodies eagerly.
+  func `$`(x: Self): string
+
 func addr*[T](x: T): ptr T {.magic: "Addr", noSideEffect.}
   ## Returns the address of `x`.
 func unsafeAddr*[T](x: T): ptr T {.magic: "Addr", noSideEffect.}

--- a/tests/nimony/errmsgs/tdistinctinfos.msgs
+++ b/tests/nimony/errmsgs/tdistinctinfos.msgs
@@ -22,5 +22,5 @@ WINBOOL(0) == 0
 [1] expected: float64 but got: WINBOOL (declared in lib/std/system/comparisons.nim(105, 1))
 [1] expected: string but got: WINBOOL (declared in lib/std/system/stringimpl.nim(587, 1))
 [1] expected: openArray[T] but got: WINBOOL (declared in lib/std/system/openarrays.nim(71, 1))
-[1] WINBOOL does not match constraint T (declared in lib/std/system.nim(345, 1))
-[1] expected: seq[T] but got: WINBOOL (declared in lib/std/system.nim(351, 1))
+[1] WINBOOL does not match constraint T (declared in lib/std/system.nim(351, 1))
+[1] expected: seq[T] but got: WINBOOL (declared in lib/std/system.nim(357, 1))

--- a/tests/nimony/stdlib/tstringable.nim
+++ b/tests/nimony/stdlib/tstringable.nim
@@ -1,0 +1,20 @@
+import std/[syncio, assertions]
+
+# A fresh consumer (no local Stringable) that relies on system.Stringable
+# being exported and auto-imported.
+type Celsius = object
+  deg: int
+
+func `$`(c: Celsius): string =
+  result = $c.deg
+  result.add "C"
+
+func show[T: Stringable](x: T): string = $x
+
+proc main =
+  assert show(42) == "42"
+  assert show("hi") == "hi"
+  assert show(Celsius(deg: 7)) == "7C"
+  echo "stringable: OK"
+
+main()


### PR DESCRIPTION
Adds a `Stringable*` concept to `system`, beside the existing `HasDefault` / `Equatable` / `Orderable` / `Comparable`:

```nim
type Stringable* = concept
  func `$`(x: Self): string
```

### Why

nimony binds generic proc bodies eagerly, so generic code that stringifies an abstract type parameter `T` must gate `$` behind a concept (a `mixin` does not defer resolution). With no shared concept, every such module reinvents a byte-identical private copy. Two already do:

- `std/options` (#2047) — `$*[T: Stringable](self: Option[T])`
- `std/deques` (#2049) — `$*[T: Stringable](d: Deque[T])`

This gives them (and future modules) one canonical concept to depend on, mirroring how `Equatable` already backs the generic `==`/`contains` machinery.

### No merge-order dependency

The exported concept **coexists** with those private copies — the local definition simply shadows the imported one — so this PR can merge in any order relative to #2047/#2049 without breaking them. Removing the now-redundant local copies from those modules is left as a trivial follow-up once this lands (and is intentionally *not* done here, since those files don't exist on `master` yet).

### Tests

`tests/nimony/stdlib/tstringable.nim` exercises the concept from a fresh module (no local copy) over `int`, `string`, and a user-defined object type. Verified with `nimony c` (`stringable: OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
