### PR TITLE
hastur: skip the submodule fetch when mimalloc is already present

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -2372,7 +2372,13 @@ proc handleCmdLine =
 
   of "build":
     const showProgress = true
-    exec "git submodule update --init"
+    # Only fetch the submodule when it is actually missing. A `jj` workspace
+    # (or a `git worktree`) shares one repo and has no gitlink of its own, so
+    # `git submodule update --init` fails there with "Unable to find current
+    # revision" even when the sources are present. Checking for the files is
+    # what the build cares about anyway.
+    if not fileExists("vendor" / "mimalloc" / "src" / "static.c"):
+      exec "git submodule update --init"
     case (if args.len > 0: args[0] else: "")
     of "", "all":
       buildNifler(showProgress)


### PR DESCRIPTION
`hastur build` runs `git submodule update --init` unconditionally. That fails inside a `jj` workspace or a `git worktree`:

```
fatal: Unable to find current revision in submodule path 'vendor/mimalloc'
FAILURE git submodule update --init
```

Both share a single repo and have no gitlink of their own, so git can't resolve the submodule revision from there even when `vendor/mimalloc` is fully populated. The build stops before it starts, which makes those checkouts unusable for running the suite.

The build only needs mimalloc's sources, so check for them and fetch only when they're missing.

Tested in a `jj workspace` with no `.git` at all: `hastur build` completes and `hastur all` gives 655/655. Normal clones are unaffected, the file is absent on a fresh checkout so the fetch still runs.