### PR TITLE
Tighten plugin genSym state handling

### DIFF
--- a/src/lib/nifcoreparse.nim
+++ b/src/lib/nifcoreparse.nim
@@ -260,20 +260,25 @@ proc emitValueWithoutLineInfo(bld: var Builder; c: var Cursor;
   of ExtendedSuffix, LineInfoLit:
     assert false, "suffix token is not a value head"
 
-proc toString*(b: var TokenBuf; sizeHint = 0;
-               includeLineInfo = true): string =
-  ## Canonical NIF text for the whole buffer (one or more top-level values).
-  ## Set `includeLineInfo` to false for location-free diagnostic rendering.
-  var bld = nifbuilder.open(if sizeHint > 0: sizeHint else: b.len * 8)
+proc appendTo*(b: var TokenBuf; dest: var Builder;
+               includeLineInfo = true) =
+  ## Appends canonical NIF text for the whole buffer to `dest`.
   var c = b.beginRead()
   if includeLineInfo:
     var cur = NoNifLineInfo
     var parents = @[NoNifLineInfo]
     while c.hasMore:
-      emitValueWithLineInfo(bld, c, cur, parents, b.tags, b.pool)
+      emitValueWithLineInfo(dest, c, cur, parents, b.tags, b.pool)
   else:
     while c.hasMore:
-      emitValueWithoutLineInfo(bld, c, b.tags, b.pool)
+      emitValueWithoutLineInfo(dest, c, b.tags, b.pool)
+
+proc toString*(b: var TokenBuf; sizeHint = 0;
+               includeLineInfo = true): string =
+  ## Canonical NIF text for the whole buffer (one or more top-level values).
+  ## Set `includeLineInfo` to false for location-free diagnostic rendering.
+  var bld = nifbuilder.open(if sizeHint > 0: sizeHint else: b.len * 8)
+  b.appendTo(bld, includeLineInfo)
   result = bld.extract()
 
 proc toString*(node: Cursor; sizeHint = 0;

--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -13,7 +13,7 @@
 import std / [assertions, hashes, syncio, cmdline]
 import ".." / ".." / "lib" / nifcore except symId, `$`, addSymUse, addSymDef
 import ".." / ".." / "lib" / nifcoreparse except symId, `$`, addSymUse, addSymDef
-import ".." / ".." / "lib" / [bitabs, symparser]
+import ".." / ".." / "lib" / [bitabs, nifbuilder, symparser]
 import ".." / ".." / "models" / [tags, nimony_tags]
 import ".." / nif_annotations
 export NimonyType, NimonyExpr, NimonyStmt, NimonyPragma, NimonyOther
@@ -713,27 +713,33 @@ template peek*(t: var Replacer; body: untyped) =
 # ── Entry points ──────────────────────────────────────────────────────────
 
 proc loadPluginTree(filename: string): NifBuilder =
-  unusedNameBase = ""
-  nextUnusedName = 0
   var hint = ""
   result = parseFromFile(
     filename, hint, sharedPool = pluginPool, sharedTags = pluginTags,
     denseLineInfo = true)
   if hint.len > 0:
-    assert splitLocalSymName(hint, unusedNameBase, nextUnusedName),
+    var hintBase = ""
+    var hintNumber = 0
+    assert splitLocalSymName(hint, hintBase, hintNumber),
       "plugin .unusedname must be a local symbol"
+    if unusedNameBase.len == 0:
+      unusedNameBase = hintBase
+      nextUnusedName = hintNumber
+    else:
+      assert unusedNameBase == hintBase,
+        "plugin inputs must use the same .unusedname base"
+      if nextUnusedName < hintNumber:
+        nextUnusedName = hintNumber
 
 proc writePluginTree(tree: var NifBuilder; filename: string) =
-  var content = ""
+  var output = nifbuilder.open(filename)
   if unusedNameBase.len > 0:
-    content.add "(.unusedname "
-    content.add unusedNameBase
-    content.add "."
-    content.add $nextUnusedName
-    content.add ")\n"
-  content.add nifcoreparse.toString(tree)
+    output.addRaw "(.unusedname "
+    output.addSymbol unusedNameBase & "." & $nextUnusedName
+    output.addRaw ")\n"
+  tree.appendTo(output)
   try:
-    writeFile filename, content
+    output.close()
   except:
     quit "FAILURE: cannot write " & filename
 

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -382,44 +382,49 @@ proc writeFileIfChanged(file, content: string) {.canRaise.} =
   else:
     writeFile file, content
 
-const PluginTempBase = "tmp"
+const pluginTempBase = "tmp"
 
 proc addUnusedName(input, name: string): string =
   result = "(.unusedname " & name & ")\n"
   result.add input
 
-proc registerGeneratedSymbols(c: var SemContext;
-                              firstName, nextName: string) =
+proc registerGeneratedSymbols(c: var SemContext; firstDisamb: int;
+                              nextName: string) =
   if nextName.len == 0:
     return
 
-  var firstBase = ""
   var nextBase = ""
-  var firstDisamb = 0
   var nextDisamb = 0
-  assert splitLocalSymName(firstName, firstBase, firstDisamb),
-    "invalid .unusedname passed to plugin"
   assert splitLocalSymName(nextName, nextBase, nextDisamb) and
-    nextBase == firstBase and nextDisamb >= firstDisamb,
+    nextBase == pluginTempBase and nextDisamb >= firstDisamb,
     "invalid .unusedname returned by plugin"
 
   for disamb in firstDisamb ..< nextDisamb:
-    let name = firstBase & "." & $disamb
+    let name = pluginTempBase & "." & $disamb
     c.freshSyms.incl pool.syms.getOrIncl(name)
 
   if nextDisamb > firstDisamb:
-    let lastUsed = nextDisamb - 1
-    if c.locals.getOrDefault(firstBase, -1) < lastUsed:
-      c.locals[firstBase] = lastUsed
+    c.locals[pluginTempBase] = nextDisamb - 1
 
-proc runPluginOutput(c: var SemContext; dest: var TokenBuf;
-                     info: PackedLineInfo; pluginName: string;
-                     input: string; additionalInput: string): string =
-  ## Builds and runs a plugin, parses its output into `dest`, and returns the
-  ## output's `.unusedname` hint (or `""` when an older plugin omitted it).
+proc runPlugin*(c: var SemContext; dest: var TokenBuf; info: PackedLineInfo;
+                pluginName: string; input: string; additionalInput = "") =
+  ## Runs a plugin with a NIF `.unusedname` hint and registers every generated
+  ## local symbol as fresh for subsequent semantic checking.
+  let firstDisamb = c.locals.getOrDefault(pluginTempBase, -1) + 1
+  let firstName = pluginTempBase & "." & $firstDisamb
+  let pluginInput = addUnusedName(input, firstName)
+  let pluginAdditionalInput =
+    if additionalInput.len > 0: addUnusedName(additionalInput, firstName)
+    else: ""
+
   let p = splitFile(pluginName)
-  let checksumA = if additionalInput.len > 0: "_" & computeChecksum(additionalInput) else: ""
-  let basename = c.g.config.nifcachePath / p.name & "_" & computeChecksum(input) & checksumA
+  let checksumA =
+    if pluginAdditionalInput.len > 0:
+      "_" & computeChecksum(pluginAdditionalInput)
+    else:
+      ""
+  let basename = c.g.config.nifcachePath / p.name & "_" &
+    computeChecksum(pluginInput) & checksumA
   let inputFile = basename & ".in.nif"
   let outputFile = basename & ".out.nif"
   let inputFileB = basename & ".types.nif"
@@ -430,38 +435,26 @@ proc runPluginOutput(c: var SemContext; dest: var TokenBuf;
     compilePlugin(c, info, nf, pluginExe)
 
   try:
-    writeFileIfChanged(inputFile, input)
-    if additionalInput.len > 0:
-      writeFileIfChanged(inputFileB, additionalInput)
+    writeFileIfChanged(inputFile, pluginInput)
+    if pluginAdditionalInput.len > 0:
+      writeFileIfChanged(inputFileB, pluginAdditionalInput)
   except:
     quit "FAILURE: cannot write plugin input file " & inputFile
 
   if needsRecompile(pluginExe, outputFile):
     var cmd = quoteShell(pluginExe) & " " & quoteShell(inputFile) & " " & quoteShell(outputFile)
-    if additionalInput.len > 0:
+    if pluginAdditionalInput.len > 0:
       cmd &= " "
       cmd &= quoteShell(inputFileB)
     exec cmd
   var s = nifstreams.open(outputFile)
+  var nextName = ""
   try:
-    result = rd.firstUnusedName(s.r)
+    nextName = rd.firstUnusedName(s.r)
     parse s, dest, NoLineInfo
   finally:
     close s
-
-proc runPlugin*(c: var SemContext; dest: var TokenBuf; info: PackedLineInfo;
-                pluginName: string; input: string; additionalInput = "") =
-  ## Runs a plugin with a NIF `.unusedname` hint and registers every generated
-  ## local symbol as fresh for subsequent semantic checking.
-  let firstName = PluginTempBase & "." &
-    $(c.locals.getOrDefault(PluginTempBase, -1) + 1)
-  let pluginInput = addUnusedName(input, firstName)
-  let pluginAdditionalInput =
-    if additionalInput.len > 0: addUnusedName(additionalInput, firstName)
-    else: ""
-  let nextName = runPluginOutput(c, dest, info, pluginName, pluginInput,
-                                 pluginAdditionalInput)
-  registerGeneratedSymbols(c, firstName, nextName)
+  registerGeneratedSymbols(c, firstDisamb, nextName)
 
 proc runProgram(file: string; nimcachePath: string; usedModules: HashSet[string];
                 commandLineArgs: string;

--- a/tests/nimony/nifcore/tnifcoreparse.nim
+++ b/tests/nimony/nifcore/tnifcoreparse.nim
@@ -7,6 +7,7 @@
 # destructors (incl. the shared-pool GC_ref / GC_unref) at scope exit.
 
 import nifcoreparse
+import nifbuilder
 import std / [assertions, syncio]
 
 proc sameTokens(a, b: var TokenBuf): bool =
@@ -68,6 +69,10 @@ proc main =
   let fresh = symbols.pool.syms.getOrIncl("tmp.14")
   symbols.addSymDef(fresh)
   assert toString(symbols, includeLineInfo = false) == ":tmp.14"
+  var rendered = nifbuilder.open(32)
+  rendered.addRaw "prefix "
+  symbols.appendTo(rendered, includeLineInfo = false)
+  assert rendered.extract() == "prefix :tmp.14"
   echo "ok"
 
 main()

--- a/tests/nimony/plugins/deps/mtypeplugin.nim
+++ b/tests/nimony/plugins/deps/mtypeplugin.nim
@@ -1,5 +1,5 @@
 
-import std / [strutils, tables]
+import std / [assertions, strutils, tables]
 
 import plugins
 
@@ -123,7 +123,10 @@ proc tr(n: NifCursor): NifBuilder =
 
 
 var inp = loadPluginInput()
+let generatedBeforeTypes = genSym()
 var inpTypes = loadTypeDefinitions()
+let generatedAfterTypes = genSym()
+assert generatedBeforeTypes != generatedAfterTypes
 
 typesTr(inpTypes)
 saveTree tr(inp)


### PR DESCRIPTION
  ## Summary

  - Preserve the generated-symbol counter when plugins load multiple input files.
  - Validate that all plugin inputs use the same `.unusedname` base.
  - Serialize plugin output directly through `nifbuilder`, including proper symbol escaping.
  - Add `TokenBuf.appendTo` to avoid constructing and copying an intermediate NIF string.
  - Simplify plugin execution and generated-symbol registration in `semos`.
  - Test `genSym` across primary and type-definition input loads.

  ## Testing

  - `nim c -r src/hastur build nimony`
  - `nim c -r src/hastur test tests/nimony/nifcore/tnifcoreparse.nim`
  - `nim c -r src/hastur test tests/nimony/plugins` — 15/15 passed