### PR TITLE
strutils: add toHex

### DIFF
--- a/lib/std/strutils.nim
+++ b/lib/std/strutils.nim
@@ -871,6 +871,27 @@ func multiReplace*(s: openArray[char]; replacements: openArray[(set[char], char)
 
 const HexChars = "0123456789ABCDEF"
 
+func toHex*(x: BiggestInt; len: Positive): string =
+  ## Converts `x` to a hexadecimal string exactly `len` uppercase digits wide
+  ## (no `0x` prefix). Negative values render in two's complement, and a value
+  ## needing more than `len` digits keeps only its least-significant `len` nibbles.
+  runnableExamples:
+    doAssert toHex(BiggestInt(1984), 4) == "07C0"
+    doAssert toHex(BiggestInt(-1), 2) == "FF"
+  var n = x
+  result = newString(len)
+  for j in countdown(len - 1, 0):
+    result[j] = HexChars[int(n and 0xF)]
+    n = n shr 4
+    # Keep sign nibbles coming for a negative value regardless of whether `shr`
+    # is arithmetic or logical, so its two's-complement form fills `len`.
+    if n == 0 and x < 0: n = -1
+
+func toHex*[T: SomeInteger](x: T): string {.inline.} =
+  ## Full-width hex for `x`: `2 * sizeof(T)` uppercase digits, e.g.
+  ## `toHex(0'u16) == "0000"`, `toHex(255'u8) == "FF"`.
+  toHex(BiggestInt(x), 2 * sizeof(T))
+
 func escape*(s: string, prefix = "\"", suffix = "\""): string =
   ## Escapes a string `s`.
   ##

--- a/tests/nimony/stdlib/tstrutils.nim
+++ b/tests/nimony/stdlib/tstrutils.nim
@@ -990,3 +990,22 @@ block: # formatSize
   assert formatSize(4096, includeSpace = true) == "4 KiB"
   # (5378934).float / (1024 * 1024) = 5.12975...
   assert formatSize(5_378_934, prefix = bpColloquial, decimalSep = ',') == "5,129MB"
+
+block: # toHex
+  # explicit width, uppercase, no prefix
+  assert toHex(BiggestInt(1984), 4) == "07C0"
+  assert toHex(BiggestInt(0), 2) == "00"
+  # a value needing more than `len` digits keeps its least-significant nibbles
+  assert toHex(BiggestInt(0xABCD), 2) == "CD"
+  # negatives render in two's complement, filling `len`
+  assert toHex(BiggestInt(-1), 2) == "FF"
+  assert toHex(BiggestInt(-100), 4) == "FF9C"
+  # generic shortcut: exactly 2 * sizeof(T) digits
+  assert toHex(0'u8) == "00"
+  assert toHex(255'u8) == "FF"
+  assert toHex(-1'i8) == "FF"
+  assert toHex(127'i8) == "7F"
+  assert toHex(0'u16) == "0000"
+  assert toHex(0xBEEF'u16) == "BEEF"
+  assert toHex(0'u32) == "00000000"
+  assert toHex(0xDEADBEEF'u32) == "DEADBEEF"


### PR DESCRIPTION
nimony's libc-free strutils had `join`, `parseHex`, and the rest of the string utilities but not `toHex` — so code wanting a hex string (e.g. flag-hashed cache filenames) had to hand-roll a nibble loop. Add the two standard Nim overloads: `toHex(x: BiggestInt, len)` (exact width, two's complement) and the `toHex[T: SomeInteger](x)` shortcut for `2 * sizeof(T)` digits. Freestanding — just newString + countdown, no libc.