### PR TITLE
vtables: export class `=destroy` so foreign TUs dispatch it correctly

### DIFF
--- a/src/hexer/vtables_backend.nim
+++ b/src/hexer/vtables_backend.nim
@@ -13,7 +13,7 @@
 ## - Transform calls to virtual methods into calls to the vtable
 ## - Translate the `of` operator into something NIFC can understand
 
-import std/[assertions, tables, hashes, sets, syncio]
+import std/[assertions, tables, hashes, sets, syncio, strutils]
 include ".." / lib / nifprelude
 include ".." / lib / compat2
 import ".." / lib / tinyhashes
@@ -675,6 +675,19 @@ proc processMethods(c: var Context) =
         if m.cls == cls:
           var methodName = pool.syms[m.name]
           extractBasename methodName
+          # The synthesized virtual `=destroy`/`=trace` object hooks are named
+          # `=destroy_<mangledType>` / `=trace_<mangledType>`. Normalize to the
+          # bare hook name so `methodKey` routes them through the canonical
+          # destroy/trace signature — the SAME key the frontend writes into the
+          # exported `(methods)` pragma (see derefs.trType). Otherwise the
+          # collected method (per-type name key) and the pragma entry (canonical
+          # key) land in different vtable slots, and a foreign consumer — which
+          # only sees the pragma — dispatches the destroy through the wrong slot
+          # (running the base hook instead of the derived one, or leaking).
+          if methodName == "=destroy" or methodName.startsWith("=destroy_"):
+            methodName = "=destroy"
+          elif methodName == "=trace" or methodName.startsWith("=trace_"):
+            methodName = "=trace"
           processMethod c, m, methodName
       # Also load methods from the frontend pragmas (for imported generic instances)
       let diff = vtables_frontend.loadVTable(cls)

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -1246,6 +1246,40 @@ proc trType(c: var Context; n: var Cursor) =
             c.dest.takeTree n # existing individual pragmas
       if c.hooks.hasKey(s):
         addHookDecls c.dest, c.hooks.getOrQuit(s)
+      # RTTI classes: the object-level `=destroy` hook is virtual (generated as a
+      # method, see lifter.genMissingHooks). It must live in the exported
+      # `(methods)` vtable AND be discoverable as a `(destroy)` hook pragma —
+      # otherwise a foreign consumer that materializes a destroy of this class
+      # forges its OWN module-suffixed hook, which is not in the class's vtable
+      # ("method `=destroy_...` not found in class"). Publishing the owner's
+      # symbol lets the consumer reuse it (via loadHook/tryLoadHook) so the
+      # dispatched method IS in the vtable.
+      #
+      # Only `=destroy` is handled here (not `=trace`): it is the hook the
+      # consumer materializes on scope-exit / reassignment / seq-clear. Forcing
+      # `=trace` generation for every class — even `{.acyclic.}` ones that never
+      # need it — bloats vtables and trips a latent nilability bug in the
+      # synthesized `=trace` body; leave it to the existing forged-hooks path.
+      if hasMethods and not isGeneric and hasRtti(s):
+        var buf = createTokenBuf(1)
+        buf.addSymUse s, info
+        let typeCursor = cursorAt(buf, 0)
+        c.typeSymBufs.add buf
+        let existing = if c.hooks.hasKey(s): c.hooks.getOrQuit(s)
+                       else: default(HooksPerType)
+        let hookProc = getHook(c.lifter[], attachedDestroy, typeCursor, info)
+        if hookProc != SymId(0):
+          if existing.a[attachedDestroy] == SymId(0):
+            # not already emitted from c.hooks above
+            c.dest.addParLe hookToTag(attachedDestroy), NoLineInfo
+            c.dest.addSymUse hookProc, NoLineInfo
+            c.dest.addParRi()
+          let key = destroyMethodKey()
+          var dup = false
+          for (k, _) in methodsToAdd:
+            if k == key: dup = true; break
+          if not dup:
+            methodsToAdd.add (key, hookProc)
       if hasMethods:
         addMethodsDecl c.dest, methodsToAdd
       c.dest.addParRi()

--- a/tests/nimony/methods/deps/mxdestroy.nim
+++ b/tests/nimony/methods/deps/mxdestroy.nim
@@ -1,0 +1,31 @@
+## Helper for txdestroy: an RTTI (method-carrying) ref-object hierarchy whose
+## LabelObj embeds a canary field. The class itself defines NO user `=destroy` —
+## the observable effect comes from the
+## COMPILER-SYNTHESIZED object `=destroy` unravelling the canary field. A
+## foreign module that destroys a Label must dispatch through the class vtable
+## to this synthesized destroy; regression for "method `=destroy_...` not found
+## in class" + wrong-slot dispatch.
+{.feature: "lenientnils".}
+
+type
+  CanaryObj = object
+    live: bool
+
+var gDestroyed: int = 0
+proc destroyCount*(): int = gDestroyed
+proc `=destroy`(x: CanaryObj) =
+  if x.live: inc gDestroyed
+
+type
+  NodeObj* = object of RootObj
+    children*: seq[Node]
+  Node* = ref NodeObj
+  LabelObj* = object of NodeObj
+    canary: CanaryObj
+  Label* = ref LabelObj
+
+method draw*(n: Node) {.base.} = discard
+method draw*(n: Label) = discard
+
+proc newLabel*(): Label = Label(canary: CanaryObj(live: true))
+proc childCount*(n: Node): int = n.children.len

--- a/tests/nimony/methods/txdestroy.nim
+++ b/tests/nimony/methods/txdestroy.nim
@@ -1,0 +1,35 @@
+import std/syncio
+import deps/mxdestroy
+
+type
+  PanelObj = object of NodeObj
+    lbl: Label
+    labels: seq[Label]
+  Panel = ref PanelObj
+
+proc use(l: Label): int = childCount(l)
+
+proc main() =
+  var base = destroyCount()
+  block:
+    let l = newLabel()
+    discard use(l)                 # scope-exit destroys l
+  echo "scope ", destroyCount() - base
+
+  base = destroyCount()
+  let p = Panel()
+  p.lbl = newLabel()
+  discard use(p.lbl)
+  p.lbl = newLabel()               # reassignment destroys the first
+  discard use(p.lbl)
+  echo "reassign ", destroyCount() - base
+
+  base = destroyCount()
+  p.labels = @[]
+  p.labels.add(newLabel())
+  p.labels.add(newLabel())
+  discard use(p.labels[0]) + use(p.labels[1])
+  p.labels = @[]                   # seq-clear destroys both
+  echo "seqclear ", destroyCount() - base
+
+main()

--- a/tests/nimony/methods/txdestroy.output
+++ b/tests/nimony/methods/txdestroy.output
@@ -1,0 +1,3 @@
+scope 1
+reassign 1
+seqclear 2


### PR DESCRIPTION
A module that materializes a destroy of an imported polymorphic class — scope-exit, field reassignment, or seq-clear of a `ref object of` that has methods — failed hexer codegen with "method `=destroy_...` not found in class ...Obj". Once that was worked around it linked but dispatched the destroy through the WRONG vtable slot (running the base hook, leaking the derived object's fields). Two coupled gaps:

- derefs.trType built a class's `(methods)` vtable from its USER methods only. The synthesized virtual object `=destroy` (a method for RTTI types, see lifter.genMissingHooks) was neither in the vtable nor discoverable as a `(destroy)` hook pragma, so a consumer forged its own module-suffixed `=destroy` — absent from the class's vtable. The owner now publishes its `=destroy` symbol as a `(destroy)` pragma (consumer reuses it via loadHook/tryLoadHook) and in `(methods)` (getMethodIndex resolves the slot). Restricted to non-generic RTTI classes. `=trace` is deliberately left to the existing forged-hooks path: forcing it on every class bloats vtables and trips a latent nilability bug in the synthesized `=trace`.

- processMethods keyed the collected `=destroy_<mangledType>` method via methodKeyImpl (a per-type name key) while the pragma entry uses the canonical destroyMethodKey(); the two never collapsed, so the owner assembled destroy at a different slot than a pragma-only consumer computes. Normalize `=destroy_*`/`=trace_*` basenames to the bare hook name so both sides use the canonical signature and agree on the slot.

VTABLE ABI CHANGE: classes now carry a `=destroy` method slot, so every cached module interface that defines a class must be regenerated — clear nimcache after this lands.

Test: tests/nimony/methods/txdestroy.nim — a foreign module destroys an imported RTTI Label three ways (scope-exit, reassign, seq-clear) and observes the synthesized destroy firing exactly once per object through an embedded canary field.