### PR TITLE
posix: declare mmap/munmap lengths as csize_t

### DIFF
--- a/lib/std/memfiles.nim
+++ b/lib/std/memfiles.nim
@@ -232,7 +232,7 @@ proc open*(filename: string, mode: FileMode = fmRead,
       result.flags = result.flags or MAP_SHARED
 
     let pr = if readonly: PROT_READ else: PROT_READ or PROT_WRITE
-    result.mem = mmap(nil, result.size, pr, result.flags, result.handle, offset)
+    result.mem = mmap(nil, csize_t(result.size), pr, result.flags, result.handle, offset)
     if mmapFailed(result.mem):
       fail(OSErrorCode(mmapErrno(result.mem)), "file mapping failed")
 
@@ -258,7 +258,7 @@ proc close*(f: var MemFile) {.raises.} =
       if error:
         lastErr = osLastError()
   else:
-    let mr = pcall(munmap(f.mem, f.size))
+    let mr = pcall(munmap(f.mem, csize_t(f.size)))
     error = mr < 0
     lastErr = if mr < 0: OSErrorCode(int32(0 - mr)) else: OSErrorCode(0)
     if f.handle >= 0:

--- a/lib/std/posix/io_uring.nim
+++ b/lib/std/posix/io_uring.nim
@@ -457,14 +457,14 @@ proc `+`(p: pointer; i: uint32): pointer =
 proc uringMap(offset: Off; fd: FileHandle; begin: uint32;
                count: uint32; typSize: int): pointer {.raises, tags: [].} =
   let size = int(begin + count * typSize.uint32)
-  result = mmap(nil, size, PROT_READ or PROT_WRITE, MAP_SHARED or MAP_POPULATE,
+  result = mmap(nil, csize_t(size), PROT_READ or PROT_WRITE, MAP_SHARED or MAP_POPULATE,
                 fd.cint, offset)
   if mmapFailed(result):
     raiseOSError(osLastError(), "io_uring uringMap failed")
 
 proc uringUnmap(p: pointer; size: int) {.raises, tags: [].} =
   ## interface to tear down some memory (probably mmap'd)
-  let code = munmap(p, size)
+  let code = munmap(p, csize_t(size))
   if code < 0:
     raiseOSError(osLastError(), "io_uring uringUnmap failed")
 

--- a/lib/std/posix/posix.nim
+++ b/lib/std/posix/posix.nim
@@ -200,13 +200,16 @@ when defined(posix):
   proc S_ISLNK*(m: Mode): bool = fileType(m) == 0o120000'u32  ## symlink
   proc S_ISSOCK*(m: Mode): bool = fileType(m) == 0o140000'u32 ## socket
 
+  # `a2` is C `size_t`: a bare-importc `int` declaration conflicts with the
+  # glibc prototype when another binding pulls `<sys/mman.h>` into the same
+  # C unit (same fix as osalloc's posix arm).
   when defined(linux) and defined(i386):
-    proc mmap*(a1: nil pointer, a2: int, a3, a4, a5: cint, a6: Off): pointer {.
+    proc mmap*(a1: nil pointer, a2: csize_t, a3, a4, a5: cint, a6: Off): pointer {.
       importc: "mmap64".}
   else:
-    proc mmap*(a1: nil pointer, a2: int, a3, a4, a5: cint, a6: Off): pointer {.
+    proc mmap*(a1: nil pointer, a2: csize_t, a3, a4, a5: cint, a6: Off): pointer {.
       importc: "mmap".}
-  proc munmap*(a1: nil pointer, a2: int): cint {.importc: "munmap".}
+  proc munmap*(a1: nil pointer, a2: csize_t): cint {.importc: "munmap".}
 
   when defined(nimNativeIo):
     var errnoVar: cint = 0


### PR DESCRIPTION
The bare-importc `int` length conflicts with the glibc size_t prototype whenever another binding pulls <sys/mman.h> into the same C unit (post-#2209 downstream constant bindings do exactly that) - clang rejects the unit. Same fix osalloc's posix arm already carries; update memfiles and io_uring call sites.


(cherry picked from commit 3dd4cceccd29b6c4ec44c48cef936381b868c29b)