### PR TITLE
Fix lazy template promotion binding wrong homonymous typevars.

### DIFF
--- a/src/nimony/templates.nim
+++ b/src/nimony/templates.nim
@@ -132,6 +132,24 @@ proc expandPlugin(c: var SemContext; dest: var TokenBuf; temp: Routine, args: Cu
       else:
         skip p
 
+proc addTemplFormalsToScope(c: var SemContext; buf: TokenBuf; at: int) =
+  ## Register published generic/type/formal params on `c.currentScope` so
+  ## `semTemplBody`'s `buildSymChoice` resolves to this template's symbols,
+  ## not homonymous typevars from an enclosing caller during lazy promotion.
+  var p = readonlyCursorAt(buf, at)
+  if p.substructureKind in {ParamsU, TypevarsU}:
+    p.into:
+      while p.hasMore:
+        let param = asLocal(p)
+        if param.name.kind == SymbolDef:
+          var nameStr = pool.syms[param.name.symId]
+          extractBasename(nameStr)
+          if nameStr.len > 0:
+            let s = Sym(kind: param.kind, name: param.name.symId, pos: 0)
+            addOverloadable(c.currentScope,
+                            pool.strings.getOrIncl(nameStr), s)
+        skip p
+
 proc tryPromoteTemplateBody*(c: var SemContext; sym: SymId): bool =
   ## On-demand upgrade of a verbatim-published template body. Phase 2's
   ## `semProcImpl` takes the template body verbatim via `takeTree` and
@@ -188,32 +206,13 @@ proc tryPromoteTemplateBody*(c: var SemContext; sym: SymId): bool =
     inc c.routine.inLoop
     inc c.routine.inGeneric
     c.openScope()  # parameter scope
+    addTemplFormalsToScope(c, newBuf, typevarsAt)
+    addTemplFormalsToScope(c, newBuf, paramsAt)
     c.openScope()  # body scope
 
     var ctx = createUntypedContext(addr c, UntypedTemplate, dirty = false)
     addParams(ctx, newBuf, typevarsAt)
     addParams(ctx, newBuf, paramsAt)
-
-    # `addParams` populates `ctx.params` (used by `getIdentReplaceParams`'s
-    # `isTemplParam` check) — but `getIdentReplaceParams` first calls
-    # `buildSymChoice`, which scans the actual SemContext scope. The
-    # original phase-3 path got params into scope via `semParams`, which
-    # ran `addSym` for each param. Lazily promoting from the published
-    # decl skips that, so re-attach the params to the scope here.
-    block addParamsToScope:
-      var p = readonlyCursorAt(newBuf, paramsAt)
-      if p.substructureKind == ParamsU:
-        p.into ParamsU:
-          while p.hasMore:
-            let param = asLocal(p)
-            if param.name.kind == SymbolDef:
-              var nameStr = pool.syms[param.name.symId]
-              extractBasename(nameStr)
-              if nameStr.len > 0:
-                let s = Sym(kind: ParamY, name: param.name.symId, pos: 0)
-                addOverloadable(c.currentScope,
-                                pool.strings.getOrIncl(nameStr), s)
-            skip p
 
     semTemplBody ctx, newBuf, oldHead
     # `oldHead` is now past the body, at the template's (possibly elided) close.

--- a/tests/nimony/concepts/tconcept_forward_template.nim
+++ b/tests/nimony/concepts/tconcept_forward_template.nim
@@ -1,0 +1,17 @@
+## Regression: lazy template-body promotion must bind a promoted template's
+## own typevars, not homonymous typevars from an enclosing caller.
+## Previously produced `type mismatch: got: T but wanted: T` when two
+## forward-referencing templates used different concept constraints on `T`
+## before the callee's definition.
+
+type
+  Add = concept
+    func `+`(a, b: Self): Self
+    func identity(_: typedesc[Self]): Self
+  Plain = concept of Add
+  Extra = concept of Add
+    func `*`(a, b: Self): Self
+
+template x*[T: Plain](_: typedesc[T]): T = T.two
+template y*[T: Extra](_: typedesc[T]): T = T.two
+template two*[T: Add](_: typedesc[T]): T = T.identity + T.identity


### PR DESCRIPTION
When a template forward-references another generic template, lazy body promotion must register the callee's typevars on scope before `semTemplBody` runs; otherwise `buildSymChoice` picks the caller's `T` and produces bogus "T vs T" mismatches at expansion sites.

## Root cause
When template `x` forward-referenced `T.two`, nimony lazily promoted template `two`'s body via `semTemplBody`. That pass runs `buildSymChoice` against the live `SemContext` scope, which still contained `x`'s `T`. Because only formal **params** (not **typevars**) were registered on scope during promotion, `two`'s body bound the wrong `T` SymId into the cached AST.

Later, when `y` expanded `two`, the body and return type used different `T` symbols, both printing as `T`, hence:
```
Error: type mismatch: got: T but wanted: T
```

## Fix (`templates.nim`)
Pulled out the `addParamsToScope` block in `tryPromoteTemplateBody` into its own function `addTemplFormalsToScope` to register **both typevars and params** on the parameter scope before `semTemplBody`, matching what phase 3 does via `semGenericParams` / `semParams`.

Promotion now calls it for `typevarsAt` and `paramsAt` in the parameter scope (body scope stays separate).

Fixes https://github.com/nim-lang/nimony/issues/2181