### PR TITLE
dce: write the shared live.nif OnlyIfChanged so an unchanged live set…

### DIFF
--- a/src/hexer/dce2.nim
+++ b/src/hexer/dce2.nim
@@ -213,7 +213,7 @@ proc writeLiveFile*(outfile: string; resolved: ResolveTable;
   ## filename, but this file aggregates symbols from many modules — only
   ## one expansion would be correct, all the others would be wrong. So
   ## we pay the file-size cost rather than mis-expand.
-  var b = nifbuilder.open(outfile)
+  var b = nifbuilder.open(outfile, writeMode = OnlyIfChanged)
   b.withTree "stmts":
     b.withTree resolveTag:
       for key, winner in pairs(resolved):


### PR DESCRIPTION
… doesn't re-fire every dceEmit

`writeLiveFile` emitted the shared `<main>.live.nif` — a read-only input to *every* `dceEmit` node — with `AlwaysWrite`. Whenever `dceLive` re-runs (any module's `.dce.nif` looks newer) it rewrites `live.nif` with a fresh mtime even when the recomputed global live set is byte-identical, so nifmake sees the shared input as newer than every `.c.nif` output and re-fires the whole backend.

Reproduced on a 2-module project (`nimony c --report`): forcing `dceLive` to re-run over an unchanged live set gave `dceEmit=5 dceLive=1` — the full backend storm. With `OnlyIfChanged` the same scenario is `dceLive=1` and `dceEmit=0`: `dceLive` still re-runs (cheap, reads the `.dce.nif`s) but the preserved mtime keeps every `dceEmit` idle. O(1)-mtime design intact — no content hashing.

This is the mtime-side fix for the branch-round-trip rebuild churn (the git-checkout case is already covered by nifler's OnlyIfChanged on `.p.nif`).