### PR TITLE
nimsem: use structured cursor loops (hasMore / loopInto)

### DIFF
--- a/src/nimony/macro_plugin.nim
+++ b/src/nimony/macro_plugin.nim
@@ -45,7 +45,7 @@ proc spliceBodyWithoutResult(dest: var TokenBuf; body: Cursor) =
   if n.kind == ParLe and n.stmtKind == ResultS:
     # Skip the leading result declaration.
     skip n
-  while n.kind != ParRi:
+  while n.hasMore:
     dest.takeTree n
   dest.addParRi()  # the closing ParRi of stmts
 
@@ -72,7 +72,7 @@ proc rewriteSymsToIdents(buf: var TokenBuf) =
           var name = pool.syms[n.symId]
           extractBasename name
           newBuf.add identToken(pool.strings.getOrIncl(name), n.info)
-          while n.kind != ParRi: skip n
+          while n.hasMore: skip n
           skipParRi n  # consume ParRi
         else:
           newBuf.takeToken n
@@ -127,7 +127,7 @@ proc copyParamsRewritingMetatypes(dest: var TokenBuf; params: Cursor;
   dest.add params.load
   var n = params
   inc n
-  while n.kind != ParRi:
+  while n.hasMore:
     if n.substructureKind == ParamU:
       dest.takeToken n
       # Slot 0: name (SymbolDef or Ident)
@@ -232,8 +232,7 @@ proc countParams(macroDecl: Cursor): int =
   if r.params.kind == DotToken or r.params.substructureKind != ParamsU:
     return 0
   var p = r.params
-  inc p
-  while p.kind != ParRi:
+  p.loopInto():
     if p.substructureKind == ParamU:
       inc result
     skip p

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -459,5 +459,5 @@ proc skipNilAnnotation*(n: var Cursor) {.inline.} =
   ## Skip a trailing nil annotation `(notnil)`, `(nil)`, or `(unchecked)`
   ## plus any further attributes (importc/header/...) that `fitTypeToPragmas`
   ## may have appended when an importc'd pointer alias was inlined.
-  while n.kind != ParRi:
+  while n.hasMore:
     skip n

--- a/src/nimony/renderer.nim
+++ b/src/nimony/renderer.nim
@@ -800,7 +800,7 @@ proc gtype(g: var SrcGen, n: var Cursor, c: Context) =
         skip n # unchecked or other annotation
       # Skip any importc/header attrs trailing the nilness annotation —
       # these get inlined when a `{.importc.}` pointer alias is expanded.
-      while n.kind != ParRi:
+      while n.hasMore:
         skip n
       skipParRi(n)
     of OrdinalT:

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -651,8 +651,7 @@ proc hasUntypedOrTypedParam(dest: var TokenBuf; beforeParams: int): bool =
   if n.substructureKind != ParamsU:
     endRead(dest)
     return
-  inc n
-  while n.kind != ParRi:
+  n.loopInto():
     if n.substructureKind == ParamU:
       var p = n
       inc p
@@ -1028,7 +1027,7 @@ proc fitTypeToPragmas(c: var SemContext; dest: var TokenBuf; pragmas: CrucialPra
            t.substructureKind in {NotnilU, NilU, UncheckedU}:
           takeTree rebuilt, t
       else: discard
-      while t.kind != ParRi:
+      while t.hasMore:
         skip t
       for tok in attrs:
         rebuilt.add tok

--- a/src/nimony/semmagics.nim
+++ b/src/nimony/semmagics.nim
@@ -237,7 +237,7 @@ proc semBindSymName*(c: var SemContext; dest: var TokenBuf; it: var Item) =
   if it.n.kind != StringLit:
     c.buildErr dest, info,
       "bindSym expects a string literal as the name, got: " & asNimCode(orig), orig
-    while it.n.kind != ParRi: skip it.n
+    while it.n.hasMore: skip it.n
     skipParRi it.n
     return
   let nameStr = pool.strings[it.n.litId]
@@ -315,7 +315,7 @@ proc semBindSym*(c: var SemContext; dest: var TokenBuf; it: var Item) =
     c.buildErr dest, info,
       "bindSym expects a string literal, got: " & asNimCode(orig), orig
     skip it.n
-    while it.n.kind != ParRi: skip it.n
+    while it.n.hasMore: skip it.n
     skipParRi it.n
     return
   let nameStr = pool.strings[it.n.litId]

--- a/src/nimony/sempragmas.nim
+++ b/src/nimony/sempragmas.nim
@@ -421,7 +421,7 @@ proc semPragma*(c: var SemContext; dest: var TokenBuf; n: var Cursor; crucial: v
       # `pragmas` closer) and swallow the routine body.
       dest.add parLeToken(PragmaP, n.info)
       inc n
-      while n.kind != ParRi:
+      while n.hasMore:
         takeTree dest, n
       dest.addParRi()
     else:

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -901,7 +901,7 @@ proc semLocalTypeImpl*(c: var SemContext; dest: var TokenBuf; n: var Cursor;
         dest.addParPair UncheckedU, info
       # Carry over any further attributes (e.g. importc/header injected by
       # `fitTypeToPragmas` on imported pointer aliases like `posix_spawnattr_t`).
-      while n.kind != ParRi:
+      while n.hasMore:
         takeTree dest, n
       takeParRi dest, n
     of VoidT:


### PR DESCRIPTION
Second incremental step toward #2064, following #2070.

Replaces the unstructured `while <cursor>.kind != ParRi:` traversal loops across nimsem with the structured `hasMore` predicate, and the two enter-and-scan loops (param count in `macro_plugin`, the untyped/typed-param scan in `semdecls`) with `loopInto`.

Why this helps the fast-skip work: `hasMore` is the loop predicate that *also* terminates correctly under the bounded-`rem` nifcore/virtualParRi representation (`rem > 0 and kind != ParRi`), whereas a raw `kind != ParRi` check assumes a physical closing `)` is always present. Converting these is a prerequisite for nimsem to move onto the faster skip representation.

Touches: `sempragmas`, `semtypes`, `semdecls`, `semmagics`, `macro_plugin`, `nimony_model`, `renderer` (12 loops total).

Behaviour-preserving; the full `tests/nimony` suite stays green (only the pre-existing `concepts` `concept of` parse failure remains, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)