### PR TITLE
sem: make semBaseobj re-sem of checked downcasts idempotent

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -740,7 +740,23 @@ proc semBaseobj(c: var SemContext; dest: var TokenBuf; it: var Item) =
       dest.shrink beforeExpr
       dest.add m.args
     else:
-      c.typeMismatch dest, it.n.endInfo, it.typ, destType
+      # A downcast `(baseobj T -depth x)` (produced by an explicit
+      # conversion) fails the implicit direction above when re-semmed;
+      # try the flipped direction like `semConvArg` does:
+      var m2 = createMatch(addr c)
+      m2.flipped = true
+      var matchArg = arg
+      matchArg.typ = destType
+      typematch m2, skipModifier(arg.typ), matchArg
+      if not m2.err and m2.args[0].tagEnum == BaseobjTagId:
+        dest.shrink beforeExpr
+        dest.add m2.args
+      else:
+        # replace the partially written type so dest holds exactly one
+        # (err) tree instead of `[type][err]` that readers of a single
+        # tree silently truncate to the bare type:
+        dest.shrink beforeExpr
+        c.typeMismatch dest, it.n.endInfo, arg.typ, destType
   commonType c, dest, it, beforeExpr, destType
 
 proc addMaybeBaseobjConv(c: var SemContext; dest: var TokenBuf; m: var Match; beforeExpr: int) =

--- a/tests/nimony/object/tdowncast_dotcall.nim
+++ b/tests/nimony/object/tdowncast_dotcall.nim
@@ -1,0 +1,26 @@
+import std/assertions
+
+# A checked downcast re-semmed through the method-call-syntax rewrite:
+# `Sub(p).xs.len` sems the receiver `(ddot (baseobj T -1 p) xs)` once, then
+# `.len` fails field lookup and is rebuilt as `len(receiver)`, re-semming
+# the already-semmed tree. semBaseobj's typematch only knew the implicit
+# (upcast) direction, so the -1 downcast "mismatched" — and the failure
+# path left `[type][err]` in dest where callers read one tree, silently
+# truncating the operand to a bare type that the C code generator then
+# rejected with "expected expression but got: (ptr ...)".
+
+type
+  Base = ref object of RootObj
+    kind: int
+  Sub = ref object of Base
+    xs: seq[int]
+
+proc f(b: Base): bool =
+  var p = b
+  p.kind == 1 and Sub(p).xs.len > 0
+
+proc main =
+  let s = Sub(kind: 1, xs: @[1, 2, 3])
+  assert f(s)
+
+main()


### PR DESCRIPTION
The method-call-syntax rewrite re-sems an already-semmed receiver: `Sub(p).xs.len` first sems to (ddot (baseobj T -1 p) xs), then `.len` fails field lookup, is rebuilt as len(receiver) and semmed again. semBaseobj recomputes the conversion via typematch, which implements the implicit (upcast) direction only - a re-semmed -1 downcast "mismatched" every time.

The mismatch path appended the error after the type it had already written into dest, so callers reading a single tree at beforeExpr saw the bare type and the error node was silently ignored: the conversion operand vanished from the final NIF and surfaced only as lengc's "expected expression but got: (ptr ...)".

Fix both: retry the flipped direction like semConvArg does for explicit conversions, and shrink before reporting a genuine mismatch so dest holds exactly one (err) tree.