### PR TITLE
hastur: only run golden .c/.nif diffs on 64-bit hosts (#1569)

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -134,6 +134,15 @@ proc diffFiles(c: var TestCounters; file, a, b: string; overwrite: bool) =
 const
   ErrorKeyword = "Error:"
 
+  targetIs64bit = sizeof(int) == 8
+    ## The checked-in golden `.nim.c` and `.nif` outputs are generated for a
+    ## 64-bit target (e.g. `(i +64)`, `IL64(...)`, `NIM_INTBITS 64`). nimony
+    ## defaults its target word size to the host CPU, so on a 32-bit host the
+    ## generated code legitimately differs and those diffs would spuriously
+    ## fail. Per nim-lang/nimony#1569, only run the golden-file comparisons on
+    ## 64-bit hosts. (`sizeof(int)` reflects the host hastur was built for,
+    ## which is the same machine that runs nimony for the tests.)
+
 type
   LineInfo = object
     line, col: int
@@ -415,7 +424,7 @@ proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category;
 
   if compilerExitCode == 0:
     let cfile = file.changeFileExt(".nim.c")
-    if cfile.fileExists():
+    if targetIs64bit and cfile.fileExists():
       let nimcacheC = generatedFile(file, ".c")
       diffFiles c, file, cfile, nimcacheC, overwrite
 
@@ -442,7 +451,7 @@ proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category;
     # depend on `lib/std/system.nim` and so remain stable across system
     # changes. With the phase validator in place, diffing NIF for normal
     # tests causes noisy churn without meaningfully improving coverage.
-    if cat == Basics:
+    if cat == Basics and targetIs64bit:
       let ast = file.changeFileExt(".nif")
       if ast.fileExists():
         let nif = generatedFile(file, ".s.nif")


### PR DESCRIPTION
Fixes #1569.

The checked-in golden `.nim.c` and `.nif` expected outputs are generated for a **64-bit target** — they contain word-size-specific code such as `(i +64)`, `IL64(...)` and `#define NIM_INTBITS 64`. nimony defaults its target word size to the host CPU, so on a 32-bit host the generated code legitimately differs and the golden-file comparisons fail spuriously.

### Fix

Per [Araq's suggestion on the issue](https://github.com/nim-lang/nimony/issues/1569) — *"we make hastur only do these checks for 64bit archs, problem solved"* — both golden diffs are gated on a new `targetIs64bit = sizeof(int) == 8` const:

- the `.nim.c` codegen diff, and
- the `Basics` / `nosystem` `.s.nif` diff.

`sizeof(int)` reflects the host hastur was built for, which is the same machine that runs nimony for the tests, so it is a faithful proxy for the target word size. On 64-bit hosts behavior is unchanged; on 32-bit hosts the two diffs are skipped while the rest of each test (compile-success / exit code, program output, valgrind) still runs.

### Testing

- 64-bit (this host): `basics`, `nosystem`, `object`, and `ffi/tunion` all still pass — the golden diffs run exactly as before.
- Verified the gate empirically: with a deliberately corrupted `tests/nimony/ffi/tunion.nim.c` golden, the test **fails** with the diff enabled (64-bit) and **passes** with the const forced to `false` (simulated 32-bit), confirming the diff is correctly skipped on 32-bit and still enforced on 64-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)