### PR TITLE
sem: implicitlyDiscardable must not overrun an empty statement list

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -56,6 +56,12 @@ proc implicitlyDiscardable(n: Cursor, dest: var TokenBuf, noreturnOnly = false):
       # it now points to the last son (the expression); continue unwrapping if needed
     else:
       inc it
+      if not it.hasMore:
+        # Empty statement list — e.g. a `case`/`if` branch whose whole body
+        # was a compile-time-false `when`. Nothing to inspect; stepping into
+        # the loop below would `skip` past the ParRi and overrun the span
+        # (`isLastSon` skips blindly, so it never sees the empty case).
+        return false
       while not isLastSon(it):
         skip it
 

--- a/tests/nimony/casestmt/temptywhenbranch.nim
+++ b/tests/nimony/casestmt/temptywhenbranch.nim
@@ -1,0 +1,46 @@
+import std/syncio
+
+# Regression: a branch whose whole body is a compile-time-false `when`
+# sems to an empty statement list; `implicitlyDiscardable` (via `isNoReturn`)
+# used to skip past its ParRi and overrun the cursor span (nifcursors
+# `load` assertion). Both the plain and the value-yielding case shapes.
+
+type Kind = enum kA, kB, kC
+
+proc handle(k: Kind) =
+  case k
+  of kA:
+    when defined(neverDefinedPlatform):
+      echo "unreachable"
+  of kB:
+    echo "b"
+  of kC:
+    discard
+
+handle(kA)
+handle(kB)
+
+proc describe(k: Kind): string =
+  result = "none"
+  case k
+  of kA:
+    when defined(neverDefinedPlatform):
+      result = "a"
+  of kB:
+    result = "b"
+  of kC:
+    discard
+
+echo describe(kA)
+echo describe(kB)
+
+# if-branch flavour of the same hole
+proc viaIf(x: int) =
+  if x == 1:
+    when defined(neverDefinedPlatform):
+      echo "unreachable"
+  else:
+    echo "else"
+
+viaIf(1)
+viaIf(2)

--- a/tests/nimony/casestmt/temptywhenbranch.output
+++ b/tests/nimony/casestmt/temptywhenbranch.output
@@ -1,0 +1,4 @@
+b
+none
+b
+else


### PR DESCRIPTION
A case/if branch whose entire body is a compile-time-false `when` sems to an empty `(stmts)` list. implicitlyDiscardable's StmtsS/BlockS unwrap loop stepped into the list and skipped past its ParRi looking for the last son, overrunning the cursor span — nifcursors load asserted (`c.p != nil and c.rem > 0`) via semStmtBranch -> isNoReturn. Guard the empty list: nothing to inspect, return false (matches Nim 2, where an empty stmt list is neither noreturn nor discardable).

Nine-line repro: a case with one branch = `when defined(never): discard`.