### PR TITLE
fixes #2191; checks ErrT node

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -4631,7 +4631,11 @@ proc semSubscript(c: var SemContext; dest: var TokenBuf; it: var Item) =
   semExpr c, lhsBuf, lhs, {KeepMagics}
   it.n = lhs.n
   lhs.n = cursorAt(lhsBuf, 0)
-  semBuiltinSubscript(c, dest, it, lhs, atStart)
+  if lhs.n.isTagLit and lhs.n.cursorTagId == nifpools.ErrT:
+    it.n = atStart
+    dest.takeTree it.n
+  else:
+    semBuiltinSubscript(c, dest, it, lhs, atStart)
 
 proc semCurlyat(c: var SemContext; dest: var TokenBuf; it: var Item) =
   let info = it.n.info


### PR DESCRIPTION
Fix https://github.com/nim-lang/nimony/issues/2191

With this fix, following compile error is generated:
```
testgene.nim(4, 21) Error: argument for a `static` generic parameter must be a constant expression                                   
testgene.nim(4, 25) Error: argument for a `static` generic parameter must be a constant expression                                   
testgene.nim(4, 40) Error: undeclared identifier: T                                                                                  
testgene.nim(4, 47) Error: undeclared identifier: T                                                                                  
testgene.nim(5, 12) Error: undeclared identifier: H                                                                                  
```
from following code:
```
type Matrix[W, H: static[int], T] = object
  data: array[W * H, T]

proc `[]`(m: Matrix[W, H: static[int], T], x, y: int): T {.inline.} =
  m.data[x*H + y]
```