### PR TITLE
std/terminal: fluent npm-`colors`-style ANSI string styling

### DIFF
--- a/lib/std/terminal.nim
+++ b/lib/std/terminal.nim
@@ -154,3 +154,117 @@ template styledWriteLine*(f: File) {.varargs.} =
     styledEchoProcessArg(f, x)
   write f, '\n'
   resetAttributes(f)
+
+# ------------------------------------------------------------------------
+# Fluent string styling, in the spirit of the npm `colors` package.
+#
+# In addition to the `File`-oriented procs above, these `func`s return the
+# styled *string*: each wraps its argument in the matching ANSI SGR escape
+# sequence, so they compose through method-call syntax. `"err".red.bold` is
+# just `bold(red("err"))`, and because every styler emits its own reset code
+# the wrappers nest correctly:
+#
+#   ```nim
+#   echo "this is red and bold".red.bold
+#   echo "warning".yellow
+#   echo "selected".black.onWhite
+#   ```
+#
+# Backgrounds are named `on<Colour>` (e.g. `onRed`) rather than `bg<Colour>`
+# to avoid clashing with the `BackgroundColor` enum values above, and because
+# `"x".black.onWhite` reads naturally in a chain. Escape codes are always
+# emitted; pass a result through `stripAnsi` to recover the plain text.
+
+func sgrWrap(s: string; on, off: int): string {.inline.} =
+  stylePrefix & $on & "m" & s & stylePrefix & $off & "m"
+
+# --- foreground colours (reset with 39) ---
+
+func black*(s: string): string = sgrWrap(s, 30, 39)
+  ## Colours `s` black.
+func red*(s: string): string = sgrWrap(s, 31, 39)
+  ## Colours `s` red.
+func green*(s: string): string = sgrWrap(s, 32, 39)
+  ## Colours `s` green.
+func yellow*(s: string): string = sgrWrap(s, 33, 39)
+  ## Colours `s` yellow.
+func blue*(s: string): string = sgrWrap(s, 34, 39)
+  ## Colours `s` blue.
+func magenta*(s: string): string = sgrWrap(s, 35, 39)
+  ## Colours `s` magenta.
+func cyan*(s: string): string = sgrWrap(s, 36, 39)
+  ## Colours `s` cyan.
+func white*(s: string): string = sgrWrap(s, 37, 39)
+  ## Colours `s` white.
+func gray*(s: string): string = sgrWrap(s, 90, 39)
+  ## Colours `s` gray (bright black).
+func grey*(s: string): string = sgrWrap(s, 90, 39)
+  ## Alias for `gray`.
+
+# --- bright foreground colours ---
+
+func brightRed*(s: string): string = sgrWrap(s, 91, 39)
+func brightGreen*(s: string): string = sgrWrap(s, 92, 39)
+func brightYellow*(s: string): string = sgrWrap(s, 93, 39)
+func brightBlue*(s: string): string = sgrWrap(s, 94, 39)
+func brightMagenta*(s: string): string = sgrWrap(s, 95, 39)
+func brightCyan*(s: string): string = sgrWrap(s, 96, 39)
+func brightWhite*(s: string): string = sgrWrap(s, 97, 39)
+
+# --- background colours (reset with 49) ---
+
+func onBlack*(s: string): string = sgrWrap(s, 40, 49)
+  ## Renders `s` on a black background.
+func onRed*(s: string): string = sgrWrap(s, 41, 49)
+  ## Renders `s` on a red background.
+func onGreen*(s: string): string = sgrWrap(s, 42, 49)
+  ## Renders `s` on a green background.
+func onYellow*(s: string): string = sgrWrap(s, 43, 49)
+  ## Renders `s` on a yellow background.
+func onBlue*(s: string): string = sgrWrap(s, 44, 49)
+  ## Renders `s` on a blue background.
+func onMagenta*(s: string): string = sgrWrap(s, 45, 49)
+  ## Renders `s` on a magenta background.
+func onCyan*(s: string): string = sgrWrap(s, 46, 49)
+  ## Renders `s` on a cyan background.
+func onWhite*(s: string): string = sgrWrap(s, 47, 49)
+  ## Renders `s` on a white background.
+
+# --- styles (each with its own reset) ---
+
+func bold*(s: string): string = sgrWrap(s, 1, 22)
+  ## Renders `s` bold.
+func dim*(s: string): string = sgrWrap(s, 2, 22)
+  ## Renders `s` dim (faint).
+func italic*(s: string): string = sgrWrap(s, 3, 23)
+  ## Renders `s` italic.
+func underline*(s: string): string = sgrWrap(s, 4, 24)
+  ## Underlines `s`.
+func inverse*(s: string): string = sgrWrap(s, 7, 27)
+  ## Swaps the foreground and background of `s`.
+func hidden*(s: string): string = sgrWrap(s, 8, 28)
+  ## Renders `s` hidden (not displayed).
+func strikethrough*(s: string): string = sgrWrap(s, 9, 29)
+  ## Renders `s` with a line through it.
+
+# --- ANSI parsing ---
+
+func stripAnsi*(s: string): string =
+  ## Removes ANSI SGR escape sequences (`\e[ ... m`) from `s`, yielding the
+  ## plain text.
+  result = ""
+  var i = 0
+  let n = s.len
+  while i < n:
+    if s[i] == '\e' and i + 1 < n and s[i+1] == '[':
+      i += 2
+      while i < n and s[i] != 'm':
+        inc i
+      if i < n: inc i          # skip the terminating 'm'
+    else:
+      result.add s[i]
+      inc i
+
+func visibleLen*(s: string): int =
+  ## The number of visible characters in `s`, ignoring ANSI escape sequences.
+  stripAnsi(s).len

--- a/tests/nimony/stdlib/tterminal.nim
+++ b/tests/nimony/stdlib/tterminal.nim
@@ -1,0 +1,43 @@
+import std/assertions
+import std/terminal
+
+# --- single foreground colour ---
+assert "hi".red == "\e[31mhi\e[39m"
+assert "hi".green == "\e[32mhi\e[39m"
+assert "hi".blue == "\e[34mhi\e[39m"
+assert "hi".black == "\e[30mhi\e[39m"
+assert "hi".white == "\e[37mhi\e[39m"
+assert "hi".gray == "\e[90mhi\e[39m"
+assert "hi".brightCyan == "\e[96mhi\e[39m"
+
+# --- styles ---
+assert "hi".bold == "\e[1mhi\e[22m"
+assert "hi".dim == "\e[2mhi\e[22m"
+assert "hi".underline == "\e[4mhi\e[24m"
+assert "hi".italic == "\e[3mhi\e[23m"
+assert "hi".inverse == "\e[7mhi\e[27m"
+assert "hi".strikethrough == "\e[9mhi\e[29m"
+
+# --- background ("on<Colour>", not "bg<Colour>") ---
+assert "hi".onWhite == "\e[47mhi\e[49m"
+assert "hi".onRed == "\e[41mhi\e[49m"
+
+# --- chaining ("x".red.bold == bold(red("x")), nested resets) ---
+assert "hi".red.bold == "\e[1m\e[31mhi\e[39m\e[22m"
+assert "x".green.underline.bold == "\e[1m\e[4m\e[32mx\e[39m\e[24m\e[22m"
+assert "sel".black.onWhite == "\e[47m\e[30msel\e[39m\e[49m"
+
+# --- alias ---
+assert "hi".grey == "hi".gray
+
+# --- ANSI parsing ---
+assert stripAnsi("this is red and bold".red.bold) == "this is red and bold"
+assert stripAnsi("plain") == "plain"
+assert stripAnsi("a".red & "b".blue.bold) == "ab"
+assert stripAnsi("") == ""
+assert visibleLen("hi".red.bold) == 2
+assert visibleLen("plain") == 5
+
+# --- the existing File-oriented API still works alongside the new funcs ---
+assert ansiForegroundColorCode(fgRed) == "\e[31m"
+assert ansiStyleCode(styleBright) == "\e[1m"


### PR DESCRIPTION
Reworks #2088 to follow @Araq's guidance on that PR:

> nah. std/colors it is and "ansi" styling is part of terminal.nim, as before.

So this drops the new-module approach entirely. Instead of adding `std/colors`/`std/rgb`, it adds the npm `colors`-style **fluent string styling directly to `std/terminal`**, alongside the existing enum/`File` API. The name `std/colors` is left free to mean the RGB `Color` value type, as before.

### Usage

```nim
import std/terminal

echo "this is red and bold".red.bold
echo "warning".yellow
echo "selected".black.onWhite
```

Each styler is a `func (s: string): string` that wraps `s` in the matching ANSI SGR sequence and emits its own reset code, so `"x".red.bold` is exactly `bold(red("x"))` and the wrappers nest correctly.

### What's added to `std/terminal`

- Foreground: `black red green yellow blue magenta cyan white gray/grey` + `brightRed … brightWhite`
- Background: `onBlack … onWhite` — named `on<Colour>` (not `bg<Colour>`) to avoid clashing with the existing `BackgroundColor` enum values, and because `"x".black.onWhite` reads naturally in a chain
- Styles: `bold dim italic underline inverse hidden strikethrough`
- Helpers: `stripAnsi` and `visibleLen` for recovering plain text / measuring visible width

The existing `setForegroundColor`, `styledWriteLine`, enums, etc. are untouched.

### Deferred

A truecolor bridge (`"x".fg(rgb(255,128,0))`) is intentionally left out until a `std/colors` RGB value type exists to hang it on — at which point `terminal` can import it for `fg`/`bg`.

### Tests

Adds `tests/nimony/stdlib/tterminal.nim` covering colours, styles, chaining/nesting, ANSI stripping, and interop with the existing enum API. Passes locally via `bin/nimony c -r`.