### PR TITLE
Refactored concept matching and error rendering

### DIFF
--- a/src/nimony/conceptcache.nim
+++ b/src/nimony/conceptcache.nim
@@ -37,7 +37,6 @@ type
 
   ConceptBodyResult* = object
     satisfied*: bool
-    missing*: seq[SymId]
 
   ConceptRoutineImplResult* = object
     found*: bool
@@ -241,13 +240,6 @@ proc getConceptMetadata*(c: ptr SemContext; conceptSym: SymId; body: Cursor): Co
       return cache.metadata.getOrDefault(conceptSym)
   collectConceptMetadata(body)
 
-proc loadConceptRequirement*(reqSym: SymId): Cursor =
-  let res = tryLoadSym(reqSym)
-  if res.status == LacksNothing:
-    res.decl
-  else:
-    default(Cursor)
-
 proc lruTouchBody(order: var seq[BodyCacheKey]; key: BodyCacheKey) =
   for i, k in order:
     if k == key:
@@ -351,39 +343,12 @@ proc tryRoutineImplFromCache*(c: ptr SemContext; conceptSym, reqSym: SymId; a: C
   lruTouchRoutine(cache.routineImplCacheOrder, key)
   (true, cache.routineImplCache.getOrDefault(key))
 
-proc bodyResultFromMissing*(missing: openArray[Cursor]): ConceptBodyResult =
-  result = ConceptBodyResult(satisfied: missing.len == 0)
-  for routine in missing:
-    let rs = conceptRequirementSym(routine)
-    if rs != SymId(0):
-      result.missing.add rs
-
 proc storeBodyCheck*(c: ptr SemContext; conceptSym: SymId; a: Cursor; res: sink ConceptBodyResult) =
   if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
     return
   let cache = ensureConceptCache(c)
   let key = bodyCacheKey(conceptSym, a)
   lruPutBody(cache.bodyCache, cache.bodyCacheOrder, cacheCapacity(cache), key, res)
-
-proc tryMissingFromBodyCache*(c: ptr SemContext; conceptSym: SymId; a: Cursor;
-                              missing: var seq[Cursor]): bool =
-  if c == nil or conceptSym == SymId(0) or not isCacheableConcreteType(a) or isConceptTypeArg(a):
-    return false
-  let cache = ensureConceptCache(c)
-  let key = bodyCacheKey(conceptSym, a)
-  if not cache.bodyCache.hasKey(key):
-    return false
-  lruTouchBody(cache.bodyCacheOrder, key)
-  let cached = cache.bodyCache.getOrDefault(key)
-  if not cached.satisfied and cached.missing.len == 0:
-    return false
-  if cached.satisfied:
-    missing = @[]
-  else:
-    missing = @[]
-    for reqSym in cached.missing:
-      missing.add loadConceptRequirement(reqSym)
-  true
 
 proc storeCandidates*(c: ptr SemContext; conceptSym: SymId; basename: StrId;
                       res: sink seq[SymId]) =

--- a/src/nimony/renderer.nim
+++ b/src/nimony/renderer.nim
@@ -124,6 +124,32 @@ proc initSrcGen(renderFlags: RenderFlags): SrcGen =
                    pendingWhitespace: -1, inside: {},
                    )
 
+proc isErrNode*(n: Cursor): bool =
+  n.kind == ParLe and (n.typeKind == ErrT or n.exprKind == ErrX)
+
+proc errPayload*(n: Cursor): Cursor =
+  ## First child of `(err …)`: the wrapped expression, or `.` if none was recorded.
+  result = n
+  assert isErrNode(result)
+  inc result
+
+proc errMsgFromCursor*(n: Cursor): string =
+  ## Extract the human-readable message from an `(err …)` node. Mirrors the
+  ## walk in `reportErrors` so diagnostics and the reporter stay in sync.
+  var c = n
+  assert isErrNode(c)
+  c = sub(c)
+  if c.kind == DotToken:
+    inc c
+  else:
+    skip c
+  while c.kind == DotToken:
+    inc c
+  assert c.kind == StringLit
+  result = pool.strings[c.litId]
+
+proc typeToString*(n: Cursor; renderFlags: RenderFlags = {}): string
+
 proc addTok(g: var SrcGen, kind: TokType, s: string; sym: SymId = SymId(0);
             isDef = false) =
   g.tokens.add RenderTok(kind: kind, length: int16(s.len), sym: sym, isDef: isDef)
@@ -994,7 +1020,7 @@ proc gtype(g: var SrcGen, n: var Cursor, c: Context) =
       put(g, tkBracketRi, "]")
 
     of ErrT:
-      put(g, tkStrLit, toString(n, false))
+      put(g, tkStrLit, typeToString(n, g.flags))
       skip n
 
     of RoutineTypes:
@@ -1857,7 +1883,10 @@ proc gsub(g: var SrcGen, n: var Cursor, c: Context, fromStmtList = false, isTopL
       skip n
 
     of ErrX:
-      put(g, tkStrLit, toString(n, false))
+      if renderIr in g.flags:
+        put(g, tkStrLit, toString(n, false))
+      else:
+        put(g, tkStrLit, errMsgFromCursor(n))
       skip n
 
     of QuotedX:
@@ -1983,7 +2012,8 @@ proc renderTree(n: Cursor, renderFlags: RenderFlags = {}, renderType = false): s
     gsub(g, n, isTopLevel = true)
   result = g.buf
   if result.len == 0:
-    result = toString(orig, false)
+    result = if isErrNode(orig): typeToString(orig, g.flags)
+             else: toString(orig, false)
 
 proc asNimCode*(n: Cursor; renderFlags: RenderFlags = {}): string =
   var m0: PackedLineInfo = NoLineInfo
@@ -2026,7 +2056,21 @@ proc asNimCode*(n: Cursor; renderFlags: RenderFlags = {}): string =
     result = renderTree(n, renderFlags = renderFlags)
 
 proc typeToString*(n: Cursor; renderFlags: RenderFlags = {}): string =
-  result = renderTree(n, renderFlags = renderFlags, renderType = true)
+  var typ = n
+  if isErrNode(typ):
+    if renderIr in renderFlags:
+      return toString(typ, false)
+    let payload = errPayload(typ)
+    if payload.kind == DotToken:
+      return "<type error>"
+    if isErrNode(payload):
+      return typeToString(payload, renderFlags)
+    typ = payload
+  result = renderTree(typ, renderFlags = renderFlags, renderType = true)
+
+proc typeExprToString*(n: Cursor): string {.inline.} =
+  ## Like `typeToString`, but always unwraps `(err …)` to the wrapped type.
+  typeToString(n)
 
 proc typeToSrcGen*(n: Cursor; renderFlags: RenderFlags = {}): SrcGen =
   ## Render a type expression and return both rendered buffer and token stream.

--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -542,6 +542,14 @@ proc semStaticInvokeArg(c: var SemContext; dest: var TokenBuf; n: var Cursor;
       c.buildErr dest, info, "argument for a `static` generic parameter must be a constant expression"
       result = false
 
+proc clearMissingConstraints(m: var Match) =
+  m.missingConstraints.clear()
+
+proc constraintMismatchMsg(m: var Match; constraint, arg: Cursor): string =
+  result = typeExprToString(arg) & " does not match constraint " & typeToString(constraint)
+  for key, _ in m.missingConstraints:
+    result.add "\nmissing: " & key
+
 proc semInvoke(c: var SemContext; dest: var TokenBuf; n: var Cursor) =
   let typeStart = dest.len
   let info = n.info
@@ -609,11 +617,14 @@ proc semInvoke(c: var SemContext; dest: var TokenBuf; n: var Cursor) =
       semLocalTypeImpl c, argBuf, n, AllowValues
       if haveParam and constraint.kind != DotToken:
         var arg = beginRead(argBuf)
+        let argSnap = cursorAt(argBuf, 0)
         var constraintMatch = constraint
+        clearMissingConstraints(m)
         if not matchesConstraint(m, constraintMatch, arg):
-          c.buildErr dest, argInfo, constraintMismatchMsg(m, constraint, arg)
+          c.buildErr dest, argInfo, constraintMismatchMsg(m, constraint, argSnap), argSnap
           ok = false
           addArg = false
+        endRead(argBuf)
     if addArg:
       dest.add argBuf
   let usedTypevarsFinal = c.usedTypevars

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -79,9 +79,27 @@ type
     firstVarargPosition*: int
     varargsEndPosition*: int
     genericConverter*, refineArgType*, insertedParam*: bool
+    missingConstraints*: OrderedTable[string, Cursor]
 
 proc createMatch*(context: ptr SemContext): Match =
   Match(context: context, firstVarargPosition: -1, varargsEndPosition: -1)
+
+proc addMissingConstraint*(m: var Match; routine: Cursor) =
+  let key = asNimCode(routine, {renderNoBody})
+  if key notin m.missingConstraints:
+    m.missingConstraints[key] = routine
+
+proc errArgForConstraintCheck(a: Cursor): Cursor =
+  ## When matching concept requirements, use the type inside an `(err …)` node,
+  ## not the error wrapper itself.
+  result = a
+  if isErrNode(result):
+    let payload = errPayload(result)
+    if payload.kind == DotToken:
+      return result
+    if isErrNode(payload):
+      return errArgForConstraintCheck(payload)
+    return payload
 
 proc scopeBump(m: Match): int =
   ## Models an implicit `Scope` parameter on every routine. Same-module
@@ -406,9 +424,7 @@ proc matchBooleanConstraint(m: var Match; f: var Cursor; a: Cursor): bool =
         var f2 = f
         if not matchBooleanConstraint(m, f2, a):
           result = false
-          break
         skip f
-      while f.hasMore: skip f                  # consume the rest after early break
   of OrT:
     f.into:
       while f.hasMore:
@@ -470,6 +486,7 @@ proc matchesConstraint*(m: var Match; f: var Cursor; a: Cursor): bool =
   if f.kind == DotToken:
     inc f
     return a.typeKind != AutoT
+  let a = errArgForConstraintCheck(a)
   if a.kind == Symbol:
     let res = tryLoadSym(a.symId)
     assert res.status == LacksNothing
@@ -796,80 +813,16 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
   storeRoutineImpl(m.context, conceptSym, reqSym, a, ConceptRoutineImplResult(found: false))
   false
 
-proc collectMissingConceptRequirements(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): seq[Cursor] =
-  var cachedMissing = default(seq[Cursor])
-  if tryMissingFromBodyCache(m.context, conceptSym, a, cachedMissing):
-    return cachedMissing
-  let actualIsConcept = isConceptType(a)
-  let actualBody = if actualIsConcept: getTypeSection(a.symId).body else: default(Cursor)
-  let meta = getConceptMetadata(m.context, conceptSym, body)
-  for parent in meta.parents:
-    let parentBody = getTypeSection(parent).body
-    let parentMissing = collectMissingConceptRequirements(m, parent, parentBody, a)
-    if parentMissing.len > 0:
-      storeBodyCheck(m.context, conceptSym, a, bodyResultFromMissing(parentMissing))
-      return parentMissing
-  if not actualIsConcept and meta.parents.len == 0:
-    if not conceptTargetNeedsStrictCheck(a):
-      storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: true))
-      return @[]
-  result = @[]
-  for cbody, routine in conceptHierarchyRoutines(body):
-    if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
-      result.add routine
-  storeBodyCheck(m.context, conceptSym, a, bodyResultFromMissing(result))
-
-proc collectMissingConceptRequirementsFromConstraint(m: var Match; f: Cursor; a: Cursor): seq[Cursor] =
-  var f = f
-  var a = a
-  if f.kind == DotToken:
-    return @[]
-  if a.kind == Symbol:
-    let res = tryLoadSym(a.symId)
-    assert res.status == LacksNothing
-    if res.decl.symKind == TypevarY:
-      var typevar = asTypevar(res.decl)
-      return collectMissingConceptRequirementsFromConstraint(m, f, typevar.typ)
-  if f.kind == Symbol:
-    if isConceptSym(f.symId):
-      let body = getTypeSection(f.symId).body
-      return collectMissingConceptRequirements(m, f.symId, body, a)
-    let res = tryLoadSym(f.symId)
-    if res.status == LacksNothing and res.decl.symKind == TypevarY:
-      var typevar = asTypevar(res.decl)
-      return collectMissingConceptRequirementsFromConstraint(m, typevar.typ, a)
-  if f.typeKind == ConceptT:
-    return collectMissingConceptRequirements(m, SymId(0), f, a)
-  @[]
-
-proc constraintMismatchMsg*(m: var Match; constraint, arg: Cursor): string =
-  result = "type " & typeToString(arg) & " does not match constraint: " & typeToString(constraint)
-  let missing = collectMissingConceptRequirementsFromConstraint(m, constraint, arg)
-  if missing.len > 0:
-    result.add "; missing required "
-    if missing.len == 1:
-      result.add "proc: "
-    else:
-      result.add "procs: "
-    for i, routine in missing:
-      if i > 0:
-        result.add ", "
-      result.add asNimCode(routine, {renderNoBody})
-
 proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor): bool =
   let (hit, cached) = tryBodyCheckFromCache(m.context, conceptSym, a)
-  if hit:
-    return cached.satisfied
+  if hit and cached.satisfied:
+    return true
   if isOpenTypevar(a):
     storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: true))
     return true
   let actualIsConcept = isConceptType(a)
   let actualBody = if actualIsConcept: getTypeSection(a.symId).body else: default(Cursor)
   let meta = getConceptMetadata(m.context, conceptSym, body)
-  for parent in meta.parents:
-    if not matchConceptSym(m, parent, a):
-      storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: false))
-      return false
   # Until concrete-type requirement matching is complete, standalone concepts
   # match any concrete type (legacy stub behaviour). Concept-to-concept
   # subsumption always checks requirements structurally.
@@ -881,15 +834,14 @@ proc matchConceptBody(m: var Match; conceptSym: SymId; body: Cursor; a: Cursor):
       let satisfied = a.kind != DotToken
       storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: satisfied))
       return satisfied
-  var bodyResult = ConceptBodyResult(satisfied: true)
+  var hasMissing = false
   for cbody, routine in conceptHierarchyRoutines(body):
     if not conceptRoutineAvailable(m, conceptSym, cbody, routine, a, actualBody):
-      bodyResult.satisfied = false
-      let rs = conceptRequirementSym(routine)
-      if rs != SymId(0):
-        bodyResult.missing.add rs
-  storeBodyCheck(m.context, conceptSym, a, bodyResult)
-  bodyResult.satisfied
+      addMissingConstraint(m, routine)
+      hasMissing = true
+  let satisfied = not hasMissing
+  storeBodyCheck(m.context, conceptSym, a, ConceptBodyResult(satisfied: satisfied))
+  satisfied
 
 proc isTypevar(s: SymId): bool =
   let res = tryLoadSym(s)

--- a/tests/nimony/concepts/tconceptcacheparent.msgs
+++ b/tests/nimony/concepts/tconceptcacheparent.msgs
@@ -1,1 +1,3 @@
-tests/nimony/concepts/tconceptcacheparent.nim(19, 12) Error: type X does not match constraint: C; missing required procs: proc bar(x: Self), proc foo(x: Self)
+tests/nimony/concepts/tconceptcacheparent.nim(19, 12) Error: X does not match constraint C
+missing: proc bar(x: Self)
+missing: proc foo(x: Self)

--- a/tests/nimony/concepts/tconceptconstraintbad.msgs
+++ b/tests/nimony/concepts/tconceptconstraintbad.msgs
@@ -1,1 +1,3 @@
-tests/nimony/concepts/tconceptconstraintbad.nim(15, 12) Error: type Partial does not match constraint: NeedsOps; missing required procs: proc -(a: Self, b: Self), proc +(a: Self, b: Self)
+tests/nimony/concepts/tconceptconstraintbad.nim(15, 12) Error: Partial does not match constraint NeedsOps
+missing: proc -(a: Self, b: Self)
+missing: proc +(a: Self, b: Self)

--- a/tests/nimony/concepts/tconceptfuncprocbad.msgs
+++ b/tests/nimony/concepts/tconceptfuncprocbad.msgs
@@ -1,1 +1,2 @@
-tests/nimony/concepts/tconceptfuncprocbad.nim(17, 12) Error: type BadType does not match constraint: NeedsFuncEq; missing required proc: func ==(x: Self, y: Self)
+tests/nimony/concepts/tconceptfuncprocbad.nim(17, 12) Error: BadType does not match constraint NeedsFuncEq
+missing: func ==(x: Self, y: Self)

--- a/tests/nimony/concepts/tconceptstandalonebad.msgs
+++ b/tests/nimony/concepts/tconceptstandalonebad.msgs
@@ -1,1 +1,2 @@
-tests/nimony/concepts/tconceptstandalonebad.nim(17, 12) Error: type Foo does not match constraint: Comparable; missing required proc: func >(a: Self, b: Self)
+tests/nimony/concepts/tconceptstandalonebad.nim(17, 12) Error: Foo does not match constraint Comparable
+missing: func >(a: Self, b: Self)

--- a/tests/nimony/errmsgs/tbadconverter.msgs
+++ b/tests/nimony/errmsgs/tbadconverter.msgs
@@ -1,2 +1,2 @@
-tests/nimony/errmsgs/tbadconverter.nim(1, 1) Error: cannot attach converter to type (err Foo "undeclared identifier\3A Foo")
+tests/nimony/errmsgs/tbadconverter.nim(1, 1) Error: cannot attach converter to type Foo
 tests/nimony/errmsgs/tbadconverter.nim(1, 11) Error: undeclared identifier: Foo

--- a/tests/nimony/generics/tgenerictypeconstraints.msgs
+++ b/tests/nimony/generics/tgenerictypeconstraints.msgs
@@ -1,4 +1,4 @@
-tests/nimony/generics/tgenerictypeconstraints.nim(6, 12) Error: type float64 does not match constraint: int64|int8|int16|int32|int64|uint64|uint8|uint16|uint32|uint64
+tests/nimony/generics/tgenerictypeconstraints.nim(6, 12) Error: float64 does not match constraint int64|int8|int16|int32|int64|uint64|uint8|uint16|uint32|uint64
 tests/nimony/generics/tgenerictypeconstraints.nim(7, 11) Error: wrong amount of generic parameters for type Foo.0.tge70svym, expected 1 but got 2
 tests/nimony/generics/tgenerictypeconstraints.nim(13, 4) Error: Type mismatch at [position]
 bar(1.0, false)


### PR DESCRIPTION
While working on better error logging for mismatched concept constraints I ended up refactoring concept matching in general because I noticed a number of problems.

## Changes

1. Single-pass concept matching (`sigmatch.nim`, `conceptcache.nim`)
  - Replaced the two-pass match + re-walk model for error collection with a single hierarchy walk in `matchConceptBody`
  - Missing constraint requirements are now collected on the fly during matching (`Match.missingConstraints`)
  - Removed lookup of missing requirements that leaked into concept cache
2. Error rendering (`renderer.nim`)
  - Nimony now logs a human readable list of missing constraints instead of NIF formatted output
  - Missing requirements are now deduplicated instead of being repeated for each inherited concept
  - Now correctly supports sumtype constraints (`T: A and B`, `T: A or B`, `T: float32|float64|int` etc.)
3. Updated unit tests with new expected error outputs


Fixes https://github.com/nim-lang/nimony/issues/2173