### PR TITLE
fixes-#2159; Dont create the root directory of an absolute path

### DIFF
--- a/lib/std/dirs.nim
+++ b/lib/std/dirs.nim
@@ -50,14 +50,21 @@ proc tryCreateFinalDir*(dir: Path): ErrorCode =
 proc createDir*(dir: Path) {.raises.} =
   ## Creates a new directory `dir`. If the directory already exists, no error is raised.
   ## This can be used to create a nested directory structure directly.
+
+  # issue #2159
+  # creating directory `c:\` results in error on Windows
+  var omitNext = isAbsolute(dir)
   # fromRoot=true: parents must be created root-first; the default leaf-first
   # order makes the first mkdir fail with ENOENT for any nested path.
   for d in parentDirs(dir, fromRoot=true, inclusive=true):
-    let res = tryCreateFinalDir(d)
-    if res == Success or res == NameExists:
-      discard "fine"
+    if omitNext:
+      omitNext = false
     else:
-      raise res
+      let res = tryCreateFinalDir(d)
+      if res == Success or res == NameExists:
+        discard "fine"
+      else:
+        raise res
 
 proc tryRemoveFinalDir*(dir: Path): ErrorCode =
   ## Tries to remove the final directory in a path.

--- a/tests/nimony/stdlib/tdirs.nim
+++ b/tests/nimony/stdlib/tdirs.nim
@@ -1,0 +1,12 @@
+import std/[assertions, dirs, os, syncio]
+
+proc main =
+  block:
+    # issue #2159
+    let testdir = getTempDir() / "nimony_test_dir"
+    try:
+      createDir(path(testdir))
+    except:
+      quit "createDir test failed"
+
+main()


### PR DESCRIPTION
fixes https://github.com/nim-lang/nimony/issues/2159
Skip creating the root directory of an absolute path in the same way as `createDir` proc in `lib/std/private/osdirs.nim` in Nim 2.