### PR TITLE
fixes #2234; walk nested case sections when building object constructors

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3880,13 +3880,20 @@ proc buildObjConstrField(c: var SemContext; dest: var TokenBuf; field: Local;
       dest.addIntLit(depth, info)
     dest.addParRi()
 
+proc buildObjConstrFields(c: var SemContext; dest: var TokenBuf; n: var Cursor;
+                          setFields: Table[SymId, Cursor]; info: NifLineInfo;
+                          bindings: Table[SymId, Cursor]; depth = 0;
+                          isUnion = false)
+
 proc fieldsPresentInInitExpr(c: var SemContext; n: Cursor; setFields: Table[SymId, Cursor]): (bool, SymId) =
-  var n = n
-  inc n
+  # A branch body is not a flat field list: it can contain a nested `case`
+  # section, so walk it with the field iterator instead of `takeLocal` in a
+  # loop (which would read the `(case ...)` node as a local and run the
+  # cursor off its bounds).
+  var n = sub(n)
   result = (false, SymId(0))
-  if n.substructureKind == NilU:
-    return
-  while n.hasMore:
+  var iter = initObjFieldIter()
+  while nextField(iter, n):
     let local = takeLocal(n, SkipFinalParRi)
     if local.name.symId in setFields:
       result = (true, local.name.symId)
@@ -3994,9 +4001,7 @@ proc fieldsPresentInBranch(c: var SemContext; dest: var TokenBuf; n: var Cursor;
             elif state == Unknown:
               wrongBranchError(c, dest, info, presentFieldSymId, selectorSymId, getValueInKv(setFields.getOrQuit(selectorSymId)))
             n.into: # stmt
-              while n.hasMore:
-                let field = takeLocal(n, SkipFinalParRi)
-                buildObjConstrField(c, dest, field, setFields, info, bindings, depth)
+              buildObjConstrFields(c, dest, n, setFields, info, bindings, depth)
             lastFieldSymId = presentFieldSymId
           else:
             skip n
@@ -4009,9 +4014,7 @@ proc fieldsPresentInBranch(c: var SemContext; dest: var TokenBuf; n: var Cursor;
             elif isBranchSelected and setFields.hasKey(selectorSymId):
               wrongBranchError(c, dest, info, presentFieldSymId, selectorSymId, getValueInKv(setFields.getOrQuit(selectorSymId)))
             n.into: # stmt
-              while n.hasMore:
-                let field = takeLocal(n, SkipFinalParRi)
-                buildObjConstrField(c, dest, field, setFields, info, bindings, depth)
+              buildObjConstrFields(c, dest, n, setFields, info, bindings, depth)
             lastFieldSymId = presentFieldSymId
           else:
             skip n
@@ -4026,12 +4029,7 @@ proc fieldsPresentInBranch(c: var SemContext; dest: var TokenBuf; n: var Cursor;
       badDiscriminatorError(c, dest, info, lastFieldSymId, selectorSymId)
     elif bestBranch != default(Cursor):
       bestBranch.peekInto: # stmt
-        while bestBranch.hasMore:
-          if bestBranch.substructureKind == NilU:
-            skip bestBranch
-            break
-          let field = takeLocal(bestBranch, SkipFinalParRi)
-          buildObjConstrField(c, dest, field, setFields, info, bindings, depth)
+        buildObjConstrFields(c, dest, bestBranch, setFields, info, bindings, depth)
 
 proc buildObjConstrFields(c: var SemContext; dest: var TokenBuf; n: var Cursor;
                           setFields: Table[SymId, Cursor]; info: NifLineInfo;

--- a/tests/nimony/object/tnestedcase.nim
+++ b/tests/nimony/object/tnestedcase.nim
@@ -1,0 +1,19 @@
+import std/assertions
+
+type
+  Outer = object
+    case a: bool
+    of true:
+      case b: bool
+      of true: inner: int
+      of false: nil
+    of false:
+      other: string
+
+var o1: Outer
+var o2 = default(Outer)
+var o3 = Outer(a: true, b: true, inner: 5)
+var o4 = Outer(a: false, other: "x")
+
+assert o3.inner == 5
+assert o4.other == "x"


### PR DESCRIPTION
Fixes #2234.

`buildObjConstrFields` already descends into a `case` section, since it runs on `nextField(keepCase = true)`. The three places that walk an individual `of`/`else` branch body did not. Each ran a bare `while n.hasMore: takeLocal(n, SkipFinalParRi)` loop, so a nested `(case ...)` node got read as if it were a local and the cursor ran off its bounds. `load` then hit its own assert instead of reporting anything at source level. `fieldsPresentInInitExpr` walked branch bodies the same flat way.

All four now go through the iterator. `fieldsPresentInInitExpr` uses `nextField`, and the branch bodies call `buildObjConstrFields` recursively, so a nested `case` emits its selector plus the selected branch's fields.

That is also why `Outer(a: false, other: "x")` crashed even though it never touches the inner `case`. The walk runs regardless of which branch the construction selects.

`tests/nimony/object/tnestedcase.nim` covers the four rows from the issue.

Ran on WSL: `tests/nimony/object` 23/23, `tests/nimony/generics` 29/29, `tests/nimony/arc` 43/43. The `tests/nimony/concepts` failures in my full-suite run come from a locally built `nifler` on Nim 2.2.10, which cannot parse `concept of`. `tconceptdiamond` fails the same way with this patch stashed.
