### PR TITLE
shoggoth/cse: invalidate on access paths, not only on alias classes

### DIFF
--- a/doc/cse.md
+++ b/doc/cse.md
@@ -278,6 +278,48 @@ the cheaper description of the problem, but on *this* workload they do not yet
 pay for themselves — the case for them is the type machinery they let the summary
 producer drop, not a speed-up here.
 
+## Where else the same question is asked
+
+Most of the pipeline asks no memory-disambiguation question at all — constant
+folding, the rewrite engine and constructor projection are syntax; `copyprop`
+deliberately propagates only symbols and literals of non-addr-taken locals, so
+"a call cannot touch a non-addr-taken local" is its whole theory; `scalarizer`'s
+eligibility test is a path *shape* predicate that needs no overlap. Two places do
+ask it, and both now use the rules above.
+
+**LICM** (`cse.invariantIn`) asks exactly the store question, so it gets exactly
+the store answer: `LoopFrame` carries the in-loop stores as paths, and a loop
+that writes `o.b` no longer holds a load of `o.a` down. Its call test
+(`callWouldClobber`) uses the call rule for the same reason — hoisting must not
+be stricter than invalidation, or a load stays in the loop that the cache would
+have kept across the same call.
+
+**The inliner** (`hexer/intramodinliner`) was blocked on this question by name:
+`isSubstitutableArg` excluded symbol arguments because "the inliner cannot prove
+the caller's variable is unmodified during the body without alias info", and
+`isStableAddrArg` excluded compound lvalues because "the body could write through
+another pointer parameter to a symbol the path mentions". Both facts come from
+the body it is about to splice, so no alias info is needed at all:
+`bodyIsCallerReadOnly` asks whether every write goes to a plain slot of one of
+the body's own locals (never through a pointer, never to a global) and whether
+every call it makes is `noreturn` — `panic`, which every lowered bounds check
+contains, is why that exemption matters. When it holds, the body cannot change
+anything the caller can observe, so any pure path argument has the same value at
+every use site and is substituted instead of copied into a parameter. Capped at
+`MaxPathSubstUses` uses, since a path (unlike a symbol) is re-evaluated per use.
+
+Measured over 12 `nimsem` modules: 10 change, and the emitted Leng shrinks by
+13KB — 9, 24 and 6 parameter copies gone in the three largest.
+`-d:inlinerNoPathSubst` restores the old rule.
+
+**`induction_variables`** turned out to ask no aliasing question — `addr arr[0]`
+is the address of stable storage — but it never checked that the *base* is one.
+`typenav` admits `(at …)` on `ptr`/`aptr`/`flexarray` too, where the hoisted
+address is the base's *value*, so a loop that rebinds it would leave the pointer
+walking the old buffer. `baseIsStable` now proves the base is an array, or else
+requires it to be unassigned, not address-taken, and free of calls in the loop.
+(A `(store …)` write-target bug — the first child is the *source* — went with it.)
+
 ## Still to do
 
 1. Rewrite the summary producer in `hexer/funcsummary.nim` in path vocabulary —

--- a/doc/cse.md
+++ b/doc/cse.md
@@ -1,0 +1,291 @@
+# Path-based invalidation for CSE
+
+This document describes how CSE should decide *"can this event change what my
+cached expression reads?"* — and argues that the answer must be built out of
+**expression paths and nesting levels**, the way borrow checking already is, not
+out of types and alias partitions.
+
+The immediate motivation is the state of the type-based approach. Answering the
+question with types requires, for every nominal type in a type slot, a walk of
+that type's declaration; a pass that runs where the type world is incomplete then
+needs a *second* implementation of that walk over the other world. That is
+`src/hexer/pointertypes.nim` (268 lines over Nimony declarations) plus
+`src/lengc/pointerbearing.nim` (281 lines over Leng types) plus two resolver
+callbacks threaded through every entry point of the latter — and it grew that way
+because `funcsummary` runs inside `hexer c`, which is the one pipeline stage that
+sees only its own module's Leng output. Borrow checking answers a question of the
+same shape with no type information at all, in about eighty lines.
+
+
+## The question, stated once
+
+CSE caches the value of a memory load and reuses it later. The cache entry is
+valid until something writes the memory the load reads. Every hard part of CSE is
+one predicate:
+
+> Given a cached read `R` and a write `W` (a store, or a call that may store),
+> can `W` change what `R` reads?
+
+Borrow checking asks:
+
+> Given a borrowed lvalue `B` and a mutation `M`, can `M` change what `B` names?
+
+These are the same predicate. It is worth noticing that the safety analysis —
+the one that must never be wrong — is the one that answers it *without* types.
+
+
+## What borrow checking does
+
+See `doc/language.md#borrow-checking` for the user-facing rules and
+`src/nimony/contracts_fir.nim` for the implementation. Five lessons carry over.
+
+**1. A path, not a type.** A borrow is a `seq[SymId]`: root, then one symbol per
+field selector (`contracts_fir.nim:56`). `extractBorrowPath`
+(`contracts_fir.nim:185`) peels the expression — `dot`, `at`, `conv`, `baseobj`,
+`haddr`/`hderef`, a call's first argument, an inline temp's defining expression —
+and appends a symbol per step. Nothing anywhere loads a type declaration.
+
+**2. Overlap is a prefix test.** `pathsOverlap` (`contracts_fir.nim:277`)
+compares element by element up to the shorter length: paths overlap iff one is a
+prefix of the other. `a.b` and `a.b.c` overlap; `a.b` and `a.c` do not. Field
+precision comes out of the *path length* — the nesting level — for free, with no
+knowledge of what `a` is.
+
+**3. Indices collapse; the path stays.** `a[i]` contributes `a` and nothing else:
+"recurse into container, don't distinguish indices" (`contracts_fir.nim:214`).
+Two different elements of one array are assumed to overlap. This is the one
+deliberate imprecision, and it is what keeps the analysis free of arithmetic
+reasoning.
+
+**4. A path ends where the compiler stops being able to follow it.** A `deref` in
+the middle of a path sets `NotBorrowable`; an explicit `addr` sets `HasAddr`
+(`contracts_fir.nim:50-54`). The checker does not *guess* what a pointer points
+to and does not consult the pointee's type: it marks the path as unfollowable and
+takes the conservative branch. Where a path cannot be followed, the answer is
+refusal, not a type-shaped estimate.
+
+**5. What must cross a call boundary is declared, not inferred from types.**
+`.establishesBorrow` (`contracts_fir.nim:168`) says "the result keeps aliasing the
+first argument". At the call site itself, `borrowCheckForCall`
+(`contracts_fir.nim:1000`) needs nothing but the argument *shapes*: an argument
+wrapped in `haddr` is a mutable path, everything else is an immutable path, and
+the check is `pathsOverlap` over those two lists.
+
+
+## The model for CSE
+
+### Paths
+
+A path is a root symbol plus a list of selectors:
+
+```
+Sel = Field(SymId) | Elem | Deref
+Path = (root: SymId, sels: seq[Sel])
+```
+
+`Elem` is the collapsed index (lesson 3): `a[i]` and `a[j]` both give
+`(a, [Elem])`. `Deref` is a marker, not a step into anything known.
+
+`accessRoots` in `src/lengc/shoggoth/aliasing.nim:89` already performs exactly
+this walk over Leng and then throws the selectors away, keeping only the root.
+Path extraction is that function with the selectors retained — the same peeling
+of `DotC`, `AtC`, `DerefC`, `PatC`, `AddrC`/`HaddrC`, `ConvC`, `CastC`,
+`BaseobjC`, and the same treatment of a call (union of operand paths).
+
+### Levels
+
+The **level** of a path is the position of its first `Deref`, or `∞` if it has
+none:
+
+* **Direct** (level `∞`): rooted in a symbol, reached only by field selection and
+  indexing. `x`, `x.a.b`, `arr[i].f`.
+* **Indirect** (finite level): the path passes through a pointer at that position.
+  `p[]`, `x.next[].val`, `(deref (dot x p)) .a`.
+
+Two facts follow from the IR alone, with no types:
+
+* A direct path rooted at a **local whose address is never taken** cannot be
+  reached by any indirect write, by any callee, or by any pointer at all. Nothing
+  can point at it. (`cse.nim:661` `unreachableByCallee` argues exactly this
+  today, but derives it from an alias partition instead of from the path.)
+* Two direct paths overlap iff one is a prefix of the other. Their roots are
+  symbols, and distinct symbols are distinct storage.
+
+### Buckets
+
+The cache is partitioned once, at insert time, by the path of the cached read:
+
+| bucket | membership | killed by |
+|---|---|---|
+| `direct[root]` | direct paths, per root symbol | a write whose path overlaps (prefix either way); `addr`/`haddr` of that root moves it to `escaped` |
+| `escaped[root]` | direct paths whose root has had its address taken | as `direct`, plus every indirect write and every call that can reach the root |
+| `indirect` | every path containing a `Deref` | any indirect write; any call that writes indirectly |
+
+Three rules, and none of them asks what a type contains.
+
+
+## Kill rules
+
+Let `W` be the path of a store's LHS and `R` the path of a cached read.
+
+1. **Direct store, direct read.** Kill iff `overlap(W, R)` — prefix in either
+   direction, comparing selectors pairwise, `Elem` matching `Elem`. `o.x = 1`
+   leaves a cached `o.y` alive; today `invalidateMentioning` (`cse.nim:609`)
+   kills it, because it tests "does the expression mention `o`" and nothing
+   finer. Prefix exclusion is *more* precise than the current type-based code
+   here, not less.
+2. **Indirect store.** Kill the whole `indirect` bucket and every `escaped`
+   entry. Leave `direct` untouched: no pointer can name a local whose address
+   was never taken.
+3. **`addr`/`haddr` of a root.** Move that root's entries from `direct` to
+   `escaped`. (`&L` itself is not invalidated by taking `&L`, the existing
+   `exempt` handling.)
+4. **Call.** Kill:
+   * every `escaped` entry whose root the callee can reach (argument roots,
+     globals, previously escaped roots);
+   * the `indirect` bucket, unless the callee's summary says it performs no
+     indirect write;
+   * for each argument the summary marks written, the entries whose path is
+     prefixed by that argument's path.
+
+   `direct` entries rooted at never-addr-taken locals survive every call. That is
+   the case that matters in loops and it needs no summary at all.
+5. **Unknown callee.** Rules 4 minus the summary refinements: kill `indirect` and
+   all of `escaped`, keep `direct`.
+
+Worked example — the shape this pass exists for:
+
+```
+while i < n:
+  t = x.field[i]      # direct path (x, [Field field, Elem]) — cached
+  p[] = t             # indirect store → kills `indirect`, not `x.…`
+  o.other = 3         # direct store, path (o, [Field other]) — disjoint root
+  f(y)                # y's root escapes; x is a local, never addr-taken → survives
+  u = x.field[i]      # reuse
+```
+
+Every decision above is a prefix comparison on symbol lists. The type-based
+pipeline reaches the same conclusions only after asking whether `x`'s type can
+hold a pointer, which for an imported `x` means loading a declaration out of
+another module.
+
+
+## Calls, in path vocabulary
+
+The summary `(smry …)` stays — lesson 5 says the information that cannot be seen
+at the call site must be declared — but its contents change from a type-derived
+partition to path facts read off the callee's body:
+
+* per parameter: `reads`, `writesDirect` (the parameter's own slot),
+  `writesIndirect` (a store whose path is rooted at that parameter and contains a
+  `Deref`);
+* whole proc: `writesGlobal`, `writesIndirect`, `callsUnknown`, `raises`;
+* parameter classes, when two parameters were joined by an assignment inside the
+  callee, computed by unioning parameter *indices* along assignments between
+  paths — again a path fact.
+
+The critical simplification: **"can this argument's graph be written?" is
+answered by the callee's body, not by the argument's type.** Today the pass asks
+whether a parameter's type can hold a pointer, as a proxy for whether a store
+through it is possible. The body settles it directly: if the callee never stores
+through a path rooted at parameter *i*, no type walk can make it write there; if
+it does, the store is visible as a `Deref` in that path.
+
+That single change is what removes the type world from `hexer/funcsummary`, and
+with it `hexer/pointertypes.nim`, the two `ForeignSymResolver` /
+`ForeignFieldResolver` hooks, and the entire type half of
+`lengc/pointerbearing.nim`. The stage-1 placement of the summary pass stops
+mattering, because nothing in it needs to resolve an imported *type* any more —
+only the module's own body.
+
+
+## Two answers, intersected
+
+Paths and the alias partition are each a sound over-approximation of the same
+predicate, and they are blind in *opposite* directions: the partition knows only
+roots, so it cannot separate two fields of one object; a path deliberately stops
+at a pointer, so it cannot separate two unrelated pointers. Intersecting two
+over-approximations is still one (`A ⊇ T` and `B ⊇ T` ⇒ `A ∩ B ⊇ T`), so the
+implementation kills a cache entry only when **both** analyses say the write may
+reach it. That is why the type-based analysis stays exactly as `master` has it:
+it is not scaffolding to be removed, it is the half that answers rule 2.
+
+`cse.nim`'s self-tests pin both halves. `sibling_field_store_survives` is the
+path half (a store to `x.other` leaves a cached `x.fld` alive; the partition
+alone drops it), and `store_disjoint_survives` is the partition half (a store
+through `qq` leaves a load through `pp` alive; the paths alone drop it).
+
+## What is given up
+
+Honest accounting:
+
+* **Indirect reads still depend on the partition.** Nothing in a path
+  distinguishes two pointers, so if the partition is ever removed, rule 2 becomes
+  "an indirect store clears the indirect bucket" and loads through unrelated
+  pointers stop surviving each other's stores.
+* **Whole-aggregate copies.** `x = y` between two structs that both contain
+  pointers creates aliasing with no syntactic `deref`. Path discipline does not
+  try to prove anything about it: both `x.…[]` and `y.…[]` are indirect paths, so
+  rule 2 covers them without a type test. This is precisely where the type-based
+  design spent its complexity and where refusal is cheaper than proof.
+* **Indices stay collapsed.** `a[i]` and `a[i+1]` overlap. Same trade the borrow
+  checker makes; index reasoning belongs to the induction-variable pass, which
+  already exists and can feed a stronger `Elem` when it proves two indices
+  distinct.
+
+Nothing here is a soundness risk in the dangerous direction: every rule kills a
+superset of what a perfect analysis would kill, except rule 1, which is exact for
+direct paths.
+
+
+## What stays type-shaped
+
+One use of `typenav` in CSE is legitimate and unaffected: `getType` to skip
+value-CSE of large aggregates (`cse.nim`'s import comment). That is a *cost*
+question about this module's own expression — is copying this value into a temp
+cheaper than reloading it — not an aliasing question, it needs no cross-module
+resolution, and it stays.
+
+
+## What is implemented
+
+`src/lengc/shoggoth/accesspaths.nim` (the vocabulary) plus the store and call
+rules in `cse.nim`, both intersected with the partition as above.
+`-d:cseTypeInvalidation` compiles the type/alias-class analysis alone, exactly as
+`master` has it, so the two can be measured against each other; nothing else
+changes between the two builds.
+
+Measured on this machine, 25 modules of `nimsem` (the largest in the boot) and
+four alternating 3-stage native bootstraps:
+
+| | path (default) | type (`-d:cseTypeInvalidation`) |
+|---|---|---|
+| boot total | 19.11s / 19.70s | 19.65s / 19.47s |
+| emitted `.oc.nif` | byte-identical across the two modes | — |
+| `cse.N` temps over 25 modules | 398 | 398 |
+
+With `-d:cseSummaryStats`, the path rule keeps **413** cache entries across
+stores and **14** across calls that the partition alone would have dropped, out
+of 8748 path tests. So the rule is live, but none of those survivals is followed
+by a reuse of the same expression — hence identical output and identical time.
+The reason is upstream: `scalarizer` explodes non-escaping local objects into
+per-field scalars before CSE runs, which is precisely the shape rule 1 exists to
+separate. The remaining field loads go through pointers, where the partition
+answers.
+
+Two ways to read that, both worth stating: the path rules cost nothing and are
+the cheaper description of the problem, but on *this* workload they do not yet
+pay for themselves — the case for them is the type machinery they let the summary
+producer drop, not a speed-up here.
+
+## Still to do
+
+1. Rewrite the summary producer in `hexer/funcsummary.nim` in path vocabulary —
+   "does the body store through a path rooted at parameter *i*" — which is what
+   removes the type world from a pass that runs where it cannot see one.
+2. Keep the `(smry …)` wire format's field names but drop the pointer-bearing
+   derived bits; `doc/tags.md` needs the corresponding edit.
+3. Re-measure with the SROA interaction in mind: if rule 1 is to earn its keep on
+   compiler-shaped code, the input it wants is field loads that survive
+   scalarization (large or escaping objects), so measure a workload that has
+   them before concluding either way.

--- a/src/hexer/intramodinliner.nim
+++ b/src/hexer/intramodinliner.nim
@@ -624,6 +624,61 @@ proc slotRootOf(c: Cursor): SymId =
       else: return rootOf(n)                  # unmodelled spine: stay conservative
     else: return SymId(0)
 
+const PathArgSubstitution* = not defined(inlinerNoPathSubst)
+  ## Substitute a compound-lvalue or global argument into the splice when the
+  ## callee body provably writes nothing the caller can observe
+  ## (`bodyIsCallerReadOnly`). `-d:inlinerNoPathSubst` restores the older, purely
+  ## shape-based rule (literals, `(haddr S)`, `(deref S)`, bare locals) as the
+  ## A/B reference.
+
+const MaxPathSubstUses = 2
+  ## How often a substituted *path* argument may appear in the body. Unlike a
+  ## bare symbol, a path is re-evaluated at each use (`(dot o f)` is a load), so
+  ## substituting it at many sites trades one copy for many loads. Two keeps the
+  ## win — the `var`-parameter case is one or two uses — without that trade.
+  ## (`cse` would re-fold the repeats, but it only runs under `--opt`.)
+
+proc countParamUses(c: Cursor; params: HashSet[SymId]; uses: var Table[SymId, int]) =
+  case c.kind
+  of Symbol:
+    if c.symId in params: uses[c.symId] = uses.getOrDefault(c.symId) + 1
+  of TagLit:
+    var n = c
+    n.into:
+      while n.hasMore:
+        countParamUses(n, params, uses)
+        skip n
+  else: discard
+
+proc isPurePathArg(c: Cursor): bool =
+  ## Is the argument an lvalue path — symbols, fields, indices, derefs, casts —
+  ## with no call and no constructor in it? Such an expression can be spliced at
+  ## a use site and re-evaluated there, PROVIDED nothing writes what it reads;
+  ## that second half is `bodyIsCallerReadOnly`'s job.
+  case c.kind
+  of Symbol, SymbolDef, IntLit, UIntLit, FloatLit, CharLit, StrLit:
+    result = true
+  of TagLit:
+    case c.exprKind
+    of DotC, AtC, DerefC, PatC, AddrC, HaddrC, ConvC, CastC, BaseobjC, ParC:
+      result = true
+      var n = c
+      n.into:
+        while n.hasMore:
+          if not isPurePathArg(n): result = false
+          skip n
+    else:
+      result = false
+  else:
+    result = false
+
+proc writeTargetIsLocalSlot(dst: Cursor): bool =
+  ## True when the written lvalue is a plain slot of a symbol this body owns:
+  ## no deref/index-through-pointer step (`slotRootOf` answers 0 for those), and
+  ## a *local* name, since assigning a global is visible to the caller.
+  let s = slotRootOf(dst)
+  result = s != SymId(0) and isLocalName(pool.syms[s])
+
 proc scanParamUsage(c: Cursor; params: HashSet[SymId];
                     assigned, addrTaken: var HashSet[SymId]) =
   ## Record which parameters have their *slot* reassigned (a bare `p = …`) or
@@ -939,7 +994,57 @@ proc emitBody(c: var InlinerCtx; dest: var TokenBuf; body: var Cursor;
   dest.addParRi()
   dest.addParRi()                           # close (scope …)
 
-proc bindingsFor(pSyms: seq[SymId]; argCursors: seq[Cursor];
+proc calleeIsNoReturn(c: var InlinerCtx; calleeSym: SymId): bool =
+  ## `(attr "noreturn")` on the callee — `lengcgen` carries Nimony's noreturn
+  ## that way. Control never comes back, so nothing such a call writes can be
+  ## observed by a later use in the body that called it. `panic` is the case
+  ## that matters: every lowered bounds check contains one.
+  var decl = default(Cursor)
+  if not lookupBody(c, calleeSym, decl): return false
+  var p = decl
+  let pd = takeProcDecl(p)
+  if not pd.pragmas.isTagLit: return false
+  var pr = pd.pragmas
+  pr.into:
+    while pr.hasMore:
+      if pr.isTagLit and pr.pragmaKind == AttrP:
+        var a = pr
+        inc a
+        if a.kind == StrLit and pool.strings[a.strId] == "noreturn": return true
+      skip pr
+  result = false
+
+proc bodyIsCallerReadOnly(c: var InlinerCtx; body: Cursor): bool =
+  ## Can this body change ANY memory its caller can observe?
+  ##
+  ## It cannot when every write goes to a plain slot of one of its own locals
+  ## (never through a pointer, never to a global) and every call it makes is one
+  ## that does not return. Such a body leaves every caller-side expression
+  ## exactly as it found it — so an argument that is a pure path
+  ## (`isPurePathArg`) has the same value at every use site inside the splice,
+  ## and can be substituted instead of copied into a parameter.
+  ##
+  ## This is the fact the two "cannot prove it without alias info" refusals in
+  ## `isSubstitutableArg` / `isStableAddrArg` were missing. It is answered from
+  ## the body about to be spliced — no summaries, no types, no alias partition.
+  if not body.isTagLit: return false
+  result = true
+  var n = body
+  if n.stmtKind in {AsgnS, StoreS}:
+    var dst = n.childCursor
+    if n.stmtKind == StoreS: skip dst        # `(store value dest)`
+    if not writeTargetIsLocalSlot(dst): return false
+  elif n.stmtKind == CallS or n.exprKind == CallC:
+    var callee = n.childCursor
+    if callee.kind != Symbol: return false
+    if not calleeIsNoReturn(c, callee.symId): return false
+  var m = n
+  m.into:
+    while m.hasMore:
+      if not bodyIsCallerReadOnly(c, m): return false
+      skip m
+
+proc bindingsFor(c: var InlinerCtx; pSyms: seq[SymId]; argCursors: seq[Cursor];
                  body: Cursor; rename: Table[SymId, SymId]): Bindings =
   ## Bundle the param→fresh-sym rename with the set of params that can be
   ## replaced by their argument value (read-only, not addr-taken, substitutable
@@ -950,6 +1055,21 @@ proc bindingsFor(pSyms: seq[SymId]; argCursors: seq[Cursor];
   var assigned = initHashSet[SymId]()
   var addrTaken = initHashSet[SymId]()
   scanParamUsage(body, paramSet, assigned, addrTaken)
+  # A body that cannot write anything the caller sees makes every pure PATH
+  # argument stable across the splice — the fact the refusals below could not
+  # establish. Computed once per call site, and only when it can pay off.
+  var uses = initTable[SymId, int]()
+  var callerReadOnly = false
+  when PathArgSubstitution:
+    var anyPathArg = false
+    for i in 0 ..< pSyms.len:
+      if pSyms[i] notin assigned and pSyms[i] notin addrTaken and
+         not argCursors[i].isSymbol and isPurePathArg(argCursors[i]):
+        anyPathArg = true
+        break
+    if anyPathArg:
+      callerReadOnly = bodyIsCallerReadOnly(c, body)
+      if callerReadOnly: countParamUses(body, paramSet, uses)
   for i in 0 ..< pSyms.len:
     if pSyms[i] in assigned or pSyms[i] in addrTaken:
       continue                               # slot mutated / addr observed → copy
@@ -963,6 +1083,14 @@ proc bindingsFor(pSyms: seq[SymId]; argCursors: seq[Cursor];
     # whereas the copy captured its entry value.
     if isSubstitutableArg(arg) or isStableAddrArg(arg) or isStableDerefArg(arg) or
        (arg.isSymbol and isLocalName(pool.syms[arg.symId])):
+      result.subst[pSyms[i]] = arg
+    elif callerReadOnly and isPurePathArg(arg) and
+         uses.getOrDefault(pSyms[i]) <= MaxPathSubstUses:
+      # A compound lvalue (`(haddr (dot o f))`, `(at a i)`) or a global: stable
+      # here because this body writes nothing the caller can observe. Splicing
+      # it leaves `(deref (haddr (dot o f)))` at the use, which the rewrite
+      # engine's `deref_addr` rule folds back to `(dot o f)` — the same reason
+      # `isStableAddrArg` exists, now without the bare-symbol restriction.
       result.subst[pSyms[i]] = arg
 
 proc seedRenameWalk(c: var InlinerCtx; n: var Cursor;
@@ -1061,7 +1189,7 @@ proc trySplice*(c: var InlinerCtx; dest: var TokenBuf; n: var Cursor): int =
   for i in 0 ..< pSyms.len:
     argCursors.add ac
     skip ac
-  let bnd = bindingsFor(pSyms, argCursors, pd.body, rename)
+  let bnd = bindingsFor(c, pSyms, argCursors, pd.body, rename)
 
   dest.addParLe TagId(ScopeS), info
 
@@ -1181,7 +1309,7 @@ proc trySpliceVarInit*(c: var InlinerCtx; dest: var TokenBuf; n: var Cursor): in
   for i in 0 ..< pSyms.len:
     argCursors.add ac
     skip ac
-  var bnd = bindingsFor(pSyms, argCursors, pd.body, rename)
+  var bnd = bindingsFor(c, pSyms, argCursors, pd.body, rename)
   bnd.dropDecl = resultLocal
 
   dest.addParLe TagId(ScopeS), info
@@ -1432,7 +1560,7 @@ proc trySpliceCond*(c: var InlinerCtx; dest: var TokenBuf; n: var Cursor;
   for i in 0 ..< pSyms.len:
     argCursors.add ac
     skip ac
-  let bnd = bindingsFor(pSyms, argCursors, pd.body, rename)
+  let bnd = bindingsFor(c, pSyms, argCursors, pd.body, rename)
   for i in 0 ..< pSyms.len:
     if not bnd.subst.hasKey(pSyms[i]): return 0
 

--- a/src/lengc/shoggoth/accesspaths.nim
+++ b/src/lengc/shoggoth/accesspaths.nim
@@ -1,0 +1,198 @@
+#
+#
+#        Lengc access paths for CSE invalidation
+#        (c) Copyright 2026 Andreas Rumpf
+#
+#    See the file "license.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Access paths in the sense of `doc/cse.md`: a root symbol plus one selector
+## per step of an lvalue, so that "can this write change what that read reads?"
+## is a **prefix comparison on the paths**, not a question about their types.
+##
+## This is the vocabulary Nimony's borrow checker already uses
+## (`nimony/contracts_fir.nim`: `BorrowInfo.path` + `pathsOverlap`), moved to
+## Leng. The three rules it inherits:
+##
+## * **Indices collapse.** `a[i]` and `a[j]` both give `a :: Elem`. Distinguishing
+##   them is arithmetic, which this analysis stays out of; the induction-variable
+##   pass is where index reasoning belongs.
+## * **A path ends at a pointer.** A `deref` is recorded as a step, not followed:
+##   nothing here guesses what a pointer points to. A path that contains one is
+##   *indirect*, and indirect paths are only ever compared coarsely.
+## * **What cannot be described is not guessed at.** A call result, a forging
+##   cast, an unrecognized shape: `known = false`, which every comparison reads
+##   as "may overlap".
+##
+## `aliasing.accessRoots` performs this same walk and keeps only the root;
+## everything below is that walk with the selectors retained. The one deliberate
+## difference is index operands: `accessRoots` skips them (an index selects
+## *within* the base, so it roots no separate object), while an invalidator must
+## treat them as reads of their own — `a[y.i]` changes when `y.i` is written.
+## `collectReadPaths` therefore descends into them, `pathOfLvalue` does not.
+
+import ".." / ".." / "lib" / nifcoreparse   # re-exports nifcore
+import ".." / ".." / "lib" / nifcdecl        # exprKind, tag enums
+
+const MaxPathSteps* = 8
+  ## Paths this long do not occur in lowered Leng (`x.a.b[i].c` is 4). Beyond
+  ## the bound the tail is dropped and `truncated` is set, which only ever makes
+  ## a comparison answer "may overlap".
+
+type
+  StepKind* = enum
+    FieldStep,   ## `(dot base fld)` — the selected field symbol
+    ElemStep,    ## `(at base i)` / `(pat base i)` — index collapsed away
+    DerefStep    ## `(deref base)` / the pointer step of `(pat …)`
+
+  PathStep* = object
+    kind*: StepKind
+    field*: SymId   ## `FieldStep` only
+
+  AccessPath* = object
+    ## A value type on purpose: paths are built per invalidation event and per
+    ## cache entry, and a heap allocation there would show up in shoggoth's own
+    ## runtime, which is compile time for everyone else.
+    root*: SymId          ## `SymId(0)` when there is none
+    known*: bool          ## false ⇒ every comparison answers "may overlap"
+    truncated*: bool      ## deeper than `MaxPathSteps`
+    len*: int
+    steps*: array[MaxPathSteps, PathStep]
+
+proc firstChild(c: Cursor): Cursor {.inline.} =
+  result = c
+  inc result
+
+proc unknownPath*(): AccessPath {.inline.} =
+  AccessPath(root: SymId(0), known: false, truncated: false, len: 0)
+
+proc add(p: var AccessPath; s: PathStep) {.inline.} =
+  if p.len < MaxPathSteps:
+    p.steps[p.len] = s
+    inc p.len
+  else:
+    p.truncated = true
+
+proc isIndirect*(p: AccessPath): bool {.inline.} =
+  ## Does the path pass through a pointer? An unknown path counts as indirect:
+  ## the caller must treat it as reaching anywhere.
+  if not p.known: return true
+  for i in 0 ..< p.len:
+    if p.steps[i].kind == DerefStep: return true
+  result = false
+
+proc isDirect*(p: AccessPath): bool {.inline.} =
+  ## Rooted in a named symbol and reached without following a pointer, so the
+  ## storage it names is exactly the root's.
+  p.known and p.root != SymId(0) and not isIndirect(p)
+
+proc samePrefix*(a, b: AccessPath): bool =
+  ## Do the two paths select overlapping storage, assuming a common root? True
+  ## iff one selector list is a prefix of the other. `a.b` vs `a.b.c` overlap;
+  ## `a.b` vs `a.c` do not. `ElemStep` matches `ElemStep` — indices are collapsed,
+  ## so two elements of one array always overlap.
+  let n = min(a.len, b.len)
+  for i in 0 ..< n:
+    if a.steps[i].kind != b.steps[i].kind: return false
+    if a.steps[i].kind == FieldStep and a.steps[i].field != b.steps[i].field:
+      return false
+  result = true
+
+proc directOverlap*(a, b: AccessPath): bool {.inline.} =
+  ## For two DIRECT paths: distinct roots are distinct storage, so the whole
+  ## question is the root plus the prefix test.
+  a.root == b.root and samePrefix(a, b)
+
+# ---- extraction -----------------------------------------------------------
+
+proc build(n: Cursor; p: var AccessPath) =
+  ## Walk outside-in, append the step on the way back out, so `steps` ends up in
+  ## root-first order (`x.a[i]` ⇒ `[Field a, Elem]`).
+  case n.kind
+  of Symbol, SymbolDef:
+    p.root = symId(n)
+    p.known = true
+  of TagLit:
+    case n.exprKind
+    of DotC:
+      var fld = firstChild(n)
+      skip fld                       # past the object; the field symbol follows
+      build(firstChild(n), p)
+      if p.known:
+        if fld.kind == Symbol:
+          p.add PathStep(kind: FieldStep, field: symId(fld))
+        else:
+          # A field slot that is not a plain symbol: describe no further rather
+          # than describe wrongly.
+          p.truncated = true
+    of AtC:
+      build(firstChild(n), p)
+      if p.known: p.add PathStep(kind: ElemStep, field: SymId(0))
+    of DerefC:
+      build(firstChild(n), p)
+      if p.known: p.add PathStep(kind: DerefStep, field: SymId(0))
+    of PatC:
+      # `p[i]` through a pointer: the pointer step and then the element.
+      build(firstChild(n), p)
+      if p.known:
+        p.add PathStep(kind: DerefStep, field: SymId(0))
+        p.add PathStep(kind: ElemStep, field: SymId(0))
+    of AddrC, HaddrC:
+      # The VALUE is an address; as a location it is the addressed lvalue, which
+      # is what a store target or a conservative reader wants.
+      build(firstChild(n), p)
+    of ConvC, CastC:
+      var inner = firstChild(n)
+      skip inner                     # the type operand
+      build(inner, p)
+    of BaseobjC:
+      var inner = firstChild(n)
+      skip inner                     # type
+      skip inner                     # inheritance-depth intlit
+      build(inner, p)
+    of ParC:
+      build(firstChild(n), p)
+    else:
+      p = unknownPath()
+  else:
+    p = unknownPath()
+
+proc pathOfLvalue*(n: Cursor): AccessPath =
+  ## The path an lvalue names — a store target, or the principal path of a read.
+  ## Index operands are NOT descended into: they are values selecting within the
+  ## base, not part of the location.
+  result = AccessPath(root: SymId(0), known: false, truncated: false, len: 0)
+  build(n, result)
+
+proc collectReadPaths*(n: Cursor; acc: var seq[AccessPath]) =
+  ## Every path the expression READS: its own, plus those of index operands and
+  ## of any nested operand. An entry is invalidated when a write may overlap any
+  ## one of them.
+  case n.kind
+  of Symbol, SymbolDef:
+    acc.add pathOfLvalue(n)
+  of TagLit:
+    case n.exprKind
+    of DotC, AtC, DerefC, PatC, AddrC, HaddrC, ConvC, CastC, BaseobjC, ParC:
+      acc.add pathOfLvalue(n)
+      # The selectors themselves can read memory (`a[y.i]`), so walk the operands
+      # that are not part of the location.
+      case n.exprKind
+      of AtC, PatC:
+        var idx = firstChild(n)
+        skip idx                     # the base
+        collectReadPaths(idx, acc)
+      else: discard
+    of CallC:
+      # A call's value is not described by any path (`isPureExpr` keeps calls out
+      # of the load cache; guard facts can still hold one).
+      acc.add unknownPath()
+    else:
+      # Constructors, arithmetic, comparisons: the union of the operands' reads.
+      var r = n
+      r.loopInto:
+        collectReadPaths(r, acc)
+        skip r
+  else:
+    discard                          # literals read no memory

--- a/src/lengc/shoggoth/cse.nim
+++ b/src/lengc/shoggoth/cse.nim
@@ -163,6 +163,11 @@ type
     writes: HashSet[SymId]      ## symbols assigned in the loop
     memStoreRoots: HashSet[SymId] ## `rootOf` of through-pointer stores;
                                   ## `SymId(0)` = indeterminate store
+    memStorePaths: seq[AccessPath] ## the same stores as PATHS, in the same
+                                   ## order they were seen. Invariance asks the
+                                   ## question `invalidateForStore` asks, so it
+                                   ## gets the same two answers intersected
+                                   ## (`doc/cse.md`)
     callPos: seq[int]           ## `(call …)` nodes, for summary-based clobber
 
   CachedEntry = object
@@ -1155,8 +1160,10 @@ proc preScanLoop(c: Context; start: Cursor; frame: var LoopFrame) =
     else:
       if c.aa.forged and goesThroughPointer(lhs):
         frame.memStoreRoots.incl SymId(0)
+        frame.memStorePaths.add unknownPath()
       else:
         frame.memStoreRoots.incl rootOf(lhs)
+        frame.memStorePaths.add pathOfLvalue(lhs)
   if sk == CallS or ek == CallC:
     frame.callPos.add cursorToPosition(c.orig[], start)
   var n = start
@@ -1175,6 +1182,7 @@ proc callWouldClobber(c: var Context; call, expr: Cursor): bool =
   if summary.writesGlobal or summary.callsUnknown:
     return not unreachableByCallee(c, expr, escapedClassReps(c))
   var argSyms: seq[SymId] = @[]
+  var argPaths: seq[AccessPath] = @[]
   var writtenClasses = initHashSet[uint32]()
   var argIndex = 0
   var ca = call
@@ -1183,6 +1191,7 @@ proc callWouldClobber(c: var Context; call, expr: Cursor): bool =
     while ca.hasMore:
       let s = rootOf(ca)
       argSyms.add s
+      argPaths.add pathOfLvalue(ca)
       if paramMayWrite(summary, argIndex):
         let cls = if argIndex < summary.params.len: summary.params[argIndex].cls
                   else: uint32(argIndex)
@@ -1197,19 +1206,51 @@ proc callWouldClobber(c: var Context; call, expr: Cursor): bool =
     let cls = if i < summary.params.len: summary.params[i].cls else: uint32(i)
     if cls in writtenClasses:
       reps.incl c.aa.find(argSyms[i])
-  result = expressionTouchesClass(c, expr, reps)
+  when PathCallInvalidation:
+    # Hoisting must ask the question invalidation asks, or LICM would leave a
+    # load in the loop that the cache would have kept across the same call.
+    var written: seq[AccessPath] = @[]
+    for i in 0 ..< argPaths.len:
+      let cls = if i < summary.params.len: summary.params[i].cls else: uint32(i)
+      if cls in writtenClasses: written.add argPaths[i]
+    result = callClobbersEntry(c, expr, written, reps, escapedClassReps(c))
+  else:
+    result = expressionTouchesClass(c, expr, reps)
+
+proc storeInLoopClobbersByClass(c: var Context; expr: Cursor;
+                                frame: LoopFrame): bool =
+  ## `master`'s invariance test: an in-loop store kills the expression when its
+  ## root's alias class touches it, at root granularity.
+  for s in frame.memStoreRoots:
+    if s == SymId(0):
+      if not unreachableByCallee(c, expr, escapedClassReps(c)): return true
+    else:
+      var one = initHashSet[SymId]()
+      one.incl c.aa.find(s)
+      if expressionTouchesClass(c, expr, one): return true
+  result = false
+
+proc storeInLoopClobbers(c: var Context; expr: Cursor; frame: LoopFrame): bool =
+  ## Does any store in the loop reach `expr`? The path answer, intersected with
+  ## the alias classes inside `mayOverlap` — the same rule the cache uses for a
+  ## store, so a loop that writes `o.b` stops holding a load of `o.a` down.
+  let escaped = escapedClassReps(c)
+  for i in 0 ..< frame.memStorePaths.len:
+    let w = frame.memStorePaths[i]
+    if not w.known:
+      if not unreachableByCallee(c, expr, escaped): return true
+    elif expressionOverlaps(c, expr, w, escaped):
+      return true
+  result = false
 
 proc invariantIn(c: var Context; expr: Cursor; frame: LoopFrame): bool =
   ## True when `expr` is a loop invariant of `frame`: no mentioned symbol is
   ## assigned, no in-loop store aliases it, no in-loop call clobbers it.
   if expressionMentionsAny(expr, frame.writes): return false
-  for s in frame.memStoreRoots:
-    if s == SymId(0):
-      if not unreachableByCallee(c, expr, escapedClassReps(c)): return false
-    else:
-      var one = initHashSet[SymId]()
-      one.incl c.aa.find(s)
-      if expressionTouchesClass(c, expr, one): return false
+  when PathStoreInvalidation:
+    if storeInLoopClobbers(c, expr, frame): return false
+  else:
+    if storeInLoopClobbersByClass(c, expr, frame): return false
   for pos in frame.callPos:
     if callWouldClobber(c, cursorAt(c.orig[], pos), expr): return false
   result = true
@@ -2249,6 +2290,31 @@ when isMainModule:
       "(while c.0.M (stmts (asgn y.0.M (at `cse.1 i.0.M)) " &
       "(asgn z.0.M (at `cse.1 i.0.M)) " &
       "(asgn i.0.M (add (i 64) i.0.M 1)))))")
+
+  when PathStoreInvalidation:
+    block loop_sibling_field_store_hoists:
+      # The loop writes `o.b`; a load of `o.a` is still invariant, so it moves to
+      # the pre-header. At root granularity the store holds it in the loop.
+      chk(
+        "(stmts (while c.0.M (stmts " &
+        "(asgn y.0.M (dot o.0.M a.0.M)) " &
+        "(asgn (dot o.0.M b.0.M) 7))))",
+        "(stmts (var :`cse.1 . . (dot o.0.M a.0.M)) " &
+        "(while c.0.M (stmts (asgn y.0.M `cse.1) " &
+        "(asgn (dot o.0.M b.0.M) 7))))")
+  else:
+    block loop_sibling_field_store_blocks_hoist:
+      assertUnchanged(
+        "(stmts (while c.0.M (stmts " &
+        "(asgn y.0.M (dot o.0.M a.0.M)) " &
+        "(asgn (dot o.0.M b.0.M) 7))))")
+
+  block loop_prefix_store_not_hoisted:
+    # The loop writes `o.a` itself → the load of `o.a.f` is not invariant.
+    assertUnchanged(
+      "(stmts (while c.0.M (stmts " &
+      "(asgn y.0.M (dot (dot o.0.M a.0.M) f.0.M)) " &
+      "(asgn (dot o.0.M a.0.M) 7))))")
 
   block loop_unknown_call_not_hoisted:
     # Unknown callee in the body may clobber `pp` → not invariant.

--- a/src/lengc/shoggoth/cse.nim
+++ b/src/lengc/shoggoth/cse.nim
@@ -70,6 +70,7 @@ import ".." / ".." / "lib" / nifcdecl        # stmtKind/exprKind/pragmaKind, tag
 import ".." / ".." / "models" / tags          # *TagId ordinals for synthesis
 import trackers, patchsets
 import aliasing                               # intra-proc Steensgaard alias classes
+import accesspaths                            # root :: selector paths (doc/cse.md)
 import ".." / nifmodules                      # MainModule (type context, threaded through)
 import ".." / typenav                         # getType — to skip value-CSE of aggregates
 
@@ -82,6 +83,20 @@ const AddressCSE = false
   ## in the allocator hot path (9 held pointers in rawAlloc). Value-CSE of genuine
   ## loads stays on (a load is a real memory access worth factoring); the write-target
   ## aggregate-skip at `handleCandidate` still holds with an empty `writeTargets`.
+
+const
+  PathStoreInvalidation* = not defined(cseTypeInvalidation)
+    ## Invalidate on a store by comparing ACCESS PATHS (`doc/cse.md`), not by
+    ## comparing the alias classes of every symbol the entry mentions.
+  PathCallInvalidation* = not defined(cseTypeInvalidation)
+    ## The same for the clobber step of a call whose summary is known.
+  ##
+  ## `-d:cseTypeInvalidation` restores both to the type/alias-class analysis
+  ## exactly as `master` has it — the reference the path rules are measured
+  ## against, and the fallback if they ever cost more than they save. Everything
+  ## the type-based analysis needs (`aliasing`, `pointerBearing`, the summary
+  ## partition) is untouched and still built in both modes; only which of the two
+  ## answers the invalidation question changes.
 
 # ---- function summaries (alias-aware; pure data, mirrors hexer/funcsummary) -
 # These are read from `(smry …)` pragmas in the buffer by the nifcore loader
@@ -114,6 +129,12 @@ when defined(cseSummaryStats):
   var gCallsSeen*, gForeignFound*, gForeignMissing*, gNoReturnSaved*: int
   var gClearUnknown*, gClearGlobal*: int
   var gEntriesKept*: int
+  var gPathTests*, gPathSavedStore*, gPathSavedCall*: int
+    ## How often the PATH rule kept a cache entry the alias partition alone
+    ## would have dropped — i.e. how much work `doc/cse.md`'s rule 1 is doing on
+    ## real input. Zero here means the two analyses agree everywhere, which is a
+    ## result about the input (SROA has already scalarized the local objects
+    ## whose sibling fields the path rule separates), not about the rule.
 
 proc paramMayWrite(s: FunctionSummary; idx: int): bool {.inline.} =
   if s.callsUnknown: return true
@@ -208,6 +229,14 @@ type
                                     ## resolved on demand through `c.m`; negatives
                                     ## cached too (see `callSummary`)
     aa: Aliasing                ## intra-proc alias partition of this body
+    pathScratch: seq[AccessPath]    ## reused by the path invalidator so that
+                                    ## describing an entry allocates nothing
+    paramSyms: HashSet[SymId]       ## this proc's parameters. For the path rules
+                                    ## they count as locals: a DIRECT path rooted
+                                    ## at a by-value param names the callee's own
+                                    ## copy, and a `var`/`out` param is a pointer,
+                                    ## so a read through it is an INDIRECT path
+                                    ## and never takes the direct branch anyway
     m: ptr MainModule           ## module type context; nil ⇒ no type-based skips
     localDefPos: Table[SymId, int]  ## local symbol → position of its `(var …)` decl,
                                     ## so a cached load is never hoisted above the
@@ -698,6 +727,18 @@ proc clearCacheReachable(c: var Context) =
       dropFacts.add key
   for key in dropFacts: c.proven[key] = 0
 
+proc dropFactsInClasses(c: var Context; reps: HashSet[SymId]) =
+  ## The guard facts carry resolved ROOTS, not paths, so they keep the
+  ## alias-class rule in both modes — identical to `master` either way.
+  var dropFacts: seq[string] = @[]
+  for key, idx in c.proven.pairs:
+    if idx == 0: continue
+    for s in c.provenRoots[idx-1]:
+      if c.aa.find(s) in reps:
+        dropFacts.add key
+        break
+  for key in dropFacts: c.proven[key] = 0
+
 proc clobberClasses(c: var Context; reps: HashSet[SymId]; exempt = "") =
   ## Drop every cached entry that reads memory in one of the alias classes,
   ## except the entry keyed `exempt` (the address temp of the exact location a
@@ -711,14 +752,129 @@ proc clobberClasses(c: var Context; reps: HashSet[SymId]; exempt = "") =
       toClear.add key
   for key in toClear:
     c.cache[key] = default(CachedEntry)
-  var dropFacts: seq[string] = @[]
-  for key, idx in c.proven.pairs:
-    if idx == 0: continue
-    for s in c.provenRoots[idx-1]:
-      if c.aa.find(s) in reps:
-        dropFacts.add key
-        break
-  for key in dropFacts: c.proven[key] = 0
+  dropFactsInClasses(c, reps)
+
+# ---- path-based invalidation (doc/cse.md) ---------------------------------
+
+proc reachableByPointer(c: var Context; root: SymId;
+                        escaped: HashSet[SymId]): bool =
+  ## Can any pointer in this body name `root`'s storage? Only if the address of
+  ## `root` (or of something its alias class was merged with) has been taken, or
+  ## if it is not a local of this body at all — a global or a parameter is
+  ## reachable from outside by construction. This is `unreachableByCallee`'s
+  ## argument, applied to one root instead of to a whole expression.
+  if root == SymId(0): return true
+  if root notin c.bodyLocals and root notin c.paramSyms: return true
+  if root in c.addrTaken: return true
+  result = c.aa.find(root) in escaped
+
+proc classesMayAlias(c: var Context; a, b: SymId): bool {.inline.} =
+  ## `master`'s answer: the intra-proc alias partition, which is what the type
+  ## information feeds. Unknown roots alias everything.
+  if a == SymId(0) or b == SymId(0): return true
+  result = c.aa.find(a) == c.aa.find(b)
+
+proc mayOverlap(c: var Context; p, w: AccessPath;
+                escaped: HashSet[SymId]): bool =
+  ## Can a write to `w` change what a read of `p` reads?
+  ##
+  ## Two independent over-approximations, and an entry only dies when BOTH say
+  ## it may: the path rule (this proc) and the alias partition
+  ## (`classesMayAlias`). Intersecting two sound answers stays sound, and it is
+  ## what keeps this at least as precise as `master` everywhere — the partition
+  ## carries the case paths deliberately refuse to decide (two unrelated
+  ## pointers), the paths carry the case the partition is blind to (two fields
+  ## of one object).
+  if not p.known or not w.known: return true
+  var byPath: bool
+  if w.isDirect:
+    if p.isDirect:
+      # Both name storage directly: distinct roots are distinct storage, and
+      # within one root it is the prefix test. `o.x = 1` leaves `o.y` alone.
+      byPath = directOverlap(p, w)
+    else:
+      # `p` reads through a pointer; it can only land on `w`'s storage if that
+      # storage is something a pointer can name at all.
+      byPath = reachableByPointer(c, w.root, escaped)
+  else:
+    if p.isDirect:
+      byPath = reachableByPointer(c, p.root, escaped)
+    else:
+      # Two indirect paths: nothing in the path distinguishes two pointers
+      # (`doc/cse.md`, lesson 4), so this is where the partition answers.
+      byPath = true
+  result = byPath and classesMayAlias(c, p.root, w.root)
+
+proc expressionOverlaps(c: var Context; cur: Cursor; w: AccessPath;
+                        escaped: HashSet[SymId]): bool =
+  ## Does any path the expression READS overlap the written path?
+  c.pathScratch.setLen 0
+  collectReadPaths(cur, c.pathScratch)
+  if c.pathScratch.len == 0: return true      # described nothing → conservative
+  for i in 0 ..< c.pathScratch.len:
+    if mayOverlap(c, c.pathScratch[i], w, escaped): return true
+  result = false
+
+proc callClobbersEntry(c: var Context; cur: Cursor; written: seq[AccessPath];
+                       reps: HashSet[SymId]; escaped: HashSet[SymId]): bool =
+  ## Rule 4 of `doc/cse.md`, for a call whose summary is known and which writes
+  ## neither a global nor through an unknown callee. What it can still write is
+  ## the written arguments' own locations, and the memory reachable THROUGH them
+  ## — which is indirect memory this analysis does not name. So a read survives
+  ## when it is direct, rooted where no pointer can reach, and disjoint from
+  ## every written argument.
+  c.pathScratch.setLen 0
+  collectReadPaths(cur, c.pathScratch)
+  if c.pathScratch.len == 0: return true
+  for i in 0 ..< c.pathScratch.len:
+    let p = c.pathScratch[i]
+    if not p.known: return true
+    # `reps` is `master`'s answer (the classes of the written actuals plus the
+    # escaped ones); as in `mayOverlap`, a kill needs both analyses to agree.
+    if p.root != SymId(0) and c.aa.find(p.root) notin reps: continue
+    if p.isIndirect: return true
+    if reachableByPointer(c, p.root, escaped): return true
+    for w in written:
+      if mayOverlap(c, p, w, escaped): return true
+  result = false
+
+proc clobberForCall(c: var Context; written: seq[AccessPath];
+                    reps: HashSet[SymId]) =
+  var toClear: seq[string] = @[]
+  let escaped = escapedClassReps(c)
+  for key, entry in c.cache.pairs:
+    if not entry.hasFirst: continue
+    let exprCur = cursorAt(c.orig[], entry.firstExprPos)
+    let killed = callClobbersEntry(c, exprCur, written, reps, escaped)
+    when defined(cseSummaryStats):
+      if not killed and expressionTouchesClass(c, exprCur, reps):
+        inc gPathSavedCall
+    if killed:
+      toClear.add key
+  for key in toClear:
+    c.cache[key] = default(CachedEntry)
+  dropFactsInClasses(c, reps)
+
+proc clobberPath(c: var Context; w: AccessPath; exempt = "") =
+  ## Drop every cached load a write to `w` may have changed.
+  var toClear: seq[string] = @[]
+  let escaped = escapedClassReps(c)
+  when defined(cseSummaryStats):
+    var reps = initHashSet[SymId]()
+    reps.incl c.aa.find(w.root)
+  for key, entry in c.cache.pairs:
+    if not entry.hasFirst: continue
+    if key == exempt: continue
+    let exprCur = cursorAt(c.orig[], entry.firstExprPos)
+    let killed = expressionOverlaps(c, exprCur, w, escaped)
+    when defined(cseSummaryStats):
+      inc gPathTests
+      if not killed and expressionTouchesClass(c, exprCur, reps):
+        inc gPathSavedStore
+    if killed:
+      toClear.add key
+  for key in toClear:
+    c.cache[key] = default(CachedEntry)
 
 proc goesThroughPointer(lhs: Cursor): bool =
   ## True if the lvalue is reached through a deref/index — not a stack field.
@@ -753,7 +909,19 @@ proc invalidateForStore(c: var Context; lhs: Cursor) =
     return
   var reps = initHashSet[SymId]()
   reps.incl c.aa.find(s)
-  clobberClasses(c, reps, exempt = hashExpr(lhs))
+  when PathStoreInvalidation:
+    # Same event, described as a path: the loads it can reach are the ones whose
+    # own paths overlap it (prefix either way), plus — when the written storage
+    # is something a pointer can name — the loads that go through a pointer.
+    # The guard facts keep the class rule.
+    let w = pathOfLvalue(lhs)
+    if not w.known:
+      clobberClasses(c, reps, exempt = hashExpr(lhs))
+    else:
+      clobberPath(c, w, exempt = hashExpr(lhs))
+      dropFactsInClasses(c, reps)
+  else:
+    clobberClasses(c, reps, exempt = hashExpr(lhs))
 
 # ---- summary loader: read `(smry …)` pragmas from the buffer ---------------
 # A nifcore reader for the wire format produced by hexer/funcsummary (which
@@ -923,6 +1091,7 @@ proc invalidateForCall(c: var Context; call: Cursor) =
   # and mark escaping pointer args as addr-taken. Iterate with `into` so the
   # scope is bounded to the call's own children (nifcore has no ParRi).
   var argSyms: seq[SymId] = @[]
+  var argPaths: seq[AccessPath] = @[]
   var writtenClasses = initHashSet[uint32]()
   var argIndex = 0
   var ca = call
@@ -931,6 +1100,7 @@ proc invalidateForCall(c: var Context; call: Cursor) =
     while ca.hasMore:
       let s = rootOf(ca)
       argSyms.add s
+      argPaths.add pathOfLvalue(ca)   # `(haddr x.f)` ⇒ the path `x.f`
       if s != SymId(0) and argIndex < summary.params.len and
          summary.params[argIndex].escapes:
         markAddrTaken(c, s)
@@ -955,7 +1125,19 @@ proc invalidateForCall(c: var Context; call: Cursor) =
     let cls = if i < summary.params.len: summary.params[i].cls else: uint32(i)
     if cls in writtenClasses:
       reps.incl c.aa.find(argSyms[i])
-  clobberClasses(c, reps)
+  when PathCallInvalidation:
+    # The same summary, read as paths: which ARGUMENTS the callee may write.
+    # A parameter the callee placed in a written partition class counts too —
+    # it may have aliased them internally — which is the class information doing
+    # the job it is actually good at (relating parameters to each other), while
+    # the paths decide what in THIS body those arguments can reach.
+    var written: seq[AccessPath] = @[]
+    for i in 0 ..< argPaths.len:
+      let cls = if i < summary.params.len: summary.params[i].cls else: uint32(i)
+      if cls in writtenClasses: written.add argPaths[i]
+    clobberForCall(c, written, reps)
+  else:
+    clobberClasses(c, reps)
 
 # ---- loop-invariant code motion ------------------------------------------
 
@@ -1806,9 +1988,22 @@ proc collectWriteTargets(c: var Context; n: var Cursor) =
 
 # ---- public entry --------------------------------------------------------
 
+proc registerParams(c: var Context; params: Cursor) =
+  ## The proc's parameters, which the body alone does not show (the driver hands
+  ## CSE the body only). They matter to the path rules exactly as `bodyLocals`
+  ## does — see `Context.paramSyms`.
+  if not params.hasMore or params.kind != TagLit: return
+  var p = params
+  p.loopInto:
+    if p.kind == TagLit and p.substructureKind == ParamU:
+      let nameCur = child0(p)
+      if nameCur.kind == SymbolDef: c.paramSyms.incl symId(nameCur)
+    skip p
+
 proc runCSE*(buf: var TokenBuf; moduleSuffix = "M";
              summaries: ptr FunctionSummaryTable = nil;
-             m: ptr MainModule = nil): int {.discardable.} =
+             m: ptr MainModule = nil;
+             params: Cursor = default(Cursor)): int {.discardable.} =
   ## Two-phase CSE for a single proc `buf` (a Leng body has no nested procs).
   ## `summaries` is the module-level table from `collectFunctionSummaries` run
   ## once on the whole module; nil ⇒ every call conservatively clears. `m` is the
@@ -1817,6 +2012,7 @@ proc runCSE*(buf: var TokenBuf; moduleSuffix = "M";
   var ctx = createContext(addr buf, moduleSuffix, summaries)
   ctx.m = m                          # type context: skip value-CSE of aggregates
   ctx.aa = computeAliasing(buf, m)   # alias pre-pass: drives precise invalidation
+  registerParams(ctx, params)
   block:
     var wn = beginRead(buf)
     collectWriteTargets(ctx, wn)  # identify write-target / addr-of'd lvalues
@@ -1901,6 +2097,42 @@ when isMainModule:
       "(stmts (var :`cse.1 . . (dot (deref (deref pp.0.M)) fld.0.M)) " &
       "(asgn y.0.M `cse.1) (asgn (dot (deref (deref qq.0.M)) g.0.M) v.0.M) " &
       "(asgn z.0.M `cse.1))")
+
+  when PathStoreInvalidation:
+    block sibling_field_store_survives:
+      # `x.other = v` cannot change `x.fld`: same root, but the selector lists
+      # diverge at the first step (`doc/cse.md`, rule 1). The alias partition
+      # knows only roots, so this is the case paths add.
+      chk(
+        "(stmts (asgn y.0.M (dot x.0.M fld.0.M)) " &
+        "(asgn (dot x.0.M other.0.M) v.0.M) " &
+        "(asgn z.0.M (dot x.0.M fld.0.M)))",
+        "(stmts (var :`cse.1 . . (dot x.0.M fld.0.M)) " &
+        "(asgn y.0.M `cse.1) (asgn (dot x.0.M other.0.M) v.0.M) " &
+        "(asgn z.0.M `cse.1))")
+  else:
+    block sibling_field_store_kills:
+      # Same input under `-d:cseTypeInvalidation`: the entry mentions `x`, whose
+      # class the store writes, so it dies and nothing is reused.
+      assertUnchanged(
+        "(stmts (asgn y.0.M (dot x.0.M fld.0.M)) " &
+        "(asgn (dot x.0.M other.0.M) v.0.M) " &
+        "(asgn z.0.M (dot x.0.M fld.0.M)))")
+
+  block prefix_store_kills:
+    # A write to `x.a` changes every read below it — `x.a.b` has it as a prefix.
+    assertUnchanged(
+      "(stmts (asgn y.0.M (dot (dot x.0.M a.0.M) b.0.M)) " &
+      "(asgn (dot x.0.M a.0.M) v.0.M) " &
+      "(asgn z.0.M (dot (dot x.0.M a.0.M) b.0.M)))")
+
+  block indices_collapse:
+    # `arr[j] = v` kills a cached `arr[i]`: indices are collapsed to one `Elem`
+    # step, so two elements of one array always overlap.
+    assertUnchanged(
+      "(stmts (asgn y.0.M (at arr.0.M i.0.M)) " &
+      "(asgn (at arr.0.M j.0.M) v.0.M) " &
+      "(asgn z.0.M (at arr.0.M i.0.M)))")
 
   block store_aliasing_prevents_cse:
     # Same shape as `store_disjoint_survives` but the store is through `pp` (same

--- a/src/lengc/shoggoth/induction_variables.nim
+++ b/src/lengc/shoggoth/induction_variables.nim
@@ -87,6 +87,14 @@ proc loopBodyCursor(loopCursor: Cursor): Cursor =
     skip result                              # past cond
   else: discard
 
+proc writeTargetOf(start: Cursor): Cursor =
+  ## The lvalue a statement writes: `(asgn dest src)` → `dest`, but
+  ## `(store src dest)` → the SECOND child. Reading the first child for both
+  ## looked at the *source* of a `store` and missed its target.
+  result = start
+  inc result                                 # past the tag
+  if start.stmtKind == StoreS: skip result   # past the source
+
 proc countWritesOf(start: Cursor; sym: SymId; counter: var int) =
   ## Counts Symbol-LHS assignments to `sym` anywhere in the subtree at `start`,
   ## including nested loops.
@@ -94,8 +102,7 @@ proc countWritesOf(start: Cursor; sym: SymId; counter: var int) =
   case start.kind
   of TagLit:
     if start.stmtKind in {AsgnS, StoreS}:
-      var lhs = start
-      inc lhs
+      let lhs = writeTargetOf(start)
       if lhs.kind == Symbol and symId(lhs) == sym:
         inc counter
     var n = start
@@ -130,6 +137,57 @@ proc scanBody(c: var Context; n: Cursor;
   m.loopInto:
     scanBody(c, m, candidates, addrTaken)
     skip m
+
+type
+  LoopFacts = object
+    ## What the loop does to the symbols an access is rooted at. Collected once
+    ## per loop; used to decide whether the hoisted `addr base[0]` stays valid
+    ## for the whole loop (see `baseIsStable`).
+    assigned: HashSet[SymId]   ## symbol-LHS writes anywhere in the loop
+    addrTaken: HashSet[SymId]  ## `(addr S)` / `(haddr S)` anywhere in the loop
+    hasCall: bool              ## a callee can rebind a global or an escaped local
+
+proc collectLoopFacts(n: Cursor; f: var LoopFacts) =
+  if not n.hasMore or n.kind != TagLit: return
+  if n.stmtKind in {AsgnS, StoreS}:
+    let lhs = writeTargetOf(n)
+    if lhs.kind == Symbol: f.assigned.incl symId(lhs)
+  if n.stmtKind == CallS or n.exprKind == CallC: f.hasCall = true
+  if n.exprKind in AddrKinds:
+    var probe = n
+    inc probe
+    while probe.hasMore:
+      if probe.kind == Symbol:
+        f.addrTaken.incl symId(probe)
+        break
+      elif probe.kind == TagLit:
+        inc probe
+      else:
+        inc probe
+  var m = n
+  m.loopInto:
+    collectLoopFacts(m, f)
+    skip m
+
+proc baseIsStable(c: var Context; base: Cursor; f: LoopFacts): bool =
+  ## Is `addr base[0]` — the address this rewrite hoists out of the loop — the
+  ## same on every iteration?
+  ##
+  ## For an ARRAY base it always is: the address is the variable's own storage,
+  ## which no assignment moves (`arr = other` copies *into* it) and no callee can
+  ## relocate. That is the case this pass was written for.
+  ##
+  ## For a POINTER-like base (`ptr`/`aptr`/`flexarray`, all of which `typenav`
+  ## admits under `(at …)`) the hoisted address IS the base's value, so a loop
+  ## that rebinds it — directly, through a taken address, or through a callee
+  ## that can reach it — would leave the pointer walking the old buffer. The
+  ## same holds when the type does not resolve at all: unproven is not proven.
+  if base.kind != Symbol: return false
+  if c.m != nil:
+    let t = navigateToObjectBody(c.m[], getType(c.m[], base))
+    if t.typeKind == ArrayT: return true
+  let s = symId(base)
+  result = s notin f.assigned and s notin f.addrTaken and not f.hasCall
 
 proc findIV(c: var Context; body: Cursor): tuple[ivSym: SymId, incPos: int, found: bool] =
   ## Identifies the loop body's induction variable (exactly one
@@ -251,8 +309,14 @@ proc transformLoop(c: var Context; n: var Cursor) =
   if ivInfo.found:
     var accesses: seq[AccessInfo] = @[]
     collectAccesses(c, body, ivInfo.ivSym, accesses)
+    var facts = LoopFacts(assigned: initHashSet[SymId](),
+                          addrTaken: initHashSet[SymId]())
+    collectLoopFacts(body, facts)
     var arrToP = initTable[SymId, string]()
     for acc in accesses:
+      var base = acc.atCursor
+      inc base                               # past `(at` → the base
+      if not baseIsStable(c, base, facts): continue
       var p: string
       if acc.arrSym in arrToP:
         p = arrToP[acc.arrSym]
@@ -390,6 +454,28 @@ when isMainModule:
 
   block no_iv_no_transform:
     assertUnchanged("(stmts (while c.0.M (stmts (asgn x.0.M 1))))")
+
+  block base_reassigned_in_loop:
+    # The hoisted `addr arr[0]` is only the loop-invariant address of a stable
+    # storage if `arr` is an array. Here the type does not resolve (no module
+    # context), and the loop rebinds `arr`, so the rewrite would leave the
+    # pointer walking the old buffer.
+    assertUnchanged(
+      "(stmts (while (lt (i 32) i.0.M 10) (stmts (asgn x.0.M (at arr.0.M i.0.M)) " &
+      "(asgn arr.0.M other.0.M) (asgn i.0.M (add (i 32) i.0.M 1)))))")
+
+  block call_in_loop_with_unresolved_base:
+    # Same reasoning one step removed: a callee can rebind a global or an escaped
+    # local. With a resolved ARRAY type this transforms as before — the address
+    # of an array variable is not something a callee can move.
+    assertUnchanged(
+      "(stmts (while (lt (i 32) i.0.M 10) (stmts (asgn x.0.M (at arr.0.M i.0.M)) " &
+      "(call f.0.M) (asgn i.0.M (add (i 32) i.0.M 1)))))")
+
+  block base_addr_taken_in_loop:
+    assertUnchanged(
+      "(stmts (while (lt (i 32) i.0.M 10) (stmts (asgn x.0.M (at arr.0.M i.0.M)) " &
+      "(call f.0.M (addr arr.0.M)) (asgn i.0.M (add (i 32) i.0.M 1)))))")
 
   block iv_written_twice_disqualifies:
     assertUnchanged(

--- a/src/lengc/shoggoth/optdriver.nim
+++ b/src/lengc/shoggoth/optdriver.nim
@@ -84,7 +84,7 @@ proc optimizeBody(buf: var TokenBuf; suffix: string; st: var Stats;
   runInductionVariables(buf, bodySuffix, m)
   # CSE also deletes index checks a dominating identical check already made:
   # same expression keys, same invalidation, same walk (see `cse.guardCondition`).
-  st.checksRemoved += runCSE(buf, bodySuffix, summaries, m)
+  st.checksRemoved += runCSE(buf, bodySuffix, summaries, m, params)
 
 proc rebuildTree(dest: var TokenBuf; n: var Cursor; suffix: string; st: var Stats;
                  summaries: ptr FunctionSummaryTable; m: ptr MainModule;

--- a/src/lengc/shoggoth/shoggoth.nim
+++ b/src/lengc/shoggoth/shoggoth.nim
@@ -91,3 +91,6 @@ when defined(cseSummaryStats):
                    " noReturnSaved=", cse.gNoReturnSaved,
                    " clearUnknown=", cse.gClearUnknown,
                    " clearGlobal=", cse.gClearGlobal, " entriesKeptAcrossCalls=", cse.gEntriesKept
+  stderr.writeLine "[cse] pathTests=", cse.gPathTests,
+                   " pathSavedStore=", cse.gPathSavedStore,
+                   " pathSavedCall=", cse.gPathSavedCall


### PR DESCRIPTION
CSE's invalidation predicate — "can this write change what this cached load reads?" — is the one borrow checking already answers, and answers without types: a path of symbols and a prefix test (`nimony/contracts_fir.nim`, `doc/language.md#borrow-checking`). This ports that vocabulary to Leng.

`accesspaths.nim` is `aliasing.accessRoots` with the selectors kept instead of discarded: root :: Field/Elem/Deref, indices collapsed, a path stopping at a pointer rather than guessing through it, and an unknown shape answering "may overlap". Index operands become reads of their own, which roots do not model (`a[y.i]` changes when `y.i` is written).

The two analyses run as a CONJUNCTION: an entry dies only when the paths AND the alias partition both say the write may reach it. They are blind in opposite directions — the partition knows only roots, so it cannot separate two fields of one object; a path stops at a pointer, so it cannot separate two unrelated pointers — and intersecting two sound over-approximations stays sound while being no less precise than either. So the type-based analysis is kept exactly as master has it; `-d:cseTypeInvalidation` selects it alone, as the A/B reference. Both halves are pinned by self-tests: `sibling_field_store_survives` (paths win) and `store_disjoint_survives` (partition wins).

Measured: 698/698 green in both modes, native boot stages 1=2=3 byte-identical, boot total 19.11/19.70s (paths) vs 19.65/19.47s (types), and the optimized output over 25 nimsem modules is byte-identical between the two. Under -d:cseSummaryStats the path rule keeps 413 entries across stores and 14 across calls that the partition alone would drop, out of 8748 tests — the rule is live, but no reuse follows, because `scalarizer` has already exploded the local objects whose sibling fields it separates. The payoff is therefore not here: it is that `hexer/funcsummary` can be rewritten in the same vocabulary and stop needing a type world it cannot see. See `doc/cse.md`.