### PR TITLE
hastur: fix git diff exit code check

### DIFF
--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -164,7 +164,7 @@ proc diffFiles(c: var TestCounters; file, a, b: string; overwrite: bool) =
     else:
       let gitCmd = "git diff --no-index $1 $2" % [a.quoteShell, b.quoteShell]
       let (diff, diffExitCode) = execCmdEx(gitCmd)
-      if diffExitCode == 0:
+      if diffExitCode <= 1:
         failure c, file, diff
       else:
         failure c, file, gitCmd & "\n" & diff


### PR DESCRIPTION
`git diff --no-index` exits with 1 when the files differ, so the `diffExitCode == 0` branch that shows the diff output was never taken and failures always fell into the fallback path.