### PR TITLE
[codex] add cps async queue regression test

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -853,6 +853,7 @@ const
     "tests/nimony/cps/tclosure_iter_envcheck",
     "tests/nimony/cps/tclosure_iter_string",
     "tests/nimony/cps/tclosure_iter_var",
+    "tests/nimony/cps/tasync_queue",
     "tests/nimony/cps/tfirstpassive",
     "tests/nimony/cps/tif",
     "tests/nimony/cps/tmethods",

--- a/tests/nimony/cps/tasync_queue.nim
+++ b/tests/nimony/cps/tasync_queue.nim
@@ -1,0 +1,53 @@
+## Regression for externally resumed passive coroutines:
+## multiple parked continuations can be resumed in scheduler-defined order.
+import std / [syncio, assertions]
+
+const MaxPending = 8
+
+type
+  Pending = object
+    ms: int
+    cont: Continuation
+
+var
+  pending: array[MaxPending, Pending]
+  pendingCount = 0
+
+proc enqueue(ms: int; cont: Continuation) =
+  assert pendingCount < MaxPending
+  pending[pendingCount] = Pending(ms: ms, cont: cont)
+  inc pendingCount
+
+proc dequeueSoonest(): Pending =
+  assert pendingCount > 0
+  var best = 0
+  for i in 1..<pendingCount:
+    if pending[i].ms < pending[best].ms:
+      best = i
+  result = pending[best]
+  for i in best+1..<pendingCount:
+    pending[i - 1] = pending[i]
+  dec pendingCount
+
+proc sleepAsync(ms: int) {.passive.} =
+  let cont = delay()
+  enqueue(ms, cont)
+  suspend()
+
+proc task(name: string; ms: int) {.passive.} =
+  echo name, " start"
+  sleepAsync(ms)
+  echo name, " resumed after ", ms
+
+proc launch() {.passive.} =
+  let a = delay task("A", 20)
+  let b = delay task("B", 10)
+  complete(a)
+  complete(b)
+
+  assert pendingCount == 2
+  while pendingCount > 0:
+    let next = dequeueSoonest()
+    complete(next.cont)
+
+launch()

--- a/tests/nimony/cps/tasync_queue.output
+++ b/tests/nimony/cps/tasync_queue.output
@@ -1,0 +1,4 @@
+A start
+B start
+B resumed after 10
+A resumed after 20


### PR DESCRIPTION
## What changed
- add a CPS regression test covering multiple parked `.passive` continuations resumed in scheduler-defined order
- include the new test in Hastur's curated native test whitelist

## Why
The async work in the old `nimony-web` worktree never turned into a web event-loop implementation, but it did contain a useful continuation-ordering scenario. This ports that scenario into `nimony`'s core CPS test suite so the continuation runtime and scheduler behavior stay covered.

## Impact
- improves regression coverage for `.passive` coroutine parking and external resumption order
- keeps the test runnable through the existing native CPS whitelist

## Validation
- `../nimony/bin/nimony c --silentMake tests/nimony/cps/tasync_queue.nim`
- `./nimcache/tasf8fv8c/tasync_queue`
