### PR TITLE
hastur: build the toolchain in parallel

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -1388,6 +1388,55 @@ proc buildPnak*(showProgress = false) =
   let exe = "pnak".addFileExt(ExeExt)
   robustMoveFile "src/pnak/" & exe, binDir() / exe
 
+const AllTools = [
+  # (source path, executable name) for every host-Nim tool `build all` produces.
+  # Order is irrelevant: these are independent `nim c` invocations with no
+  # build-order dependency on each other.
+  ("src/nifler/nifler.nim", "nifler"),
+  ("src/nimony/nimsem.nim", "nimsem"),
+  ("src/nimony/nimony.nim", "nimony"),
+  ("src/lengc/lengc.nim", "lengc"),
+  ("src/lengc/shoggoth/shoggoth.nim", "shoggoth"),
+  ("src/niflink/niflink.nim", "niflink"),
+  ("src/hexer/hexer.nim", "hexer"),
+  ("src/nifmake/nifmake.nim", "nifmake"),
+  ("src/njvl/nj.nim", "nj"),
+  ("src/njvl/vl.nim", "vl"),
+  ("src/validator/validator.nim", "validator"),
+  ("src/dagon/dagon.nim", "dagon"),
+  ("src/pnak/pnak.nim", "pnak")]
+
+proc buildAllTools(jobs: int) =
+  ## Compile every tool in `AllTools` at once, then move the results into
+  ## `bin/`. The old code ran the 13 `nim c` calls back to back, which left
+  ## most of the machine idle: a GitHub runner has 4 cores, and after the test
+  ## suite this is the largest step in the job.
+  ##
+  ## Running them together is safe because the invocations are independent.
+  ## Each writes to Nim's default per-project cache (`~/.cache/nim/<name>_r`),
+  ## keyed by project name so no two tools share one, and each emits a distinct
+  ## executable, so the `nimsem`/`nimony` and `nj`/`vl` pairs that share a
+  ## source directory still cannot clobber each other. The binaries this
+  ## produces are byte-identical to the ones the sequential path produced.
+  ##
+  ## `nimsem` and `nimony` also take `validatePassesFlag()`, matching what the
+  ## sequential path did.
+  var cmds: seq[string] = @[]
+  for (src, name) in items(AllTools):
+    let extra = if name in ["nimsem", "nimony"]: validatePassesFlag() else: ""
+    cmds.add nimcPrefix() & extra & src
+
+  # execProcesses returns the highest exit code of any command rather than a
+  # count of failures, so report the code instead of a number of tools.
+  let worstExit = execProcesses(cmds, n = max(1, jobs),
+    options = {poStdErrToStdOut, poUsePath, poEvalCommand, poParentStreams})
+  if worstExit != 0:
+    quit "FAILURE: a tool failed to build (worst exit code " & $worstExit & ")"
+
+  for (src, name) in items(AllTools):
+    let exe = name.addFileExt(ExeExt)
+    robustMoveFile src.parentDir / exe, binDir() / exe
+
 # ---------------------------------------------------------------------------
 # Bootstrapping progress (see https://github.com/nim-lang/nimony/issues/1788).
 #
@@ -2320,19 +2369,7 @@ proc handleCmdLine =
     exec "git submodule update --init"
     case (if args.len > 0: args[0] else: "")
     of "", "all":
-      buildNifler(showProgress)
-      buildNimsem(showProgress)
-      buildNimony(showProgress)
-      buildLengc(showProgress)
-      buildShoggoth(showProgress)
-      buildNiflink(showProgress)
-      buildHexer(showProgress)
-      buildNifmake(showProgress)
-      buildNj(showProgress)
-      buildVl(showProgress)
-      buildValidator(showProgress)
-      buildDagon(showProgress)
-      buildPnak(showProgress)
+      buildAllTools(if parallelJobs > 1: parallelJobs else: countProcessors())
     of "nifler":
       buildNifler(showProgress)
     of "nimony":


### PR DESCRIPTION
Follow-up to #2195, which noted that the test suite dominates CI. The build step is the next thing down, and it was leaving most of the machine idle.

`hastur build all` ran 13 `nim c` calls one after another. Nothing forces that order: the tools do not depend on each other, so on a 4 core runner three cores sat unused for the whole step. This runs them together and moves the binaries into `bin/` afterwards.

## Timing

Measured in WSL2 Ubuntu, pinned to 4 CPUs with `taskset` to match a GitHub hosted runner, 3 reps:

| | median |
|---|---|
| sequential (current) | 137.5s |
| parallel | 120.3s |

About 17s per job, on all four jobs. Modest against a Windows job that runs ~30 minutes, but it costs nothing and the step is pure waiting today.

## Why it is safe to run these together

The 13 invocations are independent. Each writes to Nim's default per-project cache at `~/.cache/nim/<name>_r`, keyed by project name, so no two tools share a cache directory. Each also emits its own executable name, which is what matters for the two pairs that share a source directory: `nimsem`/`nimony` in `src/nimony/`, and `nj`/`vl` in `src/njvl/`. Neither pair can overwrite the other's output.

I checked this rather than assuming it. Building all 13 sequentially and then in parallel from a cold `~/.cache/nim` gives byte-identical binaries under `sha256sum`, all 13 of them.

`nimsem` and `nimony` still get `validatePassesFlag()`, which is what the sequential path passed them.

## Testing

Built from scratch on the merged master: 13 binaries, all report `--version`. The full `tests/nimony` suite passes 613/613 against a parallel-built toolchain. The other `build` subcommands (`nimony`, `hexer`, `lengc`, `nifmake`, `validator`, `pnak`) are untouched and still work; only the `all` path changed.

## One thing worth a reviewer's eye

`execProcesses` with `poParentStreams` lets 13 compilers write to the terminal at once, so on a failure the output is interleaved and harder to read than the old sequential log. The exit code is still correct and CI logs are already noisy, so I left it. If you would rather have clean output, dropping `poParentStreams` and printing each command's captured output on failure would fix it at the cost of no live progress.

Windows is still the real outlier, and this does not address that. The gap there is process spawn overhead in `parallelTestDir`, which spawns a `hastur test` subprocess per test.
