### PR TITLE
fix: preserve PreferIterators through template plugin expansion

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -112,7 +112,7 @@ proc typeofCallIs(c: var SemContext; dest: var TokenBuf; it: var Item; beforeCal
   commonType c, dest, it, beforeCall, expected
 
 proc semTemplateCall(c: var SemContext; dest: var TokenBuf; it: var Item; fnId: SymId; beforeCall: int;
-                     m: Match) =
+                     m: Match; flags: set[SemFlag]) =
   var expandedInto = createTokenBuf(30)
 
   # If we are about to expand a template whose published body is still
@@ -142,7 +142,7 @@ proc semTemplateCall(c: var SemContext; dest: var TokenBuf; it: var Item; fnId: 
     var a = Item(n: cursorAt(expandedInto, 0), typ: c.types.autoType)
     let aInfo = a.n.info
     inc c.routine.inInst
-    semExpr c, dest, a
+    semExpr c, dest, a, flags
     # make sure template body expression matches return type, mirrored with `semProcBody`:
     let returnType =
       if m.inferred.len == 0 or m.returnType.kind == DotToken:
@@ -940,7 +940,7 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
         c.expanded.addSymUse finalFn.sym, cs.callNode.info
         inc c.templateInstCounter
         withErrorContext c, cs.callNode.info:
-          semTemplateCall c, dest, it, finalFn.sym, cs.beforeCall, m[idx]
+          semTemplateCall c, dest, it, finalFn.sym, cs.beforeCall, m[idx], cs.flags
         dec c.templateInstCounter
       else:
         buildErr c, dest, cs.callNode.info, "recursion limit exceeded for template expansions"

--- a/tests/nimony/plugins/deps/mforloop.nim
+++ b/tests/nimony/plugins/deps/mforloop.nim
@@ -35,6 +35,20 @@ proc loopVarSym(n: NifCursor): SymId =
       return vars.symId
   result = default(SymId)
 
+proc emitValueSource(n: NifCursor): NifBuilder =
+  result = createTree()
+  result.withTree CallX, n.info:
+    result.withTree AtX, n.info:
+      result.addIdent "pluginValues"
+      result.addIdent "int"
+    result.addIntLit 1
+
+proc loopVarType(n: NifCursor): NifCursor =
+  result = firstChild(firstChild(forLoopVars(n)))
+  skip result # symbol
+  skip result # export marker
+  skip result # pragmas
+
 proc transform(n: NifCursor): NifBuilder =
   let info = n.info
   let mode = pluginName(n)
@@ -46,6 +60,15 @@ proc transform(n: NifCursor): NifBuilder =
       for i in 1..3:
         var body = forLoopBody(n)
         emitSubst(result, body, loopSym, i)
+  elif mode == "valueSource":
+    result = emitValueSource(n)
+  elif mode == "pluginValues":
+    let typ = loopVarType(n)
+    if typ.typeKind != IT:
+      result = errorTree("template-emitted plugin iterator must yield int", typ)
+    else:
+      result.withTree StmtsS, info:
+        discard
   else:
     result = errorTree("unknown for-loop plugin mode: " & mode)
 

--- a/tests/nimony/plugins/tforloopplugin.nim
+++ b/tests/nimony/plugins/tforloopplugin.nim
@@ -1,6 +1,13 @@
 import std / syncio
 
 iterator unroll3(): int {.plugin: "deps/mforloop".}
+template valueSource(): untyped {.plugin: "deps/mforloop".}
+iterator pluginValues[T](value: T): T {.plugin: "deps/mforloop".}
+
+# A template plugin can expand to a generic for-loop plugin. The generated
+# iterator call must retain `PreferIterators` so `value` gets the `int` type.
+for value in valueSource():
+  discard value + 1
 
 # The plugin unrolls this into `total = total + 1/2/3`, substituting the
 # (typed) loop variable. This only works because the for-loop plugin now


### PR DESCRIPTION
  ## Summary

  Preserve PreferIterators while semantically checking template expansions.

  This allows a template plugin to emit a generic for-loop plugin iterator call without losing its concrete yield type.

  ## Changes

  - Forward filtered semantic flags through semTemplateCall
  - Add a regression covering template-plugin → for-loop-plugin expansion
  - Verify the generated iterator retains its specialized int yield type

  ## Testing

  Passed plugin, iterator, template, overload, generic, macro, basics, sysbasics, and call test suites.
