### PR TITLE
threadpool: report residual epoll failures via panics' writeErr

### DIFF
--- a/lib/std/system/panics.nim
+++ b/lib/std/system/panics.nim
@@ -13,32 +13,32 @@ when defined(nimNativeIo):
                        written: ptr uint32; overlapped: pointer): int32 {.
       stdcall, importc: "WriteFile".}
 
-    proc writeErr(s: string) =
+    proc writeErr*(s: string) =
       var written: uint32 = 0
       discard cWriteErrFile(cGetStdHandle(STD_ERROR_HANDLE), readRawData(s),
                             s.len.uint32, addr written, nil)
-    proc writeErr(s: cstring) =
+    proc writeErr*(s: cstring) =
       var n = 0
       let p = cast[ptr UncheckedArray[char]](s)
       while p[n] != '\0': inc n
       var written: uint32 = 0
       discard cWriteErrFile(cGetStdHandle(STD_ERROR_HANDLE), p, n.uint32,
                             addr written, nil)
-    proc writeErr(x: int64) = writeErr($x)
-    proc writeErr(x: uint64) = writeErr($x)
+    proc writeErr*(x: int64) = writeErr($x)
+    proc writeErr*(x: uint64) = writeErr($x)
   else:
     # POSIX: error text goes straight to fd 2 via the `write` syscall.
     proc cWriteErr(fd: cint; buf: pointer; n: uint): int {.importc: "write".}
 
-    proc writeErr(s: string) =
+    proc writeErr*(s: string) =
       discard cWriteErr(2'i32, readRawData(s), s.len.uint)
-    proc writeErr(s: cstring) =
+    proc writeErr*(s: cstring) =
       var n = 0
       let p = cast[ptr UncheckedArray[char]](s)
       while p[n] != '\0': inc n
       discard cWriteErr(2'i32, p, n.uint)
-    proc writeErr(x: int64) = writeErr($x)
-    proc writeErr(x: uint64) = writeErr($x)
+    proc writeErr*(x: int64) = writeErr($x)
+    proc writeErr*(x: uint64) = writeErr($x)
 
   proc die(value: int32) {.noreturn.} = cExit(value.int)
 else:
@@ -58,10 +58,10 @@ else:
     importc: "fwrite", header: "<stdio.h>".}
   proc fprintf(f: ptr RawCFile; fmt: cstring) {.varargs, importc: "fprintf", header: "<stdio.h>".}
 
-  proc writeErr(x: int64) = fprintf(cstderr, cstring"%lld", x)
-  proc writeErr(x: uint64) = fprintf(cstderr, cstring"%llu", x)
-  proc writeErr(s: string) = discard c_fwrite(readRawData(s), 1'u, s.len.uint, cstderr)
-  proc writeErr(s: cstring) = discard c_fwrite(s, 1'u, s.len.uint, cstderr)
+  proc writeErr*(x: int64) = fprintf(cstderr, cstring"%lld", x)
+  proc writeErr*(x: uint64) = fprintf(cstderr, cstring"%llu", x)
+  proc writeErr*(s: string) = discard c_fwrite(readRawData(s), 1'u, s.len.uint, cstderr)
+  proc writeErr*(s: cstring) = discard c_fwrite(s, 1'u, s.len.uint, cstderr)
 
 proc panic*(s: string) {.noinline, noreturn.} =
   writeErr s

--- a/lib/std/threadpool.nim
+++ b/lib/std/threadpool.nim
@@ -240,16 +240,13 @@ when hasEpoll:
     ## std/posix). Read immediately after a failing epoll_ctl, no intervening
     ## call, to classify the failure.
 
-  proc cWrite(fd: cint; buf: cstring; n: csize_t): int {.importc: "write",
-    sideEffect.}
-
   proc reportResidualFailure(msg: string) =
     ## A residual epoll_ctl failure (both the primary op and its fallback
     ## failed on a live pollable fd) — report on stderr with the errno number.
-    ## Replaces libc `perror`: same destination, no stdio dependency; the
-    ## numeric errno stands in for `strerror`.
-    var line = msg & " (errno " & $errnoLocation()[] & ")\n"
-    discard cWrite(2, toCString(line), line.len.csize_t)
+    ## Rides the panic path's `writeErr` (raw fd 2, no stdio); a private
+    ## bare-importc `write` here would collide with the <unistd.h> prototype
+    ## that this module's usleep/close header imports pull into the TU.
+    writeErr(msg & " (errno " & $errnoLocation()[] & ")\n")
 
   proc fdNotPollable(): bool {.inline.} =
     ## True when a failed epoll_ctl means the fd is no longer a live pollable


### PR DESCRIPTION
threadpool's private cWrite bound `write` bare-importc, but this TU already includes <unistd.h> (usleep/close header imports), and the codegen prototype for `write` (NC8* buf) conflicts with glibc's (const void*) — a hard error on gcc and clang. Upstream tests never kept cWrite alive through DCE (it is only reachable via registerFd's error path), so the first real io-polling consumer hit it at C compile time.

The stdlib already owns exactly this primitive: panics.nim's writeErr (raw fd-2 write on POSIX, WriteFile on the Windows std error handle, fwrite in the libc-stdio arm). Export it and drop threadpool's duplicate — which also gains the Windows arm for free.

The report itself stays: after the benign EPERM/EBADF skip and the ADD<->MOD fallback, a residual epoll_ctl failure (ENOSPC watch limit, ENOMEM) parks the fd's continuation forever — the stderr line is the only witness for what otherwise presents as a silent per-connection stall.

Suite: 685/685.