### PR TITLE
xints: avoid division by zero in `*` overflow check

### DIFF
--- a/src/nimony/xints.nim
+++ b/src/nimony/xints.nim
@@ -99,7 +99,7 @@ proc `*`*(a, b: xint): xint =
   )
 
   # Check for overflow (requires casting to uint128 in Nim)
-  if result.val div a.val != b.val:
+  if a.val != 0 and result.val div a.val != b.val:
     result.nan = true
 
 proc `div`*(a, b: xint): xint =


### PR DESCRIPTION
The overflow check in `*` divides by `a.val`, which crashes with SIGFPE when multiplying by zero (e.g. `createXint(0) * createXint(5)`). A zero factor can never overflow, so skip the check in that case, like `div` already guards against a zero divisor.