### PR TITLE
sigmatch: don't assert when a formal type symbol isn't a type decl

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -1498,6 +1498,15 @@ proc matchSymbol(m: var Match; f: Cursor; arg: CallArg) =
     # fast check that works for aliases too:
     if a.isSymbol and sameSymbol(a.symId, fs):
       discard "perfect match"
+    elif (let fdecl = tryLoadSym(fs);
+          fdecl.status != LacksNothing or fdecl.decl.stmtKind != TypeS):
+      # `fs` names something that is not a type declaration — e.g. a template
+      # parameter left in type position (`symKind == ParamY`) while a template
+      # body is semchecked generically. It is not a valid formal type, so no
+      # argument can match it: reject with the normal diagnostic rather than
+      # asserting in `typeImpl`. (An instantiation with a concrete type binds
+      # `fs` to a real type and never reaches this branch.)
+      m.error InvalidMatch, f, a
     else:
       var impl = typeImpl(fs)
       if impl.isTagLit and impl.cursorTagId == nifpools.ErrT:

--- a/tests/nimony/templates/ttemplate_param_as_type.msgs
+++ b/tests/nimony/templates/ttemplate_param_as_type.msgs
@@ -1,0 +1,5 @@
+tests/nimony/templates/ttemplate_param_as_type.nim(19, 17) Error: not a type
+tests/nimony/templates/ttemplate_param_as_type.nim(19, 22) Error: not a type
+tests/nimony/templates/ttemplate_param_as_type.nim(19, 46) Error: Type mismatch at [position]
+gvec2(x, y)
+[1] expected: typ but got: <type error> (declared in tests/nimony/templates/ttemplate_param_as_type.nim(17, 1))

--- a/tests/nimony/templates/ttemplate_param_as_type.nim
+++ b/tests/nimony/templates/ttemplate_param_as_type.nim
@@ -1,0 +1,20 @@
+# Regression guard: a generic routine called inside a template body, with a
+# template parameter used as the generic type argument (`GVec2[typ]` /
+# `gvec2[typ]`), used to CRASH the compiler during overload resolution —
+# `typeprops.typeImpl` asserted `result.stmtKind == TypeS`, but the formal
+# symbol resolved to the template parameter `typ` (symKind ParamY), not a type.
+#
+# `genCtor` is a plain (typed) template, so its body IS type-checked and `typ`
+# used in type position is legitimately "not a type" — that error is correct.
+# `matchSymbol` must simply not CRASH when a non-type formal reaches it: it now
+# rejects with the normal diagnostic instead of asserting in `typeImpl`.
+#
+# To actually USE this pattern (vmath's genVecConstructor), the template must be
+# `{.untyped.}` (or the module `{.feature: "untyped".}`) — only then does the
+# body go through the untyped walk (`semTemplBody`) instead of typed sigmatch.
+# This test pins the plain-template case: correct "not a type" errors, no crash.
+type GVec2[T] = array[2, T]
+proc gvec2[T](x, y: T): GVec2[T] = [x, y]
+template genCtor(typ: untyped) =
+  proc mk(x, y: typ): GVec2[typ] = gvec2[typ](x, y)
+genCtor(float32)


### PR DESCRIPTION
Overload resolution crashed nimsem with an AssertionDefect when a template body was semchecked generically and a template parameter appeared in type position — e.g. `proc mk(x: typ): GVec2[typ] = gvec2[typ](x)` inside a `template genCtor(typ: untyped)`. Matching the (already error-typed) argument against the generic routine's formal reached `matchSymbol`'s final `else` branch via the concreteMatch typevar-rematch path, where the formal symbol `fs` resolved to the template parameter itself (symKind ParamY), not a type declaration. `typeImpl(fs)` then tripped `assert result.stmtKind == TypeS`.

Guard the branch: if `fs` doesn't load as a type declaration, treat it as a wildcard placeholder rather than asserting — the real type check happens when the template is instantiated with concrete arguments (where `fs` is a genuine type and this branch is never taken). The crash becomes nimony's normal "not a type" diagnostic.

This is the genVecConstructor pattern in vmath; it no longer crashes the compiler (a separate limitation — the eager template-body type check rejecting a parameter used as a type — still errors rather than deferring to instantiation, and is tracked separately).

(cherry picked from commit 7a8fbabfee0a4fc945f7430455e973ed71eeaf88)