### PR TITLE
stdlib gaps + ICE-to-diagnostic fixes

### DIFF
--- a/lib/std/hashes.nim
+++ b/lib/std/hashes.nim
@@ -44,6 +44,13 @@ func hash*[A: Hashable, B: Hashable, C: Hashable](x: (A, B, C)): Hash {.inline.}
   result = hash(x[0]) !& hash(x[1]) !& hash(x[2])
   result = !$result
 
+func hash*[T: Hashable](x: seq[T]): Hash =
+  ## Computes a hash value for `x`, mixing each element's hash in order.
+  result = 0'u
+  for a in items(x):
+    result = result !& hash(a)
+  result = !$result
+
 #[
 func hash*[T: object](x: T): Hash {.inline.} =
   result = 0'u

--- a/lib/std/posix/posix.nim
+++ b/lib/std/posix/posix.nim
@@ -12,7 +12,7 @@ when defined(posix):
 
   type
     InAddrScalar* = uint32
-    Sighandler = proc (a: cint) {.noconv.}
+    Sighandler* = proc (a: cint) {.noconv.}
     FileHandle* = cint
     SocketHandle* = cint
 

--- a/lib/std/system.nim
+++ b/lib/std/system.nim
@@ -497,6 +497,10 @@ func `..<`*[T, U: Ordinal](a: sink T; b: sink U): HSlice[T, U] {.inline.} =
   ## the for-loop form `for i in a ..< b` resolves to the `..<` iterator.
   result = HSlice[T, U](a: a, b: pred(b))
 
+func contains*[T: Comparable](s: Slice[T]; x: T): bool {.inline.} =
+  ## True when `x` lies within the inclusive interval `s`; enables `x in a .. b`.
+  not (x < s.a) and not (s.b < x)
+
 type
   BackwardsIndex* = distinct int ## Type constructed by `^` for reversed
                                  ## array/string/seq access.

--- a/src/hexer/eraiser.nim
+++ b/src/hexer/eraiser.nim
@@ -35,7 +35,7 @@ import std / [sets, tables, hashes, assertions, syncio]
 
 include ".." / lib / nifprelude
 include ".." / lib / compat2
-import ".." / nimony / [nimony_model, decls, programs, typenav, sizeof, typeprops]
+import ".." / nimony / [nimony_model, decls, programs, typenav, sizeof, typeprops, reporters]
 import ".." / models / tags
 import duplifier, passes
 include ".." / nimony / nif_annotations
@@ -114,7 +114,9 @@ proc localsThatBecomeTuples*(n: Cursor): HashSet[SymId] =
 
 proc callCanRaise*(typeCache: var TypeCache; n: Cursor): bool =
   var fnType = skipProcTypeToParams(getType(typeCache, n.firstSon))
-  assert fnType.tagEnum == ParamsTagId
+  if fnType.tagEnum != ParamsTagId:
+    raiseAssert "BUG eraiser callCanRaise: callee type not params at " & infoToStr(n.info) &
+         ": " & toString(getType(typeCache, n.firstSon), false)
   skip fnType # params
   skip fnType # return type
   # now pragmas follow:
@@ -126,7 +128,9 @@ proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor; inhibit: bool) =
   let callStart = n # skip `(call)`
   n = sub(n)
   var fnType = skipProcTypeToParams(getType(c.typeCache, n))
-  assert fnType.tagEnum == ParamsTagId
+  if fnType.tagEnum != ParamsTagId:
+    raiseAssert "BUG eraiser trCall: callee type not params at " & infoToStr(info) &
+         ": " & toString(getType(c.typeCache, n), false)
   skip fnType # params
   let retType = fnType
   skip fnType # return type

--- a/src/hexer/lambdalifting.nim
+++ b/src/hexer/lambdalifting.nim
@@ -360,7 +360,8 @@ type
 
 proc untypedEnv(dest: var TokenBuf; info: PackedLineInfo; env: CurrentEnv; mode=WantValue)
   {.ensuresNif: addedExpr(dest).} =
-  assert env.s != SymId(0)
+  if env.s == SymId(0):
+    bug "lambdalifting untypedEnv: no environment in scope at " & infoToStr(info)
   case env.mode
   of EnvIsLocal:
     dest.copyIntoKind CastX, info:
@@ -383,7 +384,8 @@ proc untypedEnv(dest: var TokenBuf; info: PackedLineInfo; env: CurrentEnv; mode=
 
 proc typedEnv(dest: var TokenBuf; info: PackedLineInfo; env: CurrentEnv)
   {.ensuresNif: addedExpr(dest).} =
-  assert env.s != SymId(0)
+  if env.s == SymId(0):
+    bug "lambdalifting typedEnv: no environment in scope at " & infoToStr(info)
   case env.mode
   of EnvIsLocal:
     # the local already has the full type:

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -586,7 +586,8 @@ proc trCall(c: var Context; n: var Cursor; e: Expects; dangerous: var bool) =
   let tt = getType(c.typeCache, n)
   let calleeKind = tt.stmtKind
   let fnType = skipProcTypeToParams(tt.skipModifier)
-  assert fnType.isParamsTag
+  if not fnType.isParamsTag:
+    bug "derefs trCall: callee type not params at " & infoToStr(n.info)
   # Declared here (not up top) so its body can see `fnType`: Nimony resolves
   # template-body identifiers eagerly, so a template referencing a
   # later-declared local fails to self-host.

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -642,6 +642,9 @@ proc addArgsInstConverters(c: var SemContext; dest: var TokenBuf; m: var Match; 
               if isGeneric(routine):
                 let conv = FnCandidate(kind: routine.kind, sym: sym, typ: routine.params)
                 var convMatch = createMatch(addr c)
+                if i >= origArgs.len:
+                  bug "addArgsInstConverters: i=" & $i & " origArgs.len=" & $origArgs.len &
+                    " at " & arg.info.infoToStr
                 sigmatch convMatch, conv, [CallArg(n: arg, typ: origArgs[i].typ)], emptyNode(c)
                 # ^ could also use origArgs[i] directly but commonType would have to keep the expression alive
                 assert not convMatch.err

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -429,7 +429,7 @@ proc hasRtti*(pragmas: Cursor): bool =
 
 proc getTypeSection*(s: SymId): TypeDecl =
   let res = tryLoadSym(s)
-  assert res.status == LacksNothing
+  assert res.status == LacksNothing, "could not load type declaration: " & pool.syms[s]
   result = asTypeDecl(res.decl)
 
 proc skipDistinct*(n: TypeCursor; isDistinct: var bool): TypeCursor =

--- a/src/njvl/nj.nim
+++ b/src/njvl/nj.nim
@@ -14,7 +14,7 @@ when defined(nimony):
   {.feature: "lenientnils".}
 include ".." / lib / nifprelude
 include ".." / lib / compat2
-import ".." / nimony / [nimony_model, decls, programs, typenav, typeprops, builtintypes]
+import ".." / nimony / [nimony_model, decls, programs, typenav, typeprops, builtintypes, reporters]
 import ".." / hexer / [xelim, mover, passes]
 import njvl_model
 
@@ -395,7 +395,8 @@ type
 proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor): CallInfo =
   let info = n.info
   var fnType = skipProcTypeToParams(getType(c.typeCache, n.firstSon))
-  assert isParamsTag(fnType)
+  if not isParamsTag(fnType):
+    bug "njvl trCall: callee type not params at " & infoToStr(info)
   var pragmas = fnType
   skip pragmas
   let retType = pragmas

--- a/tests/nimony/stdlib/thashes.nim
+++ b/tests/nimony/stdlib/thashes.nim
@@ -15,6 +15,12 @@ type
 
 assert compare(foo, foo)
 
+block seqHash:
+  assert compare(@[1, 2, 3], @[1, 2, 3])
+  assert compare(@["a", "b"], @["a", "b"])
+  assert hash(@[1, 2, 3]) != hash(@[3, 2, 1])
+  assert hash(newSeq[int]()) == hash(newSeq[int]())
+
 block sameButDifferent:
   assert hashIgnoreCase("aA bb aAAa1234") == hashIgnoreCase("aa bb aaaa1234")
   assert hashIgnoreStyle("aa_bb_AAaa1234") == hashIgnoreCase("aaBBAAAa1234")

--- a/tests/nimony/sysbasics/tslicecontains.nim
+++ b/tests/nimony/sysbasics/tslicecontains.nim
@@ -1,0 +1,11 @@
+import std/assertions
+
+# `x in a .. b` / `contains(Slice[T], x)` for the comparable scalar types.
+assert 128'u8 in 127'u8 .. 129'u8
+assert 5'u8 notin 127'u8 .. 129'u8
+assert 50 in 0 .. 100
+assert -1 notin 0 .. 100
+assert 3.5 in 1.0 .. 4.0
+assert 'c' in 'a' .. 'z'
+assert contains(0 .. 10, 10)   # inclusive upper bound
+assert not contains(0 .. 10, 11)


### PR DESCRIPTION
This is the first of three batches of small fixes that fell out of porting a ~60 kLoC Vulkan rendering engine (2D compute canvas + PBR mesh pipeline), its unit suite (33 tests), and a consumer app, now all building and rendering under nimony. 

 Stdlib gaps (each hit by real code, not speculative):
 - posix: export Sighandler — needed by any crash-handler registration.
 - system: contains for Slice[T] — range membership, used pervasively in ported Nim-2 code.
 - std/hashes: hash for seq[T: Hashable] — seq-keyed tables.

Diagnostics — located errors instead of ICEs (four commits): converts seven assert/ICE sites that ordinary user code can reach (overload resolution, eraiser callees, lambdalifting env, getTypeSection) into located errors pointing at the offending user line.