### PR TITLE
sizeof: fix never-decremented alias resolution loop counters

### DIFF
--- a/src/nimony/sizeof.nim
+++ b/src/nimony/sizeof.nim
@@ -137,6 +137,7 @@ proc getSize(c: var SizeofValue; cache: var Table[SymId, SizeofValue]; n: Cursor
   let cacheKey = if n.isSymbol: n.symId else: NoSymId
   var pragmas = default(TypePragmas)
   while counter > 0 and n.isSymbol:
+    dec counter
     if cache.hasKey(n.symId):
       # `hasKey` just returned true, so `getOrQuit` will not quit.
       let c2 = cache.getOrQuit(n.symId)
@@ -270,6 +271,7 @@ proc typeSectionMode(n: Cursor): PragmaKind =
   var n = n
   var counter = 20
   while counter > 0 and n.isSymbol:
+    dec counter
     let sym = tryLoadSym(n.symId)
     if sym.status == LacksNothing:
       var local = asTypeDecl(sym.decl)


### PR DESCRIPTION
The alias resolution loops in `getSize` and `typeSectionMode` use `while counter > 0 and n.isSymbol` as a guard but never decrement `counter`, so the loop can hang when the symbol chain stops advancing. Similar loops in `typenav.nim` and `typeprops.nim` all do `dec counter`; added the missing decrements.