### PR TITLE
Emit func for generated enum stringification routines.

### DIFF
--- a/src/nimony/enumtostr.nim
+++ b/src/nimony/enumtostr.nim
@@ -67,7 +67,7 @@ proc genEnumToStrProc*(c: var SemContext; dest: var TokenBuf; typeDecl: var Curs
   let dollorName = "dollar`." & pool.syms[enumSymId]
   let dollorSymId = pool.syms.getOrIncl(dollorName)
 
-  dest.add tagToken("proc", enumSymInfo)
+  dest.add tagToken("func", enumSymInfo)
   dest.add symdefToken(dollorSymId, enumSymInfo)
 
   # TODO: defaults to (nodecl)
@@ -103,4 +103,4 @@ proc genEnumToStrProc*(c: var SemContext; dest: var TokenBuf; typeDecl: var Curs
   genEnumToStrProcCase(c, dest, body, paramSymId, enumSymId)
   dest.addParRi() # stmts
 
-  dest.addParRi() # proc
+  dest.addParRi() # func

--- a/tests/nimony/nosystem/t2.nif
+++ b/tests/nimony/nosystem/t2.nif
@@ -26,7 +26,7 @@
     (tup 0 "typeOfProc"))
    (efld~C,2 :typeOfIter.0. x . TypeOfMode.0.
     (tup 1 "typeOfIter"))))
- (proc@2,7 :dollar`.TypeOfMode.0. x . .
+ (func@2,7 :dollar`.TypeOfMode.0. x . .
   (params
    (param :e.0 . . TypeOfMode.0. .))string.0.sysvq0asl . .
   (stmts

--- a/tests/nimony/nosystem/tbool.nif
+++ b/tests/nimony/nosystem/tbool.nif
@@ -15,7 +15,7 @@
     (true).
     (bool)
     (tup 1 "true"))))
- (proc@5 :dollar`.bool.0. x . .
+ (func@5 :dollar`.bool.0. x . .
   (params
    (param :e.0 . .
     (bool).))string.0.sysvq0asl . .

--- a/tests/nimony/nosystem/tdistinct.nif
+++ b/tests/nimony/nosystem/tdistinct.nif
@@ -34,7 +34,7 @@
     (tup 0 "typeOfProc"))
    (efld~C,2 :typeOfIter.0. x . TypeOfMode.0.
     (tup 1 "typeOfIter"))))
- (proc@2,9 :dollar`.TypeOfMode.0. x . .
+ (func@2,9 :dollar`.TypeOfMode.0. x . .
   (params
    (param :e.0 . . TypeOfMode.0. .))string.0.sysvq0asl . .
   (stmts

--- a/tests/nimony/nosystem/tenumsizes.nif
+++ b/tests/nimony/nosystem/tenumsizes.nif
@@ -12,7 +12,7 @@
     (tup 2 "a2"))
    (efld@5,1 :a3.0. . . A.0.
     (tup 3 "a3"))))
- (proc@5 :dollar`.A.0. x . .
+ (func@5 :dollar`.A.0. x . .
   (params
    (param :e.0 . . A.0. .))string.0.sysvq0asl . .
   (stmts
@@ -46,7 +46,7 @@
     (tup 1 "b2"))
    (efld@F,1 :b3.0.~5 . . B.0.
     (tup 5 "b3"))))
- (proc@5,2 :dollar`.B.0. x . .
+ (func@5,2 :dollar`.B.0. x . .
   (params
    (param :e.1 . . B.0. .))string.0.sysvq0asl . .
   (stmts
@@ -80,7 +80,7 @@
     (tup 30000 "c2"))
    (efld@E,1 :c3.0. . . C.0.
     (tup 30001 "c3"))))
- (proc@5,4 :dollar`.C.0. x . .
+ (func@5,4 :dollar`.C.0. x . .
   (params
    (param :e.2 . . C.0. .))string.0.sysvq0asl . .
   (stmts

--- a/tests/nimony/nosystem/tgeneric_obj.nif
+++ b/tests/nimony/nosystem/tgeneric_obj.nif
@@ -47,7 +47,7 @@
     (tup 0 "typeOfProc"))
    (efld~C,2 :typeOfIter.0. x . TypeOfMode.0.
     (tup 1 "typeOfIter"))))
- (proc@2,C :dollar`.TypeOfMode.0. x . .
+ (func@2,C :dollar`.TypeOfMode.0. x . .
   (params
    (param :e.0 . . TypeOfMode.0. .))string.0.sysvq0asl . .
   (stmts

--- a/tests/nimony/nosystem/ttemplate.nif
+++ b/tests/nimony/nosystem/ttemplate.nif
@@ -37,7 +37,7 @@
     (tup 0 "typeOfProc"))
    (efld~C,2 :typeOfIter.0. x . TypeOfMode.0.
     (tup 1 "typeOfIter"))))
- (proc@2,A :dollar`.TypeOfMode.0. x . .
+ (func@2,A :dollar`.TypeOfMode.0. x . .
   (params
    (param :e.0 . . TypeOfMode.0. .))string.0.sysvq0asl . .
   (stmts

--- a/tests/nimony/nosystem/tvarargs.nif
+++ b/tests/nimony/nosystem/tvarargs.nif
@@ -30,7 +30,7 @@
     (tup 0 "typeOfProc"))
    (efld~C,2 :typeOfIter.0. x . TypeOfMode.0.
     (tup 1 "typeOfIter"))))
- (proc@2,7 :dollar`.TypeOfMode.0. x . .
+ (func@2,7 :dollar`.TypeOfMode.0. x . .
   (params
    (param :e.0 . . TypeOfMode.0. .))string.0.sysvq0asl . .
   (stmts


### PR DESCRIPTION
Generated dollar`.EnumName procs were side-effecting by default, so enum `$` could not be called from func contexts despite the magic stub being marked noSideEffect.

Fixes https://github.com/nim-lang/nimony/issues/2170