### PR TITLE
sem: type every `nil` in the frontend, so nothing downstream has to g…

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -8,7 +8,7 @@
 | `(pat X X)`            | LengExpr, NimonyExpr | pointer indexing operation |
 | `(par X)`              | LengExpr, NimonyExpr, NiflerKind | syntactic parenthesis |
 | `(addr X)`; `(addr X (cppref)?)`  | LengExpr, NimonyExpr, NiflerKind | address of operation |
-| `(nil T? X?)`          | LengExpr, NimonyExpr, NimonyOther, NiflerKind | nil pointer value; closure `nil` carries the proc type and a nil environment |
+| `(nil T? X?)`          | LengExpr, NimonyExpr, NimonyOther, NiflerKind | nil pointer value; `T` is the pointer type it stands for. `nil` is the one type-polymorphic literal, so the frontend types every `ptr`/`ref`/`pointer`/`cstring` one (`derefs.nim`) and `T` survives into Leng; only a `nil` a later pass synthesizes is bare. A closure `nil` carries the proc type plus `X`, a nil environment |
 | `(notnil)`             | NimonyOther | `not nil` pointer annotation |
 | `(unchecked)`          | NimonyOther | `unchecked` pointer annotation (derefs do not require nil checking) |
 | `(inf T?)`             | LengExpr, NimonyExpr | positive infinity floating point value |

--- a/src/hexer/lengcgen.nim
+++ b/src/hexer/lengcgen.nim
@@ -1790,7 +1790,16 @@ proc trExpr(c: var EContext; dest: var TokenBuf; n: var Cursor) =
        InstanceofX, ProccallX, InternalTypeNameX, InternalFieldPairsX, FailedX, IsX, EnvpX, DelayX, Delay0X, SuspendX, ToClosureX:
       error c, "BUG: not eliminated: ", n
       #skip n
-    of AtX, PatX, ParX, NilX, InfX, NeginfX, NanX, FalseX, TrueX, AndX, OrX, NotX, NegX, OvfX:
+    of NilX:
+      # `(nil T)` — the frontend types every `nil` (see `trNil` in derefs.nim)
+      # and the type slot is a TYPE, not an expression. Keep it: it is what
+      # tells `intramodinliner`, which substitutes a literal argument at each
+      # use, what the pointer it splices actually is.
+      takeInto dest, n:
+        if n.hasMore:
+          trType(c, dest, n)
+          while n.hasMore: skip n   # the closure form's trailing nil environment
+    of AtX, PatX, ParX, InfX, NeginfX, NanX, FalseX, TrueX, AndX, OrX, NotX, NegX, OvfX:
       dest.addParLe(n.cursorTagId, n.info)
       n.into:
         while n.hasMore:

--- a/src/lengc/genexprs.nim
+++ b/src/lengc/genexprs.nim
@@ -137,7 +137,22 @@ proc genDeref(c: var GeneratedCode; n: var Cursor) =
     c.add ParLe
     let starAt = c.code.len
     c.add "*"
-    genx c, n
+    # `*NIM_NIL` is a dereference of `void*` and `(*NIM_NIL).f` does not even
+    # compile. The dereference is dead code — the intra-module inliner
+    # substitutes a literal argument at every use, including uses under a
+    # guard it could not fold — but it still has to be *emitted*, so give the
+    # null the pointer type the frontend attached to it. See nimony#2317.
+    if n.exprKind == NilC and n.childCursor.hasMore:
+      var t = n.childCursor
+      c.add ParLe
+      c.add ParLe
+      genType c, t
+      c.add ParRi
+      c.add NullPtr
+      c.add ParRi
+      skip n
+    else:
+      genx c, n
     c.add ParRi
     if n.hasMore and n.typeQual == CpprefQ:
       if c.m.config.backend == backendCpp:
@@ -356,6 +371,12 @@ proc genx(c: var GeneratedCode; n: var Cursor) =
     c.add "NIM_TRUE"
     skip n
   of NilC:
+    # A bare `NIM_NIL`, NOT a cast to the `(nil T)` type the frontend attaches.
+    # `NIM_NIL` is assignment-compatible with every pointer type, and casting
+    # would make an `{.importc.}` signature whose C spelling differs from
+    # Nimony's (`cstring` is `unsigned char*`, `strtod` wants `char**`) a hard
+    # `-Wincompatible-pointer-types` error. `genDeref` casts where C insists on
+    # knowing the pointee.
     c.add NullPtr
     skip n
   of InfC:

--- a/src/lengc/typenav.nim
+++ b/src/lengc/typenav.nim
@@ -281,7 +281,14 @@ proc getTypeImpl(c: var MainModule; n: Cursor): Cursor =
     of ParC:
       result = getTypeImpl(c, firstChild(n))
     of NilC:
-      result = createIntegralType(c, "(ptr (void))")
+      # `(nil T)` — the frontend types every `nil` it emits, so use that type.
+      # Only a `nil` some backend pass synthesized is still untyped, and for
+      # those `void*` remains the honest answer.
+      let t = firstChild(n)
+      if t.hasMore:
+        result = t
+      else:
+        result = createIntegralType(c, "(ptr (void))")
     of SufC:
       result = createIntegralType(c, "(err)")
       var a = firstChild(n)

--- a/src/models/leng_tags.nim
+++ b/src/models/leng_tags.nim
@@ -12,7 +12,7 @@ type
     PatC = (ord(PatTagId), "pat")  ## pointer indexing operation
     ParC = (ord(ParTagId), "par")  ## syntactic parenthesis
     AddrC = (ord(AddrTagId), "addr")  ## address of operation
-    NilC = (ord(NilTagId), "nil")  ## nil pointer value; closure `nil` carries the proc type and a nil environment
+    NilC = (ord(NilTagId), "nil")  ## nil pointer value; `T` is the pointer type it stands for. `nil` is the one type-polymorphic literal, so the frontend types every `ptr`/`ref`/`pointer`/`cstring` one (`derefs.nim`) and `T` survives into Leng; only a `nil` a later pass synthesizes is bare. A closure `nil` carries the proc type plus `X`, a nil environment
     InfC = (ord(InfTagId), "inf")  ## positive infinity floating point value
     NeginfC = (ord(NeginfTagId), "neginf")  ## negative infinity floating point value
     NanC = (ord(NanTagId), "nan")  ## NaN floating point value

--- a/src/models/nifler_tags.nim
+++ b/src/models/nifler_tags.nim
@@ -12,7 +12,7 @@ type
     DotL = (ord(DotTagId), "dot")  ## object field selection; optional integer is the inheritance depth of the field; optional trailing `STRLIT` is an *access token* carrying the suffix of the module the access was written in. When present, re-checks at expansion/serialization sites judge the private-field access against that module instead of against the module they are running in, so a template body keeps its author's visibility wherever it is expanded. The reserved value `"*"` means "already validated, originating module no longer comparable" and is used by `exprexec`, whose sub-compile runs under a synthesized module suffix. Emitted by sem whenever it resolves a non-exported field.
     ParL = (ord(ParTagId), "par")  ## syntactic parenthesis
     AddrL = (ord(AddrTagId), "addr")  ## address of operation
-    NilL = (ord(NilTagId), "nil")  ## nil pointer value; closure `nil` carries the proc type and a nil environment
+    NilL = (ord(NilTagId), "nil")  ## nil pointer value; `T` is the pointer type it stands for. `nil` is the one type-polymorphic literal, so the frontend types every `ptr`/`ref`/`pointer`/`cstring` one (`derefs.nim`) and `T` survives into Leng; only a `nil` a later pass synthesizes is bare. A closure `nil` carries the proc type plus `X`, a nil environment
     OconstrL = (ord(OconstrTagId), "oconstr")  ## object constructor
     BracketL = (ord(BracketTagId), "bracket")  ## untyped array constructor
     CurlyL = (ord(CurlyTagId), "curly")  ## untyped set constructor

--- a/src/models/nimony_tags.nim
+++ b/src/models/nimony_tags.nim
@@ -13,7 +13,7 @@ type
     PatX = (ord(PatTagId), "pat")  ## pointer indexing operation
     ParX = (ord(ParTagId), "par")  ## syntactic parenthesis
     AddrX = (ord(AddrTagId), "addr")  ## address of operation
-    NilX = (ord(NilTagId), "nil")  ## nil pointer value; closure `nil` carries the proc type and a nil environment
+    NilX = (ord(NilTagId), "nil")  ## nil pointer value; `T` is the pointer type it stands for. `nil` is the one type-polymorphic literal, so the frontend types every `ptr`/`ref`/`pointer`/`cstring` one (`derefs.nim`) and `T` survives into Leng; only a `nil` a later pass synthesizes is bare. A closure `nil` carries the proc type plus `X`, a nil environment
     InfX = (ord(InfTagId), "inf")  ## positive infinity floating point value
     NeginfX = (ord(NeginfTagId), "neginf")  ## negative infinity floating point value
     NanX = (ord(NanTagId), "nan")  ## NaN floating point value
@@ -255,7 +255,7 @@ proc rawTagIsNimonyType*(raw: TagEnum): bool {.inline.} =
 type
   NimonyOther* = enum
     NoSub
-    NilU = (ord(NilTagId), "nil")  ## nil pointer value; closure `nil` carries the proc type and a nil environment
+    NilU = (ord(NilTagId), "nil")  ## nil pointer value; `T` is the pointer type it stands for. `nil` is the one type-polymorphic literal, so the frontend types every `ptr`/`ref`/`pointer`/`cstring` one (`derefs.nim`) and `T` survives into Leng; only a `nil` a later pass synthesizes is bare. A closure `nil` carries the proc type plus `X`, a nil environment
     NotnilU = (ord(NotnilTagId), "notnil")  ## `not nil` pointer annotation
     UncheckedU = (ord(UncheckedTagId), "unchecked")  ## `unchecked` pointer annotation (derefs do not require nil checking)
     KvU = (ord(KvTagId), "kv")  ## key-value pair; optional INTLIT indicates field is in an inherited object

--- a/src/nimony/derefs.nim
+++ b/src/nimony/derefs.nim
@@ -62,6 +62,7 @@ type
 
   CurrentRoutine = object
     returnExpects: Expects
+    returnType: Cursor  # so `(ret (nil))` knows what the `nil` is
     firstParamKind: TypeKind
     props: set[RoutineProp]
     firstParam: SymId
@@ -168,15 +169,72 @@ proc isAddressable*(n: Cursor): bool =
       else:
         break
 
-proc tr(c: var Context; n: var Cursor; e: Expects)
+proc tr(c: var Context; n: var Cursor; e: Expects; expected: Cursor = default(Cursor))
 
-proc trSons(c: var Context; n: var Cursor; e: Expects) =
+proc trSons(c: var Context; n: var Cursor; e: Expects; expected: Cursor = default(Cursor)) =
   if not n.isTagLit:
     takeTree c, n
   else:
     takeInto c.dest, n:
       while n.hasMore:
-        tr c, n, e
+        tr c, n, e, expected
+
+const
+  NilableTypes = {PtrT, RefT, PointerT, CstringT}
+    ## Data pointers only. A `nil` of a proc/iterator type is deliberately left
+    ## bare: the CPS transform rewrites a passive proc's type *after* the
+    ## frontend is done, so a type stamped here would name the pre-transform
+    ## signature and disagree with the local it initializes. `sigmatch` already
+    ## writes `(nil <proctype> (nil))` where a closure needs its environment.
+
+proc resolvedTypeKind(typ: Cursor): TypeKind =
+  ## `typ.typeKind`, but a type alias (`type PNode = ptr Node`) is followed to
+  ## the type it names. Bounded so a broken cycle cannot hang the compiler.
+  var t = skipModifier(typ)
+  var counter = 20
+  while counter > 0 and t.isSymbol:
+    dec counter
+    let res = tryLoadSym(t.symId)
+    if res.status != LacksNothing: return NoType
+    let decl = asTypeDecl(res.decl)
+    if decl.kind != TypeY: return NoType
+    t = skipModifier(decl.body)
+  result = t.typeKind
+
+proc typeForNil(typ: Cursor): Cursor =
+  ## The type a bare `(nil)` sitting in a slot declared as `typ` should carry,
+  ## or a nil cursor when `typ` is nothing a `nil` can be typed with (`.`, an
+  ## unresolved typevar, `nilt` itself, a non-pointer).
+  result = default(Cursor)
+  if cursorIsNil(typ) or typ.kind in {DotToken, UnknownToken, EofToken}:
+    return
+  var t = skipModifier(typ)
+  if t.typeKind == VarargsT:
+    t = t.childCursor
+    if not t.hasMore: return
+  if resolvedTypeKind(t) in NilableTypes:
+    result = t
+
+proc trNil(c: var Context; n: var Cursor; expected: Cursor) =
+  ## `nil` is the language's one type-polymorphic literal, and this is the last
+  ## place that still knows what it was written for: give it its type here so
+  ## no later pass has to reconstruct one. A `(nil)` that gets *moved* — the
+  ## intra-module inliner splices a literal argument at each use instead of
+  ## binding it to a `(var :p T arg)` copy — otherwise arrives at the backend
+  ## untyped, and `(dot (deref (nil)) f)` is `(*NIM_NIL).f` there. See
+  ## nimony#2317.
+  if n.childCursor.hasMore:
+    # already typed: sigmatch writes `(nil <proctype> (nil))` for a closure.
+    takeTree c, n
+  else:
+    let t = typeForNil(expected)
+    if cursorIsNil(t):
+      takeTree c, n
+    else:
+      c.dest.addParLe(NilX, n.info)
+      c.dest.addSubtree t
+      c.dest.addParRi()
+      skip n
 
 proc validBorrowsFrom(c: var Context; n: Cursor): bool =
   # --------------------------------------------------------------------------
@@ -354,7 +412,7 @@ proc trReturn(c: var Context; n: var Cursor) =
           if checkTupleConstrBorrowing(c, n) != Valid:
             err = true
         if not err:
-          tr c, n, c.r.returnExpects
+          tr c, n, c.r.returnExpects, c.r.returnType
         else:
           skip n
 
@@ -464,8 +522,10 @@ proc trProcDecl(c: var Context; n: var Cursor) =
         takeTree c.dest, n
       elif i == ProcPragmasPos and not isGeneric:
         trProcPragmas(c, n)
-      elif i == ReturnTypePos and n.typeKind in {MutT, OutT, LentT}:
-        c.r.returnExpects = WantVarTResult
+      elif i == ReturnTypePos:
+        c.r.returnType = n
+        if n.typeKind in {MutT, OutT, LentT}:
+          c.r.returnExpects = WantVarTResult
         takeTree c.dest, n
       else:
         takeTree c.dest, n
@@ -512,7 +572,7 @@ proc trCallArgs(c: var Context; n: var Cursor; fnType: Cursor) =
       elif pk == VarargsT:
         # do not advance formal parameter:
         fnType = previousFormalParam
-      tr c, n, e
+      tr c, n, e, param.typ
     while fnType.hasMore: skip fnType
   # skip return type:
   skip fnType
@@ -651,7 +711,8 @@ proc trCall(c: var Context; n: var Cursor; e: Expects; dangerous: var bool) =
   else:
     c.dest.add callBuf
 
-proc trAsgnRhs(c: var Context; le: Cursor; ri: var Cursor; e: Expects) =
+proc trAsgnRhs(c: var Context; le: Cursor; ri: var Cursor; e: Expects;
+               expected: Cursor = default(Cursor)) =
   if ri.exprKind in CallKinds:
     var dangerous = false
     trCall c, ri, e, dangerous
@@ -660,7 +721,7 @@ proc trAsgnRhs(c: var Context; le: Cursor; ri: var Cursor; e: Expects) =
       if s != NoSymId:
         c.r.dangerousLocations[s] = ri.info
   else:
-    tr c, ri, e
+    tr c, ri, e, expected
 
 proc trAsgn(c: var Context; n: var Cursor) =
   takeInto c.dest, n:
@@ -699,7 +760,7 @@ proc trAsgn(c: var Context; n: var Cursor) =
         skip n
         #tr c, n, e
       else:
-        trAsgnRhs c, le, n, e
+        trAsgnRhs c, le, n, e, getType(c.typeCache, le)
 
 proc trSonsLocation(c: var Context; n: var Cursor; e: Expects) =
   if not n.isTagLit:
@@ -771,7 +832,7 @@ proc trLocal(c: var Context; n: var Cursor) =
       c.dest.addParRi()
     else:
       let e = if typ.typeKind in {OutT, MutT, LentT}: WantVarT else: WantT
-      trAsgnRhs c, name, n, e
+      trAsgnRhs c, name, n, e, typ
     when defined(debugSigmatch):
       if n.hasMore:
         let u = n.info
@@ -779,11 +840,12 @@ proc trLocal(c: var Context; n: var Cursor) =
           (if n.isTagLit: " tag=" & globalTags.tags[n.tagId] else: ""),
           " at ", pool.filenames[u.file], ":", u.line, ":", u.col
 
-proc trStmtListExpr(c: var Context; n: var Cursor; outerE: Expects) =
+proc trStmtListExpr(c: var Context; n: var Cursor; outerE: Expects;
+                    expected: Cursor = default(Cursor)) =
   takeInto c.dest, n:
     while n.hasMore:
       if isLastSon(n):
-        tr c, n, outerE
+        tr c, n, outerE, expected
       else:
         tr c, n, WantT
 
@@ -807,12 +869,13 @@ proc trObjConstr(c: var Context; n: var Cursor; outerE: Expects) =
         # inside the owning type decl), so use `typenav.lookupField` which
         # walks the object body.
         var fieldKind: TypeKind = NoType
+        var fieldType = default(Cursor)
         if n.isSymbol:
-          let fieldType = lookupField(c.typeCache, objType, n.symId)
+          fieldType = lookupField(c.typeCache, objType, n.symId)
           if not cursorIsNil(fieldType):
             fieldKind = fieldType.typeKind
         takeTree c.dest, n # key
-        tr c, n, fieldMode(fieldKind, outerE)
+        tr c, n, fieldMode(fieldKind, outerE), fieldType
         if n.hasMore:
           # optional inheritance
           takeTree c.dest, n
@@ -830,9 +893,9 @@ proc trTupleConstr(c: var Context; n: var Cursor; outerE: Expects) =
       if n.substructureKind == KvU:
         takeInto c.dest, n:
           takeTree c.dest, n # skip key
-          tr c, n, e
+          tr c, n, e, fieldType
       else:
-        tr c, n, e
+        tr c, n, e, fieldType
 
 proc trVarHook(c: var Context; n: var Cursor) =
   takeInto c.dest, n:
@@ -1323,7 +1386,7 @@ proc trType(c: var Context; n: var Cursor) =
     c.dest.takeTree n # body
     c.dest.addParRi(n.endInfo)
 
-proc tr(c: var Context; n: var Cursor; e: Expects) =
+proc tr(c: var Context; n: var Cursor; e: Expects; expected: Cursor = default(Cursor)) =
   case n.kind
   of Symbol:
     # Closures are now implemented
@@ -1369,11 +1432,14 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
       else:
         trTupleConstr c, n, e
     of ExprX:
-      trStmtListExpr c, n, e
+      trStmtListExpr c, n, e, expected
+    of NilX:
+      trNil c, n, expected
     of DconvX:
       takeInto c.dest, n:
+        let target = n
         takeTree c.dest, n # takes the type as it is
-        tr c, n, e
+        tr c, n, e, target
     of BaseobjX:
       if e.wantMutable:
         # Passing a derived location to a `var Base` parameter: take the
@@ -1391,7 +1457,9 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
       else:
         trSons c, n, WantT
     of ParX:
-      trSons c, n, e
+      trSons c, n, e, expected
+    of EmoveX:
+      trSons c, n, WantT, expected
     of CopyX, WasmovedX, SinkhX, TraceX:
       trVarHook c, n
     of DupX, DestroyX:
@@ -1401,7 +1469,12 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
         cannotPassToVar c.dest, n.info, n
         skip n
       else:
-        trSons c, n, WantT
+        # `(conv T X)`: the target type is what a bare `nil` operand is.
+        takeInto c.dest, n:
+          let target = n
+          takeTree c.dest, n # the type slot is a type, never an expression
+          while n.hasMore:
+            tr c, n, WantT, target
     of DerefX:
       if e.wantMutable:
         # allows ptr indirection: e.g. `inc x.id[]` for `id: ptr int`
@@ -1416,7 +1489,28 @@ proc tr(c: var Context; n: var Cursor; e: Expects) =
         cannotPassToVar c.dest, n.info, n
         skip n
       else:
-        trSons c, n, e
+        trSons c, n, e, expected
+
+    of EqX, NeqX, LeX, LtX:
+      # `(eq T X X)` and friends carry the operand type up front: that is what
+      # tells the `nil` in `p == nil` which pointer it is.
+      takeInto c.dest, n:
+        let opType = n
+        takeTree c.dest, n
+        while n.hasMore:
+          tr c, n, WantT, opType
+
+    of AconstrX:
+      # `(aconstr (array E N) X*)`
+      takeInto c.dest, n:
+        var elemType = n
+        if elemType.typeKind == ArrayT:
+          elemType = elemType.childCursor
+        else:
+          elemType = default(Cursor)
+        takeTree c.dest, n
+        while n.hasMore:
+          tr c, n, WantT, elemType
 
     else:
       case n.stmtKind

--- a/tests/nimony/nosystem/tcstring.nif
+++ b/tests/nimony/nosystem/tcstring.nif
@@ -1,5 +1,5 @@
 (.nif27)
-(.indexat 1310             )
+(.indexat 1335             )
 (stmts@,2,tests/nimony/nosystem/tcstring.nim
  (type@2,1 :int.0.
   (i 64).
@@ -54,7 +54,9 @@
  (gvar@4,F :y.0. . .
   (pointer@7
    (nil))
-  (nil@H))
+  (nil@H
+   (pointer~A
+    (nil))))
  (const@2,I :myconst.0. . .
   (cstring
    (notnil))
@@ -75,5 +77,5 @@
  (x <=.0. 170)
  (h x.0. 167)
  (h y.0. 63)
- (h myconst.0. 55)
+ (h myconst.0. 80)
  (h zz.0. 73))

--- a/tests/nimony/opt/topt_inlined_nil_arg.nim
+++ b/tests/nimony/opt/topt_inlined_nil_arg.nim
@@ -1,0 +1,54 @@
+# A substituted `nil` must keep a type.
+#
+# Repro:   bin/nimony c -r --opt:speed tests/nimony/opt/topt_inlined_nil_arg.nim
+# Expected (see .output):
+#     -1
+#     7
+#     1 nil ok set ok
+#
+# `nil` is the language's one type-polymorphic literal. The intra-module
+# inliner substitutes literal arguments at every use instead of binding them to
+# a `(var :p T arg)` copy — so whatever type the eliminated binding gave the
+# value has to come from the value itself. It does: the frontend types every
+# `nil` it emits (`trNil` in derefs.nim), so the splice carries `(nil T)` and
+# the use site keeps a real pointer. Before that, splicing the bare `(nil)`
+# handed the rest of the pipeline an untyped nil and a use that dereferences it
+# reached the C backend as `(*NIM_NIL).field`: "member reference base type
+# 'void' is not a structure or union". See nimony#2317.
+#
+# `getVal` is the shape that broke: an inlinable proc whose body reads through
+# the reference parameter, called with a literal `nil`. `setNext` is the other
+# direction — the substituted nil is *stored* into a reference field, so the
+# assignment's destination type has to agree with it.
+
+import std / [syncio]
+
+type
+  Node = ref object
+    next: nil Node
+    val: int
+
+proc getVal(n: nil Node): int {.inline.} =
+  if n == nil:
+    result = -1
+  else:
+    result = n.val
+
+proc setNext(n: Node; x: nil Node) {.inline.} =
+  n.next = x
+
+proc main =
+  echo getVal(nil)
+  let a = Node(val: 7)
+  echo getVal(a)
+
+  let head = Node(val: 1)
+  setNext(head, nil)
+  var parts = ""
+  parts.add $head.val
+  if head.next == nil: parts.add " nil ok"
+  setNext(head, a)
+  if head.next != nil: parts.add " set ok"
+  echo parts
+
+main()

--- a/tests/nimony/opt/topt_inlined_nil_arg.output
+++ b/tests/nimony/opt/topt_inlined_nil_arg.output
@@ -1,0 +1,3 @@
+-1
+7
+1 nil ok set ok


### PR DESCRIPTION
…uess

`nil` is the language's one type-polymorphic literal, and the frontend is the last place that still knows what each one was written for. `derefs.nim` — which already walks the fully-resolved IR with the destination type of every slot in hand — now stamps that type onto the literal: `(nil)` becomes `(nil T)` for every `ptr` / `ref` / `pointer` / `cstring` slot (assignment, local init, call argument, return, object/tuple/array constructor field, `conv`/`cast` target, and the `T` an `(eq T X X)` carries). `T` survives hexer into Leng, so the whole pipeline has the answer instead of reconstructing it.

That collapses nimony#2317 instead of patching it. The intra-module inliner substitutes a literal argument at every use rather than binding it to a `(var :p T arg)` copy, and for `nil` that binding used to be the only thing giving the value a type: splicing the bare `(nil)` handed the backend an untyped nil and `f(nil)` on a proc that reads through the parameter reached C as `(*NIM_NIL).field`. The inliner needs no `nil` special case now — the type travels with the value.

Two consumers take the type where they need it: `lengc/typenav` answers `(nil T)` with `T` instead of `void*`, and `genDeref` casts the null to it, because `(*NIM_NIL).f` is a member access on `void` even when the dereference is dead code the inliner could not fold away. `genx` still emits a bare `NIM_NIL` elsewhere: it is assignment-compatible with every pointer type, and casting would turn an `{.importc.}` signature whose C spelling differs from Nimony's (`cstring` is `unsigned char*`, `strtod` wants `char**`) into a hard `-Wincompatible-pointer-types` error.

Proc and iterator types are deliberately left out of the set: the CPS transform rewrites a passive proc's type after the frontend is done, so a type stamped here would name the pre-transform signature and disagree with the local it initializes (`tests/nimony/cps/tpassive_iter_firstclass.nim`). `sigmatch` already writes `(nil <proctype> (nil))` where a closure needs its environment.