### PR TITLE
fixes #2151; recompile modules when used plugins are changed

### DIFF
--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -158,6 +158,7 @@ type
     isSystem: bool
     plugin: string
     cyclicFiles: seq[int] ## indices into `files` that are cyclic module members (need separate outputs)
+    depsPlugins: HashSet[StrId] ## Set of plugins `files` uses except import plugins
 
   Command* = enum
     DoCheck, # like `nim check`
@@ -644,6 +645,31 @@ proc traverseDeps(c: var DepContext; p: FilePair; current: Node) =
   processDeps c, beginRead(buf), current
   if {SkipSystem, IsSystem} * c.moduleFlags == {} and not current.isSystem:
     importSystem c, current
+
+proc traverseDeps2(c: var DepContext) =
+  # Get the list of used plugins from deps2File so that Nimony generates a build file that
+  # automatically rebuild modules using the plugins when the plugins are modified.
+  # So don't need to get the list when deps2File doesn't exist as modules are semchecked then.
+  # Plugins used under `when false:` or template plugins used with templates never called are not listed in deps2File.
+  for current in c.nodes:
+    for p in current.files:
+      let depsFile = c.config.deps2File(p)
+      if semos.fileExists(depsFile):
+        var r = rd.open(depsFile)
+        var buf = createTokenBuf()
+        parse(r, buf)
+        rd.close(r)
+        var n = beginRead(buf)
+        if n.stmtKind == StmtsS:
+          n.loopInto:
+            if n.pragmaKind == PluginP:
+              n.loopInto:
+                if n.isStringLit:
+                  current.depsPlugins.incl n.strId
+                skip n
+            else:
+              skip n
+
 proc rootPath(c: DepContext): string =
   # XXX: Relative paths in build files are relative to current working directory, not the location of the build file.
   result = absoluteParentDir(c.rootNode.files[0].nimFile)
@@ -1475,6 +1501,10 @@ proc generateSemInstructions(c: DepContext; v: Node; b: var Builder; isMain: boo
     # Input: cached config file
     b.withTree "input":
       b.addStrLit c.config.cachedConfigFile()
+    # Input: plugins
+    for p in v.depsPlugins:
+      b.withTree "input":
+        b.addStrLit pool.strings[p]
     # Outputs: semmed file and index file for primary module
     let docMode = c.cmd == DoDoc
     b.withTree "output":
@@ -1604,6 +1634,8 @@ proc initDepContext(config: sink NifConfig; project, nifler: string; isFinal, fo
   result.nodes.add root
   result.processedModules[p.modname] = 0
   traverseDeps result, p, root
+  if not isFinal:
+    traverseDeps2 result
 
 proc buildGraphForEval*(config: NifConfig; mainNifFile: string; dependencyNifFiles: seq[string];
     flags: set[BuildFlag]; moduleFlags: set[ModuleFlag]) =

--- a/src/nimony/semdata.nim
+++ b/src/nimony/semdata.nim
@@ -198,6 +198,7 @@ type
     pendingTypePlugins*: Table[SymId, PluginObj]
     pendingModulePlugins*: seq[PluginObj]
     pluginBlacklist*: HashSet[StrId] # make 1984 fiction again
+    depsPlugins*: HashSet[StrId]  # paths of all plugins this module uses except Import plugins
     cachedTypeboundOps*: Table[(SymId, StrId), seq[SymId]]
     conceptCache*: RootRef
       ## Opaque concept-match cache; implementation in conceptcache.nim.

--- a/src/nimony/semmain.nim
+++ b/src/nimony/semmain.nim
@@ -103,6 +103,10 @@ proc writeNewDepsFile(c: var SemContext; outfile: string) =
       deps.buildTree TagId(PassCP), NoLineInfo:
         for i in c.passC:
           deps.addStrLit i
+    if c.depsPlugins.len != 0:
+      deps.buildTree TagId(PluginP), NoLineInfo:
+        for p in c.depsPlugins:
+          deps.addStrLit p, NoLineInfo
   let depsFile = changeModuleExt(outfile, ".s.deps.nif")
   onRaiseQuit writeFile(deps, depsFile, OnlyIfChanged)
 

--- a/src/nimony/semos.nim
+++ b/src/nimony/semos.nim
@@ -489,6 +489,7 @@ proc runPlugin*(c: var SemContext; dest: var TokenBuf; info: NifLineInfo;
   let nf = resolveFile(c.g.config.paths, getFile(info), pluginName)
   if needsRecompile(nf, pluginExe):
     compilePlugin(c, info, nf, pluginExe)
+  c.depsPlugins.incl pool.strings.getOrIncl nf
 
   try:
     writeFileIfChanged(inputFile, pluginInput)


### PR DESCRIPTION
Fixes https://github.com/nim-lang/nimony/issues/2151

Unlike https://github.com/nim-lang/nimony/pull/2179, get the list of used plugins from `*.s.deps.nif` generated by nimsem instead of `*.p.deps.nif` generated by Nifler.
So unused plugins (plugins under `when false:` branchs or template plugins used with templates never called) are ignored.