### PR TITLE
fix stale isMainModule self-tests in sizeof.nim and mangler.nim

### DIFF
--- a/src/lengc/mangler.nim
+++ b/src/lengc/mangler.nim
@@ -96,7 +96,7 @@ proc makeCString*(s: string): string =
 when isMainModule:
   import std/assertions
 
-  assert mangle"foo.3.baz" == "foo_3_baz"
-  assert mangle"Query?" == "QQueryqmarkQ"
-  assert mangle"abc_def_[]=" == "abcQ_defQ_putQ"
-  assert mangle"[]" == "getQ"
+  assert mangleToC"foo.3.baz" == "foo_3_baz"
+  assert mangleToC"Query?" == "QQueryqmarkQ"
+  assert mangleToC"abc_def_[]=" == "abcQ_defQ_putQ"
+  assert mangleToC"[]" == "getQ"

--- a/src/nimony/sizeof.nim
+++ b/src/nimony/sizeof.nim
@@ -307,14 +307,14 @@ when isMainModule:
       inc n
       assert n.isSymbolDef
       let result = n.symId
-      endRead srcBuf
+      endRead n
       publish result, srcBuf, SemcheckBodies
       result
     var symBuf = createTokenBuf(1)
     symBuf.add symToken(symId)
-    let n = beginRead symBuf
+    var n = beginRead symBuf
     var sz = getSize(n, 8)
-    endRead symBuf
+    endRead n
     var err = false
     let size = sz.asSigned(err)
     assert size == expectedSize, "expected " & $expectedSize & " but got " & $size


### PR DESCRIPTION
The `when isMainModule` self-tests in `sizeof.nim` still used the pre-nifcore `endRead` API and the ones in `mangler.nim` still called `mangle`, which has been renamed to `mangleToC`. Updated both so they compile and pass again with `nim c -r`.