### PR TITLE
Fix various generic iterator related semcheck crashes

### DIFF
--- a/src/hexer/intramodinliner.nim
+++ b/src/hexer/intramodinliner.nim
@@ -396,6 +396,7 @@ proc slotRootOf(c: Cursor): SymId =
   ## it lets a param that is only ever *written through* still count as
   ## value-stable (its pointer value never changes), so its argument can be
   ## substituted instead of copied.
+  result = SymId(0)
   var n = c
   while true:
     case n.kind

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -74,10 +74,11 @@ proc skipToParams*(c: var Cursor) =
   ## Proctype/itertype layout: `(<tag> <NilTag> (params...) RetType <Pragmas>)`.
   ## Proc-decl layout: `(proc Name ExportMarker Pattern Typevars (params...) ...)`.
   let kind = c.typeKind
+  let sk = c.symKind
   inc c # skip ParLe
   if kind in {ProctypeT, ItertypeT}:
     skip c # nilability tag
-  elif kind in RoutineTypes:
+  elif kind in RoutineTypes or sk in RoutineKinds:
     skip c # name
     skip c # export marker
     skip c # pattern
@@ -100,7 +101,7 @@ proc skipRoutineDeclPrefix*(n: var Cursor; parentKind: TypeKind) =
 proc skipProcTypeToParams*(t: Cursor): Cursor =
   ## Pure version: returns a cursor advanced past the prefix slots.
   result = t
-  if result.typeKind in RoutineTypes:
+  if result.typeKind in RoutineTypes or result.symKind in RoutineKinds:
     skipToParams result
 
 const

--- a/src/nimony/decls.nim
+++ b/src/nimony/decls.nim
@@ -174,7 +174,8 @@ type
     body*: Cursor
 
 proc isGeneric*(r: Routine): bool {.inline.} =
-  r.typevars.substructureKind == TypevarsU
+  if not isRoutine(r.kind): return false
+  result = r.typevars.substructureKind == TypevarsU
 
 proc takeRoutine*(c: var Cursor; mode: SkipMode): Routine =
   let kind = symKind c

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -162,6 +162,17 @@ proc isAddressable*(n: Cursor): bool =
 
 proc tr(c: var Context; n: var Cursor; e: Expects)
 
+proc calleeRoutineType(c: var Context; callee: Cursor): Cursor =
+  ## Routine metadata for call checking. `getType` returns `(auto)` for
+  ## unresolved symchoices; callers that need params or pragmas must inspect
+  ## the choice node directly.
+  result = getType(c.typeCache, callee)
+  if result.typeKind == AutoT and callee.exprKind in {OchoiceX, CchoiceX}:
+    var it = callee
+    inc it
+    if it.kind == Symbol:
+      result = lookupSymbol(c.typeCache, it.symId)
+
 proc trSons(c: var Context; n: var Cursor; e: Expects) =
   if n.kind != ParLe:
     takeToken c, n
@@ -201,7 +212,7 @@ proc validBorrowsFrom(c: var Context; n: Cursor): bool =
       let fn = n
       skip n # skip the `fn`
       if n.hasMore:
-        var fnType = skipProcTypeToParams(getType(c.typeCache, fn))
+        var fnType = skipProcTypeToParams(calleeRoutineType(c, fn))
         assert fnType.isParamsTag
         inc fnType
         let firstParam = asLocal(fnType)
@@ -385,7 +396,7 @@ proc checkForDangerousLocations(c: var Context; n: var Cursor) =
     elif n.exprKind in CallKinds:
       n.into:
         let orig = n
-        var fnType = skipProcTypeToParams(getType(c.typeCache, n))
+        var fnType = skipProcTypeToParams(calleeRoutineType(c, n))
         skip n # skip `fn`
         assert fnType.isParamsTag
         inc fnType
@@ -583,7 +594,7 @@ proc trCall(c: var Context; n: var Cursor; e: Expects; dangerous: var bool) =
     cannotPassToVar c.dest, info, callExpr
     return
 
-  let tt = getType(c.typeCache, n)
+  let tt = calleeRoutineType(c, n)
   let calleeKind = tt.stmtKind
   let fnType = skipProcTypeToParams(tt.skipModifier)
   if not fnType.isParamsTag:

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1076,7 +1076,7 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
       var matched = ensureMove(m[idx])
       let returnType: Cursor
       if isMagic == NonMagicCall and c.routine.inGeneric == 0 and
-          isGeneric(getProcDecl(finalFn.sym)):
+          isRoutine(finalFn.kind) and isGeneric(getProcDecl(finalFn.sym)):
         let inst = c.requestRoutineInstance(finalFn.sym, matched.typeArgs, matched.inferred, cs.callNode.info)
         # `addFn` emits the callee in different shapes — usually a
         # single `Symbol` at `cs.beforeCall+1`, but a phantom-concept

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -488,14 +488,7 @@ proc getTypeImpl(c: var TypeCache; n: Cursor; flags: set[GetTypeFlag]): Cursor =
       discard "byref param access: type is already the Nim-level type"
   of QuotedX, OchoiceX, CchoiceX, UnpackX, FieldsX, FieldpairsX, TypeofX, LowX, HighX,
      InternalFieldPairsX:
-    # When an overload set is still present (common in generic bodies), use
-    # the first candidate's type so later passes can inspect the routine.
-    var it = n
-    inc it
-    if it.kind == Symbol:
-      result = lookupSymbol(c, it.symId)
-      if cursorIsNil(result) or (result.typeKind notin RoutineTypes and result.symKind notin RoutineKinds):
-        result = c.builtins.autoType
+    discard "keep the error type"
   of ErrX:
     # determining the type of `(err)` is not an error by itself:
     result = n

--- a/src/nimony/typenav.nim
+++ b/src/nimony/typenav.nim
@@ -488,7 +488,14 @@ proc getTypeImpl(c: var TypeCache; n: Cursor; flags: set[GetTypeFlag]): Cursor =
       discard "byref param access: type is already the Nim-level type"
   of QuotedX, OchoiceX, CchoiceX, UnpackX, FieldsX, FieldpairsX, TypeofX, LowX, HighX,
      InternalFieldPairsX:
-    discard "keep the error type"
+    # When an overload set is still present (common in generic bodies), use
+    # the first candidate's type so later passes can inspect the routine.
+    var it = n
+    inc it
+    if it.kind == Symbol:
+      result = lookupSymbol(c, it.symId)
+      if cursorIsNil(result) or (result.typeKind notin RoutineTypes and result.symKind notin RoutineKinds):
+        result = c.builtins.autoType
   of ErrX:
     # determining the type of `(err)` is not an error by itself:
     result = n

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -410,6 +410,9 @@ proc hasRtti*(s: SymId): bool =
     # This `startsWith` is a minor hack but we know that types of this
     # internal name only have a refcount and a payload, hence no RTTI
     return false
+  let res0 = tryLoadSym(s)
+  if res0.status == LacksNothing and res0.decl.symKind == TypevarY:
+    return false
   var root = s
   for r in inheritanceChain(s):
     root = r

--- a/tests/nimony/concepts/tconceptdocall.nim
+++ b/tests/nimony/concepts/tconceptdocall.nim
@@ -1,0 +1,24 @@
+## Concept-bound generic `do` blocks that call concept requirements like
+## `max` must survive semcheck (derefs pass). Regression test for a crash in
+## `derefs.trCall` when the callee type was `(auto)`.
+
+type
+  MagnitudeOps* = concept
+    proc max(a, b: Self): Self
+
+  RealScalar* = concept of MagnitudeOps
+    proc `+`(a, b: Self): Self
+    proc zero(_: typedesc[Self]): Self
+
+proc fold*[N: static[int], T, A](
+  values: array[N, T],
+  initial: A,
+  combine: proc(acc: A, value: T): A {.closure.}
+): A =
+  result = initial
+  for value in values:
+    result = combine(result, value)
+
+func maxElem*[N: static[int], T: RealScalar](values: array[N, T]): T =
+  fold(values, T.zero) do (acc, value: T) -> T:
+    max(acc, value)

--- a/tests/nimony/concepts/tconcepttypevarhook.nim
+++ b/tests/nimony/concepts/tconcepttypevarhook.nim
@@ -1,0 +1,31 @@
+## Regression: hexer must not crash when hook lookup reaches unconstrained type
+## variable symbols produced by concept dispatch inside generic `do` blocks.
+##
+## Before the fix, lowering modules that combine concept-bound folds with generic
+## array algorithms hit `AssertionDefect` in `tryLoadHook` while scanning
+## `TypevarY` pragmas.
+
+type
+  Field* = concept
+    proc max(a, b: Self): Self
+    proc abs(x: Self): Self
+    proc `/`(a, b: Self): Self
+    proc `-`(a, b: Self): Self
+
+proc fold*[N: static[int], T, A](
+  data: array[N, T],
+  seed: A,
+  combine: proc(acc: A, value: T): A {.closure.}
+): A =
+  result = seed
+  for value in data:
+    result = combine(result, value)
+
+func peak*[N: static[int], T: Field](data: array[N, T]): T =
+  fold(data, data[0]) do (acc, item: T) -> T:
+    max(acc, item)
+
+func rank*[N: static[int], T: Field](data: array[N, T]): int {.noinit.} =
+  var values = data
+  values[0] = values[0] - abs(values[0]) / values[0]
+  1

--- a/tests/nimony/iter/tfilterclosure.nim
+++ b/tests/nimony/iter/tfilterclosure.nim
@@ -1,0 +1,9 @@
+## Regression: semcheck must not crash when instantiating a generic call to a
+## `.closure.` proc parameter inside an iterator-returning function body.
+
+func filter*[T](iter: iterator(): T, predicate: proc(value: T): bool {.closure.}): iterator(): T =
+  result = iterator(): T =
+    for value in iter():
+      if predicate(value):
+        yield value
+  result

--- a/tests/nimony/iter/tgenclosureparam.nim
+++ b/tests/nimony/iter/tgenclosureparam.nim
@@ -1,0 +1,19 @@
+## Regression: semcheck must not crash when instantiating a generic call to a
+## `.closure.` proc parameter inside a generic function body.
+
+proc filterProc*[T](data: seq[T], predicate: proc(value: T): bool {.closure.}): seq[T] =
+  result = @[]
+  for value in data:
+    if predicate(value):
+      result.add value
+
+discard filterProc(@[1, 2, 3], proc(x: int): bool = x mod 2 == 0)
+
+
+func filterFunc*[T](data: seq[T], predicate: proc(value: T): bool {.closure, noSideEffect.}): seq[T] =
+  result = @[]
+  for value in data:
+    if predicate(value):
+      result.add value
+
+discard filterFunc(@[1, 2, 3], func(x: int): bool = x mod 2 == 0)


### PR DESCRIPTION
Fixes https://github.com/nim-lang/nimony/issues/2143

Routine decl cursors were not handled by `skipProcTypeToParams`, so derefs failed on synthesized helpers and unresolved overload sets. Resolve `ochoice` callee types and guard `hasRtti` against type variables.

## Changes:

1. **decls.nim**: treat routine decls via `symKind`:
```
elif kind in RoutineTypes or sk in RoutineKinds:
```
(and the same check in `skipProcTypeToParams`)

2. **typenav.nim**: when a callee is still an `(ochoice ...)`, use the first symbol’s routine type instead of `(auto)`.

3. **typeprops.nim**: `hasRtti` returns `false` for typevars (avoids a follow-on crash in hexer when sem generates generic helper procs).

## Regression Tests

- `tests/nimony/concepts/tconceptdocall.nim`