### PR TITLE
fixes-2097; make calling closure works

### DIFF
--- a/src/hexer/lambdalifting.nim
+++ b/src/hexer/lambdalifting.nim
@@ -676,8 +676,7 @@ proc treProcType(c: var Context; dest: var TokenBuf; n: var Cursor) =
             skip n
             if n.hasMore: skip n
         leaveScope(n, rtScope)
-      copyIntoKind dest, RefT, info:
-        dest.addSymUse pool.syms.getOrIncl(BareRootObjName), info
+      addRootRef dest, info
   else:
     let isProctypeInput = n.typeKind == ProctypeT
     takeInto dest, n:
@@ -898,7 +897,6 @@ proc genCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let info = n.info
   let callNode = n  # the call node itself
   let callScope = enterScope(n)
-  let fn = n
   let typ = c.typeCache.getType(n, {SkipAliases})
   let isStatic = n.kind == Symbol and isStaticCall(c, n.symId)
   # A closure iter-value call target type can appear here in two guises:
@@ -920,14 +918,30 @@ proc genCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
                    isClosure(typ) or isLiftedClosureTuple(typ)
   var tmp = SymId(0)
   var needNilCheck = false
+  var addTmpVar = false
   if wantsEnv:
     if isStatic:
       dest.add callNode
       # do not produce a tuple:
       dest.add n
       inc n
-    elif n.kind == Symbol:
-      tmp = n.symId
+    else:
+      if n.kind == Symbol:
+        tmp = n.symId
+        inc n
+      else:
+        addTmpVar = true
+        dest.addParLe(ExprX, info)
+        copyIntoKind dest, StmtsS, info:
+          tmp = pool.syms.getOrIncl("`llTemp." & $c.counter)
+          inc c.counter
+          copyIntoKind dest, VarS, info:
+            dest.addSymDef tmp, info
+            dest.addDotToken() # no export marker
+            dest.addDotToken() # no pragmas
+            var t = typ
+            tre c, dest, t
+            tre c, dest, n # value
       needNilCheck = true
       dest.addParLe IfS, info
       dest.addParLe ElifU, info
@@ -943,28 +957,13 @@ proc genCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
         dest.addParPair NilX, info
       dest.add callNode
       copyIntoKind dest, TupatX, info:
-        #tre c, dest, n
-        takeToken dest, n
+        dest.addSymUse tmp, info
         dest.addIntLit 0, info
-    else:
-      dest.add callNode
-      dest.addParLe(ExprX, info)
-      copyIntoKind dest, StmtsS, info:
-        tmp = pool.syms.getOrIncl("`llTemp." & $c.counter)
-        inc c.counter
-        copyIntoKind dest, VarS, info:
-          dest.addSymDef tmp, info
-          dest.addDotToken() # no export marker
-          dest.addDotToken() # no pragmas
-          var t = typ
-          tre c, dest, t
-          tre c, dest, n # value
-      dest.addSymUse tmp, info
-      dest.addParRi() # ExprX
   else:
     dest.add callNode
     if isStatic:
       takeToken dest, n
+  let firstArg = n
   while n.hasMore:
     tre(c, dest, n)
   if wantsEnv:
@@ -990,16 +989,18 @@ proc genCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
     dest.addParRi() # end of ElifU
     copyIntoKind dest, ElseU, info:
       dest.add callNode
-      var n2 = fn
       copyIntoKind dest, CastX, info:
         c.toNonClosureProcType dest, typ
         copyIntoKind dest, TupatX, info:
-          takeToken dest, n2
+          dest.addSymUse tmp, info
           dest.addIntLit 0, info
+      var n2 = firstArg
       while n2.hasMore:
         tre(c, dest, n2)
       dest.addParRi() # end of call
     dest.addParRi() # end of IfS
+    if addTmpVar:
+      dest.addParRi() # end of ExprX
 
 proc toProcType(c: var Context; dest: var TokenBuf; n: Cursor) =
   var n = n

--- a/tests/nimony/closures/tcall_closure_expr.nim
+++ b/tests/nimony/closures/tcall_closure_expr.nim
@@ -1,0 +1,20 @@
+# issue #2097
+import std/assertions
+
+proc testClosures(clsr1, clsr2: proc (): int {.closure.}; select: bool) =
+  assert clsr1() == 3
+  assert (if select: clsr1 else: clsr2)() == 7
+
+proc main =
+  var a = 3
+  var b = 7
+  proc clsr1(): int {.closure.} = a
+  proc clsr2(): int {.closure.} = b
+
+  testClosures(clsr1, clsr2, false)
+
+  proc nonClsr(): int = 7
+
+  testClosures(clsr1, nonClsr, false)
+
+main()


### PR DESCRIPTION
fixes https://github.com/nim-lang/nimony/issues/2097
When calling a closure proc from an expression, `TupatX` was not used to get the procedure from a closure tuple.
This PR also makes calling a closure proc from an expression works even if it is not closure proc.