### PR TITLE
sem: fix hang on an object variant with an empty `of X: discard` branch

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2444,6 +2444,15 @@ proc semObjectCaseBranch(c: var SemContext; dest: var TokenBuf; it: var Item;
     while it.n.hasMore:
       semObjectComponent c, dest, it.n, state
     takeParRi dest, it.n
+  elif it.n.substructureKind == NilU:
+    # An empty branch (`of X: discard`) parses to a bare `(nil)` body. Emit a
+    # well-formed empty `(stmts)` instead so downstream variant walkers (type
+    # navigation, sizeof, hooks) see the same body shape as a normal branch,
+    # rather than a `(nil)` that several `while hasMore` loops fail to advance
+    # past (an effectively-infinite compile).
+    dest.addParLe(StmtsS, it.n.info)
+    dest.addParRi()
+    skip it.n
   else:
     dest.addParLe(StmtsS, it.n.info)
     semObjectComponent c, dest, it.n, state


### PR DESCRIPTION
### Problem

An object variant with a fieldless branch — `of kE: discard` — makes the compiler hang (nimsem pinned at 100% CPU) on any program that uses the type. Minimal repro:

```nim
import std/syncio
type
  K = enum kE, kTree
  Node = ref object
    case kind: K
    of kE: discard
    of kTree: kids: seq[Node]

proc render(n: Node): string =
  case n.kind
  of kE: result = "e"
  of kTree:
    result = ""
    var i = 0
    while i < n.kids.len:
      result.add render(n.kids[i]); inc i

echo render(Node(kind: kTree, kids: @[Node(kind: kE)]))
```

Even a bare, unused declaration of such a type hangs, so the loop is in **type semchecking** — not in field access or construction. Give the empty branch any field (`of kE: pad: bool`) and it compiles instantly.

### Root cause

`of kE: discard` parses to a bare `(nil)` branch body — `(of (ranges kE) (nil))` — whereas a normal branch is `(of (ranges …) (fld …))`. `semObjectCaseBranch` sent the `(nil)` down its `else` path and emitted `(stmts (nil))`. Several downstream variant walkers (type navigation, `sizeof`, hook synthesis) run `while hasMore` / `into` loops that assume a `(stmts …)` body and fail to advance past the `(nil)` — an effectively-infinite compile.

### Fix

Normalize an empty branch to a well-formed empty `(stmts)` at the single sem emission site, so every downstream walker sees the same body shape as a normal branch.

### Verification

Rebuilt nimsem and ran locally: the repro that hung now compiles **and runs** (`e`) in ~2s. Also checked value-object variants with an empty branch, an empty branch in the middle of the `case`, `else: discard`, and normal variants (no regression).

Happy to add a regression test wherever you'd prefer it in the suite.
