### PR TITLE
std/sums: add numerically stable float summation

### DIFF
--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -1,0 +1,55 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2024 Nim contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This module implements numerically stable floating-point summation.
+##
+## Naively adding a sequence of floats accumulates rounding error that grows
+## with the number of terms. The routines here keep that error small:
+##
+## * `sumKbn` uses Kahan-Babuska-Neumaier compensated summation (an improved
+##   Kahan sum that also handles the case where the running total is smaller in
+##   magnitude than the next term).
+## * `sumPairs` uses pairwise (cascade) summation, which recursively splits the
+##   input so the error grows only logarithmically.
+##
+## This is the Nimony port; it operates on `openArray[float]`. Generic and
+## `float32` variants of Nim 2's `std/sums` are left for a follow-up.
+
+func sumKbn*(x: openArray[float]): float =
+  ## Kahan-Babuska-Neumaier compensated summation of `x`.
+  runnableExamples:
+    doAssert sumKbn([1.0, 2.0, 3.0]) == 6.0
+  if x.len == 0: return 0.0
+  var sum = x[0]
+  var c = 0.0
+  for i in 1 ..< x.len:
+    let xi = x[i]
+    let t = sum + xi
+    if abs(sum) >= abs(xi):
+      c += (sum - t) + xi
+    else:
+      c += (xi - t) + sum
+    sum = t
+  result = sum + c
+
+func sumPairsImpl(x: openArray[float]; lo, n: int): float =
+  ## Sums `x[lo ..< lo + n]` by pairwise recursion.
+  if n <= 128:
+    result = 0.0
+    for i in lo ..< lo + n:
+      result += x[i]
+  else:
+    let half = n div 2
+    result = sumPairsImpl(x, lo, half) + sumPairsImpl(x, lo + half, n - half)
+
+func sumPairs*(x: openArray[float]): float =
+  ## Pairwise (cascade) summation of `x`.
+  runnableExamples:
+    doAssert sumPairs([1.0, 2.0, 3.0]) == 6.0
+  result = sumPairsImpl(x, 0, x.len)

--- a/tests/nimony/stdlib/tsums.nim
+++ b/tests/nimony/stdlib/tsums.nim
@@ -1,0 +1,29 @@
+import std/assertions
+import std/sums
+
+# --- basic ---
+assert sumKbn([1.0, 2.0, 3.0]) == 6.0
+assert sumPairs([1.0, 2.0, 3.0]) == 6.0
+assert sumKbn([5.0]) == 5.0
+assert sumPairs([5.0]) == 5.0
+
+# --- empty ---
+var e = newSeq[float](0)
+assert sumKbn(e) == 0.0
+assert sumPairs(e) == 0.0
+
+# --- compensated summation beats naive cancellation ---
+# The true sum is 2.0; a naive left-to-right sum returns 0.0 because the two
+# 1.0 terms are lost next to 1e100.
+assert sumKbn([1.0, 1e100, 1.0, -1e100]) == 2.0
+
+# --- large input exercises the pairwise recursion (base case is 128) ---
+var big = newSeq[float](1000)
+for i in 0 ..< 1000:
+  big[i] = 1.0
+assert sumPairs(big) == 1000.0
+assert sumKbn(big) == 1000.0
+
+# --- negative and fractional values (all exactly representable) ---
+assert sumKbn([1.5, -0.5, -1.0]) == 0.0
+assert sumPairs([2.0, -2.0, 2.0, -2.0]) == 0.0


### PR DESCRIPTION
Adds `lib/std/sums.nim` with two numerically stable floating-point summation routines over `openArray[float]`:

* `sumKbn` — Kahan-Babuska-Neumaier compensated summation (an improved Kahan sum that also handles the case where the running total is smaller in magnitude than the next term).
* `sumPairs` — pairwise (cascade) summation, whose error grows only logarithmically in the number of terms.

Both keep rounding error far below a naive left-to-right sum. `sumKbn` also recovers terms that would otherwise be lost when the running total dwarfs the next term — e.g. `sumKbn([1.0, 1e100, 1.0, -1e100]) == 2.0`, where a naive sum returns `0.0`.

### Scope

This is the Nimony port; it operates on `openArray[float]`. Generic (`SomeFloat`) and `float32` variants of Nim 2's `std/sums` are left for a follow-up. `sumPairs` recurses over index ranges (base case 128) rather than `toOpenArray` slices.

### Tests

`tests/nimony/stdlib/tsums.nim` covers basic sums, single-element and empty input, the compensated-cancellation case above, a 1000-element input that exercises the pairwise recursion past its base case, and exact negative/fractional cases. Runs green via `nimony c -r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)