### PR TITLE
nimsem: drop dead `[position]` placeholder from type-mismatch error

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1032,7 +1032,7 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
         errorMsg.add " for type "
         errorMsg.add typeToString(cs.args[0].typ)
     elif m.len > 0:
-      errorMsg = "Type mismatch at [position]\n"
+      errorMsg = "type mismatch\n"
       errorMsg.add asNimCode erroredN
       for i in 0..<m.len:
         errorMsg.add "\n"

--- a/tests/nimony/calls/tcall_module_arg.msgs
+++ b/tests/nimony/calls/tcall_module_arg.msgs
@@ -1,5 +1,5 @@
 tests/nimony/calls/tcall_module_arg.nim(5, 1) Trace: instantiation from here
-lib/std/syncio.nim(453, 5) Error: Type mismatch at [position]
+lib/std/syncio.nim(453, 5) Error: type mismatch
 write stdout, syncio
 [2] expected: string but got: (module) (declared in lib/std/syncio.nim(244, 1))
 [2] expected: bool but got: (module) (declared in lib/std/syncio.nim(250, 1))

--- a/tests/nimony/errmsgs/tdistinctinfos.msgs
+++ b/tests/nimony/errmsgs/tdistinctinfos.msgs
@@ -1,5 +1,5 @@
 tests/nimony/errmsgs/tdistinctinfos.nim(4, 20) Trace: instantiation from here
-lib/std/system/comparisons.nim(110, 10) Error: Type mismatch at [position]
+lib/std/system/comparisons.nim(110, 10) Error: type mismatch
 WINBOOL(0) == 0
 [2] expected: WINBOOL but got: int64 (declared in lib/std/system/comparisons.nim(4, 1))
 [1] WINBOOL does not match constraint Enum (declared in lib/std/system/comparisons.nim(7, 1))

--- a/tests/nimony/errmsgs/tifconderr.msgs
+++ b/tests/nimony/errmsgs/tifconderr.msgs
@@ -1,5 +1,5 @@
 tests/nimony/errmsgs/tifconderr.nim(17, 22) Error: undeclared identifier: 'compare'
-tests/nimony/errmsgs/tifconderr.nim(18, 12) Error: Type mismatch at [position]
+tests/nimony/errmsgs/tifconderr.nim(18, 12) Error: type mismatch
 c < 0
 [1] expected: string but got: auto (declared in lib/std/system/stringimpl.nim(604, 1))
 [1] expected: int64 but got: auto (declared in lib/std/system/comparisons.nim(79, 1))

--- a/tests/nimony/errmsgs/tlenientfloats_off.msgs
+++ b/tests/nimony/errmsgs/tlenientfloats_off.msgs
@@ -1,3 +1,3 @@
-tests/nimony/errmsgs/tlenientfloats_off.nim(6, 1) Error: Type mismatch at [position]
+tests/nimony/errmsgs/tlenientfloats_off.nim(6, 1) Error: type mismatch
 takeF32 M_PI
 [1] expected: 32 but got: 64 (declared in tests/nimony/errmsgs/tlenientfloats_off.nim(5, 1))

--- a/tests/nimony/generics/tgenerictypeconstraints.msgs
+++ b/tests/nimony/generics/tgenerictypeconstraints.msgs
@@ -1,5 +1,5 @@
 tests/nimony/generics/tgenerictypeconstraints.nim(6, 12) Error: type float64 does not match constraint: int64|int8|int16|int32|int64|uint64|uint8|uint16|uint32|uint64
 tests/nimony/generics/tgenerictypeconstraints.nim(7, 11) Error: wrong amount of generic parameters for type Foo.0.tge70svym, expected 1 but got 2
-tests/nimony/generics/tgenerictypeconstraints.nim(13, 4) Error: Type mismatch at [position]
+tests/nimony/generics/tgenerictypeconstraints.nim(13, 4) Error: type mismatch
 bar(1.0, false)
 [2] expected: string but got: bool (declared in tests/nimony/generics/tgenerictypeconstraints.nim(11, 1))

--- a/tests/nimony/generics/tnoconstraintbad.msgs
+++ b/tests/nimony/generics/tnoconstraintbad.msgs
@@ -1,3 +1,3 @@
-tests/nimony/generics/tnoconstraintbad.nim(11, 12) Error: Type mismatch at [position]
+tests/nimony/generics/tnoconstraintbad.nim(11, 12) Error: type mismatch
 result +=? x
 [2] expected: float64 but got: T (declared in tests/nimony/generics/tnoconstraintbad.nim(6, 1))

--- a/tests/nimony/generics/ttypeclasswrongmatch.msgs
+++ b/tests/nimony/generics/ttypeclasswrongmatch.msgs
@@ -1,24 +1,24 @@
-tests/nimony/generics/ttypeclasswrongmatch.nim(3, 5) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(3, 5) Error: type mismatch
 foo2(123)
 [1] int64 does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(19, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(4, 5) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(4, 5) Error: type mismatch
 foo3(e0)
 [1] EnumA does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(26, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(9, 9) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(9, 9) Error: type mismatch
 foo2(x)
 [1] T does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(19, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(17, 9) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(17, 9) Error: type mismatch
 foo3(x)
 [1] T does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(26, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(23, 9) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(23, 9) Error: type mismatch
 foo2(x)
 [1] T does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(19, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(29, 9) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(29, 9) Error: type mismatch
 foo1(x)
 [1] T does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(12, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(30, 9) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(30, 9) Error: type mismatch
 foo2(x)
 [1] T does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(19, 1))
-tests/nimony/generics/ttypeclasswrongmatch.nim(31, 9) Error: Type mismatch at [position]
+tests/nimony/generics/ttypeclasswrongmatch.nim(31, 9) Error: type mismatch
 foo3(x)
 [1] T does not match constraint T (declared in tests/nimony/generics/deps/mtypeclassmatch.nim(26, 1))

--- a/tests/nimony/generics/twronginference.msgs
+++ b/tests/nimony/generics/twronginference.msgs
@@ -1,3 +1,3 @@
-tests/nimony/generics/twronginference.nim(7, 6) Error: Type mismatch at [position]
+tests/nimony/generics/twronginference.nim(7, 6) Error: type mismatch
 foo(x, x)
 [2] expected: int64 but got: Foo (declared in tests/nimony/generics/twronginference.nim(3, 1))

--- a/tests/nimony/overload/tvartoverloads_letrejected.msgs
+++ b/tests/nimony/overload/tvartoverloads_letrejected.msgs
@@ -1,3 +1,3 @@
-tests/nimony/overload/tvartoverloads_letrejected.nim(11, 9) Error: Type mismatch at [position]
+tests/nimony/overload/tvartoverloads_letrejected.nim(11, 9) Error: type mismatch
 takesVar(l)
 [1] expression is not a mutable lvalue, cannot be passed to var int64 parameter (declared in tests/nimony/overload/tvartoverloads_letrejected.nim(8, 1))


### PR DESCRIPTION
## Problem

The overload-resolution mismatch error was built with a literal `[position]` placeholder that is **never substituted**:

```nim
errorMsg = "Type mismatch at [position]\n"
```

`[position]` appears nowhere else in `src/` or `lib/` — nothing ever fills it in, so it prints verbatim in every type-mismatch diagnostic (one of the most common compiler errors):

```
foo.nim(11, 12) Error: Type mismatch at [position]
result +=? x
[2] expected: float64 but got: T (declared in foo.nim(6, 1))
```

The argument position is already reported per candidate as the `[N]` prefix (from `m.error.pos` via `addErrorMsg`), and the source location is already in the `Error:` line — so `at [position]` was pure dead noise.

## Fix

Drop the placeholder, and lowercase to `type mismatch` for consistency with the sibling messages produced by the same proc (`ambiguous call`, `undeclared field`, `undeclared identifier`):

```
foo.nim(11, 12) Error: type mismatch
result +=? x
[2] expected: float64 but got: T (declared in foo.nim(6, 1))
```

Affected `.msgs` goldens regenerated (header line only).

## Verification

`errmsgs` 29/29, `generics` 25/25, `calls` 10/10, `overload` 9/9 — all green.
