### PR TITLE
Implement the RangeCheck runtime mode for range conversions

### DIFF
--- a/lib/std/system/panics.nim
+++ b/lib/std/system/panics.nim
@@ -105,6 +105,27 @@ proc nimUcheckB(i, b: uint): uint {.inline, exportc: "nimUcheckB".} =
   if result > b:
     raiseIndexError3(i, 0, b)
 
+proc raiseRangeError3[T: HasWriteErr](i, a, b: T) {.noinline.} =
+  writeErr "value out of range: "
+  writeErr i
+  writeErr " notin "
+  writeErr a
+  writeErr ".."
+  writeErr b
+  writeErr "\n"
+  die 1'i32
+
+proc nimIRcheck(i, a, b: int): int {.inline, exportc: "nimIRcheck".} =
+  ## Range check for a conversion to an ordinal `range[a..b]`: returns `i`
+  ## unchanged when `a <= i <= b`, otherwise terminates. Unlike the array
+  ## bound check (`nimIcheckAB`), the value keeps its magnitude (no `- a`
+  ## rebasing), since a range value *is* its ordinal.
+  if i >= a and i <= b:
+    result = i
+  else:
+    result = 0
+    raiseRangeError3(i, a, b)
+
 proc nimInvalidObjConv(name: string) {.inline, exportc: "nimInvalidObjConv".} =
   writeErr "invalid object conversion: "
   writeErr name

--- a/src/hexer/desugar.nim
+++ b/src/hexer/desugar.nim
@@ -967,6 +967,39 @@ proc trArrAt(c: var Context; dest: var TokenBuf; n: var Cursor) =
     dest.add idxBuf
   takeParRi dest, n
 
+proc trRangeConv(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  ## Lower the runtime range check for a conversion to an ordinal range type.
+  ## `n` is at `(conv|hconv (rangetype base lo hi) value)`; rewrite the value
+  ## into `(call nimIRcheck value lo hi)` so an out-of-range conversion raises
+  ## at runtime. Done here — like `trArrAt` for bound checks — so `xelim` can
+  ## hoist the check call into a `(var :tmp … (call …))` for the inliner.
+  let info = n.info
+  let convKind = n.exprKind
+  # Grab the (compile-time) bounds off the `(rangetype base lo hi)` target
+  # before the type subtree is copied across and `n` moves on.
+  var rt = n
+  inc rt          # into conv → target type `(rangetype`
+  inc rt          # into rangetype → base type
+  skip rt         # base type → lo
+  var loBuf = createTokenBuf(4)
+  loBuf.addSubtree rt
+  skip rt         # lo → hi
+  var hiBuf = createTokenBuf(4)
+  hiBuf.addSubtree rt
+  # Rebuild `(conv <sametype> (call nimIRcheck <value> lo hi))`.
+  dest.add parLeToken(convKind, info)
+  inc n           # into conv → target type
+  takeTree dest, n  # copy the range type unchanged, advance to the value
+  var valBuf = createTokenBuf(8)
+  tr(c, valBuf, n)  # desugar the operand, advance past it
+  let p = pool.syms.getOrIncl("nimIRcheck.0." & SystemModuleSuffix)
+  copyIntoKind dest, CallX, info:
+    dest.addSymUse p, info
+    dest.add valBuf
+    dest.add loBuf
+    dest.add hiBuf
+  takeParRi dest, n  # close the conv
+
 proc tr(c: var Context; dest: var TokenBuf; n: var Cursor; isTopScope = false) =
   case n.kind
   of DotToken, UnknownToken, EofToken, Ident, Symbol, SymbolDef, IntLit, UIntLit, FloatLit, CharLit, StringLit:
@@ -1072,15 +1105,22 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor; isTopScope = false) =
         genStringConcatChain(c, dest, n)
       else:
         trSons(c, dest, n)
+    of ConvX, HconvX:
+      var t = n
+      inc t  # target type
+      if RangeCheck in c.activeChecks and t.typeKind == RangetypeT:
+        trRangeConv(c, dest, n)
+      else:
+        trSons(c, dest, n)
     of ErrX, SufX, AtX, DerefX, DotX, PatX, ParX, AddrX, NilX,
         InfX, NeginfX, NanX, FalseX, TrueX, AndX, OrX, XorX,
         NotX, NegX, SizeofX, AlignofX, OffsetofX, OconstrX,
         AconstrX, BracketX, CurlyX, CurlyatX, OvfX, AddX, SubX,
         MulX, DivX, ModX, ShrX, ShlX, BitandX, BitorX, BitxorX,
-        BitnotX, EqX, NeqX, LeX, LtX, CastX, ConvX,
+        BitnotX, EqX, NeqX, LeX, LtX, CastX,
         CchoiceX, OchoiceX, PragmaxX, QuotedX, HderefX,
         HaddrX, NewrefX, NewobjX, TupX, TupconstrX, TabconstrX,
-        AshrX, BaseobjX, HconvX, DconvX,
+        AshrX, BaseobjX, DconvX,
         CompilesX, DeclaredX, DefinedX, ProccallX, DelayX,
         AstToStrX, BindSymX, BindSymNameX, InstanceofX, HighX, LowX, UnpackX,
         FieldsX, FieldpairsX, EnumtostrX, IsmainmoduleX,

--- a/src/nimony/nimony.nim
+++ b/src/nimony/nimony.nim
@@ -80,6 +80,7 @@ Options:
   --outdir:DIR              put the executable in DIR (default = cwd).
                             Same semantics as Nim's --outdir.
   --boundchecks:on|off      turn bound checks on or off
+  --rangechecks:on|off      turn range checks on or off
   --usages:file,line,col    list usages of the symbol at the given position
   --def:file,line,col       list definition of the symbol at the given position
   --cc:C_COMPILER           set the C compiler; can be a path to the compiler's
@@ -247,6 +248,12 @@ proc handleCmdLine(c: var CmdOptions; cmdLineArgs: seq[string]; mode: CmdMode) =
             of "on": c.checkModes.incl BoundCheck
             of "off": c.checkModes.excl BoundCheck
             else: quit "invalid value for --boundchecks"
+          of "rangechecks":
+            forwardArg = false
+            case val
+            of "on": c.checkModes.incl RangeCheck
+            of "off": c.checkModes.excl RangeCheck
+            else: quit "invalid value for --rangechecks"
           of "silentmake":
             c.buildFlags.incl SilentMake
             forwardArg = false

--- a/tests/nimony/rtchecks/trangeconv.exitcode
+++ b/tests/nimony/rtchecks/trangeconv.exitcode
@@ -1,0 +1,11 @@
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+value out of range: 10 notin 0..9

--- a/tests/nimony/rtchecks/trangeconv.nim
+++ b/tests/nimony/rtchecks/trangeconv.nim
@@ -1,0 +1,16 @@
+
+import std / [syncio]
+
+# Explicit conversions to an ordinal `range` type are range-checked at runtime
+# (the `RangeCheck` mode, on by default). In-range values pass through
+# unchanged; the first out-of-range value aborts with a range error.
+
+proc toDigit(x: int): range[0..9] =
+  result = range[0..9](x)
+
+proc main =
+  for i in 0 .. 10:
+    echo toDigit(i)
+    flushFile(stdout)
+
+main()


### PR DESCRIPTION
## What

`RangeCheck` is a declared, default-on check mode — it sits next to `BoundCheck` in `DefaultSettings` and is threaded all the way into `checkFlags` (`"br"`) — but **nothing ever consumed it**. As a result a conversion to an ordinal `range[a..b]` type silently truncated an out-of-range value at runtime instead of aborting:

```nim
proc get(v: int): int = v
echo range[0..10](get(20))   # before: prints 20;  after: aborts
```

This PR implements the runtime side, closely mirroring the existing array bound check.

## How

- **`lib/std/system/panics.nim`** — add `nimIRcheck` / `raiseRangeError3`, analogous to `nimIcheckAB` / `raiseIndexError3`. Unlike the bound check, the value keeps its magnitude (no `- a` rebasing), since a range value *is* its ordinal.
- **`src/hexer/desugar.nim`** — `trRangeConv` rewrites `(conv|hconv (rangetype base lo hi) x)` into `(conv … (call nimIRcheck x lo hi))` when the `RangeCheck` mode is active. This is done in `desugar` (before `xelim`), for the same reason the bound check is: the check call can then be hoisted into a temp and inlined, instead of staying buried in the conversion expression.
- **`src/nimony/nimony.nim`** — add a `--rangechecks:on|off` switch mirroring `--boundchecks`. `-d:danger` already clears all check modes, so it turns range checks off with the rest.

The error message matches the compile-time diagnostic and the bound-check style:

```
value out of range: 20 notin 0..10
```

## Scope

This covers **explicit** `range[a..b](x)` conversions, which sem already emits as `conv` nodes (with the range type preserved). It works for `int`, `char`, and negative/`char` ordinal ranges.

**Implicit** narrowings — `var x: range[0..10] = i`, parameter passing, assignment — currently store the value bare (the `# for now acts the same as base type` path in `sigmatch`), so there is no conversion node to check. Making sem emit a conversion there is the deferred "ranges act as their base type" work; I explored it and it has non-trivial ripple effects (it changes the type of `low`/`high` results), so it belongs in its own change. The good news is the desugar machinery here already matches **any** conv/hconv-to-`rangetype`, so implicit narrowings get checked for free the moment sem starts emitting those nodes.

## Tests

`tests/nimony/rtchecks/trangeconv` exercises both the in-range pass-through and the out-of-range abort. Full `hastur nimony` is green except for a pre-existing set of `concepts/*` tests that fail at the `nifler` parse stage (`concept … of` syntax), unrelated to this change.
