### PR TITLE
sem: let an import shadow the same-named self module (#2308)

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1124,6 +1124,15 @@ proc tryBuiltinDot(c: var SemContext; dest: var TokenBuf; it: var Item; lhs: Ite
       result = MatchedDotSym
       dest.shrink exprStart
       let s = semQualifiedIdent(c, dest, moduleSym, fieldName, info)
+      if s.kind == NoSym:
+        # A module qualifier has no UFCS fallback, so a miss is a hard failure
+        # and every caller gets to say "undeclared identifier in module".
+        # `AllowUndeclared` (how `a.b(x)` stays open for `b(a, x)`) must not
+        # suppress it: leaving the bare identifier behind made overload
+        # resolution fail later with no name left to report, i.e. the
+        # "undeclared identifier: ''" of nim-lang/nimony#2308.
+        dest.shrink exprStart
+        return FailedDot
       semExprSym c, dest, it, s, exprStart, flags
       return
     let t = skipModifier(lhs.typ)

--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1433,9 +1433,18 @@ proc semCall(c: var SemContext; dest: var TokenBuf; it: var Item; flags: set[Sem
     let dotState = tryBuiltinDot(c, dest, cs.fn, lhs, fieldName, dotInfo,
                                   dotFlags, dotAccessToken)
     if dotState == FailedDot and dotLhsModuleSym(lhs) != SymId(0):
+      # `m.nosuchproc(...)`: a module qualifier has no UFCS fallback, so the
+      # miss is simply an error. Report it and leave instead of running the
+      # rest of the call machinery on an `(err ...)` callee, which buries this
+      # message under "cannot call expression of type auto" (#2308).
       dest.shrink dotStart
+      swap dest, cs.dest
+      closeArgsScope c, cs, merge = false
       buildErr c, dest, dotInfo, "undeclared identifier in module: '" &
                  pool.strings[fieldName] & "'"
+      it.n = cs.scope; skip it.n
+      it.typ = c.types.autoType
+      return
     elif dotState == FailedDot or
         # also ignore non-proc fields:
         (dotState == MatchedDotField and cs.fn.typ.typeKind notin RoutineTypes):

--- a/src/nimony/semimport.nim
+++ b/src/nimony/semimport.nim
@@ -100,6 +100,14 @@ proc importSingleFile*(c: var SemContext; dest: var TokenBuf; f1: ImportedFilena
   else:
     result = c.processedModules.getOrQuit(suffix)
   let s = Sym(kind: ModuleY, name: result, pos: ImportedPos)
+  # An import that lands under THIS module's own name shadows the implicit
+  # self-module symbol, exactly like in Nim: after `import std/math as m`
+  # inside `m.nim`, `m.sin` is math's `sin` and `m` no longer qualifies this
+  # module. Without the removal both symbols sit in the same scope under the
+  # same name, so every qualified use resolves to a two-element sym choice and
+  # dies with "ambiguous identifier" (nim-lang/nimony#2308). A no-op whenever
+  # the names differ, which is the normal case.
+  c.currentScope.removeOverloadable(moduleName, c.selfModuleSym)
   c.currentScope.addOverloadable(moduleName, s)
   let module = addr c.importedModules.mgetOrPut(result, ImportedModule(path: f2, fromPlugin: f1.plugin))
   loadInterface suffix, module.iface, result, c.importTab, c.converters,

--- a/tests/nimony/errmsgs/deps/mmodulemember.nim
+++ b/tests/nimony/errmsgs/deps/mmodulemember.nim
@@ -1,0 +1,1 @@
+proc present*(): int = 7

--- a/tests/nimony/errmsgs/tmodulemember.msgs
+++ b/tests/nimony/errmsgs/tmodulemember.msgs
@@ -1,0 +1,3 @@
+tests/nimony/errmsgs/tmodulemember.nim(9, 11) Error: undeclared identifier in module: 'nosuchproc'
+tests/nimony/errmsgs/tmodulemember.nim(10, 11) Error: undeclared identifier in module: 'nosuchvalue'
+tests/nimony/errmsgs/tmodulemember.nim(11, 11) Error: undeclared identifier in module: 'localOnly'

--- a/tests/nimony/errmsgs/tmodulemember.nim
+++ b/tests/nimony/errmsgs/tmodulemember.nim
@@ -1,0 +1,11 @@
+# A module-qualified name that the module does not have is a hard error: a
+# module qualifier has no `a.b(x)` -> `b(a, x)` fallback. Both the call and the
+# non-call form used to lose the name on the way out and report
+# "undeclared identifier: ''". https://github.com/nim-lang/nimony/issues/2308
+import deps/mmodulemember as mm
+
+proc localOnly(): int = 42
+
+discard mm.nosuchproc()
+discard mm.nosuchvalue
+discard mm.localOnly()

--- a/tests/nimony/modules/deps/mselfnamealias.nim
+++ b/tests/nimony/modules/deps/mselfnamealias.nim
@@ -1,0 +1,1 @@
+proc aliased*(): int = 7

--- a/tests/nimony/modules/tselfnamealias.nim
+++ b/tests/nimony/modules/tselfnamealias.nim
@@ -1,0 +1,11 @@
+## An import bound to THIS module's own name shadows the implicit self-module
+## symbol, as it does in Nim. Both used to sit in the same scope under the same
+## name, so every qualified use died with "ambiguous identifier" — reported as
+## "undeclared identifier: ''". https://github.com/nim-lang/nimony/issues/2308
+import std/assertions
+import deps/mselfnamealias as tselfnamealias
+
+proc mine(): int = 42
+
+assert tselfnamealias.aliased() == 7
+assert mine() == 42


### PR DESCRIPTION
`import std/math as asdf` inside `asdf.nim` left two `ModuleY` symbols in the top-level scope under the same name - the implicit self-module symbol and the import - so `asdf.sin(1.0)` resolved to a two-element sym choice and died. Nim binds the name to the import; do the same by removing the self-module symbol from the scope the import registers in. A no-op whenever the names differ, which is the normal case. Applies to a plain `import sub/asdf` too, matching Nim.

The reported message was "undeclared identifier: ''", and that was a second bug of its own, reachable without any name clash: for a module qualifier `tryBuiltinDot` reported `MatchedDotSym` even when the module had no such member, and under `AllowUndeclared` it left the bare identifier behind. `semCall` then ran the whole call machinery on it and the error tail had no name left to print. A module qualifier has no `a.b(x)` -> `b(a, x)` fallback, so the miss is now a `FailedDot` that every caller turns into "undeclared identifier in module: 'x'", and `semCall` emits that and returns instead of continuing.