### PR TITLE
fixes #2228; xints bitwise ops must use two's complement

### DIFF
--- a/src/nimony/xints.nim
+++ b/src/nimony/xints.nim
@@ -156,32 +156,36 @@ proc `shr`*(a: xint, b: int): xint =
     val: a.val shr b
   )
 
+proc toTwos(a: xint): uint64 {.inline.} =
+  ## 64 bit two's complement bit pattern of `a`.
+  if a.neg: (not a.val) + 1'u64 else: a.val
+
+proc fromTwos(bits: uint64; signed: bool): xint {.inline.} =
+  if signed and (bits shr 63) != 0'u64:
+    xint(neg: true, val: (not bits) + 1'u64)
+  else:
+    xint(neg: false, val: bits)
+
+# the bitwise ops work on the two's complement pattern, not on sign+magnitude
 proc `and`*(a, b: xint): xint =
-  xint(
-    nan: a.nan or b.nan,
-    neg: a.neg and b.neg,
-    val: a.val and b.val
-  )
+  if a.nan or b.nan: xint(nan: true)
+  else: fromTwos(toTwos(a) and toTwos(b), a.neg or b.neg)
 
 proc `or`*(a, b: xint): xint =
-  xint(
-    nan: a.nan or b.nan,
-    neg: a.neg or b.neg,
-    val: a.val or b.val
-  )
+  if a.nan or b.nan: xint(nan: true)
+  else: fromTwos(toTwos(a) or toTwos(b), a.neg or b.neg)
 
 proc `xor`*(a, b: xint): xint =
-  xint(
-    nan: a.nan or b.nan,
-    neg: a.neg xor b.neg,
-    val: a.val xor b.val
-  )
+  if a.nan or b.nan: xint(nan: true)
+  else: fromTwos(toTwos(a) xor toTwos(b), a.neg or b.neg)
 
 proc `not`*(a: xint): xint =
+  # the result's signedness depends on the operand's type, which `xint` does
+  # not track, so the raw pattern is returned; `mask` applies the sign.
   xint(
     nan: a.nan,
-    neg: a.neg,
-    val: not a.val
+    neg: false,
+    val: not toTwos(a)
   )
 
 proc `mod`*(a, b: xint): xint =

--- a/tests/nimony/sets/tsetbitops.nim
+++ b/tests/nimony/sets/tsetbitops.nim
@@ -1,0 +1,26 @@
+import std/assertions
+
+# Regression for: a set constructor whose element is a `not`/`shl`/`shr`
+# expression. `xints`' bitwise ops worked on sign+magnitude, so folding
+# `(not 0'i32) and 7` yielded `-1 and 7 == 1` instead of `7` and the wrong
+# bit was set in the constant bitset.
+
+var a: set[uint8] = {uint8((not 0'i32) and 7), 9'u8}
+assert 7'u8 in a
+assert 9'u8 in a
+assert 1'u8 notin a
+
+var b: set[uint8] = {uint8(1 shl 2), 9'u8}
+assert 4'u8 in b
+
+var c: set[uint8] = {uint8(255 shr 5), 9'u8}
+assert 7'u8 in c
+
+const K = (not 0'i32) and 7
+var d: set[uint8] = {uint8(K), 9'u8}
+assert 7'u8 in d
+
+# the same value routed through a `let` must agree with the folded form
+let v = uint8((not 0'i32) and 7)
+var e: set[uint8] = {v, 9'u8}
+assert e == a


### PR DESCRIPTION
The wrong-set half of #2228. The bug is not in the set code at all, it is in `xints`.

`and`, `or`, `xor` and `not` combined the `neg` flag and the magnitude as two separate fields:

```nim
proc `and`*(a, b: xint): xint =
  xint(nan: a.nan or b.nan, neg: a.neg and b.neg, val: a.val and b.val)
```

For `-1 and 7` that is `neg = true and false = false` and `val = 1 and 7 = 1`, so the answer comes out as 1 instead of 7. `not` had the same problem in reverse: it inverted the magnitude and kept the sign, so `not 0` gave `-0xFFFFFFFFFFFFFFFF` rather than `-1`.

Sign and magnitude are the wrong representation for a bit operation. They now convert to a 64 bit two's complement pattern, apply the op, and convert back. `not` returns the raw pattern with `neg = false`, because `xint` does not track the operand's signedness and `mask` already applies the sign for the result's width, which is what `evalBitnot` calls right after.

So `{uint8((not 0'i32) and 7), 9'u8}` folds to bit 7 now instead of bit 1, and matches what the same value does when routed through a `let`.

The nil-deref half of the issue is already fixed by #2223, which gave `evalBitSet` an explicit `bits` parameter. That part needs no further change.

Test in `tests/nimony/sets/tsetbitops.nim`, covering the `not`, `shl`, `shr` and `const` forms from the issue. It fails on master and passes here.

`sets`, `const`, `consteval`, `sysbasics` and `basicarith` all pass. The 28 failures in `concepts` are the known checked-in nifler parse errors on `concept of`; identical count on master with this commit stashed.
