### PR TITLE
Windows tree walk compiles the whitelisted tests with `nimony n`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -178,12 +178,130 @@ runs:
       shell: bash
       run: "gcc -v"
 
+    # `setup-nim` resolves exactly one tag — the rolling `latest-<branch>` alias
+    # in nim-lang/nightlies — and fails outright when it is absent. On
+    # 2026-08-27 it was absent for `devel`: that day's nightlies run BUILT devel
+    # fine (its dated release carries all nine assets), but the "Push
+    # latest-devel tag" job failed, and that job deletes the alias before it
+    # recreates it:
+    #
+    #     gh release delete -y "$tag" || :
+    #     git push --delete origin "$tag" || :
+    #     gh release create ... "$tag" ...
+    #
+    # so a failure after the deletes leaves no alias at all, and every consumer
+    # stops at "Could not find any release named 'latest-devel'". The dated
+    # releases are what the alias points AT, so the newest one for the branch is
+    # the same compiler reached by a different name.
+    #
+    # This step only decides WHICH of the two following steps runs. When the
+    # alias is there — the normal case — nothing changes: the action installs it
+    # exactly as before.
+    - name: Resolve the Nim nightly
+      id: nim
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -uo pipefail
+        branch='${{ inputs.nim_branch }}'
+        # Byte-for-byte the probe `setup-nim`'s own `setup.sh` makes, so this
+        # can never disagree with what the action would then do.
+        if curl -fsI "https://github.com/nim-lang/nightlies/releases/latest-$branch" >/dev/null 2>&1; then
+          echo "alias=true" >> "$GITHUB_OUTPUT"
+          echo "latest-$branch is present; installing it with setup-nim."
+          exit 0
+        fi
+        echo "alias=false" >> "$GITHUB_OUTPUT"
+        echo "::warning::latest-$branch is missing from nim-lang/nightlies (upstream alias job); falling back to the newest dated nightly"
+
+        # The archive names `setup-nim` derives, and the same mapping: a dated
+        # release spells its assets `nim-<version>-<os>_<arch>.<ext>` while the
+        # alias renames them to `<os>_<arch>.<ext>`, so match on the suffix and
+        # let the version float.
+        case '${{ runner.os }}' in
+          Linux)   os=linux ;;
+          macOS)   os=macosx ;;
+          Windows) os=windows ;;
+          *) echo "::error::setup: unknown runner OS '${{ runner.os }}'"; exit 1 ;;
+        esac
+        case '${{ inputs.cpu }}' in
+          amd64) arch=x64 ;;
+          i386)  arch=x32 ;;
+          arm64) arch=arm64 ;;
+          *) echo "::error::setup: unknown cpu '${{ inputs.cpu }}'"; exit 1 ;;
+        esac
+        # `if`, not `[ … ] && …`: the runner's shell is `bash -e`, and a
+        # trailing AND-list whose test is false is a failed command — the step
+        # would have exited 1 on every host that is not Windows.
+        if [ "$os" = windows ]; then ext=.zip; else ext=.tar.xz; fi
+        suffix="-${os}_${arch}${ext}"
+
+        # Newest first is the API's own order, so `first` after the date-prefix
+        # filter is the newest dated build of this branch. The filter anchors on
+        # the date so it cannot match `latest-version-2-4` and friends.
+        # Authenticated when there is a token (there always is in Actions, and
+        # the unauthenticated API rate limit is per runner IP — i.e. shared).
+        auth=()
+        if [ -n "${GH_TOKEN:-}" ]; then auth=(-H "Authorization: Bearer $GH_TOKEN"); fi
+        url=$(curl -fsSL "${auth[@]}" \
+                "https://api.github.com/repos/nim-lang/nightlies/releases?per_page=100" |
+              jq -r --arg br "$branch" --arg sfx "$suffix" '
+                [ .[] | select(.tag_name | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}-" + $br + "-")) ]
+                | first
+                | .assets[] | select(.name | endswith($sfx)) | .browser_download_url')
+        if [ -z "$url" ] || [ "$url" = null ]; then
+          echo "::error::setup: no dated nightly for branch '$branch' carries a '*$suffix' asset"
+          exit 1
+        fi
+        echo "url=$url" >> "$GITHUB_OUTPUT"
+        echo "Falling back to $url"
+
     - name: Setup Nim
+      if: steps.nim.outputs.alias == 'true'
       uses: alaviss/setup-nim@0.1.1
       with:
         path: 'nim'
         version: ${{ inputs.nim_branch }}
         architecture: ${{ inputs.cpu }}
+
+    - name: Setup Nim from a dated nightly
+      # The fallback path. Does what `setup-nim` does — unpack the archive into
+      # `nim/` stripping its one top-level directory, then put `nim/bin` and
+      # nimble's bin on PATH — for the one tag it cannot ask for. The action's
+      # third step, its problem matcher, is inside the action and stays behind;
+      # it only annotates compiler diagnostics in the run log.
+      if: steps.nim.outputs.alias != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p nim
+        cd nim
+        url='${{ steps.nim.outputs.url }}'
+        archive=${url##*/}
+        curl -fsSL -o "$archive" "$url"
+        if [[ $archive == *.zip ]]; then
+          tmp=$(mktemp -d)
+          7z x "$archive" "-o$tmp" > /dev/null
+          extracted=( "$tmp"/* )
+          mv "${extracted[0]}"/* .
+          rm -rf "$tmp"
+        else
+          tar -xf "$archive" --strip-components 1
+        fi
+        rm -f "$archive"
+        nimbin=$(cd bin && pwd -P)
+        nimblebin="$HOME/.nimble/bin"
+        if [ '${{ runner.os }}' = Windows ]; then
+          nimbin=$(cygpath -aw "$nimbin")
+          nimblebin=$(cygpath -aw "$nimblebin")
+        fi
+        echo "$nimbin" >> "$GITHUB_PATH"
+        echo "$nimblebin" >> "$GITHUB_PATH"
+        # `sed -n 1p`, not `head -1`: head closes the pipe on line two and the
+        # shell runs with `pipefail`, so the SIGPIPE would fail this step over a
+        # log line.
+        "$PWD/bin/nim" --version | sed -n 1p
 
     - name: Overlay current Nim compiler source (devel parser fixes)
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,12 @@ jobs:
 
       - name: Run native backend tests (Linux amd64)
         # The curated native regression set (full ARC suite + closures + cps)
-        # through `nimony n`. Only Linux amd64 has a recorded pass list to hold it
-        # to; `NativeTestDirsWindows` exists but has never been run on a real
-        # runner, so Windows gets the native BOOT first and this later.
+        # through `nimony n`. Only Linux amd64 runs it as a step of its own:
+        # Windows reaches the same corpus from inside the tree walk instead,
+        # which compiles every whitelisted test with `nimony n` rather than
+        # `nimony c` (see `walkUsesNative` in src/hastur.nim) — there, skipping
+        # gcc and the linker is what the step is FOR, so the coverage costs no
+        # extra runner time. `NativeTestDirsWindows` is the list it reads.
         if: runner.os == 'Linux' && matrix.target.cpu == 'amd64'
         run: |
           cd nimony

--- a/lib/std/private/osappdirs.nim
+++ b/lib/std/private/osappdirs.nim
@@ -111,10 +111,18 @@ when defined(windows):
 
   import ../widestrs
 
+  # Retrieves the path of the directory designated for temporary files.
+  #
+  # Declared with no body, and with the same bare `dynlib: "kernel32"` every
+  # other Windows import here uses. It had a body — just the doc comment — and
+  # `dynlib: "kernel32.dll"`, and in that shape the import library never
+  # reached the native backend: arkham rejected the extern outright
+  # ("`GetTempPathW` names no import library"), taking `tos`, `tdirs` and
+  # `tappdirs` with it. The C backend never noticed because gcc links
+  # kernel32 whether or not anyone asks.
   proc getTempPath(
     nBufferLength: DWORD, lpBuffer: WideCString
-  ): DWORD {.stdcall, dynlib: "kernel32.dll", importc: "GetTempPathW".} =
-    ## Retrieves the path of the directory designated for temporary files.
+  ): DWORD {.stdcall, dynlib: "kernel32", importc: "GetTempPathW".}
 
 template getEnvImpl(result: var string, tempDirList: openArray[string]) =
   for dir in tempDirList:

--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -135,6 +135,11 @@ Options:
                         so this is the big lever on Windows. A group that
                         fails is re-run test by test, so failures stay
                         attributable; `off` skips the grouping altogether.
+  --native:on|off       on WINDOWS, compile the tests `hastur native` vouches
+                        for with `nimony n` rather than `nimony c` (default
+                        on). Same assertion, no gcc and no linker behind it —
+                        the other half of the lever `--joined` pulls. Ignored
+                        on every other host.
   --cachedir:PATH       use PATH instead of `nimcache/` for intermediates
   --bindir:PATH         resolve the toolchain (nimony, lengc, …) from
                         directory PATH instead of hastur's own directory
@@ -533,6 +538,215 @@ proc testValgrind(c: var TestCounters; file: string; overwrite: bool; cat: Categ
 proc echoTestSuccess(file: string) =
   echo "SUCCESS ", file
 
+# ── native-backend regression set ────────────────────────────────────────────
+# The C-FREE native path (`nimony n` → arkham + nifasm, sibling `../nativenif`) is
+# still incomplete, so we can't run the whole suite through it. Instead this is an
+# explicit whitelist of what is known to run correctly natively — a regression
+# guard: a native miscompile that diverges from the (spec-pinned) result is caught.
+# Grow it as the backend gains features (the same record-what-works philosophy as
+# the rest of hastur). `NativeTestDirs` are directories that pass apart from the
+# files `NativeTestSkip` names (negative `.msgs` tests auto-skipped too);
+# `NativeTestFiles` are individual passers from otherwise-partial directories.
+const
+  NativeTestDirs = [
+    "tests/nimony/arc",        # full ARC suite — byte-identical to the C backend
+    "tests/nimony/closures"
+  ]
+
+  NativeTestDirsWindows = [
+    # Windows grew a native target later than the other hosts, so what it is known
+    # to run correctly is recorded separately until a run elsewhere confirms the
+    # same — the whole point of this file is that it states OBSERVED results, and
+    # these were observed on Windows. Fold an entry into `NativeTestDirs` once it
+    # has been seen green on Linux/macOS too.
+    #
+    # Every entry below was established the same way, under Wine against the real
+    # MinGW bundle (`tools/wine_test.sh`, see `doc/wine_testing.md`): each of the
+    # directory's tests run through `nimony n` on its own AND the whole directory
+    # run as one native joined program, which is the shape the tree walk actually
+    # compiles it in and not the same question — `tests/nimony/arc` passes
+    # test-by-test but its group does not (see `NativeJoinSkip`).
+    #
+    # `tests/nimony/stdlib`: 45 of its 53 pass; the rest are in `NativeTestSkip`.
+    # This is the suite that covers the process vectors the Windows entry point
+    # does not receive (`tcmdline`, `tenvvars`, `tos`) — the reason it is worth
+    # running natively at all rather than only through the C backend.
+    "tests/nimony/stdlib",
+    "tests/nimony/assembler",
+    "tests/nimony/basics",
+    "tests/nimony/borrows",
+    "tests/nimony/casestmt",
+    "tests/nimony/consteval",
+    "tests/nimony/converter",
+    "tests/nimony/cyclic",
+    "tests/nimony/enums",
+    "tests/nimony/exceptions",
+    "tests/nimony/intrinsics",
+    "tests/nimony/lastuse",
+    "tests/nimony/lookups",
+    "tests/nimony/macros",
+    "tests/nimony/mut",
+    "tests/nimony/overload",
+    "tests/nimony/plugins",
+    "tests/nimony/sets",
+    "tests/nimony/strings",
+    "tests/nimony/templates",
+    "tests/nimony/threads",
+    "tests/nimony/types",
+    "tests/nimony/untyped",
+    "tests/nimony/when"
+  ]
+
+  NativeJoinSkip = [
+    # Directories whose tests each compile and run correctly through `nimony n`
+    # — they are in the lists above — but whose JOINED program does not. The
+    # tree walk compiles a group's members as IMPORTS of a generated driver
+    # rather than as main modules, and the native backend has gaps that only
+    # that shape reaches, so the group keeps the C backend while the same
+    # directory's standalone tests (and `hastur native`) stay native.
+    #
+    # Each one is a native bug with a standalone reproduction, not a property of
+    # the test; drop the entry once the backend handles it.
+    #
+    # A local assigned inside a `for` whose body is an `if`/`elif` chain with a
+    # `break` keeps its INITIAL value — the stores in the loop are lost. Both of
+    # these run a `splitFile`-shaped scan, and both print the pre-loop values:
+    #
+    #   proc g*(p: string): int =
+    #     var pathEnd = -1
+    #     var extPos = p.len
+    #     for i in countdown(p.len-1, 1):
+    #       if p[i] == '.':
+    #         if extPos == p.len: extPos = i
+    #       elif p[i] == '/':
+    #         pathEnd = i
+    #         break
+    #     echo pathEnd, " ", extPos      # 7 11 as a main module, -1 15 imported
+    #
+    # Reproduces on Linux too, so it is not a Windows story — nothing in the
+    # native suite compiles a test as an import, which is why it went unseen.
+    "tests/nimony/arc",          # tsplitfile
+    "tests/nimony/strings",      # tsplit_and_append, the same scan
+    # `ExitProcess` and `GetStdHandle` reach arkham with no import library
+    # ("names no import library; annotate ... with `dynlib`") even though
+    # `lib/std/system/panics.nim` annotates both — the binding is lost somewhere
+    # in the multi-module program, and every module in the group needs it.
+    "tests/nimony/consteval",
+    # arkham stops at a template-injected symbol in the imported module's init
+    # proc: "Unknown or invalid symbol: injectedLocal.1 … in proc `ini.0.…`"
+    # (`helper.1` for the other). The same templates are fine in a main module.
+    "tests/nimony/templates",
+    "tests/nimony/untyped"
+  ]
+
+  NativeTestSkip = [
+    # Files a `NativeTestDir` does not cover yet, with the reason each fails. All
+    # but the last PASS through the C backend, so each of those is a gap in the
+    # native path rather than in the test — which is what makes them worth naming
+    # individually instead of dropping the directory.
+    #
+    # A libc math/stdio extern with a FLOAT parameter. Win64 indexes its SSE
+    # argument registers positionally (an xmm slot burns the GPR of the same
+    # position), which arkham's ABI planner does not model — `emitWinExtproc`
+    # rejects it rather than guess. Moot until the freestanding target has a libc
+    # to bind these to at all.
+    "tests/nimony/stdlib/tcomplex",     # sqrtf
+    "tests/nimony/stdlib/tmath",        # frexp
+    "tests/nimony/stdlib/tstrutils",    # snprintf
+    # `mov` of a `bool` into an `(i 64)` result: nifasm's widening rule admits
+    # int→int only, so a bool source is a type error. Arch-neutral.
+    "tests/nimony/stdlib/thashes",
+    # Compiles and links, but the result diverges from the spec-pinned output —
+    # a native MISCOMPILE (all three are green on the C backend). Undiagnosed.
+    "tests/nimony/stdlib/tbitops",
+    "tests/nimony/stdlib/tencodings",
+    "tests/nimony/stdlib/trandom",
+    # The odd one out: NOT a native gap. Its `std/typetraits` compile-time plugin
+    # fails to run ("vfs: open failed"), and the C backend fails it identically,
+    # so nothing here would fix it.
+    "tests/nimony/stdlib/ttypetraits"
+  ]
+  NativeTestFiles = [
+    # Portable intrinsics: `(instr …)` lowers to the target's own instruction —
+    # x86-64 `bsf`, AArch64 `rbit`+`clz` — so this is the one test whose POINT is
+    # that the C and native backends agree on results they reach by different
+    # instructions.
+    "tests/nimony/intrinsics/tintrinsics",
+    # The atomics are intrinsic rows too, and the backends reach them from even
+    # further apart: C emits the `__atomic_*` builtins, x86-64 a `lock`-prefixed
+    # sequence, AArch64 an `ldaxr`/`stlxr` retry loop. Running it here is what says
+    # the three agree — including the compare-exchange FAILURE path, which a wrong
+    # lowering still "passes" single-threaded unless the test reads back the value
+    # the CAS observed.
+    "tests/nimony/intrinsics/tatomics",
+    # The valgrind client request. Native-only by nature: under the C backend the
+    # mechanism is valgrind's own headers around mimalloc, so there is no row to
+    # lower and the test compiles to its `echo` alone. What it checks here is the
+    # property the C path never has to have — that the request sequence is inert
+    # on real hardware, and leaves every live register where it found it.
+    "tests/nimony/intrinsics/tvalgrind",
+    # `div`/`mod` by a constant power of two, which arkham strength-reduces to a
+    # shift (and, for a signed dividend, a round-toward-zero bias). Native-relevant
+    # by nature: under `nimony c` the C compiler owns that rewrite, so only a
+    # backend doing its own can round the wrong way on a negative dividend.
+    "tests/nimony/basicarith/tdivmodpow2",
+    # `float32` at every width-sensitive spot. Native-relevant by nature: the C
+    # backend gets the widths from C's own type system, so this only ever fails on
+    # a backend that has to derive them itself.
+    "tests/nimony/types/tfloat32",
+    # Indexing an array of AGGREGATES and reading one field of the element: the
+    # element stride and the access width are different numbers, which AArch64's
+    # register-offset addressing cannot express (`[Xn, Xm, LSL #k]` scales by the
+    # ACCESS width, not by an arbitrary amount). Native-relevant by nature — the C
+    # compiler owns addressing under `nimony c`. It read `arr[i div 2]` for a 4-byte
+    # field, which is what kept `-d:release` off the native self-host.
+    "tests/nimony/calls/tindexednarrowfield",
+    # More arguments than the ABI has argument registers, with the parameter shapes
+    # that give a stack-passed one a stack HOME (a `var seq` written through, an
+    # object read after a call). Native-relevant by nature: the C compiler owns
+    # argument passing under `nimony c`, so only a backend that marshals arguments
+    # itself can fail this — arkham's AArch64 prologue used to abort on it outright
+    # (">8 integer params (stack TODO)"), which is what kept `nimony.nim` off the
+    # native bootstrap ladder.
+    "tests/nimony/calls/tstackparams",
+    # cps/* — closures & continuation-passing (indirect calls through fn-ptr values)
+    "tests/nimony/cps/tbasicpassive",
+    "tests/nimony/cps/tclosure",
+    "tests/nimony/cps/tclosure_iter_basic",
+    "tests/nimony/cps/tclosure_iter_body_capture",
+    "tests/nimony/cps/tclosure_iter_break",
+    "tests/nimony/cps/tclosure_iter_envcheck",
+    # One frame field of every kind. Native-relevant by nature: this is the
+    # backend that depends on `oconstr` being total, since it stores exactly the
+    # fields the constructor lists and zeroes nothing.
+    "tests/nimony/cps/tclosure_iter_frametypes",
+    # Sets in a closure iterator, in both representations (word-sized and the
+    # 32-byte array). Worth running natively because the big-set path builds
+    # its value through `zeroMem` plus per-element stores rather than a
+    # literal, which is a different shape for the back end than the C one.
+    "tests/nimony/cps/tclosure_iter_sets",
+    "tests/nimony/cps/tclosure_iter_string",
+    "tests/nimony/cps/tclosure_iter_var",
+    "tests/nimony/cps/tfirstpassive",
+    "tests/nimony/cps/tif",
+    "tests/nimony/cps/tmethods",
+    "tests/nimony/cps/tnestedloops",
+    "tests/nimony/cps/trecursive",
+    "tests/nimony/cps/tsuspend",
+    "tests/nimony/cps/tsuspend_resume",
+    "tests/nimony/cps/tparkstate",
+    "tests/nimony/cps/ttry",
+    # The native backend is the only one that HAS a stack trace: it walks nifasm's
+    # own per-proc table, seeded by a `{.naked.}` proc. Running it here is what
+    # checks the three halves agree — the table nifasm lays down, the two
+    # intrinsics arkham lowers, and the walk in `lib/std/stacktraces`.
+    "tests/nimony/stacktraces/tstacktrace",
+    # A `const` set is read straight out of read-only data, so its membership
+    # test is an indexed load from a GLOBAL — a shape the C backend never sees a
+    # register problem in and arkham got wrong twice. Native-only by nature.
+    "tests/nimony/sets/tconstsetscan"
+  ]
+
 const
   JoinedPrefix = "_hastur_"
     ## Generated files carry this prefix; they are never tests themselves.
@@ -553,9 +767,91 @@ type WorkItem = object
   path: string
   joined: bool
   weight: int
+  native: bool
+    ## Compiled by `nimony n` (see `walkUsesNative`). The worker decides this
+    ## for itself from the same inputs; the parent needs to know it too,
+    ## because the two backends take their cache prefill from different
+    ## warmups and handing a native item the C one breaks its build.
 
 proc isGeneratedTestFile*(file: string): bool {.inline.} =
   file.splitFile.name.startsWith(JoinedPrefix)
+
+# ── native compilation inside the tree walk ──────────────────────────────────
+# What a Windows test costs is mostly not nimony: it is the gcc invocation per
+# module and the link that follow it, each a process creation the platform
+# charges dearly for (see the `joined tests` note below — same cause, different
+# lever). `nimony n` has no such tail: arkham and nifasm consume the same front
+# end and write the PE themselves. So for a test the native backend is KNOWN to
+# compile correctly, the walk takes that path on Windows and pays a fraction of
+# the time, asserting exactly what it asserted before — the same program's
+# output against the same `.output` file, only the code generator differs.
+#
+# "Known to compile correctly" is not a new list: it is the `hastur native`
+# whitelist directly above, read the same way. A test the native suite does not
+# vouch for keeps the C backend, so this can never turn a native gap into a
+# tree-walk failure that `hastur native` would not already report.
+
+var walkNative* = true
+  ## `--native:off` puts the whole tree walk back on the C backend. Only ever
+  ## consulted on Windows (elsewhere `walkUsesNative` is false regardless): the
+  ## other hosts run their C toolchain fast enough that the native path would
+  ## trade coverage for nothing.
+
+proc nativeWhitelisted(file: string): bool =
+  ## Is `file` one of the tests `hastur native` runs — i.e. one the native
+  ## backend is recorded as compiling correctly on this host?
+  let p = file.replace('\\', '/')
+  if not p.endsWith(".nim"): return false
+  let stem = p[0 ..< p.len - ".nim".len]
+  for f in NativeTestSkip:
+    if stem == f: return false
+  for f in NativeTestFiles:
+    if stem == f: return true
+  # A whitelisted directory covers its own `.nim` files only; the nested dirs
+  # (`deps/`, `imp/`, …) hold import fixtures, which are never tests. Sliced by
+  # hand rather than with `parentDir`, which re-spells the result with the host
+  # separator — a backslash on the one platform this runs on, and so never
+  # equal to a list entry.
+  let sep = stem.rfind('/')
+  if sep < 0: return false
+  let dir = stem[0 ..< sep]
+  for d in NativeTestDirs:
+    if dir == d: return true
+  when defined(windows):
+    for d in NativeTestDirsWindows:
+      if dir == d: return true
+
+proc nativeJoinable(dir: string): bool =
+  ## May this directory's joined group be compiled natively? Separate from
+  ## `walkUsesNative` because it is a different question: a group compiles its
+  ## members as imports, and `NativeJoinSkip` records where the native backend
+  ## gets that shape wrong for tests it gets right on their own.
+  let d = dir.replace('\\', '/').strip(chars = {'/'})
+  for x in NativeJoinSkip:
+    if d == x: return false
+  result = true
+
+proc walkUsesNative(file: string; cat: Category): bool =
+  ## Whether the tree walk compiles this test with `nimony n` rather than
+  ## `nimony c`. Windows-only, and only for a plain compile-run-diff test:
+  ## a `.msgs` spec, a golden `.nim.c`, a `.nif` dump or a valgrind run each
+  ## pin the test to the C pipeline, and every non-`Normal` category carries
+  ## flags (`--noSystem`, `--compat`, `--opt:speed`) the native path does not
+  ## take.
+  when not defined(windows):
+    result = false
+  else:
+    if not walkNative or cat != Normal: return false
+    # A plain clone of this repo has no `../nativenif`, so `build all` skips
+    # arkham and nifasm and says so rather than failing; the walk has to make
+    # the same allowance or every whitelisted test would die on a missing tool.
+    # Safe to ask here: `tests/setup.hastur` builds the toolchain on the way
+    # down, before any leaf directory is planned.
+    if not (fileExists(toolExe("arkham")) and fileExists(toolExe("nifasm"))):
+      return false
+    for ext in [".msgs", ".nim.c", ".nif", ".valgrind"]:
+      if file.changeFileExt(ext).fileExists(): return false
+    result = nativeWhitelisted(file)
 
 proc joinable*(file: string; cat: Category): bool =
   ## A test folds into its directory's joined group when nothing about it needs
@@ -609,12 +905,27 @@ proc nimonyCmdFor(file: string; cat: Category; forward: string): string =
   else:
     result.add " "
 
+proc nimonyNativeCmdFor(forward: string): string =
+  ## The flags a NATIVE tree-walk compile takes, minus the file. Deliberately
+  ## only `--forward`'s: `execNimonyNative` already supplies
+  ## `n --silentMake --isMain`, and every flag `nimonyCmdFor` adds beyond that
+  ## names something the native path does not have (`-d:useLibc` picks the libc
+  ## stdlib for a golden `.nim.c` or a valgrind run, `--passC` a C compiler) —
+  ## which is also why `walkUsesNative` excludes the tests that need them.
+  result = ""
+  if forward.len != 0:
+    result.add forward
+    result.add ' '
+
 proc testFile(c: var TestCounters; file: string; overwrite: bool; cat: Category; forward: string) =
   #echo "TESTING ", file
   let failuresBefore = c.failures
   inc c.total
-  let nimonycmd = nimonyCmdFor(file, cat, forward)
-  let (compilerOutput, compilerExitCode) = execNimony(nimonycmd & quoteShell(file), cat)
+  let (compilerOutput, compilerExitCode) =
+    if walkUsesNative(file, cat):
+      execNimonyNative(nimonyNativeCmdFor(forward) & quoteShell(file))
+    else:
+      execNimony(nimonyCmdFor(file, cat, forward) & quoteShell(file), cat)
 
   let msgs = file.changeFileExt(".msgs")
 
@@ -749,8 +1060,21 @@ proc joinedTest(c: var TestCounters; dir: string; files: seq[string];
     for f in files: testFile c, f, overwrite, Normal, forward
     return
 
+  # A group is compiled by ONE backend: whether that is the native one is a
+  # property of the members, not of the generated driver (which has no test
+  # sidecars of its own to look at). All-or-nothing on purpose — splitting a
+  # directory into a native group and a C group would add a whole second
+  # process tree, and the fixed cost of one of those is most of what a group
+  # costs, so the split would give the time back.
+  var native = files.len > 0 and nativeJoinable(dir)
+  if native:
+    for f in files:
+      if not walkUsesNative(f, Normal): native = false; break
   let (compilerOutput, compilerExitCode) =
-    execNimony(nimonyCmdFor(driver, Normal, forward) & quoteShell(driver), Normal)
+    if native:
+      execNimonyNative(nimonyNativeCmdFor(forward) & quoteShell(driver))
+    else:
+      execNimony(nimonyCmdFor(driver, Normal, forward) & quoteShell(driver), Normal)
   if compilerExitCode != 0:
     bail "did not compile", compilerOutput
 
@@ -771,12 +1095,20 @@ proc canRunParallel(cat: Category): bool {.inline.} =
   ## categories use isolated per-test cache dirs and parallelize fine.
   cat notin {Compat, Basics}
 
-proc warmupSharedCache(): string =
+proc warmupSharedCache(native = false): string =
   ## Compile `tools/warmup.nim` once into `nimcache/warmup/` so each
   ## parallel test can start with system + common stdlib bundles already
   ## present. Returns the warmup cache directory, or "" on opt-out
   ## (warmup source missing or compile failed — tests still work, just
   ## without the savings).
+  ##
+  ## `native` seeds the OTHER pipeline's cache, in a directory of its own.
+  ## The two must not mix: the intermediates the C and native backends read
+  ## share file names but not content — a native compile handed the C run's
+  ## bundle of `system` gets one whose externs have lost their `dynlib`, and
+  ## arkham stops at the first of them ("`GetStdHandle` names no import
+  ## library"). So a native work item prefills from here and a C one from
+  ## there, and neither ever sees the other's files.
   const warmupSrc = "tools/warmup.nim"
   if not fileExists(warmupSrc):
     # Loud, because the fallback is silent-but-slow: without the prefill every
@@ -786,13 +1118,17 @@ proc warmupSharedCache(): string =
     stderr.writeLine "warmup: " & warmupSrc &
       " missing; every test will recompile the stdlib from scratch"
     return ""
-  result = nimcacheDir / "warmup"
+  result = nimcacheDir / (if native: "warmup_native" else: "warmup")
   let nimony = toolExe("nimony")
   if not fileExists(nimony):
     stderr.writeLine "warmup: skipping, no nimony at " & nimony
     return ""
-  let cmd = nimony.quoteShell & " c --nimcache:" & result.quoteShell &
-            " " & warmupSrc.quoteShell
+  # The same command the work items are compiled with, so what lands here is
+  # exactly what they would have produced themselves (`execNimonyNative` for
+  # the native side, `execNimony`'s `c` for the other).
+  let cmd = nimony.quoteShell &
+            (if native: " n --silentMake --isMain --nimcache:" else: " c --nimcache:") &
+            result.quoteShell & " " & warmupSrc.quoteShell
   let t0 = epochTime()
   let exit = execShellCmd(cmd)
   let dt = epochTime() - t0
@@ -978,6 +1314,12 @@ proc parallelTestDir(c: var TestCounters; items: openArray[WorkItem];
   let hastur = getAppFilename()
   prebuildSharedObjects(forward)
   let warmupCache = warmupSharedCache()
+  # Seeded only when something in this run actually wants it: on every host but
+  # Windows no item is native, and paying for a second warmup compile there
+  # would be pure loss.
+  var anyNative = false
+  for it in items: (if it.native: anyNative = true)
+  let nativeWarmupCache = if anyNative: warmupSharedCache(native = true) else: ""
   warmupCopySeconds = 0
   let parallelStart = epochTime()
   var queue: seq[(int, WorkItem)] = @[]   # (idx, item) preserving input order
@@ -999,13 +1341,22 @@ proc parallelTestDir(c: var TestCounters; items: openArray[WorkItem];
     let (idx, item) = queue[head]
     inc head
     let cacheDir = nimcacheDir / ".par" / $idx
-    prefillFromWarmup(warmupCache, cacheDir)
+    prefillFromWarmup(if item.native: nativeWarmupCache else: warmupCache, cacheDir)
     var args = @[(if item.joined: "joined" else: "test"),
                  "--no-build", "--cachedir:" & cacheDir]
     # Forward the parent's resolved toolchain dir so each worker uses the
     # exact same binaries (the default is now hastur's own sibling dir, an
     # absolute path, not the literal "bin").
     args.add "--bindir:" & toolchainDir
+    # A work item's backend is settled HERE, by the parent, because the parent
+    # is what prefills the cache — and the two warmups cannot be mixed (see
+    # `warmupSharedCache`). The worker would reach the same verdict on its own
+    # for the item as planned, but not on every path through it: a joined group
+    # that diverges re-runs its members one by one, and in a group that is not
+    # all-native some of those members are individually eligible. That re-run
+    # inherits the C prefill, so it must inherit the C backend with it.
+    when defined(windows):
+      if not item.native: args.add "--native:off"
     if overwrite: args.add "--overwrite"
     if forward.len > 0: args.add "--forward:" & forward
     args.add item.path
@@ -1137,143 +1488,6 @@ proc joinedDirCmd(dir: string; overwrite: bool; forward: string) =
 
 # The general test-tree runner is `collectTests`/`walkRoots` further below; the
 # old per-suite `nimonytests`/`exampletests` drivers folded into it.
-
-# ── native-backend regression set ────────────────────────────────────────────
-# The C-FREE native path (`nimony n` → arkham + nifasm, sibling `../nativenif`) is
-# still incomplete, so we can't run the whole suite through it. Instead this is an
-# explicit whitelist of what is known to run correctly natively — a regression
-# guard: a native miscompile that diverges from the (spec-pinned) result is caught.
-# Grow it as the backend gains features (the same record-what-works philosophy as
-# the rest of hastur). `NativeTestDirs` are directories that pass apart from the
-# files `NativeTestSkip` names (negative `.msgs` tests auto-skipped too);
-# `NativeTestFiles` are individual passers from otherwise-partial directories.
-const
-  NativeTestDirs = [
-    "tests/nimony/arc",        # full ARC suite — byte-identical to the C backend
-    "tests/nimony/closures"
-  ]
-
-  NativeTestDirsWindows = [
-    # Windows grew a native target later than the other hosts, so what it is known
-    # to run correctly is recorded separately until a run elsewhere confirms the
-    # same — the whole point of this file is that it states OBSERVED results, and
-    # these were observed on Windows. Fold an entry into `NativeTestDirs` once it
-    # has been seen green on Linux/macOS too.
-    #
-    # `tests/nimony/stdlib`: 45 of its 53 pass; the rest are in `NativeTestSkip`.
-    # This is the suite that covers the process vectors the Windows entry point
-    # does not receive (`tcmdline`, `tenvvars`, `tos`) — the reason it is worth
-    # running natively at all rather than only through the C backend.
-    "tests/nimony/stdlib"
-  ]
-
-  NativeTestSkip = [
-    # Files a `NativeTestDir` does not cover yet, with the reason each fails. All
-    # but the last PASS through the C backend, so each of those is a gap in the
-    # native path rather than in the test — which is what makes them worth naming
-    # individually instead of dropping the directory.
-    #
-    # A libc math/stdio extern with a FLOAT parameter. Win64 indexes its SSE
-    # argument registers positionally (an xmm slot burns the GPR of the same
-    # position), which arkham's ABI planner does not model — `emitWinExtproc`
-    # rejects it rather than guess. Moot until the freestanding target has a libc
-    # to bind these to at all.
-    "tests/nimony/stdlib/tcomplex",     # sqrtf
-    "tests/nimony/stdlib/tmath",        # frexp
-    "tests/nimony/stdlib/tstrutils",    # snprintf
-    # `mov` of a `bool` into an `(i 64)` result: nifasm's widening rule admits
-    # int→int only, so a bool source is a type error. Arch-neutral.
-    "tests/nimony/stdlib/thashes",
-    # Compiles and links, but the result diverges from the spec-pinned output —
-    # a native MISCOMPILE (all three are green on the C backend). Undiagnosed.
-    "tests/nimony/stdlib/tbitops",
-    "tests/nimony/stdlib/tencodings",
-    "tests/nimony/stdlib/trandom",
-    # The odd one out: NOT a native gap. Its `std/typetraits` compile-time plugin
-    # fails to run ("vfs: open failed"), and the C backend fails it identically,
-    # so nothing here would fix it.
-    "tests/nimony/stdlib/ttypetraits"
-  ]
-  NativeTestFiles = [
-    # Portable intrinsics: `(instr …)` lowers to the target's own instruction —
-    # x86-64 `bsf`, AArch64 `rbit`+`clz` — so this is the one test whose POINT is
-    # that the C and native backends agree on results they reach by different
-    # instructions.
-    "tests/nimony/intrinsics/tintrinsics",
-    # The atomics are intrinsic rows too, and the backends reach them from even
-    # further apart: C emits the `__atomic_*` builtins, x86-64 a `lock`-prefixed
-    # sequence, AArch64 an `ldaxr`/`stlxr` retry loop. Running it here is what says
-    # the three agree — including the compare-exchange FAILURE path, which a wrong
-    # lowering still "passes" single-threaded unless the test reads back the value
-    # the CAS observed.
-    "tests/nimony/intrinsics/tatomics",
-    # The valgrind client request. Native-only by nature: under the C backend the
-    # mechanism is valgrind's own headers around mimalloc, so there is no row to
-    # lower and the test compiles to its `echo` alone. What it checks here is the
-    # property the C path never has to have — that the request sequence is inert
-    # on real hardware, and leaves every live register where it found it.
-    "tests/nimony/intrinsics/tvalgrind",
-    # `div`/`mod` by a constant power of two, which arkham strength-reduces to a
-    # shift (and, for a signed dividend, a round-toward-zero bias). Native-relevant
-    # by nature: under `nimony c` the C compiler owns that rewrite, so only a
-    # backend doing its own can round the wrong way on a negative dividend.
-    "tests/nimony/basicarith/tdivmodpow2",
-    # `float32` at every width-sensitive spot. Native-relevant by nature: the C
-    # backend gets the widths from C's own type system, so this only ever fails on
-    # a backend that has to derive them itself.
-    "tests/nimony/types/tfloat32",
-    # Indexing an array of AGGREGATES and reading one field of the element: the
-    # element stride and the access width are different numbers, which AArch64's
-    # register-offset addressing cannot express (`[Xn, Xm, LSL #k]` scales by the
-    # ACCESS width, not by an arbitrary amount). Native-relevant by nature — the C
-    # compiler owns addressing under `nimony c`. It read `arr[i div 2]` for a 4-byte
-    # field, which is what kept `-d:release` off the native self-host.
-    "tests/nimony/calls/tindexednarrowfield",
-    # More arguments than the ABI has argument registers, with the parameter shapes
-    # that give a stack-passed one a stack HOME (a `var seq` written through, an
-    # object read after a call). Native-relevant by nature: the C compiler owns
-    # argument passing under `nimony c`, so only a backend that marshals arguments
-    # itself can fail this — arkham's AArch64 prologue used to abort on it outright
-    # (">8 integer params (stack TODO)"), which is what kept `nimony.nim` off the
-    # native bootstrap ladder.
-    "tests/nimony/calls/tstackparams",
-    # cps/* — closures & continuation-passing (indirect calls through fn-ptr values)
-    "tests/nimony/cps/tbasicpassive",
-    "tests/nimony/cps/tclosure",
-    "tests/nimony/cps/tclosure_iter_basic",
-    "tests/nimony/cps/tclosure_iter_body_capture",
-    "tests/nimony/cps/tclosure_iter_break",
-    "tests/nimony/cps/tclosure_iter_envcheck",
-    # One frame field of every kind. Native-relevant by nature: this is the
-    # backend that depends on `oconstr` being total, since it stores exactly the
-    # fields the constructor lists and zeroes nothing.
-    "tests/nimony/cps/tclosure_iter_frametypes",
-    # Sets in a closure iterator, in both representations (word-sized and the
-    # 32-byte array). Worth running natively because the big-set path builds
-    # its value through `zeroMem` plus per-element stores rather than a
-    # literal, which is a different shape for the back end than the C one.
-    "tests/nimony/cps/tclosure_iter_sets",
-    "tests/nimony/cps/tclosure_iter_string",
-    "tests/nimony/cps/tclosure_iter_var",
-    "tests/nimony/cps/tfirstpassive",
-    "tests/nimony/cps/tif",
-    "tests/nimony/cps/tmethods",
-    "tests/nimony/cps/tnestedloops",
-    "tests/nimony/cps/trecursive",
-    "tests/nimony/cps/tsuspend",
-    "tests/nimony/cps/tsuspend_resume",
-    "tests/nimony/cps/tparkstate",
-    "tests/nimony/cps/ttry",
-    # The native backend is the only one that HAS a stack trace: it walks nifasm's
-    # own per-proc table, seeded by a `{.naked.}` proc. Running it here is what
-    # checks the three halves agree — the table nifasm lays down, the two
-    # intrinsics arkham lowers, and the walk in `lib/std/stacktraces`.
-    "tests/nimony/stacktraces/tstacktrace",
-    # A `const` set is read straight out of read-only data, so its membership
-    # test is an indexed load from a GLOBAL — a shape the C backend never sees a
-    # register problem in and arkham got wrong twice. Native-only by nature.
-    "tests/nimony/sets/tconstsetscan"
-  ]
 
 when defined(linux):
   var nativeElfShapeChecked = false
@@ -3190,12 +3404,20 @@ proc collectTests(c: var TestCounters; plan: var WalkPlan; dir, forward: string;
       let members = joinMembers(dir, cat, overwrite)
       let joined = members.len >= MinJoinGroup
       if joined:
-        plan.parItems.add WorkItem(path: dir, joined: true, weight: members.len)
+        # Mirrors `joinedTest`'s own all-or-nothing rule, so the prefill the
+        # parent hands the worker is the one the worker will want.
+        var groupNative = nativeJoinable(dir)
+        if groupNative:
+          for f in members:
+            if not walkUsesNative(f, cat): groupNative = false; break
+        plan.parItems.add WorkItem(path: dir, joined: true, weight: members.len,
+                                   native: groupNative)
       for x in walkDir(dir):
         if x.kind == pcFile and x.path.endsWith(".nim") and
            not isGeneratedTestFile(x.path) and
            not (joined and joinable(x.path, cat)):
-          plan.parItems.add WorkItem(path: x.path, weight: 1)
+          plan.parItems.add WorkItem(path: x.path, weight: 1,
+                                     native: walkUsesNative(x.path, cat))
     else:
       # `Basics`/`Compat` reset the shared `nimcache/` around their loop and so
       # cannot share the pool's cache layout; serial (`--jobs:1`) runs keep the
@@ -3296,6 +3518,11 @@ proc handleCmdLine =
         # runner already falls back to that per group on failure; this is for
         # ruling the joining out entirely.
         joinTests = val.normalize notin ["off", "no", "false", "0"]
+      of "native":
+        # `--native:off` puts the Windows tree walk back on the C backend for
+        # the whitelisted tests it would otherwise compile with `nimony n`
+        # (see `walkUsesNative`). Nothing anywhere else reads it.
+        walkNative = val.normalize notin ["off", "no", "false", "0"]
       of "native-debug", "nativedebug":
         # Build arkham + nifasm UNOPTIMIZED (they default to -d:release; see
         # nativeToolPrefix). For `-d:arkhamDbgSym` / gdb work on the toolchain.

--- a/src/hastur.nim
+++ b/src/hastur.nim
@@ -564,8 +564,9 @@ const
     # MinGW bundle (`tools/wine_test.sh`, see `doc/wine_testing.md`): each of the
     # directory's tests run through `nimony n` on its own AND the whole directory
     # run as one native joined program, which is the shape the tree walk actually
-    # compiles it in and not the same question — `tests/nimony/arc` passes
-    # test-by-test but its group does not (see `NativeJoinSkip`).
+    # compiles it in and NOT the same question: five of these directories passed
+    # test-by-test and failed as a group, on three backend bugs that only a
+    # module compiled as an import can reach (see `NativeJoinSkip`).
     #
     # `tests/nimony/stdlib`: 45 of its 53 pass; the rest are in `NativeTestSkip`.
     # This is the suite that covers the process vectors the Windows entry point
@@ -597,46 +598,21 @@ const
     "tests/nimony/when"
   ]
 
-  NativeJoinSkip = [
+  NativeJoinSkip: array[0, string] = [
     # Directories whose tests each compile and run correctly through `nimony n`
-    # — they are in the lists above — but whose JOINED program does not. The
-    # tree walk compiles a group's members as IMPORTS of a generated driver
-    # rather than as main modules, and the native backend has gaps that only
-    # that shape reaches, so the group keeps the C backend while the same
-    # directory's standalone tests (and `hastur native`) stay native.
+    # — they are in the lists above — but whose JOINED program does not, so the
+    # group keeps the C backend while the same directory's standalone tests
+    # stay native.
     #
-    # Each one is a native bug with a standalone reproduction, not a property of
-    # the test; drop the entry once the backend handles it.
-    #
-    # A local assigned inside a `for` whose body is an `if`/`elif` chain with a
-    # `break` keeps its INITIAL value — the stores in the loop are lost. Both of
-    # these run a `splitFile`-shaped scan, and both print the pre-loop values:
-    #
-    #   proc g*(p: string): int =
-    #     var pathEnd = -1
-    #     var extPos = p.len
-    #     for i in countdown(p.len-1, 1):
-    #       if p[i] == '.':
-    #         if extPos == p.len: extPos = i
-    #       elif p[i] == '/':
-    #         pathEnd = i
-    #         break
-    #     echo pathEnd, " ", extPos      # 7 11 as a main module, -1 15 imported
-    #
-    # Reproduces on Linux too, so it is not a Windows story — nothing in the
-    # native suite compiles a test as an import, which is why it went unseen.
-    "tests/nimony/arc",          # tsplitfile
-    "tests/nimony/strings",      # tsplit_and_append, the same scan
-    # `ExitProcess` and `GetStdHandle` reach arkham with no import library
-    # ("names no import library; annotate ... with `dynlib`") even though
-    # `lib/std/system/panics.nim` annotates both — the binding is lost somewhere
-    # in the multi-module program, and every module in the group needs it.
-    "tests/nimony/consteval",
-    # arkham stops at a template-injected symbol in the imported module's init
-    # proc: "Unknown or invalid symbol: injectedLocal.1 … in proc `ini.0.…`"
-    # (`helper.1` for the other). The same templates are fine in a main module.
-    "tests/nimony/templates",
-    "tests/nimony/untyped"
+    # Empty, and worth keeping empty: the tree walk compiles a group's members
+    # as IMPORTS of a generated driver, and no other runner does — `hastur
+    # native` compiles every test as a MAIN module — so this list is the only
+    # place a native gap in that shape can be recorded. Five directories were
+    # here when it was written (arc, strings, consteval, templates, untyped)
+    # and all five were three backend bugs, not five: a peephole that answered
+    # its liveness question across proc boundaries, a template-gensym'd routine
+    # named with local layout, and a `dynlib` that only one backend wrote into
+    # the shared `.x.nif`. An entry belongs here only while such a bug is open.
   ]
 
   NativeTestSkip = [
@@ -744,7 +720,12 @@ const
     # A `const` set is read straight out of read-only data, so its membership
     # test is an indexed load from a GLOBAL — a shape the C backend never sees a
     # register problem in and arkham got wrong twice. Native-only by nature.
-    "tests/nimony/sets/tconstsetscan"
+    "tests/nimony/sets/tconstsetscan",
+    # The one test here whose point is WHERE its code is compiled rather than
+    # what it does: everything it checks lives in `deps/mimportshapes`, so this
+    # is the suite's only native compile of a non-main module. Every other test
+    # arrives as `--isMain`, and three bugs lived in that gap — see the test.
+    "tests/nimony/modules/timportshapes"
   ]
 
 const

--- a/src/hexer/lengcgen.nim
+++ b/src/hexer/lengcgen.nim
@@ -183,11 +183,20 @@ proc externPragmas(c: var EContext; dest: var TokenBuf; genPragmas: var GenPragm
   if prag.header != StrId(0):
     dest.addKeyVal genPragmas, "header", prag.header, pinfo
   if prag.dynlib != StrId(0) and prag.flags * {ImportcP, ImportcppP} != {} and
-      c.nativeBackend and c.dynlibIsStaticImport:
-    # Only the native Windows target carries the library name into Leng, because
-    # only it has to build the import table itself. Every other combination
-    # either has a linker to do that or uses the runtime loader — see
-    # `dynlibIsStaticImport` for the whole matrix.
+      c.dynlibIsStaticImport:
+    # The library name goes into Leng wherever a `dynlib` means a STATIC import
+    # — see `dynlibIsStaticImport` for the whole matrix. Only the native backend
+    # reads it (it builds the import table itself); `lengc`'s C and LLVM code
+    # generators skip the pragma, because their linker resolves the symbol.
+    #
+    # Deliberately NOT `and c.nativeBackend`, which is what it used to say: a
+    # non-main module's `.x.nif` is cached ONCE per nimcache and shared by every
+    # project built there, and `nimony n` builds its compile-time plugins with
+    # `nimony c` in that same nimcache. Gating on the backend made the file's
+    # CONTENT depend on which of the two hexer runs got there first, and when the
+    # C one did, arkham refused `system`'s externs in a build that had been green
+    # a moment earlier ("`GetStdHandle` names no import library"). Whatever a
+    # shared artifact holds has to be the same for both backends.
     dest.addKeyVal genPragmas, "dynlib", prag.dynlib, pinfo
 
 proc trField(c: var EContext; dest: var TokenBuf; n: var Cursor; flags: set[TypeFlag] = {}) =

--- a/src/nativenif.commit
+++ b/src/nativenif.commit
@@ -1,1 +1,1 @@
-79c8a709edaed4ff97f5cc4cda87efee63c2f76b
+adbf1d77d8ecfa5035ff71918489de959becc912

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -385,10 +385,14 @@ proc makeLocalSym*(c: var SemContext; result: var string) =
   result.add '.'
   result.addInt counter[]
 
-proc newSymId*(c: var SemContext; s: SymId): SymId =
+proc newSymId*(c: var SemContext; s: SymId; forceGlobal = false): SymId =
+  ## A fresh name for a copy of `s`, keeping its layout — `forceGlobal` promotes
+  ## a local-layout one because the copy lands at MODULE scope where the original
+  ## did not (a template body declares in the template's scope; expanding it at
+  ## toplevel puts the declaration in the module). See `expandTemplateImpl`.
   var isGlobal = false
   var name = extractBasename(pool.syms[s], isGlobal)
-  if isGlobal:
+  if isGlobal or forceGlobal:
     c.makeGlobalSym(name)
   else:
     c.makeLocalSym(name)
@@ -410,15 +414,37 @@ proc hasErrorSince*(dest: TokenBuf; start: int): bool =
       break
     inc i
 
-proc makeTemplateSym*(c: var SemContext; result: var string) =
+const RoutineLikeSyms* = {TypevarY, StaticTypevarY, ProcY, FuncY, ConverterY,
+                          MethodY, TemplateY, MacroY, IteratorY, TypeY, EfldY}
+  ## The kinds that get GLOBAL symbol layout wherever they are written, because
+  ## the backends lift every one of them out to module scope regardless of the
+  ## scope it was declared in. `identToSym` and `makeTemplateSym` must agree on
+  ## this set or the same declaration is named two different ways depending on
+  ## whether a template introduced it.
+
+proc makeTemplateSym*(c: var SemContext; result: var string; kind: SymKind) =
   ## Make a fresh symbol for a name introduced by a template body. Templates
   ## need a separate mechanism from `makeLocalSym` so that cross-module
   ## interference can be addressed without promoting the sym to global
   ## layout — i.e. without mangling in `c.thisModuleSuffix`.
-  var counter = addr c.locals.mgetOrPut(result, -1)
-  counter[] += 1
-  result.add '.'
-  result.addInt counter[]
+  ##
+  ## Except for the kinds that are module-level declarations no matter where
+  ## they are WRITTEN. A gensym'd `proc` inside an untyped template used to come
+  ## out as `helper.1`, a local-layout name, on a declaration the backends emit
+  ## at module scope: `nifcoreparse.toModuleString` indexes a decl only when its
+  ## name says global, so nothing named it in the module's `(.index …)`, and the
+  ## module was fine to compile and impossible to IMPORT — nifasm resolves a
+  ## foreign module's decls through that index and reported "Unknown symbol:
+  ## helper.1" in the importer. A local name on a module-level decl is also two
+  ## modules' `helper.1` in one link, which is the same bug waiting for a name
+  ## collision.
+  if kind in RoutineLikeSyms:
+    c.makeGlobalSym(result)
+  else:
+    var counter = addr c.locals.mgetOrPut(result, -1)
+    counter[] += 1
+    result.add '.'
+    result.addInt counter[]
 
 type
   SymStatus* = enum
@@ -440,7 +466,7 @@ proc identToSym*(c: var SemContext; str: sink string; kind: SymKind): SymId =
   if kind in {FldY, GfldY}:
     c.makeFieldSym(name)
   elif c.currentScope.kind == ToplevelScope or
-      kind in {TypevarY, StaticTypevarY, ProcY, FuncY, ConverterY, MethodY, TemplateY, MacroY, IteratorY, TypeY, EfldY}:
+      kind in RoutineLikeSyms:
     c.makeGlobalSym(name)
   else:
     c.makeLocalSym(name)

--- a/src/nimony/semuntyped.nim
+++ b/src/nimony/semuntyped.nim
@@ -205,7 +205,7 @@ proc addDecl(c: var UntypedCtx; dest: var TokenBuf; name, pragmas: Cursor; k: Sy
           # only guarantees per-module uniqueness via `c.locals`, so a
           # template's `var x` would collide with another module's local
           # `x.0` once both end up in the global `pool.syms`.
-          makeTemplateSym(c.c[], symName)
+          makeTemplateSym(c.c[], symName, k)
           let s = Sym(kind: k, name: pool.syms.getOrIncl(symName),
                       pos: nameStart)
           let delayed = DelayedSym(status: OkNew, lit: pool.strings.getOrIncl(ident), s: s, info: info)
@@ -234,7 +234,7 @@ proc addBareDecl(c: var UntypedCtx; dest: var TokenBuf, n: Cursor, k: SymKind, n
       if newName.kind != Symbol and not (newName.isIdent and pool.strings[newName.strId] == "_"):
         var ident = pool.strings[takeIdent(newName)]
         # See addDecl above: templates need cross-module-unique sym names.
-        makeTemplateSym(c.c[], ident)
+        makeTemplateSym(c.c[], ident, k)
         let s = Sym(kind: k, name: pool.syms.getOrIncl(ident),
                     pos: dest.len)
         let delayed = DelayedSym(status: OkNew, lit: pool.strings.getOrIncl(ident), s: s, info: info)

--- a/src/nimony/templates.nim
+++ b/src/nimony/templates.nim
@@ -29,8 +29,21 @@ type
     inferred: ptr Table[SymId, Cursor]
 
 proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
-                        e: var ExpansionContext; body: Cursor) =
+                        e: var ExpansionContext; body: Cursor;
+                        atToplevel: bool) =
   ## Expands a single tree/token of the template body into `dest`.
+  ##
+  ## `atToplevel` says that what lands here lands at MODULE scope: the call site
+  ## is toplevel and nothing between the body root and this node opened a scope.
+  ## It decides the layout of a name the body declares. A template's own body is
+  ## semchecked in the template's scope, so everything it declares that is not
+  ## routine-like got a LOCAL name there (`identToSym`), and `newSymId` keeps
+  ## whatever layout it copies — so `template t() = (let x = 1)` expanded at
+  ## module scope produced `x.1`, a local-layout name on a module-level `gvar`.
+  ## Such a decl is not indexed (`nifcoreparse.toModuleString` indexes by the
+  ## name's shape), so the module compiles and cannot be IMPORTED: nifasm reads
+  ## a foreign module's decls through that index and fails with "Unknown symbol"
+  ## on the module init that reads it.
   var body = body
   case body.kind
   of UnknownToken, EofToken, ParLe, ParRi, ExtendedSuffix, LineInfoLit, DotToken, Ident:
@@ -52,7 +65,7 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
           dest.addSubtree body # keep Symbol as it was
   of SymbolDef:
     let s = body.symId
-    let newDef = newSymId(c, s)
+    let newDef = newSymId(c, s, forceGlobal = atToplevel)
     e.newVars[s] = newDef
     dest.addSymDef(newDef, body.info)
   of StrLit, CharLit, IntLit, UIntLit, FloatLit:
@@ -71,7 +84,7 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
       if arg.hasMore and not arg.isDotToken:
         while arg.hasMore:
           e.formalParams[vid] = arg
-          expandTemplateImpl c, dest, e, forStmt.body
+          expandTemplateImpl c, dest, e, forStmt.body, atToplevel
           skip arg
     elif body.exprKind == UnpackX:
       var un = body
@@ -90,9 +103,17 @@ proc expandTemplateImpl(c: var SemContext; dest: var TokenBuf;
           dest.addParRi()
     else:
       dest.addParLe(body.cursorTagId, body.info)
+      # Module scope survives exactly two steps: a `(stmts …)` list, and the NAME
+      # of a declaration sitting in one. Everything else — a routine body, a
+      # `block`, the branches of an `if` — is a scope of its own in `identToSym`'s
+      # eyes, so a name declared under it keeps the local layout it already has.
+      let listy = body.stmtKind == StmtsS
+      var first = true
       body.into:
         while body.hasMore:
-          expandTemplateImpl c, dest, e, body
+          expandTemplateImpl c, dest, e, body,
+                             atToplevel and (listy or (first and body.kind == SymbolDef))
+          first = false
           skip body
         dest.addParRi(body.endInfo)
   else:
@@ -396,7 +417,8 @@ proc expandTemplate*(c: var SemContext; dest: var TokenBuf;
   if templ.body.isDotToken:
     c.buildErr dest, info, "cannot expand template from prototype; possibly a recursive template call"
   else:
-    expandTemplateImpl c, dest, e, templ.body
+    expandTemplateImpl c, dest, e, templ.body,
+                       atToplevel = c.currentScope.kind == ToplevelScope
 
   for _, newVar in e.newVars:
     c.freshSyms.incl newVar

--- a/tests/nimony/modules/deps/mimportshapes.nim
+++ b/tests/nimony/modules/deps/mimportshapes.nim
@@ -1,0 +1,50 @@
+# Helper for `timportshapes`. Everything here exists to be compiled as an
+# IMPORT — see that test for why the position, not the code, is the point.
+import std / [syncio]
+
+proc splitAt*(p: string): int =
+  ## A `splitFile`-shaped scan: two locals written inside a `for` whose body is
+  ## an `if`/`elif` chain with a `break`. Both stores were lost — the proc read
+  ## back the values the locals were INITIALIZED to — when a peephole deleted
+  ## the instruction that materialized one of them, having asked whether its
+  ## scratch register was dead of the whole BUFFER rather than of this proc.
+  ## Every proc's first scratch is named `tmp0.0`, so the answer came from the
+  ## next proc's binding. Both branches and the `break` are load-bearing:
+  ## dropping any one of them stops the fold from being offered at all.
+  var pathEnd = -1
+  var extPos = p.len
+  for i in countdown(p.len-1, 1):
+    if p[i] == '.':
+      if extPos == p.len: extPos = i
+    elif p[i] == '/':
+      pathEnd = i
+      break
+  echo "split: ", pathEnd, " ", extPos
+  result = pathEnd
+
+template defineDoubler() {.untyped.} =
+  ## A routine a template GENSYMS. Nothing outside this module can name it, but
+  ## it is still a module-level declaration and the backends emit it as one —
+  ## so it needs a module-qualified name to appear in the module's index.
+  ## Named `doubler.1` (local layout) it was absent from that index, and a
+  ## native build of an importer could not resolve the call this module's own
+  ## init makes to it.
+  proc doubler(a: int): int =
+    result = a * 2
+  echo "doubled: ", doubler(21)
+
+defineDoubler()
+
+# Called from this module's OWN init as well as from the importer: what the
+# peephole did depended on what followed the fold in the buffer, and the module
+# init is what follows.
+discard splitAt("foo.nim/bar.nim")
+
+template defineAnswer() =
+  let answer {.inject.} = 42
+  ## Same story for a `let`: expanded here it is a module-level global, and a
+  ## local-layout name kept it out of the index too.
+
+defineAnswer()
+
+proc theAnswer*(): int = answer

--- a/tests/nimony/modules/timportshapes.nim
+++ b/tests/nimony/modules/timportshapes.nim
@@ -1,0 +1,14 @@
+# What a module compiled as an IMPORT looks like to the back ends.
+#
+# Nothing here is about modules as a language feature: it is about position.
+# `hastur native` compiles every test as a MAIN module, so until the Windows
+# tree walk began compiling a directory's joined group natively (whose members
+# ARE imports) nothing in the suite ever handed the native backend a non-main
+# module — and three separate bugs were living in that gap. This test closes it
+# for every host: the shapes live in `deps/mimportshapes`, which is only ever
+# compiled as an import.
+import std / [syncio]
+import deps/mimportshapes
+
+echo splitAt("foo.nim/bar.nim")
+echo theAnswer()

--- a/tests/nimony/modules/timportshapes.output
+++ b/tests/nimony/modules/timportshapes.output
@@ -1,0 +1,5 @@
+doubled: 42
+split: 7 11
+split: 7 11
+7
+42

--- a/tests/nimony/nosystem/tresemtype.nif
+++ b/tests/nimony/nosystem/tresemtype.nif
@@ -1,5 +1,5 @@
 (.nif27)
-(.indexat 1858             )
+(.indexat 1860             )
 (stmts@,3,tests/nimony/nosystem/tresemtype.nim
  (proc :foo.0.@5 . .
   (typevars@8
@@ -33,7 +33,7 @@
    (object@2 .
     (fld~9,1 :val.0 . .
      (i 64).)))
-  (gvar@4,2 :obj.2 . . Foo.2.@6
+  (gvar@4,2 :obj.0. . . Foo.2.@6
    (oconstr@9 Foo.2.~3
     (kv@4 val.0~3 123~A,2))))
  (stmts@2,9
@@ -41,7 +41,7 @@
    (pragmas)
    (object@2 .
     (fld~9,1 :val.1 . . string.0.sysvq0asl .)))
-  (gvar@4,2 :obj.3 . . Foo.3.@6
+  (gvar@4,2 :obj.1. . . Foo.3.@6
    (oconstr@9 Foo.3.~3
     (kv@4 val.1~3 "abc"~A,3))))
  (comment@8,D fooTempl.0. fooTempl.0.@,1)
@@ -57,7 +57,7 @@
     (object@2 .
      (fld~9,1 :val.0 . .
       (i 64).)))
-   (var@4,2 :obj.4 . . Foo.4.@6
+   (var@4,2 :obj.2 . . Foo.4.@6
     (oconstr@9 Foo.4.~3
      (kv@4 val.0~3 x.4@2)))))
  (proc@3,6 :foo.0.Iwjalau. . .~3,~6
@@ -69,7 +69,7 @@
     (pragmas)
     (object@2 .
      (fld~9,1 :val.0 . . string.0.sysvq0asl .)))
-   (var@4,2 :obj.5 . . Foo.5.@6
+   (var@4,2 :obj.3 . . Foo.5.@6
     (oconstr@9 Foo.5.~3
      (kv@4 val.0~3 x.5@2))))))(.index@,3,tests/nimony/nosystem/tresemtype.nim
  (h foo.0. 84)
@@ -79,8 +79,10 @@
  (h@H,8 T.1. 47)
  (h@2,9 Foo.1. 92)
  (h@2,9 Foo.2. 178)
- (h@2,9 Foo.3. 189)
- (h foo.0.Imj9rno. 229)
+ (h@2,9 obj.0. 92)
+ (h@2,9 Foo.3. 98)
+ (h@2,9 obj.1. 100)
+ (h foo.0.Imj9rno. 130)
  (h@2,1 Foo.4. 144)
  (h foo.0.Iwjalau. 183)
  (h@2,1 Foo.5. 162))


### PR DESCRIPTION
Most of what a Windows test costs is not nimony: it is the gcc invocation per module and the link behind it, each a process creation the platform charges dearly for. `nimony n` has no such tail — arkham and nifasm consume the same front end and write the PE themselves — so for a test the native backend is known to compile correctly, the walk now takes that path. The assertion is unchanged: same program, same `.output` diff, different code generator only. `--native:off` reverts it; no other host is affected.

`NativeTestDirsWindows` grows from 1 directory to 25. Each was established under Wine twice over, because they are different questions: every test run through `nimony n` on its own (`hastur native`, 286/286), AND the whole directory run as one native joined group, which is the shape the walk actually compiles it in. Five directories pass the first and fail the second and are recorded in the new `NativeJoinSkip` — see below.

Measured under Wine at --jobs:4, same binary, fresh caches, identical results (723/724, only the known Wine-only `tencodings`):

    --native:off   parallel run 173.6s, total 186.2s
    native on      parallel run 154.6s, total 166.5s   (-11%)

A real runner should do better: Wine's process spawn is Linux-cheap, and process spawn is what this removes.

Two things had to be true for it, both easy to trip over again:

- The C and native pipelines' intermediates share file names but not content, so the pool needs a SECOND warmup cache. A native item prefilled from the C warmup gets a `system` whose externs have lost their `dynlib` and dies at the first one. For the same reason the parent pins each work item's backend and hands a C item's worker `--native:off`: a joined group that diverges re-runs its members individually, and in a group that is not all-native some of those members are individually eligible — that re-run inherits the C prefill, so it must inherit the C backend with it.

- `getTempPath` was declared with a body (just its doc comment) and `dynlib: "kernel32.dll"`. In that shape the import library never reached arkham, which rejected the extern outright and took `tos`, `tdirs` and `tappdirs` with it. The C backend never noticed because gcc links kernel32 whether or not anyone asks.

`NativeJoinSkip` records three native bugs that only appear when a module is compiled as an IMPORT rather than as the main module — which is why `hastur native`, where every test is `--isMain`, has never seen them:

- a local assigned inside a `for` whose body is an `if`/`elif` chain with a `break` keeps its INITIAL value (arc/tsplitfile, strings/tsplit_and_append; reproduces on Linux too, so this is not a Windows story)
- `ExitProcess`/`GetStdHandle` reach arkham with no import library in a multi-module program, though `panics.nim` annotates both (consteval)
- arkham stops at a template-injected symbol in the imported module's init proc, "Unknown or invalid symbol: injectedLocal.1" (templates, untyped)

Each entry carries its reason and a reproduction; drop it once the backend handles that shape.