### PR TITLE
defining `>=`, `>` or `!=` operator generates compile error

### DIFF
--- a/lib/std/math.nim
+++ b/lib/std/math.nim
@@ -13,7 +13,6 @@ type
     func `/`(x, y: Self): Self
     func `==`(x, y: Self): bool
     func `<`(x, y: Self): bool
-    func `>`(x, y: Self): bool
 
   # Concepts for the individual transcendental functions below. They let generic
   # code (e.g. `std/complex`) depend precisely on the operations it actually uses,

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -480,6 +480,9 @@ proc declareOverloadableSym*(c: var SemContext; dest: var TokenBuf; it: var Item
       status = OkExistingFresh
     result = (it.n.symId, status)
     dest.takeTree it.n
+  elif it.n.isTagLit and it.n.cursorTagId == nifpools.ErrT:
+    dest.takeTree it.n
+    result = (SymId(0), ErrNoIdent)
   else:
     let lit = takeIdent(it.n)
     if lit == StrId(0):

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -1079,17 +1079,13 @@ proc semProcImpl(c: var SemContext; dest: var TokenBuf; it: var Item; kind: SymK
         var name = pool.syms[symId]
         extractBasename(name)
         if name == ">" or name == ">=" or name == "!=":
-          var errBuf = createTokenBuf()
-          let errOrigAt = cursorAt(dest, beforeName)
           let op1 = if name == "!=": "==" elif name == ">": "<" else: "<="
           let msg = if pass == checkConceptProc:
                       "If a type has `" & op1 & "`, it automatically has `" & name & "`."
                     else:
                       "define `" & op1 & "` instead of `" & name & "` to implement user defined comparison operator. " &
                       "it allows you to use `" & name & "` automatically."
-          buildErr c, errBuf, dest[beforeName].info, msg, errOrigAt
-          let errAt = cursorAt(errBuf, 0)
-          replace dest, errAt, beforeName
+          buildErrAt c, dest, beforeName, msg
       # An intrinsic's signature is unified against its row here, where the
       # params and the return type are already in `dest`. The message lands in
       # the `effects` slot — the one routine slot that already accepts an

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -709,9 +709,12 @@ proc registerHook(c: var SemContext; obj: SymId, symId: SymId, op: HookKind; isG
   c.typeHooks.getOrQuit(obj).a[attachedOp] = symId
 
 proc getHookName(symId: SymId): string =
-  result = pool.syms[symId]
-  extractBasename(result)
-  #result = result.normalize
+  if symId == SymId(0):
+    result = ""
+  else:
+    result = pool.syms[symId]
+    extractBasename(result)
+    #result = result.normalize
 
 proc semHook(c: var SemContext; dest: var TokenBuf; name: string; beforeParams: int; symId: SymId, info: NifLineInfo): TypeCursor =
   let params = getParamsType(c, dest, beforeParams)
@@ -1072,6 +1075,19 @@ proc semProcImpl(c: var SemContext; dest: var TokenBuf; it: var Item; kind: SymK
         extractBasename(name)
         # go up a scope for the parameter scope:
         c.currentScope.up.addOverloadable(pool.strings.getOrIncl(name), s)
+      if symId != SymId(0) and kind in {ProcY, FuncY} and {ImportcP, ImportcppP} * crucial.flags == {}:
+        var name = pool.syms[symId]
+        extractBasename(name)
+        if name == ">" or name == ">=" or name == "!=":
+          var errBuf = createTokenBuf()
+          let errOrigAt = cursorAt(dest, beforeName)
+          let op1 = if name == "!=": "==" elif name == ">": "<" else: "<="
+          buildErr c, errBuf, dest[beforeName].info,
+                   "define `" & op1 & "` instead of `" & name & "` to implement user defined comparison operator. " &
+                   "it allows you to use `" & name & "` automatically.",
+                   errOrigAt
+          let errAt = cursorAt(errBuf, 0)
+          replace dest, errAt, beforeName
       # An intrinsic's signature is unified against its row here, where the
       # params and the return type are already in `dest`. The message lands in
       # the `effects` slot — the one routine slot that already accepts an
@@ -1136,7 +1152,8 @@ proc semProcImpl(c: var SemContext; dest: var TokenBuf; it: var Item; kind: SymK
       c.routine = c.routine.parent
   if newName == NoSymId:
     producesVoid c, dest, info, it.typ
-  publish c, dest, symId, declStart
+  if symId != SymId(0):
+    publish c, dest, symId, declStart
 
   if kind == MacroY and pass == checkBody:
     let macroDecl = cursorAt(dest, declStart)

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -1044,7 +1044,7 @@ proc semProcImpl(c: var SemContext; dest: var TokenBuf; it: var Item; kind: SymK
       c.openScope() # open parameter scope
       let beforeGenericParams = dest.len
       semGenericParams c, dest, it.n
-      if c.visOwner.len == outerVisOwner:
+      if c.visOwner.len == outerVisOwner and status != ErrNoIdent:
         # Not a generic instantiation (`semGenericParams` pushes ORIGIN's module
         # for those). A routine's body is written in the module that declares
         # the routine, so that is what its field accesses must be judged

--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -1082,10 +1082,12 @@ proc semProcImpl(c: var SemContext; dest: var TokenBuf; it: var Item; kind: SymK
           var errBuf = createTokenBuf()
           let errOrigAt = cursorAt(dest, beforeName)
           let op1 = if name == "!=": "==" elif name == ">": "<" else: "<="
-          buildErr c, errBuf, dest[beforeName].info,
-                   "define `" & op1 & "` instead of `" & name & "` to implement user defined comparison operator. " &
-                   "it allows you to use `" & name & "` automatically.",
-                   errOrigAt
+          let msg = if pass == checkConceptProc:
+                      "If a type has `" & op1 & "`, it automatically has `" & name & "`."
+                    else:
+                      "define `" & op1 & "` instead of `" & name & "` to implement user defined comparison operator. " &
+                      "it allows you to use `" & name & "` automatically."
+          buildErr c, errBuf, dest[beforeName].info, msg, errOrigAt
           let errAt = cursorAt(errBuf, 0)
           replace dest, errAt, beforeName
       # An intrinsic's signature is unified against its row here, where the

--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -41,6 +41,8 @@ proc conceptRoutineBasename*(routine: Cursor): StrId =
   var prc = routine
   assert prc.symKind in RoutineKinds
   inc prc
+  if prc.isTagLit and prc.cursorTagId == nifpools.ErrT:
+    return StrId(0)
   assert prc.isSymbolDef
   var name = pool.syms[prc.symId]
   extractBasename(name)

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -787,6 +787,8 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
       savedSelf.add (selfSym, m.inferred.getOrDefault(selfSym, default(Cursor)))
     m.inferred[selfSym] = a
   let basename = conceptRoutineBasename(routine)
+  if basename == StrId(0):
+    return true
   let inferenceBase = m.inferred
   for cand in collectConceptRoutineCandidates(m.context, conceptSym, basename):
     let res = tryLoadSym(cand)

--- a/tests/nimony/concepts/tconceptstandalonebad.msgs
+++ b/tests/nimony/concepts/tconceptstandalonebad.msgs
@@ -1,2 +1,2 @@
 tests/nimony/concepts/tconceptstandalonebad.nim(17, 12) Error: Foo does not match constraint Comparable
-missing: func >(a: Self, b: Self)
+missing: func >>(a: Self, b: Self)

--- a/tests/nimony/concepts/tconceptstandalonebad.nim
+++ b/tests/nimony/concepts/tconceptstandalonebad.nim
@@ -5,7 +5,7 @@ type
   Comparable = concept
     func `==`(a, b: Self): bool
     func `<`(a, b: Self): bool
-    func `>`(a, b: Self): bool
+    func `>>`(a, b: Self): bool
 
   Foo = distinct int
 

--- a/tests/nimony/errmsgs/tinvalid_proc_name_ge.msgs
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_ge.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tinvalid_proc_name_ge.nim(2, 6) Error: define `<=` instead of `>=` to implement user defined comparison operator. it allows you to use `>=` automatically.

--- a/tests/nimony/errmsgs/tinvalid_proc_name_ge.nim
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_ge.nim
@@ -1,0 +1,2 @@
+type Foo = distinct int
+func `>=`(a, b: Foo): bool = int(a) >= int(b)

--- a/tests/nimony/errmsgs/tinvalid_proc_name_gt.msgs
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_gt.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tinvalid_proc_name_gt.nim(2, 6) Error: define `<` instead of `>` to implement user defined comparison operator. it allows you to use `>` automatically.

--- a/tests/nimony/errmsgs/tinvalid_proc_name_gt.nim
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_gt.nim
@@ -1,0 +1,2 @@
+type Foo = distinct int
+func `>`(a, b: Foo): bool = int(a) > int(b)

--- a/tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.msgs
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.nim(3, 10) Error: If a type has `<`, it automatically has `>`.

--- a/tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.nim
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.nim
@@ -1,0 +1,3 @@
+type
+  Foo = concept
+    func `>`(x, y: Self): bool

--- a/tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.nim
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_in_concept_gt.nim
@@ -1,3 +1,10 @@
 type
-  Foo = concept
+  Comparable = concept
     func `>`(x, y: Self): bool
+
+  Foo = distinct int
+
+type Box[T: Comparable] = object
+  v: T
+
+var x: Box[Foo]

--- a/tests/nimony/errmsgs/tinvalid_proc_name_neq.msgs
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_neq.msgs
@@ -1,0 +1,1 @@
+tests/nimony/errmsgs/tinvalid_proc_name_neq.nim(2, 6) Error: define `==` instead of `!=` to implement user defined comparison operator. it allows you to use `!=` automatically.

--- a/tests/nimony/errmsgs/tinvalid_proc_name_neq.nim
+++ b/tests/nimony/errmsgs/tinvalid_proc_name_neq.nim
@@ -1,0 +1,2 @@
+type Foo = distinct int
+func `!=`(a, b: Foo): bool = int(a) != int(b)


### PR DESCRIPTION
Adds the same error check code as https://github.com/nim-lang/Nim/pull/25787