### PR TITLE
std/algorithm: sort on len < 2 must not touch the uninit temp buffer

### DIFF
--- a/lib/std/algorithm.nim
+++ b/lib/std/algorithm.nim
@@ -113,6 +113,10 @@ proc sort*[T](a: var openArray[T];
     assert d == ["fo", "qux", "boo", "barr"]
 
   var n = a.len
+  # len < 2 needs no work — and the temp buffer would be empty, making the
+  # manual `dealloc b.rawData` below free a bogus pointer (a SIGSEGV on some
+  # backends, a silent heap-header scribble on others).
+  if n < 2: return
   var b = newSeqUninit[T](n div 2)
   var s = 1
   while s < n:

--- a/tests/nimony/stdlib/talgorithm.nim
+++ b/tests/nimony/stdlib/talgorithm.nim
@@ -26,3 +26,12 @@ block:
   assert not isSorted([3, 2, 1], myCmpInt)
   assert isSorted(["a", "bc", "def", "ghij"], myCmpStr)
   assert not isSorted(["aaa", "bb", "c"], myCmpStr)
+
+block:
+  # len < 2: sort must not touch (or free) its empty temp buffer
+  var e: seq[int] = @[]
+  sort(e, myCmpInt)
+  assert e.len == 0
+  var one = @[42]
+  sort(one, myCmpInt)
+  assert one == @[42]


### PR DESCRIPTION
merge sort allocates `newSeqUninit[T](n div 2)` and manually `dealloc`s its raw data at the end. For `n < 2` that buffer is EMPTY, and freeing its bogus non-allocation pointer corrupts the heap — a SIGSEGV on some backends, a silent heap-header scribble on others, so every single-element sort was quietly dangerous. Return early: there is nothing to sort.

Regression shapes added to tests/nimony/stdlib/talgorithm.nim.