### PR TITLE
std: add missing syncio import in parseopt smoke test

### DIFF
--- a/lib/std/parseopt.nim
+++ b/lib/std/parseopt.nim
@@ -149,6 +149,7 @@ iterator getopt*(cmdLine: sink seq[string]): (CmdLineKind, string, string) {.sid
     yield (p.kind, p.key, p.val)
 
 when isMainModule:
+  import std/syncio
   proc main =
     for kind, key, val in getopt():
       echo $kind, "##", key, "##", val


### PR DESCRIPTION
Add the missing `std/syncio` import so the parseopt `isMainModule` smoke test compiles.