### PR TITLE
system: remove concat in favor of efficient & chaining

### DIFF
--- a/examples/seqs_and_strings.nim
+++ b/examples/seqs_and_strings.nim
@@ -76,12 +76,11 @@ var s2 = s1
 s2[0] = 'X'
 assert s1 == "abc"   # s1 is unchanged
 
-# --- concat for efficient string building ---
+# --- string building with `&` ---
 
-# `&` allocates a new string each time.
-# `concat` is much more efficient for multiple pieces:
+# Chained `&` builds a new string from multiple pieces:
 let name = "world"
-let msg = concat("hello, ", name, "!")
+let msg = "hello, " & name & "!"
 assert msg == "hello, world!"
 
 # --- Bulk writes with beginStore / endStore ---

--- a/lib/std/dirs.nim
+++ b/lib/std/dirs.nim
@@ -155,7 +155,7 @@ proc fillDirEntry(w: var DirWalker; e: var DirEntry) =
 when defined(posix):
   proc pathComponentFromEntry(w: var DirWalker; name: string; dType: uint8): PathComponent =
     if dType == DT_UNKNOWN or dType == DT_LNK:
-      var fullPath = concat($w.dir, "/", name)
+      var fullPath = $w.dir & "/" & name
       var s = default Stat
       if lstat(fullPath.toCString, s) == 0:
         if S_ISLNK(s.st_mode):

--- a/lib/std/system/stringimpl.nim
+++ b/lib/std/system/stringimpl.nim
@@ -675,13 +675,7 @@ func newStringOfCap*(len: int): string =
   else:
     strOom result, LongStringDataOffset + len
 
-# ---- concat / & ----
-
-template concat*(): string {.varargs.} =
-  var res = ""
-  for s in unpack():
-    res.add s
-  res
+# ---- & ----
 
 func `&`*(a, b: string): string {.semantics: "string.&".} =
   result = string(bytes: 0'u, more: nil)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -118,11 +118,6 @@ proc scopeBump(m: Match): int =
     dec i
   return 0
 
-when not defined(nimony):
-  proc concat(a: varargs[string]): string =
-    result = a[0]
-    for i in 1..high(a): result.add a[i]
-
 proc error(m: var Match; k: MatchErrorKind; expected, got: Cursor) =
   m.err = true
   if m.hasError: return # first error is the important one
@@ -175,13 +170,13 @@ proc constraintToString(c: Cursor): string =
 proc getErrorMsg*(m: Match): string =
   case m.error.kind
   of InvalidMatch:
-    concat("expected: ", typeToString(m.error.expected), " but got: ", typeToString(m.error.got))
+    "expected: " & typeToString(m.error.expected) & " but got: " & typeToString(m.error.got)
   of InvalidRematch:
-    concat("Could not match again: ", pool.syms[m.error.typeVar], " expected ",
-      typeToString(m.error.expected), " but got ", typeToString(m.error.got))
+    "Could not match again: " & pool.syms[m.error.typeVar] & " expected " &
+      typeToString(m.error.expected) & " but got " & typeToString(m.error.got)
   of ConstraintMismatch:
-    concat(typeToString(m.error.got), " does not match constraint ",
-      constraintToString(m.error.expected))
+    typeToString(m.error.got) & " does not match constraint " &
+      constraintToString(m.error.expected)
   of FormalTypeNotAtEndBug:
     "BUG: formal type not at end!"
   of FormalParamsMismatch:
@@ -197,22 +192,22 @@ proc getErrorMsg*(m: Match): string =
   of UnavailableSubtypeRelation:
     "subtype relation not available for `out` parameters"
   of ImplicitConversionNotMutable:
-    concat("implicit conversion to ", typeToString(m.error.expected), " is not mutable")
+    "implicit conversion to " & typeToString(m.error.expected) & " is not mutable"
   of VarNeeded:
-    concat("expression is not a mutable lvalue, cannot be passed to ",
-      typeToString(m.error.expected), " parameter")
+    "expression is not a mutable lvalue, cannot be passed to " &
+      typeToString(m.error.expected) & " parameter"
   of UnhandledTypeBug:
-    concat("BUG: unhandled type: ", pool.tags[m.error.expected.tagId])
+    "BUG: unhandled type: " & pool.tags[m.error.expected.tagId]
   of MismatchBug:
-    concat("BUG: expected: ", typeToString(m.error.expected), " but got: ", typeToString(m.error.got))
+    "BUG: expected: " & typeToString(m.error.expected) & " but got: " & typeToString(m.error.got)
   of MissingExplicitGenericParameter:
-    concat("missing explicit generic parameter for ", pool.syms[m.error.typeVar])
+    "missing explicit generic parameter for " & pool.syms[m.error.typeVar]
   of ExtraGenericParameter:
     "extra generic parameter"
   of RoutineIsNotGeneric:
     "routine is not generic"
   of CouldNotInferTypeVar:
-    concat("could not infer type for ", pool.syms[m.error.typeVar])
+    "could not infer type for " & pool.syms[m.error.typeVar]
   of TooManyArguments:
     "too many arguments"
   of TooFewArguments:

--- a/tests/nimony/arc/tconcat.nim
+++ b/tests/nimony/arc/tconcat.nim
@@ -2,7 +2,7 @@
 import std / syncio
 
 proc main(inp: string) =
-  let s = concat("a", inp, "c")
+  let s = "a" & inp & "c"
   echo s
 
 main("b")

--- a/tests/nimony/methods/deps/mgenericinheritance.nim
+++ b/tests/nimony/methods/deps/mgenericinheritance.nim
@@ -9,7 +9,7 @@ method foo*(x: RootObj2): string = "RootObj"
 template name(_: typedesc[int]): string = "int"
 template name(_: typedesc[float]): string = "float"
 method foo*[T](x: GenericObj[T]): string {.untyped.} =
-  concat("GenericObj ", name(T))
+  "GenericObj " & name(T)
 
 proc testFoo*(x: RootObj2) =
   echo foo(x)

--- a/tests/nimony/overload/tconcatoverload.nim
+++ b/tests/nimony/overload/tconcatoverload.nim
@@ -1,0 +1,16 @@
+import std/[assertions]
+
+# `system` no longer defines a greedy 0-parameter `concat` template, so user
+# code (e.g. `sequtils.concat`) is free to define its own `concat` overload
+# without it being shadowed and failing overload resolution.
+
+func concat[T](a, b: openArray[T]): seq[T] =
+  result = @[]
+  for i in 0 ..< a.len: result.add a[i]
+  for i in 0 ..< b.len: result.add b[i]
+
+proc main =
+  assert concat(@[1, 2], @[3, 4]) == @[1, 2, 3, 4]
+  assert concat(@["x"], @["y", "z"]) == @["x", "y", "z"]
+
+main()


### PR DESCRIPTION
## What

Removes the `concat` template from `system` entirely and switches the few
callers to chained `&`.

## Why

`system.concat` was declared as a bare 0-parameter `{.varargs.}` template:

```nim
template concat*(): string {.varargs.} =
  var res = ""
  for s in unpack():
    res.add s
  res
```

Because it takes no typed parameters, it matched **every** `concat(...)` call
and only failed later inside its body for non-string arguments. That shadowed
any user-defined `concat` overload (e.g. a `sequtils.concat` over
`openArray[T]`), so such an overload could never be selected.

Following @Araq's guidance on the previous revision of this PR: now that
chaining `&` is efficient, the right fix is to **drop `concat` from `system`
altogether** rather than retype it as `varargs[string]` (which would generate
worse code). Removing it eliminates the namespace conflict with `sequtils` at
the source.

## Changes

- Delete `template concat*` from `lib/std/system/stringimpl.nim`.
- Switch the in-tree callers to `&`:
  - `lib/std/dirs.nim` (`$w.dir & "/" & name`)
  - `examples/seqs_and_strings.nim`
  - `tests/nimony/arc/tconcat.nim`
  - `tests/nimony/methods/deps/mgenericinheritance.nim`
- Add `tests/nimony/overload/tconcatoverload.nim`: asserts a user-defined
  `concat[T](a, b: openArray[T])` overload now compiles and runs without being
  shadowed by `system`.

## Testing

`hastur test` green on the affected areas: overload (10/10), arc (40/40),
methods (8/8), stdlib (33/33, incl. `twalkdir`), examples (6/6).