### PR TITLE
eraiser: the canRaise temp must own the call's return value

### DIFF
--- a/src/hexer/duplifier.nim
+++ b/src/hexer/duplifier.nim
@@ -402,15 +402,22 @@ proc callWasMoved(c: var Context; arg: Cursor; typ: Cursor) =
   if n.exprKind == EmoveX: inc n
   # `=wasMoved` mutates its argument in place, so we have to take its address.
   # Peel any conversion wrappers — `(hconv T x)` / `(conv T x)` / `(cast T x)`
-  # — so we land on the underlying lvalue. The destination type that was
-  # passed in is no longer the right one to look up the hook with, since the
-  # location we are zeroing is the (pre-conversion) source: re-derive the type
-  # from the peeled cursor.
+  # / `(baseobj T depth x)` — so we land on the underlying lvalue. The
+  # destination type that was passed in is no longer the right one to look up
+  # the hook with, since the location we are zeroing is the (pre-conversion)
+  # source: re-derive the type from the peeled cursor.
   var hookTyp = typ
-  if n.exprKind in ConvKinds:
-    while n.exprKind in ConvKinds:
-      inc n
-      skip n  # skip the target type
+  if n.exprKind in ConvKinds or n.exprKind == BaseobjX:
+    while true:
+      if n.exprKind in ConvKinds:
+        inc n
+        skip n  # skip the target type
+      elif n.exprKind == BaseobjX:
+        inc n
+        skip n  # skip the target type
+        skip n  # skip the inheritance-depth literal
+      else:
+        break
     hookTyp = getType(c.typeCache, n)
 
   let info = n.info

--- a/src/hexer/eraiser.nim
+++ b/src/hexer/eraiser.nim
@@ -142,7 +142,12 @@ proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor; inhibit: bool) =
     copyIntoKind dest, StmtsS, info:
       let symId = pool.syms.getOrIncl("`canRaise." & $c.tmpCounter)
       inc c.tmpCounter
-      copyIntoKind dest, CursorS, info:
+      # The temp holds the call's RETURN VALUE — an owned, freshly
+      # constructed value — so it must be an owning local. As a CursorS the
+      # duplifier could only `=dup` out of it (a cursor is a borrow) and the
+      # destroyer never released it: every `dest = raisingCall()` leaked the
+      # entire returned value once per call.
+      copyIntoKind dest, VarS, info:
         addSymDef dest, symId, info
         dest.addEmpty2 info # export marker, pragma
         copyTree dest, retType

--- a/tests/nimony/arc/traises_call_owned.nim
+++ b/tests/nimony/arc/traises_call_owned.nim
@@ -1,0 +1,44 @@
+import std/syncio
+
+# Regression: the eraiser's `canRaise` temp for a raising call in expression
+# position must OWN the returned value. As a CursorS the duplifier could only
+# `=dup` out of it (a cursor is a borrow) and the destroyer never released it,
+# so every `dest = raisingCall()` leaked the entire returned value — found as
+# a JSON parser leaking its full DOM once per parse (~3.6MB/call at scale).
+# `let t = raisingCall(); dest = t` was always balanced; only the direct
+# assignment form leaked.
+
+type
+  Payload = object
+    id: int
+  Node = ref object
+    p: Payload
+
+var destroyed = 0
+
+proc `=destroy`(v: Payload) =
+  destroyed = destroyed + 1
+
+proc mkNode(id: int): Node {.raises.} =
+  result = Node(p: Payload(id: id))
+
+proc consumeDirect(): Node {.raises.} =
+  # raising call directly in `result =` position
+  result = mkNode(1)
+
+proc run() {.raises.} =
+  block:
+    var n = consumeDirect()
+    var m = Node(p: Payload(id: 2))
+    # raising call re-assigned into a pre-existing location:
+    m = mkNode(3)
+    discard n
+    discard m
+  # block end: n's payload (1), m's old (2) and new (3) payloads must all
+  # have been destroyed exactly once.
+  echo "destroyed=", destroyed
+
+try:
+  run()
+except:
+  echo "unexpected raise"

--- a/tests/nimony/arc/traises_call_owned.output
+++ b/tests/nimony/arc/traises_call_owned.output
@@ -1,0 +1,1 @@
+destroyed=3


### PR DESCRIPTION
trCall lowered a raising call in expression position to a CursorS temp holding the call's return value. A cursor is a borrow: the duplifier could only =dup out of it and the destroyer never released it, so every `dest = raisingCall()` abandoned one reference - the entire returned value leaked once per call (found as a JSON parser leaking its full DOM per parse, ~3.6MB/call, production OOM in a DICOM gateway). The `let t = raisingCall(); dest = t` spelling was balanced because trLocal makes the user's own local the tuple.

Mint the temp as VarS, matching duplifier's bindToTemp convention (VarS when the initializer constructs a value, CursorS for borrows).

The now-owning temp exposed a second gap: callWasMoved peeled hconv/conv/cast wrappers but not (baseobj T depth x), so a raising call assigned through an implicit upcast (osproc's `p.inStream = createStream(...)`) emitted =wasmoved(haddr(baseobj ..))
- "lvalue required" in the generated C. Peel baseobj too.

Test: destroy-count based (deterministic, no RSS); unfixed compilers print destroyed=1 instead of 3. Measured on the original repro: 110MB after 30 parses -> flat 6MB. Suite 651/653 (the two valgrind mismatches are a pre-existing cache-order flake: the .valgrind expectations record a malloc-built system inherited from the shared suite cache; a fresh cache builds the mmap arena and valgrind sees 0 allocs - reproduced without this change).

Closes #2249 