### PR TITLE
nifcursors: never request a zero- / sub-FreeCell allocation in TokenBuf

### DIFF
--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -446,8 +446,21 @@ else:
     else:
       if dest.data != nil: dealloc(dest.data)
 
+template allocStorage(cap: int): Storage =
+  ## Allocate backing storage for `cap` tokens, never requesting a zero- or
+  ## sub-`FreeCell` block. `alloc(0)` (cap 0) — and any request below the
+  ## allocator's `sizeof(FreeCell)` minimum, e.g. one 8-byte `PackedToken` —
+  ## is undefined for Nim's default (non-`useMalloc`) allocator: it rounds the
+  ## size through the small-block freelist and corrupts the heap. That fires
+  ## `[SYSASSERT] rawAlloc: requested size too small` under `-d:useSysAssert`
+  ## and segfaults in `rawAlloc`/`addToSharedFreeList` on some platforms (WSL2),
+  ## while `-d:useMalloc` hides it because `malloc(0)` returns a valid pointer.
+  ## Floor the request at 8 slots — the same minimum the grow path uses, so an
+  ## empty buffer's first append needs no immediate realloc.
+  cast[Storage](alloc(sizeof(PackedToken) * max(cap, 8)))
+
 proc createTokenBuf*(cap = 100): TokenBuf =
-  result = TokenBuf(data: cast[Storage](alloc(sizeof(PackedToken)*cap)), len: 0, cap: cap)
+  result = TokenBuf(data: allocStorage(cap), len: 0, cap: cap)
 
 proc prepareMutation*(b: var TokenBuf) {.inline.} =
   ## Detach the buffer from its CursorOwner so the next mutation does
@@ -477,7 +490,7 @@ proc prepareMutation*(b: var TokenBuf) {.inline.} =
       b.owner = nil
       when defined(prepMutStats): inc cowFastCount
     else:
-      let newData = cast[Storage](alloc(sizeof(PackedToken) * b.cap))
+      let newData = allocStorage(b.cap)
       copyMem(newData, b.data, sizeof(PackedToken) * b.len)
       decRcAndFree(b.owner)
       b.owner = nil


### PR DESCRIPTION
## Problem

`createTokenBuf(0)` — used in several njvl contract-analysis paths (`nj.nim` 842/944/950) — and the slow COW branch of `prepareMutation` allocated `sizeof(PackedToken) * cap` bytes directly. `PackedToken` is 8 bytes, so `cap == 0` is `alloc(0)` and `cap == 1` is `alloc(8)` — both below the default allocator's `sizeof(FreeCell)` (16 B on 64-bit) minimum.

`alloc` with a sub-`FreeCell` size is undefined for Nim's default (non-`useMalloc`) allocator: the request is rounded through the small-block freelist and corrupts the shared heap. Under `-d:useSysAssert` this fires:

```
[SYSASSERT] rawAlloc: requested size too small
```

In release it corrupts silently — benign on the current CI platforms (hence green CI) but a hard `SIGSEGV` in `rawAlloc` / `addToSharedFreeList` on some platforms (reproduced deterministically on WSL2 during `.requires` contract analysis). Building the compiler with `-d:useMalloc` only masks it, because `malloc(0)` returns a valid pointer.

## Fix

Route both raw-`alloc` sites through a small `allocStorage` helper that floors the request at 8 slots — the same minimum the grow path already uses, so an empty buffer's first append needs no extra realloc. `cap` semantics are unchanged (`createTokenBuf(0)` still reports `cap == 0`); only the physical backing size is floored. No behavioural change for non-empty buffers.

## Verification

On WSL2 without `-d:useMalloc` (default allocator, `-d:useSysAssert` on):
- the previously-crashing `.requires` contract-analysis path now compiles and runs;
- the full std-lib test suite passes **39/39** with zero crashes and zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)