### PR TITLE
move analysis: an assignment's LHS reads its base — don't skip it

### DIFF
--- a/src/hexer/mover.nim
+++ b/src/hexer/mover.nim
@@ -314,6 +314,19 @@ proc singlePath(pc: Cursor; nested: int; x: Cursor; pcs: var seq[Cursor];
           pc = sub(pc)
           let lhsRedefinesRoot = (pc.kind == Symbol and pc.symId == root) or
                                  sameTrees(pc, x)
+          if not lhsRedefinesRoot:
+            # The left-hand side of a *partial* write — `x.field = v`, `x[i] = v`,
+            # `x[] = v` — still READS the base `x`: for a `ref` it dereferences the
+            # pointer, for a value object it keeps the object live. A bare `skip` of
+            # the LHS missed that read, so an earlier whole-`x` sink was wrongly
+            # allowed and the assignment then wrote through the emptied location — a
+            # nil-deref crash for refs. Scan the LHS with `containsRoot` exactly like
+            # the RHS below; it skips statically-disjoint sibling fields, so
+            # `a.other = v` after a move of `a.field` still sinks.
+            var lhs = pc
+            if containsRoot(lhs, x):
+              otherUsage = pc
+              return false
           skip pc # skip left-hand-side; pc now at the right-hand-side
           # The RHS is evaluated *before* the store, so a read of the old value
           # here (as in `x = f(x)`) means the earlier occurrence is NOT the last

--- a/tests/nimony/arc/tsink_lastread_fieldwrite.nim
+++ b/tests/nimony/arc/tsink_lastread_fieldwrite.nim
@@ -1,0 +1,46 @@
+## Regression: a `ref` consumed by an object constructor and then written
+## through afterwards (`x.field = v`) must NOT be treated as its own last use.
+##
+## The move analyser used to `skip` an assignment's whole left-hand side, so a
+## later `x.field = v` never counted as a read of the base `x`. A prior sink of
+## `x` into an object-constructor field was then wrongly taken as the last use:
+## `x` got `=wasMoved` to nil at the constructor and the following `x.field = v`
+## dereferenced the emptied (nil) pointer — a segfault. Writing `x.field`
+## reads/derefs the base, so the constructor must COPY (dup), keeping `x` live.
+##
+## The embedded destroy canary also proves each object is destroyed exactly once
+## (a wrongful move would leak the extra reference or double-free).
+
+import std / [syncio, assertions]
+
+type
+  InnerObj = object
+    tag: int
+    note: string
+  Inner = ref InnerObj
+  Outer = ref object
+    inner: Inner
+    id: int
+
+var gDestroyed = 0
+proc `=destroy`(x: InnerObj) =
+  inc gDestroyed
+
+proc build(): Outer =
+  let inner = Inner(tag: 1, note: "orig")
+  result = Outer(inner: inner, id: 7)   # `inner` consumed here — yet used again below
+  inner.note = "changed"                # field WRITE through `inner`: reads the base
+  inner.tag = 42
+
+proc main() =
+  block:
+    let o = build()
+    assert o.inner != nil
+    assert o.inner.tag == 42
+    assert o.inner.note == "changed"
+    assert o.id == 7
+  # `o` (and its single `inner`) left scope: exactly one destroy, no double-free.
+  assert gDestroyed == 1
+  echo "destroyed ", gDestroyed
+
+main()

--- a/tests/nimony/arc/tsink_lastread_fieldwrite.output
+++ b/tests/nimony/arc/tsink_lastread_fieldwrite.output
@@ -1,0 +1,1 @@
+destroyed 1


### PR DESCRIPTION
`singlePath` walked an assignment as "the LHS is written, only the RHS reads", so the AsgnS arm did `skip pc` over the whole left-hand side and then scanned only the right-hand side with `containsRoot`. But a *partial* write — `x.field = v`, `x[i] = v`, `x[] = v` — READS the base `x`: for a `ref` it dereferences the pointer to reach the field; for a value object it keeps the object live. Skipping the LHS meant such a write never counted as a use of `x`, so an earlier sink of `x` (into an object-constructor field, a call, a return) was wrongly taken as `x`'s last read. `x` got `=wasMoved` to nil at the sink and the later `x.field = v` then dereferenced the emptied pointer — for a `ref` a nil-deref segfault.

The `skip pc` dates to 479792f1d (Feb 2025); the exposing pattern is a build-then-wire idiom: `var x = default(RefClass)`, construct an object that sinks `x` into a field, then write through `x` on the next line.

Fix: scan the LHS with `containsRoot` just like the RHS. It advances `pc` past the LHS whether or not it matches, so the existing RHS scan still lands right. `containsRoot` already skips statically-disjoint sibling fields, so a genuine disjoint write (`a.other = v` after a move of `a.field`) still sinks; and the full-redefinition arm above (`x = v` / exact-path `sameTrees`) still breaks first, so a real reassignment is unaffected.

Test: tests/nimony/arc/tsink_lastread_fieldwrite.nim — a ref consumed by an object constructor and then written through; asserts the field survived (no nil-deref) and an embedded destroy canary fires exactly once.