### PR TITLE
sem: union constructions initialize only the set member

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3804,10 +3804,17 @@ proc callDefault(c: var SemContext; dest: var TokenBuf; typ: Cursor; info: NifLi
 
 proc buildObjConstrField(c: var SemContext; dest: var TokenBuf; field: Local;
                          setFields: Table[SymId, Cursor]; info: NifLineInfo;
-                         bindings: Table[SymId, Cursor]; depth: int) =
+                         bindings: Table[SymId, Cursor]; depth: int;
+                         isUnion = false) =
   let fieldSym = field.name.symId
   if setFields.hasKey(fieldSym):
     dest.addSubtree setFields.getOrQuit(fieldSym)
+  elif isUnion:
+    # A union has ONE active member: filling the unset members with
+    # defaults emits sibling designated initializers, and C's
+    # last-initializer-wins semantics zero out the member the user
+    # actually set (black-clear-color class of bug). Emit nothing.
+    discard
   else:
     dest.addParLe(KvU, info)
     dest.addSymUse(fieldSym, info)
@@ -3966,7 +3973,8 @@ proc fieldsPresentInBranch(c: var SemContext; dest: var TokenBuf; n: var Cursor;
 
 proc buildObjConstrFields(c: var SemContext; dest: var TokenBuf; n: var Cursor;
                           setFields: Table[SymId, Cursor]; info: NifLineInfo;
-                          bindings: Table[SymId, Cursor]; depth = 0) =
+                          bindings: Table[SymId, Cursor]; depth = 0;
+                          isUnion = false) =
   var iter = initObjFieldIter()
   while nextField(iter, n, keepCase = true):
     if n.substructureKind == CaseU:
@@ -3980,7 +3988,7 @@ proc buildObjConstrFields(c: var SemContext; dest: var TokenBuf; n: var Cursor;
       skip n
     else:
       let field = takeLocal(n, SkipFinalParRi)
-      buildObjConstrField(c, dest, field, setFields, info, bindings, depth)
+      buildObjConstrField(c, dest, field, setFields, info, bindings, depth, isUnion)
 
 proc buildDefaultObjConstr(c: var SemContext; dest: var TokenBuf; typ: Cursor;
                            setFields: Table[SymId, Cursor]; info: NifLineInfo;
@@ -4058,7 +4066,8 @@ proc buildDefaultObjConstr(c: var SemContext; dest: var TokenBuf; typ: Cursor;
   if obj.kind == ObjectT:
     skip currentField  # parent type / inheritance slot
   if currentField.hasMore and not currentField.isDotToken:
-    buildObjConstrFields(c, dest, currentField, setFields, info, bindings)
+    let isUnion = objDecl.kind == TypeY and hasPragma(objDecl.pragmas, UnionP)
+    buildObjConstrFields(c, dest, currentField, setFields, info, bindings, isUnion = isUnion)
   dest.addParRi()
 
 proc getAnumOwnerType(efldSym: SymId): SymId =

--- a/tests/nimony/object/tunionconstr.nim
+++ b/tests/nimony/object/tunionconstr.nim
@@ -1,0 +1,24 @@
+import std/[syncio, assertions]
+
+type
+  Payload {.union.} = object
+    f: array[4, float32]
+    i: array[4, int32]
+    u: array[4, uint32]
+
+# Constructing a union must initialize ONLY the given member: filling the
+# siblings with defaults emits C designated initializers whose last write
+# wins, zeroing the member that was actually set.
+let p = Payload(f: [0.25'f32, 0.5'f32, 0.75'f32, 1.0'f32])
+let words = cast[ptr UncheckedArray[uint32]](p.addr)
+assert words[0] == 0x3E800000'u32
+assert words[1] == 0x3F000000'u32
+assert words[2] == 0x3F400000'u32
+assert words[3] == 0x3F800000'u32
+echo "union constr ok"
+
+# Field assignment path (was already correct) stays correct.
+var q: Payload
+q.u = [7'u32, 8'u32, 9'u32, 10'u32]
+assert q.u[3] == 10'u32
+echo "union assign ok"

--- a/tests/nimony/object/tunionconstr.output
+++ b/tests/nimony/object/tunionconstr.output
@@ -1,0 +1,2 @@
+union constr ok
+union assign ok


### PR DESCRIPTION
The object-field-defaults feature (e22b10d2) filled every UNSET field of a construction with its default — including the sibling members of a {.union.} object. NIFC emits those as sibling designated initializers and C's last-initializer-wins semantics zero out the member the user actually set: VkClearColorValue(float32: [r,g,b,a]) compiled to an all-zero union, turning every Vulkan clear color black (GCC had been warning via -Woverride-init-side-effects all along).

buildObjConstrField now emits nothing for unset fields when the enclosing object is a union.