### PR TITLE
fixes #2096; run second pass when there are closure proc type params

### DIFF
--- a/src/hexer/lambdalifting.nim
+++ b/src/hexer/lambdalifting.nim
@@ -104,11 +104,22 @@ proc trSons(c: var Context; dest: var TokenBuf; n: var Cursor) =
     while n.hasMore:
       tr(c, dest, n)
 
+proc isClosure(typ: Cursor): bool {.inline.} = procHasPragma(typ, ClosureP)
+
 proc trLocal(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let kind = n.symKind
   copyInto dest, n:
-    c.typeCache.takeLocalHeader(dest, n, kind)
+    let name = n.symId
+    takeTree dest, n # name
+    takeTree dest, n # export marker
+    takeTree dest, n # pragmas
+    let typ = n
+    if isClosure(typ):
+      # closure proc or iterator type transformed in `treProcType` proc
+      c.hasClosures = true
     tr(c, dest, n)
+    c.typeCache.registerLocal(name, kind, typ, n)
+    tr(c, dest, n)  # value
 
 proc trProc(c: var Context; dest: var TokenBuf; n: var Cursor) =
   #c.typeCache.openScope(ProcScope)
@@ -127,7 +138,12 @@ proc trProc(c: var Context; dest: var TokenBuf; n: var Cursor) =
         if hasPragma(n, ClosureP):
           c.escapes.incl symId
           c.hasClosures = true
-      takeTree dest, n
+      if i == ParamsPos:
+        takeInto dest, n:
+          while n.hasMore:
+            trLocal c, dest, n
+      else:
+        takeTree dest, n
     if isConcrete:
       tr(c, dest, n)
     else:
@@ -155,6 +171,10 @@ proc localToField(c: var Context; n: Cursor; local, typ: SymId): SymId =
 
 proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
   takeInto dest, n:
+    let calleeTyp = c.typeCache.getType(n)
+    if isClosure(calleeTyp):
+      # a call transformed by `genCall` proc
+      c.hasClosures = true
     if n.kind == Symbol:
       # if a closure proc is called, we don't want to see it as "escaping".
       dest.add n
@@ -329,8 +349,6 @@ proc tr(c: var Context; dest: var TokenBuf; n: var Cursor) =
         trSons(c, dest, n)
   of ParRi:
     bug "unexpected ')' inside"
-
-proc isClosure(typ: Cursor): bool {.inline.} = procHasPragma(typ, ClosureP)
 
 when false:
   proc paramsWithClosurePragma(typ: Cursor): bool =

--- a/tests/nimony/closures/deps/mcallclosure.nim
+++ b/tests/nimony/closures/deps/mcallclosure.nim
@@ -1,0 +1,4 @@
+import std/assertions
+
+proc callClosure*(clsr: proc (x: int): int {.closure.}) =
+  assert clsr(123) == 369

--- a/tests/nimony/closures/deps/mgetclosure.nim
+++ b/tests/nimony/closures/deps/mgetclosure.nim
@@ -1,0 +1,3 @@
+proc getClosure*(): proc (): int {.closure.} =
+  var x = 7
+  proc (): int {.closure.} = x

--- a/tests/nimony/closures/deps/mpassclosure.nim
+++ b/tests/nimony/closures/deps/mpassclosure.nim
@@ -1,0 +1,5 @@
+import mgetclosure
+
+proc passClosure*(): proc (): int {.closure.} =
+  var c = getClosure()
+  result = c

--- a/tests/nimony/closures/timported_module_closure_call.nim
+++ b/tests/nimony/closures/timported_module_closure_call.nim
@@ -1,0 +1,5 @@
+# issue #2096
+import std/assertions
+import deps/mgetclosure
+
+assert getClosure()() == 7

--- a/tests/nimony/closures/timported_module_closure_param.nim
+++ b/tests/nimony/closures/timported_module_closure_param.nim
@@ -1,0 +1,9 @@
+# issue #2096
+import deps/mcallclosure
+
+proc main() =
+  var x = 3
+  proc cl(y: int): int {.closure.} = x * y
+  callClosure(cl)
+
+main()

--- a/tests/nimony/closures/timported_module_closure_var.nim
+++ b/tests/nimony/closures/timported_module_closure_var.nim
@@ -1,0 +1,6 @@
+# issue #2096
+import std/assertions
+import deps/mpassclosure
+
+var c = passClosure()
+assert c() == 7


### PR DESCRIPTION
fixes https://github.com/nim-lang/nimony/issues/2096
Run the second pass of `elimLambdas` proc when there are any closure proc type parameters or locals, or called expression is closure type.

This PR needs https://github.com/nim-lang/nimony/pull/2150 to pass tests.