### PR TITLE
versiontabs: write join entries as raw pool refs like newValueFor does

### DIFF
--- a/src/njvl/versiontabs.nim
+++ b/src/njvl/versiontabs.nim
@@ -118,7 +118,7 @@ proc combineJoin*(v: var VersionTab; mode: JoinMode): Table[SymId, JoinVar] =
     counters.old2 = baseVersion + counters.old2
     counters.newv = max(counters.old1, counters.old2) + 1
     v.currentVersion.mgetOrPut(s, 0) = counters.newv
-    v.history.addSymUse s, NoLineInfo
+    v.history.add symToken(s)
 
 proc isValid*(x: JoinVar): bool {.inline.} =
   x.old1 >= 0 and x.old2 >= 0 and x.newv >= 0


### PR DESCRIPTION
`combineJoin` re-appends join entries to the history journal with `addSymUse`, which inline-encodes symbol names of up to `StrInlineMaxLen` bytes. But `journalSymId` decodes journal entries as raw pool refs, so an outer `combineJoin` scanning over a nested section could read back a corrupted SymId. Use `symToken` like `newValueFor` already does; this also makes the module's self-test pass again.