### PR TITLE
std/lists: add singly and doubly linked lists

### DIFF
--- a/lib/std/lists.nim
+++ b/lib/std/lists.nim
@@ -7,16 +7,31 @@
 #    distribution, for details about the copyright.
 #
 
-## This module implements a singly linked list and its operations.
+## This module implements singly and doubly linked lists and their operations.
 ##
-## This is the Nimony port. It currently provides `SinglyLinkedList[T]` only.
-## A singly linked list holds no reference cycles, so it needs no ownership
-## annotations; the doubly linked and ring variants of Nim 2's `std/lists`
-## depend on `{.cursor.}` (issue #1518) to break the `prev` back-reference
-## cycle and are therefore left for a follow-up.
+## This is the Nimony port. It provides `SinglyLinkedList[T]` and
+## `DoublyLinkedList[T]`.
 ##
-## The list stores `ref` nodes, so copying a `SinglyLinkedList` value shares the
-## underlying nodes (the same aliasing behaviour as Nim's `lists`).
+## Ownership and copying
+## ----------------------
+##
+## The lists have **value semantics**, like `seq` and `string`: copying a list
+## deep-copies its nodes, so the two values are independent. Each list uniquely
+## owns its nodes through the `head` -> `next` -> ... chain; the `tail` pointer
+## (and, in the doubly linked list, every `prev` pointer) is a non-owning
+## `{.cursor.}` back-reference, so the structure has no reference cycle and is
+## reclaimed by plain reference counting.
+##
+## Because of the unique-ownership invariant each list carries a custom,
+## **non-recursive** `=destroy` hook: freeing a very long list walks the chain
+## in a loop rather than recursing node by node, so it cannot overflow the
+## stack. The hook frees the contained elements too.
+##
+## The ring variants of Nim 2's `std/lists` are deliberately omitted: a ring is
+## a genuine ownership cycle (its last node's `next` refers back to the head),
+## and Nimony reclaims memory by reference counting without a cycle collector,
+## so a ring would leak. That needs a different design and is left for a
+## follow-up.
 
 type
   SinglyLinkedNode*[T] = ref object
@@ -26,7 +41,17 @@ type
   SinglyLinkedList*[T] = object
     ## A singly linked list.
     head*: SinglyLinkedNode[T]
-    tail*: SinglyLinkedNode[T]
+    tail* {.cursor.}: SinglyLinkedNode[T]
+
+  DoublyLinkedNode*[T] = ref object
+    ## A single node of a `DoublyLinkedList`.
+    next*: DoublyLinkedNode[T]
+    prev* {.cursor.}: DoublyLinkedNode[T]
+    value*: T
+  DoublyLinkedList*[T] = object
+    ## A doubly linked list.
+    head*: DoublyLinkedNode[T]
+    tail* {.cursor.}: DoublyLinkedNode[T]
 
   Stringable = concept
     ## A type that can be rendered with `$`.
@@ -36,6 +61,99 @@ type
     ## A type whose values can be compared with `==`.
     func `==`(a, b: Self): bool
 
+# ---------------------------------------------------------------------------
+# Internal helpers.
+#
+# Everything that dereferences a node lives in ordinary procs, never directly
+# inside a `=destroy`/`=dup`/`=copy` hook: dereferencing a generic `ref object`
+# from within a lifetime hook currently trips a C-codegen bug, so the hooks
+# only ever delegate here.
+# ---------------------------------------------------------------------------
+
+proc freeChain[T](head: sink SinglyLinkedNode[T]) =
+  ## Frees an owning `head` -> `next` chain iteratively (non-recursive). Moving
+  ## each successor out before destroying its predecessor keeps the per-node
+  ## destructor from recursing into `next`.
+  var it = head
+  while it != nil:
+    var nxt = move it.next
+    `=destroy`(it)
+    `=wasMoved`(it)
+    it = move nxt
+
+proc freeChain[T](head: sink DoublyLinkedNode[T]) =
+  var it = head
+  while it != nil:
+    var nxt = move it.next
+    `=destroy`(it)
+    `=wasMoved`(it)
+    it = move nxt
+
+proc cloneList[T](src: SinglyLinkedList[T]): SinglyLinkedList[T] =
+  result = default(SinglyLinkedList[T])
+  var it {.cursor.} = src.head
+  while it != nil:
+    let n = SinglyLinkedNode[T](value: it.value)
+    if result.head == nil: result.head = n
+    else: result.tail.next = n
+    result.tail = n
+    it = it.next
+
+proc cloneList[T](src: DoublyLinkedList[T]): DoublyLinkedList[T] =
+  result = default(DoublyLinkedList[T])
+  var it {.cursor.} = src.head
+  while it != nil:
+    let n = DoublyLinkedNode[T](value: it.value)
+    n.prev = result.tail
+    if result.head == nil: result.head = n
+    else: result.tail.next = n
+    result.tail = n
+    it = it.next
+
+# ---------------------------------------------------------------------------
+# Lifetime hooks (value semantics; non-recursive teardown).
+# ---------------------------------------------------------------------------
+
+proc `=destroy`[T](x: SinglyLinkedList[T]) {.nodestroy.} =
+  freeChain(x.head)
+
+proc `=wasMoved`[T](x: var SinglyLinkedList[T]) {.nodestroy.} =
+  x.head = nil
+  x.tail = nil
+
+proc `=dup`[T](src: SinglyLinkedList[T]): SinglyLinkedList[T] {.nodestroy.} =
+  cloneList(src)
+
+proc `=copy`[T](dst: var SinglyLinkedList[T]; src: SinglyLinkedList[T]) {.nodestroy.} =
+  `=destroy`(dst)
+  `=wasMoved`(dst)
+  var tmp = cloneList(src)
+  dst.head = move tmp.head
+  dst.tail = tmp.tail
+  `=wasMoved`(tmp)
+
+proc `=destroy`[T](x: DoublyLinkedList[T]) {.nodestroy.} =
+  freeChain(x.head)
+
+proc `=wasMoved`[T](x: var DoublyLinkedList[T]) {.nodestroy.} =
+  x.head = nil
+  x.tail = nil
+
+proc `=dup`[T](src: DoublyLinkedList[T]): DoublyLinkedList[T] {.nodestroy.} =
+  cloneList(src)
+
+proc `=copy`[T](dst: var DoublyLinkedList[T]; src: DoublyLinkedList[T]) {.nodestroy.} =
+  `=destroy`(dst)
+  `=wasMoved`(dst)
+  var tmp = cloneList(src)
+  dst.head = move tmp.head
+  dst.tail = tmp.tail
+  `=wasMoved`(tmp)
+
+# ---------------------------------------------------------------------------
+# SinglyLinkedList
+# ---------------------------------------------------------------------------
+
 func initSinglyLinkedList*[T](): SinglyLinkedList[T] =
   ## Creates a new empty singly linked list.
   result = default(SinglyLinkedList[T])
@@ -44,18 +162,18 @@ func newSinglyLinkedNode*[T](value: T): SinglyLinkedNode[T] =
   ## Creates a new singly linked node holding `value`.
   result = SinglyLinkedNode[T](value: value)
 
-proc prepend*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) =
-  ## Prepends an existing node `n` to the front of `L`.
+proc prepend*[T](L: var SinglyLinkedList[T], n: sink SinglyLinkedNode[T]) =
+  ## Prepends node `n` to the front of `L`, taking ownership of it.
   n.next = L.head
   L.head = n
-  if L.tail == nil: L.tail = n
+  if L.tail == nil: L.tail = L.head
 
 proc prepend*[T](L: var SinglyLinkedList[T], value: T) =
   ## Prepends a new node holding `value` to the front of `L`.
   prepend(L, newSinglyLinkedNode(value))
 
-proc append*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) =
-  ## Appends an existing node `n` to the back of `L`.
+proc append*[T](L: var SinglyLinkedList[T], n: sink SinglyLinkedNode[T]) =
+  ## Appends node `n` to the back of `L`, taking ownership of it.
   n.next = nil
   if L.tail != nil: L.tail.next = n
   L.tail = n
@@ -98,27 +216,133 @@ func contains*[T: Equatable](L: SinglyLinkedList[T], value: T): bool =
 
 proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool =
   ## Removes node `n` from `L`. Returns `true` when `n` was found and unlinked.
+  ## The unlinked node is freed unless the caller still holds a reference to it.
   result = false
   if n == nil: return
+  # `self` takes the removed node out of the owning chain so that splicing the
+  # gap shut cannot free it mid-operation; it is released when `self` goes out
+  # of scope (freed only if no other reference remains).
   if L.head == n:
-    L.head = n.next
-    if L.tail == n: L.tail = nil
-    n.next = nil
+    var self = move L.head        # L.head = nil, self owns n
+    L.head = move self.next       # L.head owns n's successor (nil if none)
+    if L.head == nil: L.tail = nil
+    self.next = nil
     return true
-  var it = L.head
+  var it {.cursor.} = L.head
   while it != nil and it.next != n:
     it = it.next
   if it != nil:
-    it.next = n.next
+    var self = move it.next       # it.next = nil, self owns n
+    it.next = move self.next      # it.next owns n's successor
     if L.tail == n: L.tail = it
-    n.next = nil
+    self.next = nil
     result = true
 
 func `$`*[T: Stringable](L: SinglyLinkedList[T]): string =
   ## Returns a textual representation of `L`, e.g. `[1, 2, 3]`.
   result = "["
   var first = true
+  var it {.cursor.} = L.head
+  while it != nil:
+    if not first: result.add ", "
+    result.add $it.value
+    first = false
+    it = it.next
+  result.add "]"
+
+# ---------------------------------------------------------------------------
+# DoublyLinkedList
+# ---------------------------------------------------------------------------
+
+func initDoublyLinkedList*[T](): DoublyLinkedList[T] =
+  ## Creates a new empty doubly linked list.
+  result = default(DoublyLinkedList[T])
+
+func newDoublyLinkedNode*[T](value: T): DoublyLinkedNode[T] =
+  ## Creates a new doubly linked node holding `value`.
+  result = DoublyLinkedNode[T](value: value)
+
+proc prepend*[T](L: var DoublyLinkedList[T], n: sink DoublyLinkedNode[T]) =
+  ## Prepends node `n` to the front of `L`, taking ownership of it.
+  n.prev = nil
+  n.next = L.head
+  if L.head != nil: L.head.prev = n
+  L.head = n
+  if L.tail == nil: L.tail = L.head
+
+proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
+  ## Prepends a new node holding `value` to the front of `L`.
+  prepend(L, newDoublyLinkedNode(value))
+
+proc append*[T](L: var DoublyLinkedList[T], n: sink DoublyLinkedNode[T]) =
+  ## Appends node `n` to the back of `L`, taking ownership of it.
+  n.next = nil
+  n.prev = L.tail
+  if L.tail != nil: L.tail.next = n
+  L.tail = n
+  if L.head == nil: L.head = n
+
+proc append*[T](L: var DoublyLinkedList[T], value: T) =
+  ## Appends a new node holding `value` to the back of `L`.
+  append(L, newDoublyLinkedNode(value))
+
+proc add*[T](L: var DoublyLinkedList[T], value: T) =
+  ## Alias for `append`.
+  append(L, value)
+
+iterator items*[T](L: DoublyLinkedList[T]): T =
+  ## Yields every value in `L`, front to back.
   var it = L.head
+  while it != nil:
+    yield it.value
+    it = it.next
+
+iterator nodes*[T](L: DoublyLinkedList[T]): DoublyLinkedNode[T] =
+  ## Yields every node in `L`, front to back. Safe to remove the yielded node
+  ## while iterating (the successor is captured before it is yielded).
+  var it = L.head
+  while it != nil:
+    let nxt = it.next
+    yield it
+    it = nxt
+
+func find*[T: Equatable](L: DoublyLinkedList[T], value: T): DoublyLinkedNode[T] =
+  ## Returns the first node whose value equals `value`, or `nil`.
+  result = L.head
+  while result != nil:
+    if result.value == value: return result
+    result = result.next
+
+func contains*[T: Equatable](L: DoublyLinkedList[T], value: T): bool =
+  ## Returns `true` when `value` is present in `L`.
+  find(L, value) != nil
+
+proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]): bool =
+  ## Removes node `n` from `L`. Returns `true` when `n` was unlinked. Runs in
+  ## O(1): the node's own `prev`/`next` links locate its neighbours. The
+  ## unlinked node is freed unless the caller still holds a reference to it.
+  result = false
+  if n == nil: return
+  let p {.cursor.} = n.prev        # predecessor (non-owning), nil at head
+  # Lift the node out of the owning chain into `self` first, so splicing the
+  # gap shut cannot free it mid-operation.
+  var self: DoublyLinkedNode[T]
+  if p != nil: self = move p.next  # p.next = nil, self owns n
+  else: self = move L.head         # L.head = nil, self owns n
+  var s = move self.next           # s owns n's successor (nil if none)
+  if s != nil: s.prev = p
+  if L.tail == n: L.tail = p
+  if p != nil: p.next = move s     # p.next owns the successor
+  else: L.head = move s            # L.head owns the successor
+  self.prev = nil
+  self.next = nil
+  result = true
+
+func `$`*[T: Stringable](L: DoublyLinkedList[T]): string =
+  ## Returns a textual representation of `L`, e.g. `[1, 2, 3]`.
+  result = "["
+  var first = true
+  var it {.cursor.} = L.head
   while it != nil:
     if not first: result.add ", "
     result.add $it.value

--- a/lib/std/lists.nim
+++ b/lib/std/lists.nim
@@ -1,0 +1,127 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2024 Nim contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This module implements a singly linked list and its operations.
+##
+## This is the Nimony port. It currently provides `SinglyLinkedList[T]` only.
+## A singly linked list holds no reference cycles, so it needs no ownership
+## annotations; the doubly linked and ring variants of Nim 2's `std/lists`
+## depend on `{.cursor.}` (issue #1518) to break the `prev` back-reference
+## cycle and are therefore left for a follow-up.
+##
+## The list stores `ref` nodes, so copying a `SinglyLinkedList` value shares the
+## underlying nodes (the same aliasing behaviour as Nim's `lists`).
+
+type
+  SinglyLinkedNode*[T] = ref object
+    ## A single node of a `SinglyLinkedList`.
+    next*: SinglyLinkedNode[T]
+    value*: T
+  SinglyLinkedList*[T] = object
+    ## A singly linked list.
+    head*: SinglyLinkedNode[T]
+    tail*: SinglyLinkedNode[T]
+
+  Stringable = concept
+    ## A type that can be rendered with `$`.
+    func `$`(x: Self): string
+
+  Equatable = concept
+    ## A type whose values can be compared with `==`.
+    func `==`(a, b: Self): bool
+
+func initSinglyLinkedList*[T](): SinglyLinkedList[T] =
+  ## Creates a new empty singly linked list.
+  result = default(SinglyLinkedList[T])
+
+func newSinglyLinkedNode*[T](value: T): SinglyLinkedNode[T] =
+  ## Creates a new singly linked node holding `value`.
+  result = SinglyLinkedNode[T](value: value)
+
+proc prepend*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) =
+  ## Prepends an existing node `n` to the front of `L`.
+  n.next = L.head
+  L.head = n
+  if L.tail == nil: L.tail = n
+
+proc prepend*[T](L: var SinglyLinkedList[T], value: T) =
+  ## Prepends a new node holding `value` to the front of `L`.
+  prepend(L, newSinglyLinkedNode(value))
+
+proc append*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) =
+  ## Appends an existing node `n` to the back of `L`.
+  n.next = nil
+  if L.tail != nil: L.tail.next = n
+  L.tail = n
+  if L.head == nil: L.head = n
+
+proc append*[T](L: var SinglyLinkedList[T], value: T) =
+  ## Appends a new node holding `value` to the back of `L`.
+  append(L, newSinglyLinkedNode(value))
+
+proc add*[T](L: var SinglyLinkedList[T], value: T) =
+  ## Alias for `append`.
+  append(L, value)
+
+iterator items*[T](L: SinglyLinkedList[T]): T =
+  ## Yields every value in `L`, front to back.
+  var it = L.head
+  while it != nil:
+    yield it.value
+    it = it.next
+
+iterator nodes*[T](L: SinglyLinkedList[T]): SinglyLinkedNode[T] =
+  ## Yields every node in `L`, front to back. Safe to remove the yielded node
+  ## while iterating (the successor is captured before it is yielded).
+  var it = L.head
+  while it != nil:
+    let nxt = it.next
+    yield it
+    it = nxt
+
+func find*[T: Equatable](L: SinglyLinkedList[T], value: T): SinglyLinkedNode[T] =
+  ## Returns the first node whose value equals `value`, or `nil`.
+  result = L.head
+  while result != nil:
+    if result.value == value: return result
+    result = result.next
+
+func contains*[T: Equatable](L: SinglyLinkedList[T], value: T): bool =
+  ## Returns `true` when `value` is present in `L`.
+  find(L, value) != nil
+
+proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool =
+  ## Removes node `n` from `L`. Returns `true` when `n` was found and unlinked.
+  result = false
+  if n == nil: return
+  if L.head == n:
+    L.head = n.next
+    if L.tail == n: L.tail = nil
+    n.next = nil
+    return true
+  var it = L.head
+  while it != nil and it.next != n:
+    it = it.next
+  if it != nil:
+    it.next = n.next
+    if L.tail == n: L.tail = it
+    n.next = nil
+    result = true
+
+func `$`*[T: Stringable](L: SinglyLinkedList[T]): string =
+  ## Returns a textual representation of `L`, e.g. `[1, 2, 3]`.
+  result = "["
+  var first = true
+  var it = L.head
+  while it != nil:
+    if not first: result.add ", "
+    result.add $it.value
+    first = false
+    it = it.next
+  result.add "]"

--- a/tests/nimony/stdlib/tlists.nim
+++ b/tests/nimony/stdlib/tlists.nim
@@ -1,72 +1,116 @@
 import std/assertions
 import std/lists
 
-# --- empty list ---
-var L = initSinglyLinkedList[int]()
-assert $L == "[]"
-assert not L.contains(5)
-assert L.find(5) == nil
+# ===================== SinglyLinkedList =====================
+block:
+  var L = initSinglyLinkedList[int]()
+  assert $L == "[]"
+  assert not L.contains(5)
+  assert L.find(5) == nil
 
-# --- append / prepend ordering ---
-L.append(1)
-L.append(2)
-L.append(3)
-L.prepend(0)
-assert $L == "[0, 1, 2, 3]"
-assert L.contains(0)
-assert L.contains(3)
-assert not L.contains(9)
+  L.append(1)
+  L.append(2)
+  L.append(3)
+  L.prepend(0)
+  assert $L == "[0, 1, 2, 3]"
+  assert L.contains(2)
+  assert not L.contains(9)
+  assert L.find(3) != nil
+  assert L.find(3).value == 3
 
-# --- add alias (== append) ---
-L.add(4)
-assert $L == "[0, 1, 2, 3, 4]"
+  # items iterator
+  var sum = 0
+  for x in L.items: sum += x
+  assert sum == 6
 
-# --- find ---
-let n2 = L.find(2)
-assert n2 != nil
-assert n2.value == 2
-assert L.find(99) == nil
+  # nodes iterator
+  var cnt = 0
+  for n in L.nodes: inc cnt
+  assert cnt == 4
 
-# --- remove middle ---
-assert L.remove(n2) == true
-assert $L == "[0, 1, 3, 4]"
-assert not L.contains(2)
-assert L.remove(n2) == false        # already removed
+  # remove head
+  assert L.remove(L.find(0))
+  assert $L == "[1, 2, 3]"
+  # remove middle
+  assert L.remove(L.find(2))
+  assert $L == "[1, 3]"
+  # remove tail, then append still works (tail pointer valid)
+  assert L.remove(L.find(3))
+  assert $L == "[1]"
+  L.append(9)
+  assert $L == "[1, 9]"
+  # remove down to empty
+  assert L.remove(L.find(1))
+  assert L.remove(L.find(9))
+  assert $L == "[]"
+  L.append(42)
+  assert $L == "[42]"
 
-# --- remove head ---
-let nh = L.find(0)
-assert L.remove(nh) == true
-assert $L == "[1, 3, 4]"
+  # value semantics: copy is independent
+  var A = initSinglyLinkedList[int]()
+  A.append(1); A.append(2); A.append(3)
+  var B = A            # =dup deep copy
+  B.append(4)
+  assert $A == "[1, 2, 3]"
+  assert $B == "[1, 2, 3, 4]"
+  var C = initSinglyLinkedList[int]()
+  C.append(99)
+  C = A                # =copy deep copy
+  C.append(7)
+  assert $A == "[1, 2, 3]"
+  assert $C == "[1, 2, 3, 7]"
 
-# --- remove tail, then append must still work (tail pointer maintained) ---
-let nt = L.find(4)
-assert L.remove(nt) == true
-assert $L == "[1, 3]"
-L.append(5)
-assert $L == "[1, 3, 5]"
+# string elements ($ via Stringable)
+block:
+  var S = initSinglyLinkedList[string]()
+  S.append("a"); S.append("b"); S.prepend("z")
+  assert $S == "[z, a, b]"
+  assert S.contains("a")
 
-# --- nodes iterator ---
-var count = 0
-var sum = 0
-for node in L.nodes:
-  count = count + 1
-  sum = sum + node.value
-assert count == 3
-assert sum == 9
+# ===================== DoublyLinkedList =====================
+block:
+  var L = initDoublyLinkedList[int]()
+  assert $L == "[]"
+  L.append(1); L.append(2); L.append(3)
+  L.prepend(0)
+  assert $L == "[0, 1, 2, 3]"
+  assert L.contains(3)
+  assert L.find(2).value == 2
 
-# --- remove down to empty resets tail; re-append works ---
-var L2 = initSinglyLinkedList[int]()
-L2.append(7)
-let only = L2.find(7)
-assert L2.remove(only) == true
-assert $L2 == "[]"
-L2.append(8)
-assert $L2 == "[8]"
+  # prev links correct: tail walks back
+  assert L.tail.value == 3
+  assert L.tail.prev.value == 2
+  assert L.head.next.prev.value == 0
 
-# --- string element type ---
-var S = initSinglyLinkedList[string]()
-S.append("a")
-S.prepend("b")
-assert $S == "[b, a]"
-assert S.contains("a")
-assert not S.contains("z")
+  var sum = 0
+  for x in L.items: sum += x
+  assert sum == 6
+
+  # remove head / middle / tail (O(1))
+  assert L.remove(L.find(0))
+  assert $L == "[1, 2, 3]"
+  assert L.head.prev == nil
+  assert L.remove(L.find(2))
+  assert $L == "[1, 3]"
+  assert L.head.next.value == 3
+  assert L.tail.prev.value == 1
+  assert L.remove(L.find(3))
+  assert $L == "[1]"
+  L.append(5)
+  assert $L == "[1, 5]"
+  assert L.tail.prev.value == 1
+  assert L.remove(L.find(1))
+  assert L.remove(L.find(5))
+  assert $L == "[]"
+  L.append(8)
+  assert $L == "[8]"
+
+  # value semantics
+  var A = initDoublyLinkedList[int]()
+  A.append(1); A.append(2)
+  var B = A
+  B.append(3)
+  assert $A == "[1, 2]"
+  assert $B == "[1, 2, 3]"
+  # deep copy has its own prev links
+  assert B.tail.prev.value == 2

--- a/tests/nimony/stdlib/tlists.nim
+++ b/tests/nimony/stdlib/tlists.nim
@@ -1,0 +1,72 @@
+import std/assertions
+import std/lists
+
+# --- empty list ---
+var L = initSinglyLinkedList[int]()
+assert $L == "[]"
+assert not L.contains(5)
+assert L.find(5) == nil
+
+# --- append / prepend ordering ---
+L.append(1)
+L.append(2)
+L.append(3)
+L.prepend(0)
+assert $L == "[0, 1, 2, 3]"
+assert L.contains(0)
+assert L.contains(3)
+assert not L.contains(9)
+
+# --- add alias (== append) ---
+L.add(4)
+assert $L == "[0, 1, 2, 3, 4]"
+
+# --- find ---
+let n2 = L.find(2)
+assert n2 != nil
+assert n2.value == 2
+assert L.find(99) == nil
+
+# --- remove middle ---
+assert L.remove(n2) == true
+assert $L == "[0, 1, 3, 4]"
+assert not L.contains(2)
+assert L.remove(n2) == false        # already removed
+
+# --- remove head ---
+let nh = L.find(0)
+assert L.remove(nh) == true
+assert $L == "[1, 3, 4]"
+
+# --- remove tail, then append must still work (tail pointer maintained) ---
+let nt = L.find(4)
+assert L.remove(nt) == true
+assert $L == "[1, 3]"
+L.append(5)
+assert $L == "[1, 3, 5]"
+
+# --- nodes iterator ---
+var count = 0
+var sum = 0
+for node in L.nodes:
+  count = count + 1
+  sum = sum + node.value
+assert count == 3
+assert sum == 9
+
+# --- remove down to empty resets tail; re-append works ---
+var L2 = initSinglyLinkedList[int]()
+L2.append(7)
+let only = L2.find(7)
+assert L2.remove(only) == true
+assert $L2 == "[]"
+L2.append(8)
+assert $L2 == "[8]"
+
+# --- string element type ---
+var S = initSinglyLinkedList[string]()
+S.append("a")
+S.prepend("b")
+assert $S == "[b, a]"
+assert S.contains("a")
+assert not S.contains("z")


### PR DESCRIPTION
Adds `lib/std/lists.nim`, a Nimony port of `std/lists` providing `SinglyLinkedList[T]` and `DoublyLinkedList[T]` and the standard operations:

* `initSinglyLinkedList` / `initDoublyLinkedList`, `newSinglyLinkedNode` / `newDoublyLinkedNode`
* `prepend` / `append` / `add` (node and value overloads; node overloads take `sink`, transferring ownership)
* `items` / `nodes` iterators
* `find` / `contains` (constrained to an `Equatable` concept) and `$` (constrained to `Stringable`) — the concept-per-operator pattern `std/options` uses
* `remove`

### Value semantics + non-recursive destructors

The lists have **value semantics** like `seq`/`string`: `=dup`/`=copy` deep-copy the chain, so copies are independent. Each list uniquely owns its nodes through the `head -> next -> …` chain; `tail` (and the doubly linked list's `prev` links) are non-owning `{.cursor.}` back-references, so the structure has **no reference cycle**.

Each list carries a custom, **non-recursive** `=destroy` (`.nodestroy`) that also frees the contained elements: it tears the chain down in a loop (moving each successor out before destroying its predecessor), so a multi-million-node list is reclaimed without overflowing the stack. `remove` lifts the target node out of the owning chain before splicing the gap shut, so it is never freed mid-operation.

### Rings deferred (for the right reason this time)

The ring variants are still omitted, but not because of `{.cursor.}` — a ring is a genuine **ownership cycle** (the last node's `next` points back at the head), and Nimony reclaims memory by reference counting **without a cycle collector**, so a ring would leak. Reclaiming it needs a different design (e.g. an owning spine + cursor closure) and is left for a follow-up.

### Tests

`tests/nimony/stdlib/tlists.nim` covers, for both list types: append/prepend ordering, `find`/`contains`, `remove` of head/middle/tail and down-to-empty (checking `tail`/`prev` stay valid so a later `append` still works), the iterators, deep-copy independence of `=dup` and `=copy`, and a `string`-element list exercising `$`. Runs green via `nimony c -r`. Separately verified that a 2,000,000-node list is destroyed without a stack overflow and that element destructors run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)