### PR TITLE
Windows: run five more test dirs through `nimony n`

### DIFF
--- a/src/hastur/nativelist.nim
+++ b/src/hastur/nativelist.nim
@@ -74,7 +74,15 @@ const
     "tests/nimony/threads",
     "tests/nimony/types",
     "tests/nimony/untyped",
-    "tests/nimony/when"
+    "tests/nimony/when",
+    # Added after a full tree walk on Windows drove every native-eligible test
+    # through `nimony n` (see issue #2286): these directories passed both
+    # test-by-test and as their native joined program, same as the entries above.
+    "tests/nimony/configtest",
+    "tests/nimony/nifcore",
+    "tests/nimony/pluginpaths",
+    "tests/nimony/rtchecks",
+    "tests/nimony/scopes"
   ]
 
   NativeJoinSkip*: array[0, string] = [


### PR DESCRIPTION
`nimony n` (the native backend) skips the C compiler and linker, so on Windows CI it is the faster path. The Windows tree walk already routes whitelisted dirs through it. This widens the whitelist by five.

I built the toolchain on Windows and drove every native-eligible test through `nimony n` with a temporary probe, then diffed the failures against the C-backend baseline to isolate anything the native backend broke. configtest, nifcore, pluginpaths, rtchecks and scopes came out clean: each passed test-by-test and as its native joined program, the same bar as the dirs already on the list. They are all `Normal` category with no `.msgs`/`.nif`/`.nim.c`/`.valgrind` sidecars, so `walkUsesNative` actually routes them native instead of falling back to C.

Verification on this machine:
- `hastur native`: 290 / 290 (was 284, so +6 real native tests across the five dirs)
- `hastur --jobs:auto tests/nimony`: 702 / 719, identical to baseline. The 17 failures are all in `concepts`, a pre-existing C-backend nifler parse problem unrelated to this change.

The probe forces every test native and never ships, so it is reverted here. Dirs carrying a `hastur.mode` file (compat, nosystem, opt, track) are a non-`Normal` category, so the tree walk never routes them native regardless of the whitelist. They are left off.

Part of #2286.