### PR TITLE
Added range iterators for counting down

### DIFF
--- a/lib/std/system/iterators.nim
+++ b/lib/std/system/iterators.nim
@@ -20,14 +20,6 @@ iterator `>..`*[T: Ordinal](a, b: T): T {.inline.} =
     if i == b: break
     dec i
 
-iterator `>..<`*[T: Ordinal](a, b: T): T {.inline.} =
-  ## Count down in the range `[b, a)`.
-  var i = pred(a)
-  while i >= b:
-    yield i
-    if i == b: break
-    dec i
-
 iterator countdown*[T, V: Ordinal](a, b: T; step: V = T(1)): T {.inline.} =
   ## Counts from ordinal value `a` down to `b` (inclusive) with the given
   ## step count.

--- a/lib/std/system/iterators.nim
+++ b/lib/std/system/iterators.nim
@@ -1,30 +1,31 @@
 iterator `..<`*[T: Ordinal](a, b: T): T {.inline.} =
-  ## Counts from ordinal value `a` to `b` (exclusive)
+  ## Count up in the range `[a, b)`
   var i = a
   while i < b:
     yield i
     inc i
 
 iterator `..`*[T: Ordinal](a, b: T): T {.inline.} =
-  ## Counts from ordinal value `a` to `b` (inclusive)
+  ## Count up in the range `[a, b]`
   var i = a
   while i <= b:
     yield i
     inc i
 
 iterator `>..`*[T: Ordinal](a, b: T): T {.inline.} =
-  ## Counts from ordinal value `a` down to `b` (inclusive).
-  ##
-  ## Requires ``a >= b`` for a non-empty range. Yields nothing if ``a < b``.
-  ## Equivalent to ``countdown(a, b)``.
-  for i in countdown(a, b):
+  ## Count down in the range `[b, a]`.
+  var i = a
+  while i >= b:
     yield i
+    if i == b: break
+    dec i
 
 iterator `>..<`*[T: Ordinal](a, b: T): T {.inline.} =
-  ## Counts from ordinal value `a` down to `b` (exclusive)
-  var i = a
-  while i > b:
+  ## Count down in the range `[b, a)`.
+  var i = pred(a)
+  while i >= b:
     yield i
+    if i == b: break
     dec i
 
 iterator countdown*[T, V: Ordinal](a, b: T; step: V = T(1)): T {.inline.} =

--- a/lib/std/system/iterators.nim
+++ b/lib/std/system/iterators.nim
@@ -1,14 +1,31 @@
 iterator `..<`*[T: Ordinal](a, b: T): T {.inline.} =
+  ## Counts from ordinal value `a` to `b` (exclusive)
   var i = a
   while i < b:
     yield i
     inc i
 
 iterator `..`*[T: Ordinal](a, b: T): T {.inline.} =
+  ## Counts from ordinal value `a` to `b` (inclusive)
   var i = a
   while i <= b:
     yield i
     inc i
+
+iterator `>..`*[T: Ordinal](a, b: T): T {.inline.} =
+  ## Counts from ordinal value `a` down to `b` (inclusive).
+  ##
+  ## Requires ``a >= b`` for a non-empty range. Yields nothing if ``a < b``.
+  ## Equivalent to ``countdown(a, b)``.
+  for i in countdown(a, b):
+    yield i
+
+iterator `>..<`*[T: Ordinal](a, b: T): T {.inline.} =
+  ## Counts from ordinal value `a` down to `b` (exclusive)
+  var i = a
+  while i > b:
+    yield i
+    dec i
 
 iterator countdown*[T, V: Ordinal](a, b: T; step: V = T(1)): T {.inline.} =
   ## Counts from ordinal value `a` down to `b` (inclusive) with the given
@@ -25,6 +42,16 @@ iterator countdown*[T, V: Ordinal](a, b: T; step: V = T(1)): T {.inline.} =
       if res < succ(b, step):
         break
       dec(res, step)
+
+iterator countup*[T: Ordinal](a, b: T; step: Positive = 1): T {.inline.} =
+  ## Counts from ordinal value `a` to `b` (inclusive) with the given
+  ## step count.
+  ##
+  ## `step` may only be positive.
+  var res = a
+  while res <= b:
+    yield res
+    inc(res, step)
 
 # RootObj is replaced with untyped for now:
 

--- a/tests/nimony/stdlib/system/titerators_ranges.nim
+++ b/tests/nimony/stdlib/system/titerators_ranges.nim
@@ -1,0 +1,35 @@
+import std/[assertions, sequtils, syncio]
+
+proc main =
+  # ascending exclusive: [a, b)
+  assert toSeq(3 ..< 7) == @[3, 4, 5, 6]
+  assert toSeq(7 ..< 3) == @[]
+  assert toSeq(5 ..< 5) == @[]
+
+  # ascending inclusive: [a, b]
+  assert toSeq(3 .. 7) == @[3, 4, 5, 6, 7]
+  assert toSeq(7 .. 3) == @[]
+  assert toSeq(5 .. 5) == @[5]
+
+  # descending inclusive: [b, a] traversed downward
+  assert toSeq(7 >.. 3) == @[7, 6, 5, 4, 3]
+  assert toSeq(3 >.. 7) == @[]
+  assert toSeq(5 >.. 5) == @[5]
+
+  # descending exclusive: (b, a] traversed downward
+  assert toSeq(7 >..< 3) == @[7, 6, 5, 4]
+  assert toSeq(3 >..< 7) == @[]
+  assert toSeq(5 >..< 5) == @[]
+  assert toSeq(4 >..< 3) == @[4]
+
+  # stepped variants
+  assert toSeq(countdown(9, 2, 3)) == @[9, 6, 3]
+  assert toSeq(countup(2, 9, 3)) == @[2, 5, 8]
+
+  # `>..` matches `countdown` for step 1
+  assert toSeq(7 >.. 3) == toSeq(countdown(7, 3))
+
+  # unsigned descending inclusive must stop at zero
+  assert toSeq(3'u >.. 0'u) == @[3'u, 2'u, 1'u, 0'u]
+
+main()

--- a/tests/nimony/stdlib/system/titerators_ranges.nim
+++ b/tests/nimony/stdlib/system/titerators_ranges.nim
@@ -16,12 +16,6 @@ proc main =
   assert toSeq(3 >.. 7) == @[]
   assert toSeq(5 >.. 5) == @[5]
 
-  # descending exclusive at `a`, inclusive at `b`: [b, a) traversed downward
-  assert toSeq(7 >..< 3) == @[6, 5, 4, 3]
-  assert toSeq(3 >..< 7) == @[]
-  assert toSeq(5 >..< 5) == @[]
-  assert toSeq(4 >..< 3) == @[3]
-
   # stepped variants
   assert toSeq(countdown(9, 2, 3)) == @[9, 6, 3]
   assert toSeq(countup(2, 9, 3)) == @[2, 5, 8]

--- a/tests/nimony/stdlib/system/titerators_ranges.nim
+++ b/tests/nimony/stdlib/system/titerators_ranges.nim
@@ -11,16 +11,16 @@ proc main =
   assert toSeq(7 .. 3) == @[]
   assert toSeq(5 .. 5) == @[5]
 
-  # descending inclusive: [b, a] traversed downward
+  # descending inclusive at both ends: [b, a] traversed downward
   assert toSeq(7 >.. 3) == @[7, 6, 5, 4, 3]
   assert toSeq(3 >.. 7) == @[]
   assert toSeq(5 >.. 5) == @[5]
 
-  # descending exclusive: (b, a] traversed downward
-  assert toSeq(7 >..< 3) == @[7, 6, 5, 4]
+  # descending exclusive at `a`, inclusive at `b`: [b, a) traversed downward
+  assert toSeq(7 >..< 3) == @[6, 5, 4, 3]
   assert toSeq(3 >..< 7) == @[]
   assert toSeq(5 >..< 5) == @[]
-  assert toSeq(4 >..< 3) == @[4]
+  assert toSeq(4 >..< 3) == @[3]
 
   # stepped variants
   assert toSeq(countdown(9, 2, 3)) == @[9, 6, 3]


### PR DESCRIPTION
This change introduces two new `range` iterators:

```
iterator `>..`*[T: Ordinal](a, b: T): T     # count down in the range `(b, a)`, for `a` >= `b`
iterator `>..<`*[T: Ordinal](a, b: T): T    # count down in the range `[b, a]`, for `a` >= `b`
```

My rationale was as follows:
- There are too many combinations of up/down/inclusive/exclusive iterators. Making them unambiguous, short, and intuitive is probably not possible. Most of the combinations are also not really used in practice. Therefore, I added only the two most common use cases, i.e. `[N..0]` and `[N-1..0]`
- the `>` on the left of `..` indicates that we are counting from the higher bound (on the left) to the lower bound (on the right)
- for symmetry with the two existing iterators, `>..` is down-count version of `..`, and `>..<` is the down-count version of `..<`

Example:
- `n >.. 0` counts from `n` down to `0`
- `n >..< 0` counts from `n-1` down to `0`

I'm open to suggestions on the naming of these iterators. Specifically, I interprete `>` as "counting down" and `<` as "not including the higher bound". I understand that this is not inline with the existing iterators where `<` means "not including the bound to the right".

## Update 2026/07/13

Only the `>..` and `countup` iterators are in this change now. `>..<` has poor readability, and other bound combinations can be covered by `countdown` and `countup`