### PR TITLE
hexer/xelim: bind aggregate values that read through a call

### DIFF
--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -288,12 +288,29 @@ proc trExprLoop(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Targ
       trExpr c, dest, n, tar
   tar.t.addParRi()
 
+proc readsThroughCall(n: Cursor): bool =
+  ## Goal-independent: does this value tree contain a call — i.e. a read (like
+  ## `xs.len`) that a sibling field's hoisted `wasMoved` could invalidate?
+  ## Unlike `isComplex`, this does NOT depend on `c.goal`, so it fires in the
+  ## post-duplifier `ElimExprs` pass where the ordering hazard is created.
+  var n = n
+  if n.kind != TagLit: return false
+  if n.exprKind in CallKinds: return true
+  result = false
+  n.loopInto:
+    if readsThroughCall(n): return true
+    skip n
+
 proc trAggregateValue(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) =
-  ## Bind a *call* in a value-position of an aggregate to a fresh cursor temp
-  ## so the call evaluates at a deterministic textual point relative to
-  ## sibling pre-statements (e.g. a sibling's `wasMoved`). Non-call
-  ## expressions are pure reads and are passed through to `trExpr`
-  ## unchanged.
+  ## Bind a value-position of an aggregate to a fresh cursor temp so it
+  ## evaluates at a deterministic textual point relative to sibling
+  ## pre-statements (e.g. a sibling's `wasMoved`). This covers *calls* and
+  ## *complex non-call values that contain a read* — e.g. `xs.len > 0`, whose
+  ## inner `xs.len` reads a location a later `items: xs` field moves; leaving
+  ## it inline in the constructor evaluated it AFTER the sibling's hoisted
+  ## `wasMoved`, reading the emptied seq (`tmoved_seq_sibling_field`). Only a
+  ## trivially-pure read — a bare symbol or literal — is passed through
+  ## unchanged, since it reads nothing a sibling pre-statement can invalidate.
   ##
   ## **The temp is a `cursor`, not a `let`.** The aggregate constructor
   ## that immediately consumes this temp is the rightful owner of the
@@ -304,7 +321,17 @@ proc trAggregateValue(c: var Context; dest: var TokenBuf; n: var Cursor; tar: va
   ## non-owning view that goes out of scope without cleanup, which is
   ## exactly what xelim needs here. Surfaced 2026-05-01 by self-host
   ## debugging — see `bug_self_host_nifconfig_destroy.md`.
-  if n.kind != TagLit or n.exprKind notin CallKinds:
+  # Bind a value that reads through a call (a bare `xs.len`, or a nested one like
+  # `xs.len > 0`) to a temp so it evaluates before any sibling's hoisted
+  # pre-statement (a later field's `wasMoved`) empties the read location. The old
+  # form only bound top-level `CallKinds`, so a comparison whose OPERAND was the
+  # call was left inline in the constructor and read the moved-from value
+  # (`tmoved_seq_sibling_field`). Pure atoms, literals, `nil` and structural nodes
+  # (`kv`) read nothing invalidatable and pass through unchanged.
+  # A `kv` (named tuple / table entry reaching here via the tup/tab branches) is
+  # structural, not a bindable value expression — pass it to `trExpr`, which
+  # descends into its value. Only genuine value expressions get bound.
+  if n.kind != TagLit or n.substructureKind == KvU or not readsThroughCall(n):
     trExpr c, dest, n, tar
     return
 

--- a/tests/nimony/arc/tmoved_seq_sibling_field.nim
+++ b/tests/nimony/arc/tmoved_seq_sibling_field.nim
@@ -1,0 +1,75 @@
+# A field DERIVED from a seq that a LATER field in the same object literal
+# MOVES reads the moved-from (emptied) value:
+#
+#   WithSeq(flag: xs.len > 0, n: xs.len, items: xs)   # flag=false, n=5, items=5
+#
+# Compiles clean, no warning, no crash — just a wrong answer, and the wrong
+# answer is the OPTIMISTIC one (a false `matched`/`isDegenerate` reads as
+# "nothing found"), which is why it survives review.
+#
+# TWO PROPERTIES THAT MAKE IT EASY TO MISS, both asserted below:
+#
+#   1. THE CORRUPTION IS SELECTIVE. Only the derived BOOL lies. The sibling
+#      int reads 5 correctly and the moved seq arrives intact. Checking "did
+#      the seq survive?" or "is the count right?" does NOT detect it.
+#   2. IT IS SHAPE-DEPENDENT. Built from a PARAMETER the same literal is
+#      correct; only the LOCAL-VAR form fails. A one-shape probe returns
+#      "safe" and closes the investigation.
+#
+# Negative controls (both correct today) pin this to the MOVE rather than to
+# boolean codegen in object literals: a bool from a comparison with no seq in
+# the object, and a seq READ but not moved. Field order is irrelevant —
+# derived-first and derived-last both fail. Hoisting the derived value into a
+# local before the literal is the fix.
+
+import std / [syncio, assertions]
+
+type
+  WithSeq = object
+    flag: bool
+    n: int
+    items: seq[int]
+
+  NoSeq = object
+    flag: bool
+    n: int
+
+proc fill(): seq[int] =
+  result = @[]
+  for i in 0 ..< 5:
+    result.add i
+
+proc fromParam(xs: seq[int]): WithSeq =
+  # Shape control: the same literal built from a PARAMETER is correct.
+  result = WithSeq(flag: xs.len > 0, n: xs.len, items: xs)
+
+proc main =
+  # Control 1 — bool from a comparison, no seq in the object at all.
+  let a = fill()
+  let c1 = NoSeq(flag: a.len > 0, n: a.len)
+  assert c1.flag
+
+  # Control 2 — seq READ but not moved into the literal.
+  let z = fill()
+  let c2 = NoSeq(flag: z.len > 0, n: z.len)
+  assert c2.flag
+
+  # The fix — hoisting the derived value to a local first.
+  var ys = fill()
+  let hoisted = ys.len > 0
+  let c3 = WithSeq(flag: hoisted, n: 5, items: ys)
+  assert c3.flag
+
+  # Shape control — from a parameter, correct.
+  assert fromParam(fill()).flag
+
+  # THE BUG — derived from a local var that a later field moves.
+  var xs = fill()
+  let w = WithSeq(flag: xs.len > 0, n: xs.len, items: xs)
+  assert w.n == 5            # sibling int is correct
+  assert w.items.len == 5    # moved seq arrives intact
+  assert w.flag              # FAILS: reads the moved-from value
+
+  echo "ok"
+
+main()


### PR DESCRIPTION
… calls

An object/tuple field whose value reads a location that a LATER sibling field moves was corrupted — silent wrong code, no crash:

  WithSeq(flag: xs.len > 0, n: xs.len, items: xs)   # flag == false (xs emptied)

`trAggregateValue` binds a value in an aggregate position to a cursor temp so it evaluates before a sibling's hoisted `wasMoved`, but only did so for top-level `CallKinds`. `n: xs.len` (a bare call) was bound and read `xs` before the move; `flag: xs.len > 0` is a comparison whose OPERAND is the call, so it was left inline in the constructor and evaluated AFTER the `items: xs` move's `wasMoved`, reading the emptied seq. The check must also be goal-independent: xelim2 — the pass right after the duplifier, where the move is introduced — runs at `ElimExprs`, where `isComplex` does not flag a call.

Bind any value that transitively reads through a call (`readsThroughCall`, goal-independent). Pure atoms/literals/`nil` and structural `kv` nodes (named tuples / table entries) read nothing invalidatable and pass through unchanged.

Adds tests/nimony/arc/tmoved_seq_sibling_field. arc/object/stdlib green.