### PR TITLE
fixes #2151; recompile modules when used plugins are changed

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -221,7 +221,7 @@
 | `(borrow)` | NimonyPragma | `borrow` pragma |
 | `(noSideEffect)` | NimonyPragma | `noSideEffect` pragma |
 | `(nodestroy)` | NimonyPragma | `nodestroy` pragma |
-| `(plugin X)` | NimonyPragma | `plugin` pragma |
+| `(plugin X)` | NimonyPragma, NiflerKind | `plugin` pragma; Nifler uses it only for `*.p.dep.nif` files. |
 | `(bycopy)` | NimonyPragma | `bycopy` pragma |
 | `(byref)` | NimonyPragma | `byref` pragma |
 | `(noinit)` | NimonyPragma | `noinit` pragma |

--- a/src/models/nifler_tags.nim
+++ b/src/models/nifler_tags.nim
@@ -85,6 +85,7 @@ type
     ConceptL = (ord(ConceptTagId), "concept")  ## `concept` type: two reserved slots, optional parent concepts (`.` / sym / `(and ...)`), a `Self` typevar `D`, and the concept body statements `S*` (body may be empty when parents are present)
     DistinctL = (ord(DistinctTagId), "distinct")  ## `distinct` type
     ItertypeL = (ord(ItertypeTagId), "itertype")  ## Nimony iterator type — first-class closure-iterator value at the type level. Shape mirrors `(proctype ...)`: slot 0 carries the nilability tag (`.` placeholder or one of `(notnil)`, `(nil)`, `(unchecked)`); remaining slots are params, return type, pragmas.
+    PluginL = (ord(PluginTagId), "plugin")  ## `plugin` pragma; Nifler uses it only for `*.p.dep.nif` files.
     QuotedL = (ord(QuotedTagId), "quoted")  ## name in backticks
     TupL = (ord(TupTagId), "tup")  ## untyped tuple constructor
     TabconstrL = (ord(TabconstrTagId), "tabconstr")  ## table constructor

--- a/src/models/nimony_tags.nim
+++ b/src/models/nimony_tags.nim
@@ -319,7 +319,7 @@ type
     BorrowP = (ord(BorrowTagId), "borrow")  ## `borrow` pragma
     NoSideEffectP = (ord(NoSideEffectTagId), "noSideEffect")  ## `noSideEffect` pragma
     NodestroyP = (ord(NodestroyTagId), "nodestroy")  ## `nodestroy` pragma
-    PluginP = (ord(PluginTagId), "plugin")  ## `plugin` pragma
+    PluginP = (ord(PluginTagId), "plugin")  ## `plugin` pragma; Nifler uses it only for `*.p.dep.nif` files.
     BycopyP = (ord(BycopyTagId), "bycopy")  ## `bycopy` pragma
     ByrefP = (ord(ByrefTagId), "byref")  ## `byref` pragma
     NoinitP = (ord(NoinitTagId), "noinit")  ## `noinit` pragma

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -9,7 +9,7 @@
 when defined(nifBench):
   import std / monotimes
 
-import std / [assertions, syncio, os]
+import std / [assertions, syncio, os, sets]
 
 import compiler / [ast, options, pathutils, renderer, lineinfos, syntaxes, llstream, idents, msgs]
 
@@ -122,6 +122,7 @@ type
       ## so the dep analyzer can evaluate them and skip dead branches.
       ## `negated` entries (an `else` branch carries the negation of every
       ## prior elif condition) are wrapped in `(prefix not ...)` at emission.
+    depPlugins: HashSet[string] ## Set of plugins except import plugins
 
 proc absLineInfo(i: TLineInfo; c: var TranslationContext) =
   var fp = toFullPath(c.conf, i.fileIndex)
@@ -831,6 +832,17 @@ proc toNif*(n, parent: PNode; c: var TranslationContext; allowEmpty = false) =
     for i in 1..<n.len:
       toNif(n[i], n, c)
     c.b.endTree()
+  of nkPragma:
+    c.b.withTree(nodeKindTranslation(n.kind)):
+      relLineInfo(n, parent, c)
+      attachDocComment(n, c)
+      for i in 0..<n.len:
+        toNif(n[i], n, c)
+        if c.depsEnabled and
+           n[i].kind == nkExprColonExpr and n[i].len >= 2 and
+           n[i][0].kind == nkIdent and n[i][0].ident.s == "plugin" and
+           n[i][1].kind == nkStrLit:
+          c.depPlugins.incl n[i][1].strVal
   else:
     c.b.addTree(nodeKindTranslation(n.kind))
     relLineInfo(n, parent, c)
@@ -864,6 +876,9 @@ proc close*(c: var TranslationContext; depsOnly = false) =
   else:
     c.b.close()
   if c.depsEnabled:
+    c.deps.withTree(PluginL):
+      for p in c.depPlugins:
+        c.deps.addStrLit p
     c.deps.endTree()
     c.deps.close()
 

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -572,14 +572,13 @@ proc processDep(c: var DepContext; n: var Cursor; current: Node) =
           for flag in splitWhitespace(pool.strings[n.strId]):
             c.passC.add flag
           inc n
-    elif n.tagId == TagId(PluginP):
-      n.into: # (pluginL …)
-        while n.hasMore:
-          assert n.kind == StringLit
-          let p = pool.strings[n.litId]
-          let p2 = resolveFile(c.config.paths, current.files[current.active].nimFile, p)
-          current.depPlugins.incl p2
-          inc n
+    elif n.cursorTagId == TagId(PluginP):
+      loopInto n: # (pluginL …)
+        assert n.kind == StringLit
+        let p = pool.strings[n.strId]
+        let p2 = resolveFile(c.config.paths, current.files[current.active].nimFile, p)
+        current.depPlugins.incl p2
+        inc n
     else:
       skip n
   else:

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -158,6 +158,7 @@ type
     isSystem: bool
     plugin: string
     cyclicFiles: seq[int] ## indices into `files` that are cyclic module members (need separate outputs)
+    depPlugins: HashSet[string] ## Set of plugins `files` uses except import plugins
 
   Command* = enum
     DoCheck, # like `nim check`
@@ -570,6 +571,14 @@ proc processDep(c: var DepContext; n: var Cursor; current: Node) =
           assert n.isStringLit
           for flag in splitWhitespace(pool.strings[n.strId]):
             c.passC.add flag
+          inc n
+    elif n.tagId == TagId(PluginP):
+      n.into: # (pluginL …)
+        while n.hasMore:
+          assert n.kind == StringLit
+          let p = pool.strings[n.litId]
+          let p2 = resolveFile(c.config.paths, current.files[current.active].nimFile, p)
+          current.depPlugins.incl p2
           inc n
     else:
       skip n
@@ -1464,6 +1473,19 @@ proc generateSemInstructions(c: DepContext; v: Node; b: var Builder; isMain: boo
     # Input: cached config file
     b.withTree "input":
       b.addStrLit c.config.cachedConfigFile()
+    # Input: plugins excepts import plugins
+    for p in v.depPlugins:
+      b.withTree "input":
+        b.addStrLit p
+    # Input: plugins used in imported modules
+    # When the plugin used in an imported module is changed, `*.s.idx.nif` file of the imported module might not be updated.
+    # (see `createIndex` proc in `lib/nifindexes.nim`)
+    # But if this module uses exported types or templates with the plugin in the imported module, it need to be recompiled.
+    for i in v.deps:
+      for p in c.nodes[i].depPlugins:
+        b.withTree "input":
+          b.addStrLit p
+
     # Outputs: semmed file and index file for primary module
     let docMode = c.cmd == DoDoc
     b.withTree "output":


### PR DESCRIPTION
Fixes https://github.com/nim-lang/nimony/issues/2151
Nifler scans `plugin` pragmas and generates a list of used plugins in `*.p.deps.nif` file.
Nimony read the files and generates `*.build.nif` file so that modules uses plugins are recompiled when the plugins code are changed.
