### PR TITLE
lengc/LLVM: name variant object branches in debug info

### DIFF
--- a/doc/internals/leng-spec.md
+++ b/doc/internals/leng-spec.md
@@ -198,7 +198,10 @@ ProcDecl ::= (proc SymbolDef Params Type ProcPragmas [Empty | StmtList])
 
 FieldDecl ::= (fld SymbolDef FieldPragmas Type)
 
-UnionDecl ::= (union [FieldDecl | AnonObjDecl | UnionDecl]*)
+UnionDecl ::= (union [FieldDecl | AnonObjDecl | UnionDecl]*) | # `{.union.}` form
+              (union UnionBranch+) # case object form
+UnionBranch ::= (of BranchRanges [AnonObjDecl | Empty]) |
+                (else [AnonObjDecl | Empty])
 AnonObjDecl ::= (object Empty [FieldDecl | AnonObjDecl | UnionDecl]*)
 ObjDecl ::= (object [Empty | Type] [FieldDecl | AnonObjDecl | UnionDecl]*)
 EnumFieldDecl ::= (efld SymbolDef Number)
@@ -284,6 +287,17 @@ Notes:
 - `varargs` is modelled as a special type but it must be combined with a named parameter
   just like any other parameters.
 - The type `flexarray` can only be used for a last field in an object declaration.
+- `union` has two forms and the child tag tells them apart: the `{.union.}` form
+  holds `fld`/`object`/`union` children, the case-object form holds `of`/`else`
+  children. The two never mix, because a `{.union.}` object cannot contain a
+  `case`. A case-object `union` is a *discriminated* union: the `of` branches
+  carry the `BranchRanges` that select them, and the **discriminator is the `fld`
+  immediately preceding the `union` among its siblings**. That position is an
+  invariant of the lowering, so a consumer reads the selector by remembering the
+  previous field rather than by searching. A branch with no fields is
+  `(of BranchRanges .)` — the empty body still records that the discriminant
+  value is legal. Both forms have identical memory layout: only the largest
+  branch's size matters.
 - The pragma `selectany` can be used to merge proc bodies that have the same name.
   It is used for generic procs so that only one generic instances remains in the
   final executable file.

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -89,7 +89,7 @@
 | `(if (elif X X)+ (else X)?)` | LengStmt, NimonyStmt, NiflerKind | if statement header |
 | `(when (elif X X)+ (else X)?)` | NimonyStmt, NimonyOther, NiflerKind | when statement header |
 | `(elif X X)` | LengOther, NimonyOther, NiflerKind | pair of (condition, action) |
-| `(else X)` | LengOther, NimonyOther, NiflerKind | `else` action |
+| `(else X)`; `(else .T)` | LengOther, NimonyOther, NiflerKind | `else` action, or the default branch of a Leng discriminated `union` |
 | `(typevars (typevar ...)*)` | NimonyOther, NiflerKind | type variable/generic parameters; after sem an entry may also be a `(staticTypevar ...)` |
 | `(break .Y)`; `(break)` | LengStmt, NimonyStmt, NiflerKind | `break` statement |
 | `(continue .Y)`; `(continue)` | NimonyStmt, NiflerKind, NjvlKind | `continue` statement |
@@ -97,14 +97,14 @@
 | `(while X S)` | LengStmt, NimonyStmt, NiflerKind| `while` statement |
 | `(corofor X S)` | NimonyStmt | closure-iterator for loop, lowered shape used between iterinliner and cps; first child is the iterator call, second child is a `(stmts ...)` whose first inner statement is a `(var :forLoopVar T .)` declaration that receives each yielded value |
 | `(case X (of (ranges...) S)+ (else X)?)` | LengStmt, NimonyStmt, NimonyOther, NiflerKind | `case` statement |
-| `(of (ranges ...) S)` | LengOther, NimonyOther, NiflerKind | `of` branch within a `case` statement |
+| `(of (ranges ...) S)`; `(of (ranges ...) .T)` | LengOther, NimonyOther, NiflerKind | `of` branch within a `case` statement, or of a Leng discriminated `union` |
 | `(lab D)` | LengStmt, LengSym, NimonyStmt, NimonySym, NjvlKind | label, target of a `jmp` instruction. Also a **Nimony** statement: `xelim` lowers short-circuit `and`/`or` chains to the flat `(if c (jmp L))` / `(lab L)` form (the two-target condition compiler, see `doc/final_ir.md`), which needs a merge label that is not an enclosing region's end — something `(block)`/`(break)` cannot express without one wrapper per merge |
 | `(jmp Y)` | LengStmt, NimonyStmt, NjvlKind | jump/goto instruction. In Nimony IR it is **forward-only and scoped**: it may leave enclosing constructs but never enter one, and it never crosses a scope that owns destructible locals |
 | `(ret .X)` | LengStmt, NimonyStmt, NiflerKind | `return` instruction |
 | `(yld .X)` | NimonyStmt, NiflerKind | yield statement |
 | `(stmts S*)` | LengStmt, NimonyStmt, NimonyOther, NiflerKind | list of statements |
 | `(params (param...)*)` | LengType, NimonyOther, NiflerKind | list of proc parameters, also used as a "proc type" |
-| `(union (fld ...)*)`; `(union)` | LengType, NimonyPragma | first one is Leng union declaration, second one is Nimony union pragma |
+| `(union (fld ...)*)`; `(union (of ...)+)`; `(union)` | LengType, NimonyPragma | first two are Leng union declarations (untagged, and discriminated from a case object - see `doc/internals/leng-spec.md`), third is the Nimony union pragma |
 | `(object .T (fld ...)*)` | LengType, NimonyType, NiflerKind | object type declaration |
 | `(enum (efld...)*)` | LengType, NimonyType, NiflerKind | enum type declaration |
 | `(proctype .Any (params...) T P)`; `(proctype ...)` | NimonyType, NiflerKind, LengType | Nimony proc type. Slot 0 carries the nilability tag — either a `.` placeholder or one of `(notnil)`, `(nil)`, `(unchecked)`. Leng proc type, same shape as `(proc D ...)` with anonymous name slot (varargs spec; effects/body slots present but unused). |

--- a/src/hexer/lengcgen.nim
+++ b/src/hexer/lengcgen.nim
@@ -480,41 +480,65 @@ proc addRttiField(c: var EContext; dest: var TokenBuf; info: NifLineInfo) =
   dest.addParRi() # "ptr"
   dest.addParRi() # "fld"
 
+proc trObjFields(c: var EContext; dest: var TokenBuf; n: var Cursor; flags: set[TypeFlag])
+
+proc trBranchRanges(c: var EContext; dest: var TokenBuf; n: var Cursor) =
+  ## Copy the `(ranges ...)` selector list of an `of` branch. Shared by the
+  ## `case` statement (`trCase`) and the case-object lowering in `trObjFields`,
+  ## so both spell branch values identically. Note `trExpr` folds an enum
+  ## symbol to its integer value, so the output carries numbers, not names.
+  if n.isTagLit and n.substructureKind == RangesU:
+    takeInto dest, n:            # (ranges ...)
+      while n.hasMore:
+        if n.isTagLit and n.substructureKind == RangeU:
+          takeInto dest, n:      # (range lo hi)
+            while n.hasMore:
+              trExpr c, dest, n
+        else:
+          trExpr c, dest, n
+  else:
+    trExpr c, dest, n
+
+proc trBranchBody(c: var EContext; dest: var TokenBuf; n: var Cursor;
+                  flags: set[TypeFlag]) =
+  ## Emit a branch's fields as an anonymous object, or `.` when the branch
+  ## declares none (`of x: nil`). The empty form still records that the
+  ## discriminant values of this branch are legal.
+  assert n.stmtKind == StmtsS
+  n.into:
+    if n.exprKind == NilX:
+      skip n
+      dest.addDotToken
+    else:
+      dest.addParLe("object", n.endInfo)
+      dest.addDotToken  # base type
+      trObjFields(c, dest, n, flags)
+      dest.addParRi # end of object
+
 proc trObjFields(c: var EContext; dest: var TokenBuf; n: var Cursor; flags: set[TypeFlag]) =
   while n.hasMore:
     case n.substructureKind
     of FldU, GfldU:
       trField(c, dest, n, flags)
     of CaseU:
-      # XXX for now counts each case object field as separate
+      # A case object becomes a *discriminated* union: the selector is emitted
+      # as an ordinary field and the branches keep the `(ranges ...)` that
+      # select them, so debug info can map a discriminant value to its branch
+      # (see `doc/leng-spec.md`, UnionBranch). The discriminator is found
+      # positionally by consumers - it is the `fld` emitted immediately before
+      # the `union`, which the two statements below establish.
       n.into:
         trField(c, dest, n, flags)
         dest.addParLe("union", n.info)
         while n.hasMore:
           case n.substructureKind
           of OfU:
-            n.into:
-              skip n
-              assert n.stmtKind == StmtsS
-              n.into:
-                if n.exprKind == NilX:
-                  skip n
-                else:
-                  dest.addParLe("object", n.endInfo)
-                  dest.addDotToken  # base type
-                  trObjFields(c, dest, n, flags)
-                  dest.addParRi # end of object
+            takeInto dest, n:      # (of ...)
+              trBranchRanges c, dest, n
+              trBranchBody c, dest, n, flags
           of ElseU:
-            n.into:
-              assert n.stmtKind == StmtsS
-              n.into:
-                if n.exprKind == NilX:
-                  skip n
-                else:
-                  dest.addParLe("object", n.endInfo)
-                  dest.addDotToken  # base type
-                  trObjFields(c, dest, n, flags)
-                  dest.addParRi # end of object
+            takeInto dest, n:      # (else ...)
+              trBranchBody c, dest, n, flags
           of NilU, NotnilU, KvU, VvU, RangeU, RangesU, ParamU,
               TypevarU, StaticTypevarU, EfldU, FldU, WhenU, ElifU, TypevarsU,
               CaseU, StmtsU, ParamsU, PragmasU, EitherU, JoinU,
@@ -2045,21 +2069,7 @@ proc trCase(c: var EContext; dest: var TokenBuf; n: var Cursor) =
       case n.substructureKind
       of OfU:
         takeInto dest, n:
-          if n.isTagLit and n.substructureKind == RangesU:
-            n.into:
-              dest.add "ranges", n.endInfo
-              while n.hasMore:
-                if n.isTagLit and n.substructureKind == RangeU:
-                  n.into:
-                    dest.add "range", n.endInfo
-                    while n.hasMore:
-                      trExpr c, dest, n
-                    dest.addParRi(n.endInfo)
-                else:
-                  trExpr c, dest, n
-              dest.addParRi(n.endInfo)
-          else:
-            trExpr c, dest, n
+          trBranchRanges c, dest, n
           trStmt c, dest, n
       of ElseU:
         takeInto dest, n:

--- a/src/lengc/gentypes.nim
+++ b/src/lengc/gentypes.nim
@@ -152,6 +152,11 @@ proc traverseObjectBody(m: var MainModule; o: var TypeOrder; t: Cursor) =
         elif n.typeKind in {ObjectT, UnionT}: # anonymous object/union
           traverseObjectBody(m, o, n)  # recurse into the anonymous subtree
           skip n                        # advance past it
+        elif isUnionBranch(n):          # discriminated union branch
+          let b = asUnionBranch(n)
+          if b.body.typeKind == ObjectT:
+            traverseObjectBody(m, o, b.body)
+          skip n
         else:
           error m, "unexpected node inside object: ", n
           skip n
@@ -549,6 +554,20 @@ proc genObjectOrUnionBody(c: var GeneratedCode; n: var Cursor) =
           genObjectOrUnionBody(c, n)
           c.add CurlyRi
           c.add Semicolon
+        elif isUnionBranch(n):
+          # A discriminated-union branch. C has no variant concept, so the
+          # `(ranges ...)` are ignored and only the payload is emitted - the
+          # same anonymous struct this branch produced before the branches
+          # were tagged. A field-less branch emits nothing, as before.
+          let b = asUnionBranch(n)
+          if b.body.typeKind == ObjectT:
+            var body = b.body
+            c.add AnonStruct
+            c.add CurlyLe
+            genObjectOrUnionBody(c, body)
+            c.add CurlyRi
+            c.add Semicolon
+          skip n
         else:
           error c.m, "expected `fld` but got: ", n
           skip n

--- a/src/lengc/llvmdebug.nim
+++ b/src/lengc/llvmdebug.nim
@@ -522,8 +522,57 @@ proc genDITypeForSymbol(c: var LLVMCode; symId: SymId): int =
 
 # ---- Composite type (struct / union) ----------------------------------
 
-proc genDIUnionType(c: var LLVMCode; n: var Cursor): int
-proc genDIAnonObject(c: var LLVMCode; n: var Cursor): int
+proc genDIUnionType(c: var LLVMCode; n: var Cursor; selectorType = default(Cursor)): int
+proc genDIAnonObject(c: var LLVMCode; n: var Cursor; name = ""): int
+
+proc enumFieldName(c: var LLVMCode; enumType: Cursor; value: int64): string =
+  ## Map a discriminant value back to its enum field name. `lengcgen` folds enum
+  ## symbols to plain integers when it copies a branch's `(ranges ...)`, so the
+  ## name has to be recovered from the selector's own `(enum ...)` declaration,
+  ## which sits in the same module.
+  result = ""
+  if cursorIsNil(enumType): return
+  var t = enumType
+  if t.kind == Symbol:
+    let d = c.m.getDeclOrNil(t.symId)
+    if d == nil or d.kind != TypeY: return
+    t = asTypeDecl(d.pos).body
+  if t.typeKind != EnumT: return
+  t.into:
+    skip t  # underlying integer type
+    while t.hasMore:
+      if t.substructureKind == EfldU and result.len == 0:
+        var f = t
+        f.into:
+          if f.kind == SymbolDef:
+            let nameSym = f.symId
+            inc f
+            var v = int64(0)
+            if f.kind == IntLit: v = intVal(f)
+            elif f.kind == UIntLit: v = int64(uintVal(f))
+            if v == value:
+              result = nifSymBaseName(c, nameSym)
+          while f.hasMore: skip f
+      skip t
+
+proc branchName(c: var LLVMCode; b: UnionBranch; selectorType: Cursor): string =
+  ## Name a union branch after the first discriminant value that selects it.
+  ## An `else` branch has no `ranges` to name it after, but leaving it unnamed
+  ## reproduces the very problem this is fixing, so it gets the literal name.
+  result = ""
+  if cursorIsNil(b.ranges) or b.ranges.substructureKind != RangesU:
+    return "else"
+  var r = b.ranges
+  r.into:
+    if r.hasMore:
+      var v = r
+      if v.substructureKind == RangeU:  # `(range lo hi)`: name after `lo`
+        v = v.childCursor
+      if v.kind == IntLit:
+        result = enumFieldName(c, selectorType, intVal(v))
+      elif v.kind == UIntLit:
+        result = enumFieldName(c, selectorType, int64(uintVal(v)))
+    while r.hasMore: skip r
 
 proc diElemsList(members: seq[int]): string =
   result = ""
@@ -561,12 +610,14 @@ proc addFieldMember(c: var LLVMCode; fd: FieldDecl; members: var seq[int];
   fieldOffset += fieldSize
 
 proc addUnionMember(c: var LLVMCode; n: var Cursor; members: var seq[int];
-                    fieldOffset: var int) =
+                    fieldOffset: var int; selectorType: Cursor) =
   ## Add the embedded union ``n`` (UnionT) as a single member whose baseType
   ## is an anonymous DICompositeType union. Consumes ``n``.
+  ## ``selectorType`` is the discriminator field's type for a case object, used
+  ## to name each branch after the enum value that selects it.
   let uSize = typeSizeBits(c, n)
   let uAlign = typeAlignBits(c, n)
-  let udi = genDIUnionType(c, n)
+  let udi = genDIUnionType(c, n, selectorType)
   if uAlign > 0:
     fieldOffset = ((fieldOffset + uAlign - 1) div uAlign) * uAlign
   if udi != 0:
@@ -580,13 +631,16 @@ proc addUnionMember(c: var LLVMCode; n: var Cursor; members: var seq[int];
     members.add c.addMetadata(mStr)
   fieldOffset += uSize
 
-proc genDIAnonObject(c: var LLVMCode; n: var Cursor): int =
-  ## Generate an anonymous DICompositeType struct for an inline object body.
+proc genDIAnonObject(c: var LLVMCode; n: var Cursor; name = ""): int =
+  ## Generate a DICompositeType struct for an inline object body. ``name`` is
+  ## set for a case object's branch payload so a debugger can print which
+  ## branch it is looking at; otherwise the struct stays anonymous.
   var members: seq[int] = @[]
   var fieldOffset = 0
   let oSize = typeSizeBits(c, n)
   let oAlign = typeAlignBits(c, n)
   let kind = n.typeKind
+  var selectorType = default(Cursor)
   n.into:
     if kind == ObjectT:
       if n.kind == DotToken: inc n
@@ -594,19 +648,28 @@ proc genDIAnonObject(c: var LLVMCode; n: var Cursor): int =
     while n.hasMore:
       if n.substructureKind == FldU:
         var fd = takeFieldDecl(n)
+        selectorType = fd.typ   # a union sees the field just before it
         addFieldMember(c, fd, members, fieldOffset)
       elif n.typeKind == UnionT:
-        addUnionMember(c, n, members, fieldOffset)
+        addUnionMember(c, n, members, fieldOffset, selectorType)
       else:
         skip n
-  result = c.addMetadata("!DICompositeType(tag: DW_TAG_structure_type" &
-    ", elements: !{" & diElemsList(members) & "}" &
+  var s = "!DICompositeType(tag: DW_TAG_structure_type"
+  if name.len > 0:
+    s.add ", name: \"" & name & "\""
+  s.add ", elements: !{" & diElemsList(members) & "}" &
     ", size: " & $oSize &
-    ", align: " & $oAlign & ")")
+    ", align: " & $oAlign & ")"
+  result = c.addMetadata(s)
 
-proc genDIUnionType(c: var LLVMCode; n: var Cursor): int =
+proc genDIUnionType(c: var LLVMCode; n: var Cursor; selectorType = default(Cursor)): int =
   ## Generate an anonymous DICompositeType union for an inline union body.
   ## Each branch (nested object / field) becomes an overlapping member.
+  ##
+  ## For a case object the branches arrive tagged (`(of RANGES BODY)`), and each
+  ## member is named after the enum value that selects it. Without those names
+  ## a debugger prints the branches as unnamed members, which is what
+  ## nim-lang/nimony#2068 reports.
   var members: seq[int] = @[]
   let uSize = typeSizeBits(c, n)
   let uAlign = typeAlignBits(c, n)
@@ -626,6 +689,21 @@ proc genDIUnionType(c: var LLVMCode; n: var Cursor): int =
         if ndi != 0:
           members.add c.addMetadata("!DIDerivedType(tag: DW_TAG_member" &
             ", baseType: !" & $ndi & ")")
+      elif isUnionBranch(n):
+        let b = asUnionBranch(n)
+        if b.body.typeKind == ObjectT:
+          let bname = branchName(c, b, selectorType)
+          var body = b.body
+          let bdi = genDIAnonObject(c, body, bname)
+          if bdi != 0:
+            var mStr = "!DIDerivedType(tag: DW_TAG_member"
+            if bname.len > 0:
+              mStr.add ", name: \"" & bname & "\""
+            mStr.add ", baseType: !" & $bdi &
+              ", size: " & $typeSizeBits(c, b.body) &
+              ", align: " & $typeAlignBits(c, b.body) & ")"
+            members.add c.addMetadata(mStr)
+        skip n
       else:
         skip n
   result = c.addMetadata("!DICompositeType(tag: DW_TAG_union_type" &
@@ -691,12 +769,17 @@ proc genDICompositeType(c: var LLVMCode; n: var Cursor): int =
             ", offset: 0, flags: 0)")
         inc body
 
+    var selectorType = default(Cursor)
     while body.hasMore:
       if body.substructureKind == FldU:
         var fd = takeFieldDecl(body)
+        # A case object's discriminator is the field directly before the union
+        # (an invariant of `lengcgen.trObjFields`), so remembering the last
+        # field is enough to name the branches.
+        selectorType = fd.typ
         addFieldMember(c, fd, members, fieldOffset)
       elif body.typeKind == UnionT:
-        addUnionMember(c, body, members, fieldOffset)
+        addUnionMember(c, body, members, fieldOffset, selectorType)
       elif body.typeKind == ObjectT:
         skip body
       else:

--- a/src/lengc/llvmgentypes.nim
+++ b/src/lengc/llvmgentypes.nim
@@ -220,6 +220,12 @@ proc typeSizeBits(c: var LLVMCode; n: Cursor): int =
           let sz = typeSizeBits(c, nn)
           if sz > result: result = sz
           skip nn
+        elif isUnionBranch(nn):
+          let b = asUnionBranch(nn)
+          if b.body.typeKind == ObjectT:
+            let sz = typeSizeBits(c, b.body)
+            if sz > result: result = sz
+          skip nn
         else:
           skip nn
   of VoidT, VarargsT, ParamsT:
@@ -271,6 +277,12 @@ proc typeAlignBits(c: var LLVMCode; n: Cursor): int =
           let a = typeAlignBits(c, nn)
           if a > result: result = a
           skip nn
+        elif isUnionBranch(nn):
+          let b = asUnionBranch(nn)
+          if b.body.typeKind == ObjectT:
+            let a = typeAlignBits(c, b.body)
+            if a > result: result = a
+          skip nn
         else:
           skip nn
   else:
@@ -312,6 +324,18 @@ proc collectUnionCandidates(c: var LLVMCode; n: Cursor;
           typ: genUnionBodyLLVM(c, u),
           sizeBits: typeSizeBits(c, nn),
           alignBits: typeAlignBits(c, nn))
+        skip nn
+      elif isUnionBranch(nn):
+        # Discriminated-union branch: only the payload contributes to layout.
+        # A field-less branch adds no candidate, exactly as an omitted branch
+        # did before the branches were tagged.
+        let b = asUnionBranch(nn)
+        if b.body.typeKind == ObjectT:
+          var obj = b.body
+          candidates.add UnionCandidate(
+            typ: genObjectBodyLLVM(c, obj),
+            sizeBits: typeSizeBits(c, b.body),
+            alignBits: typeAlignBits(c, b.body))
         skip nn
       else:
         skip nn
@@ -484,6 +508,25 @@ proc searchFieldIdx(c: var LLVMCode; body: var Cursor; fldSym: SymId;
               access = FieldAccess(isBranch: true, index: unionIdx,
                   branchType: brType, branchIndex: innerAccess.index)
               return true
+          elif isUnionBranch(search):
+            # Discriminated-union branch: the payload object is what carries
+            # the fields, so this resolves exactly like the untagged branch
+            # above. Missing this arm would fall through to `skip search`,
+            # leaving `access.index` at the union rather than the field - a
+            # silently wrong GEP index, not a compile error.
+            let b = asUnionBranch(search)
+            if b.body.typeKind == ObjectT:
+              var brCur = b.body
+              let brType = genObjectBodyLLVM(c, brCur)
+              var innerAccess = FieldAccess()
+              var brBfAccum = 0'i64
+              var brBfUnit = 0
+              var inner = b.body
+              if searchFieldIdx(c, inner, fldSym, innerAccess, brBfAccum, brBfUnit):
+                access = FieldAccess(isBranch: true, index: unionIdx,
+                    branchType: brType, branchIndex: innerAccess.index)
+                return true
+            skip search
           else:
             skip search
         body = unionBody
@@ -785,6 +828,21 @@ proc genGlobalConstr(c: var LLVMCode; n: var Cursor;
                                 fieldNifTypes.add fdecl.typ
                               else:
                                 skip body
+                        elif isUnionBranch(body):
+                          # Discriminated-union branch: collect its payload's
+                          # fields, same as the untagged branch above.
+                          let b = asUnionBranch(body)
+                          if b.body.typeKind == ObjectT:
+                            var inner = b.body
+                            inner.into:
+                              if inner.kind == DotToken: inc inner
+                              while inner.hasMore:
+                                if inner.substructureKind == FldU:
+                                  var fdecl = takeFieldDecl(inner)
+                                  fieldNifTypes.add fdecl.typ
+                                else:
+                                  skip inner
+                          skip body
                         else:
                           skip body
                   else:

--- a/src/lengc/shoggoth/aliasing.nim
+++ b/src/lengc/shoggoth/aliasing.nim
@@ -81,6 +81,19 @@ proc pointerBearing(m: ptr MainModule; typ: Cursor; depth = 0): bool =
         if body.substructureKind == FldU:
           let fld = takeFieldDecl(body)
           if pointerBearing(m, fld.typ, depth+1): return true
+        elif isUnionBranch(body):
+          # A discriminated-union branch holds its fields in a payload object.
+          # Skipping it would report a variant whose only pointer lives in a
+          # branch as pointer-free - an *under*-merge, which is exactly the
+          # unsound direction for this analysis (a missed invalidation).
+          let b = takeUnionBranch(body)
+          if b.body.typeKind == ObjectT and pointerBearing(m, b.body, depth+1):
+            return true
+        elif body.typeKind in {ObjectT, UnionT}:
+          # Anonymous object/union nested in this body. Same reasoning: the
+          # `skip` below would hide any pointer inside it.
+          if pointerBearing(m, body, depth+1): return true
+          skip body
         else:
           skip body
   of NoType:

--- a/src/lengc/typenav.nim
+++ b/src/lengc/typenav.nim
@@ -165,6 +165,13 @@ proc typeOfField*(c: var MainModule; n: var Cursor; fld: SymId;
       result = if sel == FieldType: decl.typ else: decl.pragmas
     else:
       result = default(Cursor)
+  elif isUnionBranch(n):
+    # Discriminated-union branch: the fields live in its payload object.
+    result = default(Cursor)
+    let b = takeUnionBranch(n)   # advances `n` past the whole branch
+    if b.body.typeKind == ObjectT:
+      var body = b.body
+      result = typeOfField(c, body, fld, sel)
   else:
     result = default(Cursor)
     let tk = n.typeKind
@@ -187,6 +194,11 @@ proc typeOfField*(c: var MainModule; n: var Cursor; fld: SymId;
           if d != nil and d.pos.stmtKind == TypeS:
             var baseBody = asTypeDecl(d.pos).body
             result = typeOfField(c, baseBody, fld, sel)
+    else:
+      # Unknown node. Every other path advances `n`, and the caller above
+      # loops `while n.hasMore and not done` - so failing to advance here is
+      # an infinite loop, not a missed field. Keep the walk progressing.
+      skip n
 
 proc navigateToObjectBody*(c: var MainModule; n: Cursor): Cursor =
   var counter = 20

--- a/src/lib/nifcdecl.nim
+++ b/src/lib/nifcdecl.nim
@@ -140,6 +140,34 @@ proc takeFieldDecl*(n: var Cursor): FieldDecl =
     skip n
 
 type
+  UnionBranch* = object
+    ranges*: Cursor  ## the `(ranges ...)` selecting this branch; `.` for `else`
+    body*: Cursor    ## the branch's anonymous `(object ...)`, or `.` if it
+                     ## declares no fields (`of x: nil`)
+
+proc isUnionBranch*(n: Cursor): bool {.inline.} =
+  ## True if `n` is a discriminated-union branch, i.e. a case object lowered by
+  ## hexer rather than the untagged `{.union.}` form. The two shapes never mix,
+  ## so testing the child tag is enough - see `doc/leng-spec.md`, UnionBranch.
+  n.substructureKind in {OfU, ElseU}
+
+proc takeUnionBranch*(n: var Cursor): UnionBranch =
+  ## Read a `(of RANGES BODY)` / `(else BODY)` branch and advance past it.
+  ## Callers that only need the fields use `result.body`; debug info also reads
+  ## `result.ranges` to name the branch after its discriminant values.
+  let isOf = n.substructureKind == OfU
+  n.into:
+    if isOf:
+      result.ranges = n
+      skip n
+    result.body = n
+    skip n
+
+proc asUnionBranch*(n: Cursor): UnionBranch =
+  var n = n
+  takeUnionBranch(n)  # local cursor is dropped on return
+
+type
   ParamDecl* = object
     name*, pragmas*, typ*: Cursor
 

--- a/src/models/leng_tags.nim
+++ b/src/models/leng_tags.nim
@@ -96,7 +96,7 @@ type
   LengType* = enum
     NoType
     ParamsT = (ord(ParamsTagId), "params")  ## list of proc parameters, also used as a "proc type"
-    UnionT = (ord(UnionTagId), "union")  ## first one is Leng union declaration, second one is Nimony union pragma
+    UnionT = (ord(UnionTagId), "union")  ## first two are Leng union declarations (untagged, and discriminated from a case object - see `doc/internals/leng-spec.md`), third is the Nimony union pragma
     ObjectT = (ord(ObjectTagId), "object")  ## object type declaration
     EnumT = (ord(EnumTagId), "enum")  ## enum type declaration
     ProctypeT = (ord(ProctypeTagId), "proctype")  ## Nimony proc type. Slot 0 carries the nilability tag — either a `.` placeholder or one of `(notnil)`, `(nil)`, `(unchecked)`. Leng proc type, same shape as `(proc D ...)` with anonymous name slot (varargs spec; effects/body slots present but unused).
@@ -127,8 +127,8 @@ type
     EfldU = (ord(EfldTagId), "efld")  ## enum field declaration; slot 2 carries the export marker *or* the compile-time value (may be `.`)
     FldU = (ord(FldTagId), "fld")  ## field declaration
     ElifU = (ord(ElifTagId), "elif")  ## pair of (condition, action)
-    ElseU = (ord(ElseTagId), "else")  ## `else` action
-    OfU = (ord(OfTagId), "of")  ## `of` branch within a `case` statement
+    ElseU = (ord(ElseTagId), "else")  ## `else` action, or the default branch of a Leng discriminated `union`
+    OfU = (ord(OfTagId), "of")  ## `of` branch within a `case` statement, or of a Leng discriminated `union`
     PragmasU = (ord(PragmasTagId), "pragmas")  ## begin of pragma section
 
 proc rawTagIsLengOther*(raw: TagEnum): bool {.inline.} =

--- a/src/models/nifler_tags.nim
+++ b/src/models/nifler_tags.nim
@@ -43,14 +43,14 @@ type
     IfL = (ord(IfTagId), "if")  ## if statement header
     WhenL = (ord(WhenTagId), "when")  ## when statement header
     ElifL = (ord(ElifTagId), "elif")  ## pair of (condition, action)
-    ElseL = (ord(ElseTagId), "else")  ## `else` action
+    ElseL = (ord(ElseTagId), "else")  ## `else` action, or the default branch of a Leng discriminated `union`
     TypevarsL = (ord(TypevarsTagId), "typevars")  ## type variable/generic parameters; after sem an entry may also be a `(staticTypevar ...)`
     BreakL = (ord(BreakTagId), "break")  ## `break` statement
     ContinueL = (ord(ContinueTagId), "continue")  ## `continue` statement
     ForL = (ord(ForTagId), "for")  ## for statement
     WhileL = (ord(WhileTagId), "while")  ## `while` statement
     CaseL = (ord(CaseTagId), "case")  ## `case` statement
-    OfL = (ord(OfTagId), "of")  ## `of` branch within a `case` statement
+    OfL = (ord(OfTagId), "of")  ## `of` branch within a `case` statement, or of a Leng discriminated `union`
     RetL = (ord(RetTagId), "ret")  ## `return` instruction
     YldL = (ord(YldTagId), "yld")  ## yield statement
     StmtsL = (ord(StmtsTagId), "stmts")  ## list of statements

--- a/src/models/nimony_tags.nim
+++ b/src/models/nimony_tags.nim
@@ -273,10 +273,10 @@ type
     GfldU = (ord(GfldTagId), "gfld")  ## guarded field declaration, cannot be accessed outside an `of` branch
     WhenU = (ord(WhenTagId), "when")  ## when statement header
     ElifU = (ord(ElifTagId), "elif")  ## pair of (condition, action)
-    ElseU = (ord(ElseTagId), "else")  ## `else` action
+    ElseU = (ord(ElseTagId), "else")  ## `else` action, or the default branch of a Leng discriminated `union`
     TypevarsU = (ord(TypevarsTagId), "typevars")  ## type variable/generic parameters; after sem an entry may also be a `(staticTypevar ...)`
     CaseU = (ord(CaseTagId), "case")  ## `case` statement
-    OfU = (ord(OfTagId), "of")  ## `of` branch within a `case` statement
+    OfU = (ord(OfTagId), "of")  ## `of` branch within a `case` statement, or of a Leng discriminated `union`
     StmtsU = (ord(StmtsTagId), "stmts")  ## list of statements
     ParamsU = (ord(ParamsTagId), "params")  ## list of proc parameters, also used as a "proc type"
     PragmasU = (ord(PragmasTagId), "pragmas")  ## begin of pragma section
@@ -300,7 +300,7 @@ type
     CastP = (ord(CastTagId), "cast")  ## `cast` operation (typed cast expression, or `{.cast(pragma).}` pragma form)
     CursorP = (ord(CursorTagId), "cursor")  ## cursor variable declaration
     EmitP = (ord(EmitTagId), "emit")  ## emit statement
-    UnionP = (ord(UnionTagId), "union")  ## first one is Leng union declaration, second one is Nimony union pragma
+    UnionP = (ord(UnionTagId), "union")  ## first two are Leng union declarations (untagged, and discriminated from a case object - see `doc/internals/leng-spec.md`), third is the Nimony union pragma
     InlineP = (ord(InlineTagId), "inline")  ## `inline` proc annotation
     NoinlineP = (ord(NoinlineTagId), "noinline")  ## `noinline` proc annotation
     ClosureP = (ord(ClosureTagId), "closure")  ## `closure` proc annotation; not a calling convention anymore, simply annotates a proc as a closure


### PR DESCRIPTION
fixes #2068

`p e1` on a variant object showed unnamed members instead of naming the active branch:

```
(Expr) {
  kind = ekInt
   = {
     = (intVal = 42, floatVal = 3.1400000000000001)
     = { strVal = {...} }
  }
}
```

`llvmdebug` renders what it is given, and the mapping from `kind` values to branches never reached it. `hexer/lengcgen.trObjFields` lowered a case object to a bare `(union (object ...)+)`, dropping each branch's `(ranges ...)` with a `skip n` and emitting nothing at all for a field-less branch. So which values select which branch, and which field is the selector, were both gone by the time the backend ran. That is why this touches two layers.

## Leng gains a discriminated union

```
UnionDecl   ::= (union [FieldDecl | AnonObjDecl | UnionDecl]*)   # {.union.}, unchanged
              | (union UnionBranch+)                             # case object
UnionBranch ::= (of BranchRanges [AnonObjDecl | Empty])
              | (else [AnonObjDecl | Empty])
```

```
(fld :kind.0 . ExprKind.0.)
(union
 (of (ranges 0 1) (object . (fld :intVal.0 ...) (fld :floatVal.0 ...)))
 (of (ranges 2)   (object . (fld :strVal.0 ...)))
 (of (ranges 3).))                                   # `of ekNone: nil`
```

No new tags. `of`, `ranges` and `else` are already `LengOther` and both backends already decode that shape, so `src/models/tags.nim` comes back byte-identical from `gen_tags` and only doc comments move. That also lines up with #1946, which keeps `case` "as existing (quite complex with range handling etc.)".

The discriminator stays positional, meaning the `fld` emitted immediately before the `union`. `trObjFields` establishes that by construction and every consumer already walks union siblings forward, so nothing needs a backward cursor or an extra slot. A `{.union.}` object can never contain a `case` (asserted at `sizeof.nim:87`), so the child tag alone separates the two forms.

Field-less branches now emit `(of RANGES .)` instead of vanishing, which keeps their discriminant value.

## Naming the branches

`llvmdebug` names each branch member and its payload struct after the enum value that selects it. `lengcgen` folds enum symbols to integers when it copies the ranges, so the name has to be recovered from the selector's own `(enum ...)` decl.

```llvm
!15 = !DICompositeType(tag: DW_TAG_structure_type, name: "ekInt", elements: !{!12, !14}, ...)
!16 = !DIDerivedType(tag: DW_TAG_member, name: "ekInt", baseType: !15, ...)
!32 = !DICompositeType(tag: DW_TAG_structure_type, name: "ekStr", ...)
!82 = !DICompositeType(tag: DW_TAG_structure_type, name: "else", ...)
```

An `else` branch has no ranges to name it after, so it gets the literal name `else`. Leaving it anonymous would reproduce the reported bug for every variant with a default branch.

## Why not `DW_TAG_variant_part`

That is the semantically correct DWARF and I built it first, but lldb 22.1.8 cannot parse the tag:

```
error: unhandled type tag DW_TAG_variant_part (DW_TAG_variant_part), please file a bug
(Expr)  (kind = '\0')
```

The payload disappears entirely, which is worse than the bug being fixed. It is not a fan-out limitation either, single-value branches fail the same way. gdb 15.1 does render it correctly, so a variant part is worth adding later behind a flag, but the default has to work on the toolchain this repo pins in its own `clang.args`.

## Consumers

Nine `src/lengc` walks learned to descend the new wrapper, through one shared helper in `nifcdecl.nim`. Two of them were failing silently rather than loudly.

`typenav.typeOfField` never advanced its cursor on an unrecognised node, and its caller loops `while n.hasMore and not done`, so an `of` child was an infinite loop rather than a missed field.

`aliasing.pointerBearing` skipped what it did not recognise and returned false, so a variant whose only pointer lives in a branch read as pointer-free. That is the unsound direction for alias analysis. The same function already skipped nested anonymous object/union children before this change, so that hole existed independently, and both now descend.

`addObjectFieldsLLVM` needed no change. Its callers only ever enter an object or union body, and branches route through `genUnionBodyLLVM` instead.

arkham consumes Leng too, from the sibling `nativenif` repo, and had four walks with the same assumption. That is nim-lang/nativenif#93, merged, and included in the `src/nativenif.commit` pin this branch builds against.

## Verification

Built the toolchain under WSL (Nim 2.2.10, clang 18) and ran a probe covering a multi-value branch, a single-value branch with a `string` field, a field-less branch and an `else`.

- generated C is unchanged, anonymous struct per branch as before
- runtime read-back of every branch field returns the right values, including mutate-then-read, which is the real guard on the GEP index change in `searchFieldIdx`
- LLVM layout `%Expr = type { i8, { { i64, double } } }`, branch access at `i32 0, i32 1`
- post-lengcgen validator over a 123-file `.c.nif` corpus: 280 violations before the grammar edit, 276 after, none new. The four that disappear are exactly the ones this lowering would otherwise have introduced.

Re-verified after rebasing onto current master:

- `gen_tags` leaves `src/models/tags.nim` byte-identical
- native suite **101 / 101**
- main suite **723 / 740**, failing set byte-identical to pristine master in the same sandbox, so no regressions (those 17 are pre-existing concept failures unrelated to this change)

## Not covered by a test

A `case` nested inside another branch is the one shape with no coverage anywhere, so I wrote a test for it. It crashes nimsem at `sem.nim:3808 buildObjConstrField` reaching `nifcore.nim:428`. A nimsem built from pristine master crashes identically, so it predates this PR, and construction is the trigger while a bare declaration is fine. That is #2234. I left the test out rather than add a red one.
