### PR TITLE
windows CI: test with the default gcc; forcing clang is ~20% slower

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,13 +279,13 @@ jobs:
 
       - name: Run tester
         if: matrix.target.cpu != 'i386' # TODO: enables i386
-        env:
-          # Read by tests/tester.nim, which forwards `--cc:clang` to nimony.
-          # On Windows the tester additionally forwards `--passL:-fuse-ld=lld`
-          # because clang emits native PE TLS by default and ld.bfd lays out
-          # `.tls$` incorrectly — only LLD produces a binary that runs.
-          # Empty on Linux/macOS so the existing default toolchains kick in.
-          NIMONY_CC: ${{ runner.os == 'Windows' && 'clang' || '' }}
+        # Every platform tests with its default C toolchain. Windows forced
+        # clang from #1846 on ("faster cc step"), but an A/B of this exact
+        # step on identical runners measured gcc 1568s vs clang 1912s, and
+        # local 3x3 reps at 4 cores agree (gcc 683-830s, clang 854-933s).
+        # Export NIMONY_CC=clang here to exercise the clang-on-MinGW path
+        # again; tools/tester.nim then also adds the -fuse-ld=lld that
+        # clang's native PE TLS needs (ld.bfd lays out `.tls$` wrong).
         run: |
           cd nimony
           nim c -r tools/tester.nim

--- a/tools/tester.nim
+++ b/tools/tester.nim
@@ -91,10 +91,9 @@ proc checkGenTags() =
 checkGenTags()
 
 proc hasturTests(overwrite: bool) =
-  # CI sets NIMONY_CC=clang on Windows so tests exercise the clang-on-MinGW
-  # path (faster cc step + native PE TLS). Locally the env var is unset
-  # and the gcc default kicks in. On Windows + clang we also force LLD as
-  # the linker: clang emits native PE TLS by default but ld.bfd lays out
+  # NIMONY_CC selects the C compiler the tests forward to nimony; unset
+  # means the gcc default. On Windows + clang we also force LLD as the
+  # linker: clang emits native PE TLS by default but ld.bfd lays out
   # `.tls$` incorrectly, producing binaries that segfault on first TLS
   # access; LLD's layout matches what the loader expects.
   var args = "--jobs:auto"


### PR DESCRIPTION
#1846 switched the Windows tester to clang for a faster cc step. Measured, it is the slower option: the same commit on two identical windows-2025 runners ran `Run tester` in 1568s with gcc and 1912s with clang ([A/B run](https://github.com/Redict/nimony/actions/runs/30373885967)). 628/628 tests pass either way.

Local reps agree. Full `tests/nimony` pinned to 4 cores, CI's exact winlibs bundle (gcc 14.2.0 + LLVM 19.1.7), alternating runs:

| rep | gcc | clang |
|---|---|---|
| 1 | 683s | 854s |
| 2 | 758s | 884s |
| 3 | 830s | 933s |

The worst gcc run beats the best clang run.

Single-file compile speed is not the cause: on a sample generated C file gcc takes 58ms and clang 69ms. The gap only shows up at suite level. I did not chase it further down.

So Windows now tests with the gcc default like the other platforms. The clang path is not deleted: `NIMONY_CC=clang` still selects it, and `tools/tester.nim` still adds `-fuse-ld=lld` in that case (clang's native PE TLS still needs LLD; ld.bfd still lays out `.tls$` wrong). If keeping clang coverage on CI matters more than the ~6 minutes, a separate non-blocking clang job would do it.