### PR TITLE
a plugin process never declared its pools (`[Assertion Failure]`, no …

### DIFF
--- a/src/nimony/lib/plugins.nim
+++ b/src/nimony/lib/plugins.nim
@@ -51,6 +51,22 @@ let
   pluginPool = newPool()
   pluginTags = createPluginTags()
 
+# A plugin process shares ONE pool world across every buffer in it, which is
+# exactly the case `nifcore.fallbackPool`/`fallbackTags` exist for — and this
+# API never declared it. `NifBuilder` is an alias for `TokenBuf`, so a builder
+# `createTree` did not mint (an object field, `default(...)`, a `seq` slot) has
+# nil pools; `nifcore.ensurePools` then minted a PRIVATE pool, and the first
+# `withTree` died in `openTagEscaped` — a fresh pool declares no escape tag —
+# as a bare `[Assertion Failure]` with no file and no line. Kind queries
+# dispatch on `pluginTags` *identity* too, so such a builder also read back as
+# `NoStmt`/`NoExpr` throughout.
+#
+# The compiler side gets this from `nifpools`, which plugins do not import.
+# Stating it here is what makes the API total: every shape of `NifBuilder`
+# lands in the plugin's own pools, not in a private one.
+nifcore.fallbackPool = pluginPool
+nifcore.fallbackTags = pluginTags
+
 var
   unusedNameBase = ""
   nextUnusedName = 0

--- a/tests/nimony/plugins/deps/mdefaultbuilder.nim
+++ b/tests/nimony/plugins/deps/mdefaultbuilder.nim
@@ -1,0 +1,36 @@
+import plugins
+import std / assertions
+
+# `NifBuilder` is an alias for `TokenBuf`, so a builder `createTree()` did not
+# mint has nil pools. Both shapes below used to die as a bare
+# `[Assertion Failure]` — no file, no line — inside `openTagEscaped`, because
+# `nifcore.ensurePools` minted a PRIVATE pool for them and a fresh pool
+# declares no escape tag. A plugin process must declare its own pools as the
+# nifcore default the way the compiler's `nifpools` does; `plugins.nim` never
+# did.
+
+type Ctx = object
+  outBuf: NifBuilder      ## an object field: never passed through createTree
+  depth: int
+
+proc tr(n: NifCursor): NifBuilder =
+  let info = n.info
+  var head = callArgs(n)
+
+  # shape 1: an object field
+  var c = Ctx(depth: 0)
+  c.outBuf.withTree StmtsS, info:
+    c.outBuf.withTree CallS, info:
+      c.outBuf.addIdent "echo"
+      c.outBuf.takeTree head
+  assert not c.outBuf.isEmpty
+
+  # shape 2: `default(...)`, and the raw appenders re-exported from nifcore
+  var d = default(NifBuilder)
+  d.addIntLit 7
+  assert renderTree(d) == "7"
+
+  result = ensureMove c.outBuf
+
+var inp = loadPluginInput()
+saveTree tr(inp)

--- a/tests/nimony/plugins/tdefaultbuilder.nim
+++ b/tests/nimony/plugins/tdefaultbuilder.nim
@@ -1,0 +1,5 @@
+import std / syncio
+
+template generateEcho(s: string) {.plugin: "deps/mdefaultbuilder".}
+
+generateEcho("default builder")

--- a/tests/nimony/plugins/tdefaultbuilder.output
+++ b/tests/nimony/plugins/tdefaultbuilder.output
@@ -1,0 +1,1 @@
+default builder


### PR DESCRIPTION
…location)

`NifBuilder` is an alias for `nifcore.TokenBuf`, so a builder `createTree()` did not mint — an object field, `default(NifBuilder)`, a `seq` slot — has nil pools. It then falls into `nifcore.ensurePools`, which binds the application-wide `fallbackPool`/`fallbackTags`. The compiler gets those from `nifpools`; a plugin is a separate process that does not import `nifpools`, so they are nil there and `ensurePools` minted a PRIVATE pool instead.

What that costs: the first `withTree` dies in `openTagEscaped` — a fresh pool declares no escape tag, and the Nimony tag ordinals are past the 9-bit field — as a bare `[Assertion Failure]` with no file and no line. Kind queries dispatch on `pluginTags` *identity*, so short of the assert such a builder also reads back as `NoStmt`/`NoExpr` throughout.

A plugin process shares one pool world across every buffer in it, which is precisely what those two nifcore variables are for. Stating it is one line and makes every shape of `NifBuilder` total.

Nimony's definite-initialization analysis already rejects the third shape, `var b: NifBuilder` ("cannot prove that b.0 has been initialized"), which is why this went unnoticed: the two that get past it are the ones a stateful plugin actually writes.
