### PR TITLE
oserrors: freestanding arm for targets with neither windows nor posix

### DIFF
--- a/lib/std/oserrors.nim
+++ b/lib/std/oserrors.nim
@@ -7,7 +7,7 @@ type
 
 when defined(windows):
   import windows/winlean
-else:
+elif defined(posix):
   from posix/posix import errno
 
 
@@ -46,6 +46,10 @@ proc osLastError*(): OSErrorCode {.sideEffect.} =
   ## * `raiseOSError proc`_
   when defined(windows):
     result = cast[OSErrorCode](getLastError())
-  else:
+  elif defined(posix):
     result = OSErrorCode(errno())
+  else:
+    # Freestanding targets (wasm32 standalone): no OS, no errno. Zero,
+    # honestly, per the wasm bring-up convention.
+    result = OSErrorCode(0)
 #{.pop.}


### PR DESCRIPTION
#2209 replaced oserrors' own header-importc errno with `from posix/posix import errno`, but posix.nim's whole body sits under `when defined(posix)` - on a target defining neither windows nor posix (e.g. wasm32 standalone) the import binds nothing and `OSErrorCode(errno())` fails with "type mismatch: got: auto but wanted: OSErrorCode". Give osLastError an honest freestanding arm (no OS, no errno - zero).