### PR TITLE
std/parseutils: signal out-of-range integers instead of aborting

### DIFF
--- a/lib/std/encodings.nim
+++ b/lib/std/encodings.nim
@@ -263,7 +263,9 @@ when defined(windows):
 
   func nameToCodePage*(name: string): CodePage =
     var nameAsInt: int = 0
-    if parseBiggestInt(name, nameAsInt) == 0: nameAsInt = -1
+    # `<= 0`: 0 = not a number, negative = out-of-range integer; neither is a
+    # valid code-page number, so fall back to the name lookup.
+    if parseBiggestInt(name, nameAsInt) <= 0: nameAsInt = -1
     for value in arrayIter(winEncodings):
       let (no, na) = value
       if no == nameAsInt or eqEncodingNames(na, name): return CodePage(no)

--- a/lib/std/json.nim
+++ b/lib/std/json.nim
@@ -224,8 +224,16 @@ proc parseValue(p: var JsonParser; t: var JsonTree; mode: LineInfoMode; file: Fi
     t.buf.addStrLit p.a; emitInfo(p, t, mode, file); discard getTok(p)
   of tkInt:
     var v: BiggestInt = 0
-    discard parseBiggestInt(p.a, v)
-    t.buf.addIntLit int64(v); emitInfo(p, t, mode, file); discard getTok(p)
+    if parseBiggestInt(p.a, v) > 0:
+      t.buf.addIntLit int64(v)
+    else:
+      # Integer literal outside the int64 range (e.g. C's UINT64_MAX in header
+      # dumps): the standard JSON fallback is to keep it as a (lossy) float atom
+      # rather than aborting the whole parse.
+      var f: BiggestFloat = 0.0
+      discard parseBiggestFloat(p.a, f)
+      t.buf.addFloatLit float64(f)
+    emitInfo(p, t, mode, file); discard getTok(p)
   of tkFloat:
     var v: BiggestFloat = 0.0
     discard parseBiggestFloat(p.a, v)

--- a/lib/std/parseutils.nim
+++ b/lib/std/parseutils.nim
@@ -16,11 +16,6 @@ const
 func toLower(c: char): char {.inline.} =
   result = if c in {'A'..'Z'}: chr(ord(c)-ord('A')+ord('a')) else: c
 
-func integerOutOfRangeError() {.noinline, noreturn.} =
-  # TODO: Uncomment when exception is implemented.
-  #raise newException(ValueError, "Parsed integer outside of valid range")
-  {.cast(noSideEffect).}: quit "Parsed integer outside of valid range"
-
 func parseHex*[T: SomeInteger](s: openArray[char], number: var T, maxLen = 0): int {.untyped.} =
   ## Parses a hexadecimal number and stores its value in ``number``.
   ##
@@ -110,28 +105,37 @@ func parseHex*[T: SomeInteger](s: string, number: var T, start = 0,
   parseHex(s.toOpenArray(start, s.high), number, maxLen)
 
 func rawParseInt(s: openArray[char], b: var BiggestInt): int =
+  ## On success returns the number of processed characters and stores the value
+  ## in `b`. Returns 0 if `s` does not start with an integer. Returns a negative
+  ## number `-n` if the first `n` characters form an integer literal whose value
+  ## does not fit in `BiggestInt`; in that case `b` is left unchanged. The whole
+  ## digit run is still consumed on overflow so the caller can skip past it.
   var
     sign: BiggestInt = -1
     i = 0
+    res = BiggestInt(0)
+    overflow = false
   if i < s.len:
     if s[i] == '+': inc(i)
     elif s[i] == '-':
       inc(i)
       sign = 1
   if i < s.len and s[i] in {'0'..'9'}:
-    b = 0
     while i < s.len and s[i] in {'0'..'9'}:
       let c = ord(s[i]) - ord('0')
-      if b >= (low(BiggestInt) + c) div 10:
-        b = b * 10 - c
-      else:
-        integerOutOfRangeError()
+      if not overflow:
+        if res >= (low(BiggestInt) + c) div 10:
+          res = res * 10 - c
+        else:
+          overflow = true
       inc(i)
       while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
-    if sign == -1 and b == low(BiggestInt):
-      integerOutOfRangeError()
+    if sign == -1 and res == low(BiggestInt):
+      overflow = true
+    if overflow:
+      result = -i
     else:
-      b = b * sign
+      b = res * sign
       result = i
   else:
     result = 0
@@ -139,61 +143,79 @@ func rawParseInt(s: openArray[char], b: var BiggestInt): int =
 func parseBiggestInt*(s: openArray[char], number: var BiggestInt): int {.
   noSideEffect.} =
   ## Parses an integer and stores the value into `number`.
-  ## Result is the number of processed chars or 0 if there is no integer.
-  ## `ValueError` is raised if the parsed integer is out of the valid range.
+  ## Result is the number of processed chars, or 0 if there is no integer.
+  ## If the parsed integer is out of the valid `BiggestInt` range the result is
+  ## a **negative** number `-n` (where `n` chars form the out-of-range literal)
+  ## and `number` is left unchanged, so the caller can detect the overflow and
+  ## handle it instead of aborting.
   runnableExamples:
     var ret: BiggestInt
     assert parseBiggestInt("9223372036854775807", ret) == 19
     assert ret == 9223372036854775807
     assert parseBiggestInt("-2024_05_09", ret) == 11
     assert ret == -20240509
+    # out of range: negative result, `ret` untouched
+    assert parseBiggestInt("9223372036854775808", ret) == -19
+    assert ret == -20240509
   var res = BiggestInt(0)
-  # use 'res' for exception safety (don't write to 'number' in case of an
-  # overflow exception):
+  # use 'res' so 'number' is only written on a successful, in-range parse:
   result = rawParseInt(s, res)
-  if result != 0:
+  if result > 0:
     number = res
 
 func rawParseUInt(s: openArray[char], b: var BiggestUInt): int =
+  ## On success returns the number of processed characters and stores the value
+  ## in `b`. Returns 0 if `s` does not start with an unsigned integer. Returns a
+  ## negative number `-n` if the first `n` characters are out of the valid
+  ## `BiggestUInt` range (including a leading `-` before digits); in that case
+  ## `b` is left unchanged.
   var
     res = 0.BiggestUInt
     i = 0
+    overflow = false
   if i < s.len - 1 and s[i] == '-' and s[i + 1] in {'0'..'9'}:
-    integerOutOfRangeError()
+    # a negative value is out of range for an unsigned integer
+    overflow = true
+    inc(i)
   if i < s.len and s[i] == '+': inc(i) # Allow
   if i < s.len and s[i] in {'0'..'9'}:
-    b = 0
     while i < s.len and s[i] in {'0'..'9'}:
-      if res > BiggestUInt.high div 10: # Highest value that you can multiply 10 without overflow
-        integerOutOfRangeError()
-      res = res * 10
-      let prev = res
-      inc res, (ord(s[i]) - ord('0')).BiggestUInt
-      if prev > res:
-        integerOutOfRangeError()
+      if not overflow:
+        if res > BiggestUInt.high div 10: # Highest value that you can multiply 10 without overflow
+          overflow = true
+        else:
+          res = res * 10
+          let prev = res
+          inc res, (ord(s[i]) - ord('0')).BiggestUInt
+          if prev > res:
+            overflow = true
       inc(i)
       while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
-    b = res
-    result = i
+    if overflow:
+      result = -i
+    else:
+      b = res
+      result = i
   else:
     result = 0
 
 func parseBiggestUInt*(s: openArray[char], number: var BiggestUInt): int {.
   noSideEffect.} =
-  ## Parses an unsigned integer and stores the value
-  ## into `number`.
-  ## `ValueError` is raised if the parsed integer is out of the valid range.
+  ## Parses an unsigned integer and stores the value into `number`.
+  ## Result is the number of processed chars, or 0 if there is no integer.
+  ## If the parsed integer is out of the valid `BiggestUInt` range (including a
+  ## leading `-`) the result is a **negative** number `-n` and `number` is left
+  ## unchanged, so the caller can detect the overflow instead of aborting.
   runnableExamples:
     var ret: BiggestUInt
-    assert parseBiggestUInt("12", ret, 0) == 2
+    assert parseBiggestUInt("12", ret) == 2
     assert ret == 12
-    assert parseBiggestUInt("1111111111111111111", ret, 0) == 19
+    assert parseBiggestUInt("1111111111111111111", ret) == 19
     assert ret == 1111111111111111111'u64
   var res = BiggestUInt(0)
-  # use 'res' for exception safety (don't write to 'number' in case of an
-  # overflow exception):
+  # use 'res' so 'number' is only written on a successful, in-range parse:
   result = rawParseUInt(s, res)
-  if result != 0:
+  if result > 0:
     number = res
 
 # Following parseBiggestFloat code is copied from `lib/system/strmantle.nim` in Nim 2.

--- a/tests/nimony/stdlib/tjson.nim
+++ b/tests/nimony/stdlib/tjson.nim
@@ -94,6 +94,25 @@ proc main() =
       if isError(el): inc seen
     check seen, 1
 
+  block out_of_range_int:
+    # An integer literal beyond int64 (e.g. C's UINT64_MAX in header dumps) used
+    # to abort the whole parse; now it falls back to a float atom, JSON-style,
+    # and the surrounding integers still parse.
+    var t = parseJson("[1, 18446744073709551615, 3]")
+    check kind(t.root), JArray
+    check len(t.root), 3
+    var c = t.root
+    var ints: seq[int64] = @[]
+    var floats = 0
+    for el in items(c):
+      var m = el
+      if kind(m) == JInt: ints.add getInt(m)
+      elif kind(m) == JFloat: inc floats
+    check ints.len, 2
+    check ints[0], 1'i64
+    check ints[1], 3'i64
+    check floats, 1
+
   block error_inside_object:
     var t = parseJson("""{"a": 1, "b": nope}""")
     check kind(t.root), JObject

--- a/tests/nimony/stdlib/tparseutils.nim
+++ b/tests/nimony/stdlib/tparseutils.nim
@@ -64,6 +64,17 @@ block:
   assert ret == high(int64)
   assert parseBiggestInt($low(int64), ret) == 20
   assert ret == low(int64)
+  # out of range -> negative processed-char count, `ret` left unchanged
+  ret = 7'i64
+  assert parseBiggestInt("9223372036854775808", ret) == -19   # int64.high + 1
+  assert ret == 7'i64
+  assert parseBiggestInt("-9223372036854775809", ret) == -20  # int64.low - 1
+  assert ret == 7'i64
+  assert parseBiggestInt("99999999999999999999999", ret) == -23
+  assert ret == 7'i64
+  # no integer at all is still 0 (distinct from the overflow signal)
+  assert parseBiggestInt("abc", ret) == 0
+  assert ret == 7'i64
 
 block:
   var ret: uint64 = 3'u64
@@ -79,6 +90,14 @@ block:
   assert ret == 123'u64
   assert parseBiggestUInt($high(uint64), ret) == 20
   assert ret == high(uint64)
+  # out of range -> negative processed-char count, `ret` left unchanged
+  ret = 7'u64
+  assert parseBiggestUInt("18446744073709551616", ret) == -20  # uint64.high + 1
+  assert ret == 7'u64
+  assert parseBiggestUInt("-5", ret) == -2                     # negative is out of range
+  assert ret == 7'u64
+  assert parseBiggestUInt("abc", ret) == 0
+  assert ret == 7'u64
 
 block:
   var ret: float64 = 3.0


### PR DESCRIPTION
Implements the approach Araq suggested on #1999 ("make `parseBiggestInt`'s return value more useful") rather than a caller-side pre-check.

### Problem
`parseutils.parseBiggestInt` / `parseBiggestUInt` called `integerOutOfRangeError`, which — since exceptions aren't available in that `noSideEffect` context — `quit`s the whole program when a literal is out of range. A caller (e.g. the JSON parser meeting C's `UINT64_MAX` in a header dump) had no way to recover.

### Change
The return value now carries the range information:
- `> 0` — success, that many chars processed, value stored in `number`
- `0` — no integer at the start
- `-n` — the first `n` chars form an **out-of-range** integer literal; `number` is left unchanged (the digit run is still consumed so callers can skip it)

No signature change, so `== 0` "no integer" checks keep working.

### Callers
- **`strutils.parseBiggestInt`** (the `.raises` wrapper): the negative result already trips its `L != s.len` guard, so it now raises `ValueError` on overflow instead of the program quitting — the documented behaviour.
- **`json` `parseValue`**: an out-of-range integer literal now falls back to a (lossy) float atom — the standard JSON approach — instead of aborting the parse. This addresses the motivation behind #1999 without the pre-check hack.
- **`encodings.nameToCodePage`**: treats the overflow signal as "not a number".

### Tests
- `tparseutils`: overflow → `-n` and `number`-untouched assertions for both int and uint (incl. a leading `-` for uint).
- `tjson`: a new block parsing `[1, 18446744073709551615, 3]` — the huge middle value becomes a float, the neighbours stay ints, no abort.

All pass on a clean build.

Refs #1999.