### PR TITLE
`x of T` was false unless a template re-semchecked it (#2377)

### DIFF
--- a/src/hexer/vtables_backend.nim
+++ b/src/hexer/vtables_backend.nim
@@ -324,13 +324,39 @@ proc trProcCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
       tr c, dest, n
     dest.addParRi(n.endInfo)
 
-proc classData(typ: Cursor): (int, UHash) =
+proc classSym(typ: Cursor): SymId =
+  ## The type operand of `of` reaches us in two different spellings: as the
+  ## expanded type (`(ref A.Obj.0. (notnil))`, produced when the expression is
+  ## re-semchecked, e.g. inside a template) or as the bare type symbol `A.0.`
+  ## (produced by the direct `of` magic call, whose argument is a `typedesc`
+  ## *expression*). `A.0.` is an alias for `(ref A.Obj.0.)`, not the object
+  ## type itself, so it has to be followed to `A.Obj.0.` before it can be
+  ## hashed or walked up the inheritance chain.
+  result = SymId(0)
   var n = typ
-  if n.typeKind in {RefT, PtrT}:
-    inc n
+  var counter = 20
+  while counter > 0:
+    dec counter
+    if n.typeKind in {RefT, PtrT}:
+      inc n
+    elif n.kind == Symbol:
+      let s = n.symId
+      result = s
+      let res = tryLoadSym(s)
+      if res.status != LacksNothing or res.decl.symKind != TypeY:
+        break
+      let body = asTypeDecl(res.decl).body
+      # a nominal type is the class itself; anything else is an alias to follow
+      if isNominal(body.typeKind):
+        break
+      n = body
+    else:
+      break
+
+proc classData(typ: Cursor): (int, UHash) =
   result = (0, UHash(0))
-  if n.kind == Symbol:
-    let s = n.symId
+  let s = classSym(typ)
+  if s != SymId(0):
     for _ in inheritanceChain(s): inc result[0]
     result[1] = uhash(pool.syms[s])
 

--- a/tests/nimony/methods/tofpositions.nim
+++ b/tests/nimony/methods/tofpositions.nim
@@ -1,0 +1,60 @@
+# `x of T` must not depend on the syntactic position of the expression:
+# the direct `of` magic passes the type as a `typedesc` *expression* (the bare
+# alias symbol `A.0.`), while a re-semchecked `of` (inside a template such as
+# `echo`) passes the expanded type. Both must resolve to the same class.
+
+import std / [syncio, assertions]
+
+type
+  Base = ref object of RootObj
+    id: int
+  Mid = ref object of Base
+    y: int
+  Leaf = ref object of Mid
+    z: int
+
+  ValBase {.inheritable.} = object
+    id: int
+  ValLeaf = object of ValBase
+    z: int
+
+proc takesBool(name: string; got, want: bool) =
+  echo (if got == want: "ok   " else: "WRONG"), " ", name
+
+proc testRef(k: Base) =
+  let bound = k of Leaf
+  takesBool "let-bound", bound, true
+
+  var vbound = k of Leaf
+  takesBool "var-bound", vbound, true
+
+  takesBool "proc-arg", k of Leaf, true
+
+  if k of Leaf: echo "ok    if-condition"
+  else: echo "WRONG if-condition"
+
+  var spins = 0
+  while (k of Leaf) and spins < 1:
+    inc spins
+  takesBool "while-condition", spins == 1, true
+
+  takesBool "middle class", k of Mid, true
+  takesBool "own class", k of Base, true
+  echo "echo-inline: ", k of Leaf
+
+proc testNegative(k: Base) =
+  takesBool "not a Leaf", k of Leaf, false
+  takesBool "is a Mid", k of Mid, true
+
+proc testValue(o: ValBase) =
+  let bound = o of ValLeaf
+  takesBool "value let-bound", bound, true
+  takesBool "value proc-arg", o of ValLeaf, true
+
+var kids: seq[Base] = @[Base(Leaf(id: 1))]
+testRef kids[0]
+testNegative Base(Mid(id: 2))
+testValue ValBase(ValLeaf(id: 3))
+
+let self = Leaf(id: 4)
+takesBool "statically exact", self of Leaf, true

--- a/tests/nimony/methods/tofpositions.output
+++ b/tests/nimony/methods/tofpositions.output
@@ -1,0 +1,13 @@
+ok    let-bound
+ok    var-bound
+ok    proc-arg
+ok    if-condition
+ok    while-condition
+ok    middle class
+ok    own class
+echo-inline: true
+ok    not a Leaf
+ok    is a Mid
+ok    value let-bound
+ok    value proc-arg
+ok    statically exact


### PR DESCRIPTION
`of` reaches hexer in two spellings. The direct magic call (`func of*[T, S](x: T; y: typedesc[S]): bool`) takes its second argument as a typedesc *expression*, so nimony emits the bare type symbol: `(instanceof k.0. A.0.)`. A re-semchecked `of` -- inside `echo`, `assert`, `not`, any template -- goes through `semInstanceof` and `semLocalTypeImpl` instead, which inlines the non-nominal alias: `(instanceof k.0. (ref A.Obj.0. (notnil)))`.

`classData` only understood the second one. For `A = ref object of Base` the symbol `A.0.` is the *alias*, not the object type, so hashing it and walking `inheritanceChain` off it produced level 0 and the hash of the wrong name -- the emitted display check was always false. Plain `object of` types have no alias indirection, which is why `tmof.nim` and every echo/assert-wrapped `of` passed all along.

Resolve the type operand to the class symbol first, following `ref`/`ptr` and type aliases until a nominal type is reached.