### PR TITLE
validator: unique per-process scratch .nif to fix parallel Windows CI race

### DIFF
--- a/src/validator/validator.nim
+++ b/src/validator/validator.nim
@@ -1211,7 +1211,15 @@ proc whileBodyLooksLikeNestedScanner(whileNode: Cursor): bool =
 
 proc parseFileViaNifler(nimFile: string): TokenBuf =
   let nifler = findTool("nifler")
-  let outFile = getTempDir() / "check_tags_" & extractFilename(nimFile).changeFileExt("nif")
+  # The scratch `.nif` name must be unique per process: `hastur` runs tests in
+  # parallel and several of them validate the *same* plugin source at once
+  # (e.g. `tparfor.nim`, `tparfib.nim` and `tparfor_race.nim` all pull in
+  # `parfor.nim`). A fixed `check_tags_<basename>.nif` made those concurrent
+  # validator processes share one file, so on Windows one process opening it
+  # for reading while another's nifler was truncating it surfaced as
+  # `cannot open: …check_tags_parfor.nif`. Tag the name with the pid.
+  let outFile = getTempDir() / "check_tags_" & $getCurrentProcessId() & "_" &
+    extractFilename(nimFile).changeFileExt("nif")
   let cmd = quoteShell(nifler) & " parse " & quoteShell(nimFile) & " " & quoteShell(outFile)
   let (output, exitCode) = execCmdEx(cmd)
   if exitCode != 0:
@@ -1223,6 +1231,7 @@ proc parseFileViaNifler(nimFile: string): TokenBuf =
     result = fromStream(stream)
   finally:
     nifstreams.close(stream)
+    removeFile(outFile)
 
 proc main() =
   if paramCount() < 1:


### PR DESCRIPTION
## Problem

The `threads/` tests intermittently fail on **Windows CI** with:

```
tests\nimony\threads\tparfor.nim --------------------------------------
FAILURE: expected:
compiler exitcode 0
but got
Error:  cannot open: C:\Users\RUNNER~1\AppData\Local\Temp\check_tags_parfor.nif
```

## Root cause

`parseFileViaNifler` in `src/validator/validator.nim` wrote nifler output to a **fixed** path `getTempDir()/check_tags_<basename>.nif`.

`hastur` runs the `threads/` directory (`Normal` category) **in parallel**. Three tests there — `tparfor.nim`, `tparfib.nim`, `tparfor_race.nim` — all import `std/parfor`. Each uses its own empty `nimcache`, so each compile rebuilds the plugin and calls `runValidatorOnPlugin(c, parfor.nim)`. The three validator processes all run `nifler parse parfor.nim` into the **same** `check_tags_parfor.nif` and read it back. On Windows, one process opening it for reading while anothers nifler truncates it surfaces as `cannot open: …`. (The scratch name derives from the *plugin* source `parfor.nim`, not the test `tparfor.nim`.)

## Fix

- Tag the scratch name with the pid (`check_tags_<pid>_<basename>.nif`) so concurrent validators no longer share a file.
- `removeFile` it in the `finally` so per-pid names dont accumulate. The remove runs after `nifstreams.close` (which unmaps the MemFile and closes the handle), so it is Windows-safe.

## Testing (Linux)

- `hastur test tests/nimony/threads` → 5/5 pass (parallel path exercised).
- `hastur validator` → 15/15 pass.
- Temp dir clean afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)