### PR TITLE
hexer/xelim: register hoisted and/or short-circuit decls with typenav

### DIFF
--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -142,7 +142,7 @@ proc trExprInto(c: var Context; dest: var TokenBuf; n: var Cursor; v: SymId) =
       dest.addSymUse v, info
       dest.addTarget tar
 
-proc hoistDeclsFromExprX(outerDest, transformed: var TokenBuf; n: var Cursor;
+proc hoistDeclsFromExprX(tc: var TypeCache; outerDest, transformed: var TokenBuf; n: var Cursor;
                          markNoinit = false) =
   ## Copy the subtree at `n` into `transformed`. If the subtree is an
   ## `(expr (stmts decls…) val…)`, top-level `let`/`var`/`cursor` decls
@@ -175,6 +175,7 @@ proc hoistDeclsFromExprX(outerDest, transformed: var TokenBuf; n: var Cursor;
             transformed.takeTree n
             continue
           let info = n.info
+          let k = n.stmtKind
           let local = takeLocal(n, SkipFinalParRi)
           let sym = local.name.symId
           let symInfo = local.name.info
@@ -197,6 +198,12 @@ proc hoistDeclsFromExprX(outerDest, transformed: var TokenBuf; n: var Cursor;
           outerDest.addSubtree local.typ
           outerDest.addDotToken()      # uninitialised
           outerDest.addParRi()
+          # The hoisted decl is written raw to `outerDest`, bypassing the
+          # `trLocal` path that registers a local's type with typenav. A later
+          # `getType` on the moved RHS — e.g. a closure-field callee lowered to
+          # `(call (tupat sym 0) …)` — must resolve `sym`'s declared type, so
+          # register it here or that lookup bugs ("could not find symbol").
+          tc.registerLocal(sym, cast[SymKind](k), local.typ)
           if local.val.kind != DotToken:
             transformed.addParLe(AsgnS, info)
             transformed.addSymUse(sym, symInfo)
@@ -218,7 +225,7 @@ proc trOr(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
       # scope so they remain visible after the `or` lowering — same idea as
       # `trAnd` below; see the comment there.
       var rhs = createTokenBuf(16)
-      hoistDeclsFromExprX(dest, rhs, n, markNoinit = c.goal == TowardsFinalIr)
+      hoistDeclsFromExprX(c.typeCache, dest, rhs, n, markNoinit = c.goal == TowardsFinalIr)
       var rhsCursor = beginRead(rhs)
       copyIntoKind dest, IfS, info:
         copyIntoKind dest, ElifU, info:
@@ -251,7 +258,7 @@ proc trAnd(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
       # and the original initialiser is rewritten into an `asgn` that runs
       # only when `x` is true (preserving short-circuit evaluation).
       var rhs = createTokenBuf(16)
-      hoistDeclsFromExprX(dest, rhs, n, markNoinit = c.goal == TowardsFinalIr)
+      hoistDeclsFromExprX(c.typeCache, dest, rhs, n, markNoinit = c.goal == TowardsFinalIr)
       var rhsCursor = beginRead(rhs)
       copyIntoKind dest, IfS, info:
         copyIntoKind dest, ElifU, info:

--- a/tests/nimony/closures/tclosure_field_in_and.nim
+++ b/tests/nimony/closures/tclosure_field_in_and.nim
@@ -1,0 +1,41 @@
+# A closure held in a FIELD, called in the RHS of an `and`, ICEs hexer:
+#
+#   [Bug] could not find symbol: `llTemp.N
+#     hexer/xelim.nim(241) trAnd -> trExprInto -> getType
+#     nimony/typenav.nim(275) tupatType -> decls.nim(46) bug
+#
+# `llTemp.N` is minted in hexer/lambdalifting.nim for an "expression callee"
+# (a closure in a field/var, not a direct proc symbol) to bind the (fn, env)
+# tuple to a temp. trAnd lowers `and` into short-circuit control flow, moving
+# the RHS operand into a branch — and the temp's declaration is then not
+# findable from its use.
+#
+# MINIMISED. Only two elements are required:
+#   1. the callee is a closure held in a FIELD (a closure PARAMETER in the
+#      same position compiles fine)
+#   2. the call is in the RHS operand of an `and` in an `if` condition
+#
+# NOT required — each still ICEs without it: a `while` loop, a `!= nil`
+# guard, `{.feature: "lenientnils".}`, and `ref` (a value object fails too).
+# Rewriting the `and` as nested ifs compiles (the workaround).
+
+import std / [syncio, assertions]
+
+type
+  H = proc(): bool {.closure.}
+  B = object
+    h: H
+
+proc callsFieldInAnd(b: B, guard: int): int =
+  result = 0
+  if guard >= 0 and b.h():
+    inc result
+
+proc main =
+  let t = 1
+  let b = B(h: proc(): bool {.closure.} = t >= 0)
+  assert callsFieldInAnd(b, 0) == 1
+  assert callsFieldInAnd(b, -1) == 0
+  echo "ok"
+
+main()


### PR DESCRIPTION
`hoistDeclsFromExprX` moves the leading let/var/cursor decls of an `and`/`or` short-circuit RHS out to the enclosing buffer via raw token ops, so they stay in scope after the operand is relocated into the `if` branch. That raw emission bypasses the `trLocal` path that registers a local's declared type with typenav, so a later `getType` on the moved RHS cannot resolve the hoisted symbol.

A plain hoisted `let x` never hit this: its use (e.g. `x > 0`, a magic returning bool) is typed without resolving `x`'s declaration. A closure held in a FIELD is the exposing shape — the RHS lowers to `(call (tupat llTemp 0) …)`, and `tupatType -> lookupSymbol(llTemp)` bugs with "could not find symbol: `llTemp.N".

Fix: thread the TypeCache into `hoistDeclsFromExprX` and register each hoisted decl right after emitting its placeholder, mirroring the normal decl-registration path. Adds a minimal reproducing test.

closures 14/14; core groups green.