### PR TITLE
fixes #2192; report invalid set element types in type declarations instead of asserting

### DIFF
--- a/src/nimony/semtypes.nim
+++ b/src/nimony/semtypes.nim
@@ -1062,20 +1062,26 @@ proc semLocalTypeImpl*(c: var SemContext; dest: var TokenBuf; n: var Cursor;
     of SetT:
       if tryTypeClass(c, dest, n):
         return
+      let setStart = dest.len
       var elemTypeStart = 0
       dest.takeInto n:
         elemTypeStart = dest.len
         semLocalTypeImpl c, dest, n, InLocalDecl
       let elemType = cursorAt(dest, elemTypeStart)
+      var errMsg = ""
       if containsGenericParams(elemType):
         # allow
         discard
       elif not isOrdinalType(elemType, allowEnumWithHoles = true):
-        c.buildErr dest, info, "set element type must be ordinal"
+        errMsg = "set element type must be ordinal"
       else:
         let length = lengthOrd(c, elemType)
         if length.isNaN or length > MaxSetElements:
-          c.buildErr dest, info, "type " & typeToString(elemType) & " is too large to be a set element type"
+          errMsg = "type " & typeToString(elemType) & " is too large to be a set element type"
+      if errMsg.len > 0:
+        # replace the `(set ...)` tree with the error node; an appended
+        # sibling would give the enclosing decl an extra child:
+        c.buildErrAt dest, setStart, errMsg
     of OrT, AndT:
       dest.takeInto n:
         while n.hasMore:

--- a/tests/nimony/errmsgs/tsetdecltoolarge.msgs
+++ b/tests/nimony/errmsgs/tsetdecltoolarge.msgs
@@ -1,0 +1,2 @@
+tests/nimony/errmsgs/tsetdecltoolarge.nim(3, 10) Error: type uint64 is too large to be a set element type
+tests/nimony/errmsgs/tsetdecltoolarge.nim(4, 10) Error: set element type must be ordinal

--- a/tests/nimony/errmsgs/tsetdecltoolarge.nim
+++ b/tests/nimony/errmsgs/tsetdecltoolarge.nim
@@ -1,0 +1,4 @@
+# issue #2192
+type
+  X = set[uint64]
+  Y = set[string]


### PR DESCRIPTION
fixes #2192

The `SetT` branch of `semLocalTypeImpl` appended the `(err ...)` node after the already closed `(set ...)` tree, giving the enclosing type decl an extra child; a later fixed-arity `into:` walk over the decl then asserted:

```
Error: unhandled exception: src/lib/nifcore.nim(712, 3) `c.rem == 0` into: body did not consume all 17 children (left 5) [AssertionDefect]
```

Now the `(set ...)` tree is replaced by the error node, with the set tree kept as the error's origin, so `type X = set[uint64]` reports:

```
tests/nimony/errmsgs/tsetdecltoolarge.nim(3, 10) Error: type uint64 is too large to be a set element type
tests/nimony/errmsgs/tsetdecltoolarge.nim(4, 10) Error: set element type must be ordinal
```

(Same replace-instead-of-append idea as `buildErrAt` from #2124, done inline since that PR is not merged yet; thanks @demotomohiro for the pointer.)
