### PR TITLE
fix #2281 c-code closure pointer mismatches

### DIFF
--- a/src/hexer/xelim.nim
+++ b/src/hexer/xelim.nim
@@ -1165,6 +1165,31 @@ proc trExpr(c: var Context; dest: var TokenBuf; n: var Cursor; tar: var Target) 
   else:
     bug "unexpected ')' inside"
 
+proc preRegisterRoutines(c: var Context; n: Cursor) =
+  ## Register the signatures of all top-level routines in the type cache before
+  ## the body walk. `getType` on a forward-referenced call otherwise falls back
+  ## to `tryLoadSym` (the *original* sem output), which still holds the
+  ## pre-lambdalifting types — e.g. a bare closure `proctype` where the lifted
+  ## `(tuple <fn> (ref RootObj))` is expected. That is exactly what happens for
+  ## the sem-inlined openarrays helpers (`toOpenArray`, `rawData`, `\5B\5D`)
+  ## in tests/nimony/closures/…: the body's forward `(call rawData)` hoists
+  ## into a cursor temp typed from the stale symbol, while the lifted `rawData`
+  ## ret type is the tuple — the lengcgen C names then disagree.
+  var it = n.sub()
+  while it.hasMore:
+    if it.stmtKind == StmtsS:
+      preRegisterRoutines(c, it)
+    elif it.stmtKind in {ProcS, FuncS, IteratorS, ConverterS, MethodS, MacroS}:
+      let decl = it
+      var h = it.sub()
+      let name = h
+      if name.kind == SymbolDef:
+        for i in 0 ..< BodyPos:
+          if i == ParamsPos:
+            c.typeCache.registerParams(name.symId, decl, h)
+          skip h
+    skip it
+
 proc lowerExprs*(pass: var Pass; goal = ElimExprs) =
   var n = pass.n  # Extract cursor locally
   # Inherit the temp counter across passes via `pass.nextTemp` — `lowerExprs`
@@ -1176,6 +1201,7 @@ proc lowerExprs*(pass: var Pass; goal = ElimExprs) =
   var c = Context(counter: pass.nextTemp, typeCache: createTypeCache(), thisModuleSuffix: pass.moduleSuffix, goal: goal)
   c.typeCache.openScope()
   assert n.stmtKind == StmtsS, $n.kind
+  preRegisterRoutines(c, n)
   pass.dest.addParLe(n.cursorTagId, n.info)
   n.into:
     while n.hasMore:

--- a/tests/nimony/closures/tclosure_in_seq_pairs.nim
+++ b/tests/nimony/closures/tclosure_in_seq_pairs.nim
@@ -1,0 +1,20 @@
+## Regression test for the closure-in-seq + openArray-iteration C type
+## mismatch (nim-lang/nimony#2281). `for i, r in seqOfClosures` lowers to
+## the sem-inlined openarrays helpers (`toOpenArray`, `rawData`, `\5B\5D`).
+## A forward `(call rawData)` inside `toOpenArray`'s body hoists into a
+## cursor temp typed from the stale pre-lambdalifting symbol (bare closure
+## `proctype`) while the lifted `rawData` returns the `(tuple <fn> (ref
+## RootObj))` tuple — lengcgen then emits incompatible pointer types (a
+## clang warning, a gcc hard error on Linux). The temp must be typed from
+## the current-IR signature, i.e. the lifted tuple.
+
+import std / syncio
+
+var offset = 5
+type Reactor = proc(timeoutMs: int): bool {.closure.}
+var reactors: seq[Reactor]
+reactors.add((proc(timeoutMs: int): bool = timeoutMs > offset))
+reactors.add((proc(timeoutMs: int): bool = timeoutMs < offset))
+reactors.add((proc(timeoutMs: int): bool = timeoutMs == offset))
+for i, reactor in reactors:
+  echo i, " ", reactor(i)

--- a/tests/nimony/closures/tclosure_in_seq_pairs.output
+++ b/tests/nimony/closures/tclosure_in_seq_pairs.output
@@ -1,0 +1,3 @@
+0 false
+1 true
+2 false


### PR DESCRIPTION
fix #2281

src/hexer/xelim.nim: preRegisterRoutines (xelim.nim:1168) pre-registers all top-level routine signatures into the type cache before the body walk, so getType on forward calls resolves the current-IR (lifted) signature instead of the stale pre-lambdalifting symbol — fixing the {fn, env} tuple vs bare proctype C type mismatch