### PR TITLE
fixes #2241; defer .borrow body generation to instantiation

### DIFF
--- a/src/nimony/semdecls.nim
+++ b/src/nimony/semdecls.nim
@@ -600,6 +600,12 @@ proc semBorrow(c: var SemContext; dest: var TokenBuf; fn: StrId; beforeParams: i
   let signature = cursorAt(dest, beforeParams)
   var procBody = genBorrowedProcBody(c, fn, signature, signature.info)
   var n = cursorAt(procBody, 0)
+  if n.exprKind == ErrX:
+    # No distinct parameter to convert from: the generated "body" is the error
+    # itself, so hand it over as-is. Opening it as a `(stmts` would splice the
+    # message into a malformed tree and lose it.
+    dest.copyTree n
+    return
   var it = Item(n: n, typ: c.types.autoType)
   var resId = SymId(0)
   let bodyStart = dest.len
@@ -990,9 +996,17 @@ proc semEmptyBody(c: var SemContext; dest: var TokenBuf; it: var Item;
   elif BorrowP in crucial.flags and pass in {checkGenericInst, checkBody}:
     if kind notin {ProcY, FuncY, ConverterY, TemplateY, MethodY}:
       c.buildErr dest, it.n.info, ".borrow only valid for proc, func, converter, template or method"
+      inc it.n # skip DotToken
+    elif kind != TemplateY and c.routine.inGeneric > 0:
+      # A generic routine's parameters are still typevars here, so there is no
+      # distinct base to convert to. Leave the body empty and let each
+      # instantiation build it: `checkGenericInst` runs with concrete types.
+      # Templates are excluded: they carry `inGeneric > 0` unconditionally and
+      # have no separate instantiation pass to defer to.
+      takeTree dest, it.n
     else:
       semBorrow(c, dest, symToIdent(symId), beforeParams)
-    inc it.n # skip DotToken
+      inc it.n # skip DotToken
   else:
     takeTree dest, it.n
   c.closeScope() # close parameter scope

--- a/tests/nimony/borrows/tborrow_generic.nim
+++ b/tests/nimony/borrows/tborrow_generic.nim
@@ -1,0 +1,33 @@
+import std/assertions
+
+type
+  Slice*[T] = distinct seq[T]
+  Meters*[T] = distinct T
+
+# generic distinct over a generic base type
+proc len*[T](x: Slice[T]): int {.borrow.}
+
+# distinct return type: the result is converted back
+proc `+`*[T](x, y: Meters[T]): Meters[T] {.borrow.}
+proc `==`*[T](x, y: Meters[T]): bool {.borrow.}
+
+# generic routine over a concrete distinct type
+proc twice*[T](x: Meters[int]; y: T): Meters[int] {.borrow.}
+proc twice*[T](x: int; y: T): int = x * 2 + int(y)
+
+var s = Slice[int](@[1, 2, 3])
+assert s.len == 3
+
+var s2 = Slice[string](@["a", "b"])
+assert s2.len == 2
+
+let a = Meters[int](3)
+let b = Meters[int](4)
+assert int(a + b) == 7
+assert a + b == Meters[int](7)
+
+assert int(twice(a, 1)) == 7
+
+let c = Meters[float](1.5)
+let d = Meters[float](2.5)
+assert float(c + d) == 4.0


### PR DESCRIPTION
`genBorrowedProcBody` builds a borrowed body by converting each distinct parameter to its base type, so it needs `skipDistinct` to find that base. In a generic routine the parameters are still typevars or `(invoke Slice T)` at definition time, no base is found, and the generated "body" is an `(err ...)` node. `semBorrow` then opened that node as a `(stmts`, which malformed the tree and surfaced as the reported `expression expected`.

Generic routines now leave the body empty at definition time and let each instantiation build it. `checkGenericInst` already runs with concrete parameter types, so `genBorrowedProcBody` sees a real distinct base there. Templates stay on the old path: they carry `inGeneric > 0` unconditionally and have no separate instantiation pass to defer to. Dropping that guard regresses `template \`+\`(x, y: VarId): VarId {.borrow.}`, which works today.

`semBorrow` also passes an error body through instead of wrapping it. `.borrow` on a proc with no distinct parameter used to print `??? Error: expression expected`; it now prints `cannot .borrow: no parameter of a 'distinct' type` with the right location. That message existed already but was being destroyed by the wrapper.

Covered by `tests/nimony/borrows/tborrow_generic.nim`: generic distinct over a generic base (`Slice[T] = distinct seq[T]`), distinct return type conversion (`Meters[T] = distinct T`), a generic routine over a concrete distinct type, and two instantiations of the same generic (`Slice[int]` / `Slice[string]`, `Meters[int]` / `Meters[float]`).

649/649 in `tests/nimony` on Linux.