### PR TITLE
add the missing tools/warmup.nim; speed up the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     - 'master'
   pull_request:
 
+# One in-flight run per branch/PR. The Windows job alone is ~40 minutes, so
+# without this every follow-up push to an open PR leaves the superseded run
+# burning a full matrix to produce results nobody will look at. `master` is
+# excluded from cancellation (github.sha makes its group unique per commit)
+# so the history of green builds there stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/master' && github.sha || '' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -85,8 +94,15 @@ jobs:
         if: runner.os == 'Linux' && matrix.target.cpu == 'amd64'
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y valgrind gcc-14 g++-14
+          # gcc-14/g++-14 ship preinstalled on the ubuntu-24.04 image, so only
+          # valgrind actually needs fetching. Installing the compilers anyway
+          # made this step ~5 minutes (apt pulled and reinstalled the full
+          # toolchain); with just valgrind it is a few seconds.
+          # `--no-install-recommends` keeps valgrind from dragging in its
+          # (unused here) debuginfo/doc recommends.
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install \
+            --no-install-recommends -yq valgrind
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 60 --slave /usr/bin/g++ g++ /usr/bin/g++-14
 
       - name: Install dependencies (Linux i386)

--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -531,10 +531,17 @@ proc warmupSharedCache(): string =
   ## without the savings).
   const warmupSrc = "tools/warmup.nim"
   if not fileExists(warmupSrc):
+    # Loud, because the fallback is silent-but-slow: without the prefill every
+    # test recompiles `system` from scratch (~3s each on Windows CI, ~700
+    # tests). A missing warmup file previously just disabled the optimization
+    # with no output at all, so the regression was invisible.
+    stderr.writeLine "warmup: " & warmupSrc &
+      " missing; every test will recompile the stdlib from scratch"
     return ""
   result = nimcacheDir / "warmup"
   let nimony = toolExe("nimony")
   if not fileExists(nimony):
+    stderr.writeLine "warmup: skipping, no nimony at " & nimony
     return ""
   let cmd = nimony.quoteShell & " c --nimcache:" & result.quoteShell &
             " " & warmupSrc.quoteShell

--- a/tools/warmup.nim
+++ b/tools/warmup.nim
@@ -1,0 +1,31 @@
+# Prebuilt cache seed for hastur's parallel test runner.
+#
+# `hastur`'s `warmupSharedCache` compiles THIS file once into
+# `nimcache/warmup/`, then copies the resulting bundles into every
+# per-test cache directory before that test runs (`prefillFromWarmup`).
+# Everything imported here is already parsed, semchecked and lowered by
+# the time a test starts, so the ~700-test suite pays the `system` +
+# common-stdlib compile once instead of once per test.
+#
+# Keep this list SMALL and only add near-universal modules. Every file
+# produced here is copied into all ~700 per-test cache dirs, so a module
+# used by a handful of tests costs more in prefill I/O than it saves.
+# `std/assertions` (171 importers) and `std/syncio` (142) cover the bulk
+# of `tests/` and `examples/`; adding `math`/`strutils` (12/7 importers)
+# measurably grew the prefill without improving test time.
+#
+# This must stay compilable by `nimony c`. A failure here is non-fatal:
+# hastur logs it and falls back to cold per-test compiles, so a silent
+# breakage shows up only as the suite getting much slower.
+
+import std/[assertions, syncio]
+
+proc main =
+  # Touch each import so nothing is dead-code-eliminated before it lands
+  # in the cache.
+  let s = "warmup"
+  assert s.len == 6
+  if s.len == 0:
+    echo s
+
+main()


### PR DESCRIPTION
## The bug

`warmupSharedCache` in `src/hastur.nim` compiles `tools/warmup.nim` once and prefills every parallel test's cache with the result, so each test skips recompiling `system` + the common stdlib.

That file was never committed. It is referenced by #1835 but was left out of the changeset, so `fileExists(warmupSrc)` has always been false and the whole optimization has been dead code since then.

The failure mode was a silent `return ""`, so nothing surfaced. The suite just ran without the prefill.

## What is actually proven

I want to be upfront about which parts of this are measured and which are not.

**Proven: the Linux apt step, 304s -> 15s.**

`gcc-14`/`g++-14` are preinstalled on `ubuntu-24.04` (runner-images README lists `GNU C++: 12.4.0, 13.3.0, 14.2.0`); only `valgrind` was actually missing. This is deterministic and repeatable, not a timing measurement. `update-alternatives` is kept since the default `gcc` is still 13.

**Proven: `tools/warmup.nim` compiles and links.**

Verified in a WSL2 Ubuntu container with gcc 13.3 and a from-source Nim devel: exit 0, 100 cache files, real executable produced. `hastur tests/nimony/arc` passes 41/41 with and without it.

**Not proven: the warmup's effect on CI wall time.**

I originally claimed -35% based on single-file `nimony c` timings. That was a bad methodology and the number does not hold up. Repeated `hastur` runs in WSL (32 cores) give inconsistent results depending on suite and job count:

| suite | jobs | with warmup | without |
|---|---|---|---|
| `arc` (41) | 32 | 3.61s | **1.70s** |
| `sysbasics` (62) | 4 | **9.54s** | 12.38s |
| `stdlib` (50) | 4 | 14.57s (median of 5) | **13.14s** (median of 5) |
| `tests/nimony` (full) | 8 | **180.87s** (median of 3) | 208.57s (median of 3) |

The full-suite run favours warmup by ~13%, but the smaller suites go both ways, and on `stdlib` the prefill is a net **loss** of ~11%. That is consistent with the mechanism: `prefillFromWarmup` copies ~100 files into every per-test cache dir, which is only worth it when the compile it saves is slower than the copy.

CI on this PR is equally inconclusive. Baseline variance on `master` over the last 6 successful runs:

| job | mean | sd | min | max |
|---|---|---|---|---|
| windows `Run tester` | 1939s | 313s | 1261s | 2175s |
| linux `Run tester` | 493s | 91s | 347s | 592s |

This PR produced windows 1804s and linux 551s. Both land within half a standard deviation of the baseline mean, i.e. inside the noise. The windows job total did drop 37.7 -> 32.4 min, but a single sample against a 47% spread does not support a causal claim.

**So: the apt fix is a real, deterministic saving. The warmup restores intended-but-dead behaviour and is a correctness fix; whether it is a net win on CI is unresolved and needs more samples than one run.**

If reviewers would rather not take the warmup on an unproven perf argument, I am happy to split this into two PRs and land the apt + concurrency changes alone.

## Changes

**`tools/warmup.nim`** (new) - the missing file. Deliberately minimal: `std/assertions` (171 importers) and `std/syncio` (142). I tested adding `math` + `strutils` (12/7 importers): prefill grew from 113 to 149 files copied per test with no gain, so they are left out. Given the prefill-cost finding above, keeping this list small matters more than I first thought.

**`src/hastur.nim`** - warn instead of silently degrading when the warmup file or `nimony` is missing. This is the part I am most confident about: the bug survived months precisely because the fallback was silent. Confirmed firing in WSL:

```
warmup: tools/warmup.nim missing; every test will recompile the stdlib from scratch
```

**`.github/workflows/ci.yml`**
- Add `concurrency` + `cancel-in-progress`. There was none: 0 cancelled runs in the last 40, and I found 4 runs on one branch within ~34 minutes, each burning a full Windows job. `master` is excluded from cancellation via `github.sha` so its build history stays complete. This saves runner capacity rather than wall time on any single run.
- Stop reinstalling `gcc-14`/`g++-14` on Linux (see above).

## Verification

- `nim check src/hastur.nim` passes.
- Full toolchain built from scratch in WSL2 Ubuntu (`hastur --release build all`, 92s), then `bin/nimony c tools/warmup.nim` -> exit 0, links a working executable.
- `hastur tests/nimony/arc` 41/41 with and without warmup.
- CI green on all 4 targets.

## Known remaining issue

Windows stays the outlier regardless of this PR (mean 1939s vs Linux 493s for the same suite). The gap is process-spawn overhead: `parallelTestDir` spawns one `hastur test` subprocess per test. That is the thing actually worth fixing for Windows CI time, and it is out of scope here.
