### PR TITLE
Fix Hexer: ExtractModule now support module starting with a number

### DIFF
--- a/src/lib/symparser.nim
+++ b/src/lib/symparser.nim
@@ -34,13 +34,17 @@ proc genericTypeName*(key, modname: string): string =
 proc extractModule*(s: string): string =
   # From "abc.12.Mod132a3bc" extract "Mod132a3bc".
   # From "abc.12" extract "".
+  # From "abc.12.13Mod" extract "13Mod"
   var i = s.len - 2
+  var isModule = false
   while i > 0:
     if s[i] == '.':
-      if s[i+1] in {'0'..'9'}:
-        return ""
-      else:
+      if isModule:
         return substr(s, i+1)
+      break
+    elif s[i] notin {'0'..'9'}:
+      isModule = true
+
     dec i
   return ""
 


### PR DESCRIPTION
The function `extractModule` in the file `src/lib/symparser.nim` failed to recognize module starting with a number

```nim
proc extractModule*(s: string): string =
  # From "abc.12.Mod132a3bc" extract "Mod132a3bc".
  # From "abc.12" extract "".
  var i = s.len - 2
  while i > 0:
    if s[i] == '.':
      # if the name was "abc.12.1mod" this will fail and output that no module was found
      if s[i+1] in {'0'..'9'}:
        return ""
      else:
        return substr(s, i+1)
    dec i
  return "" 
```