### PR TITLE
Reject orphan generic params during overload resolution

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1303,6 +1303,12 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
         dest.addSubtree erroredN
         dest.addStrLit("", cs.callNodeInfo)
       return
+    elif m.len > 0 and allFailedDueToCouldNotInfer(m):
+      # Orphan typevars are rejected in sigmatch, so no candidate survives
+      # pickBestMatch; keep the direct "could not infer type" diagnostic instead
+      # of the generic overload-set "Type mismatch" wrapper.
+      buildErr c, dest, cs.callNodeInfo, getErrorMsg(m[0])
+      return
     elif m.len > 0:
       errorMsg = "Type mismatch at [position]\n"
       errorMsg.add asNimCode erroredN

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -2430,6 +2430,45 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.error0 RoutineIsNotGeneric
       return
 
+proc typevarInType(n: var TypeCursor; v: SymId): bool =
+  case n.kind
+  of Symbol:
+    if n.symId == v: return true
+    inc n
+  of TagLit:
+    n.loopInto:
+      if typevarInType(n, v): return true
+  else:
+    inc n
+  false
+
+proc typevarInRoutineSignature(fn: FnCandidate; v: SymId): bool =
+  var f = fn.typ
+  if f.typeKind in RoutineTypes:
+    skipToParams f
+    assert f.substructureKind == ParamsU
+    var params = sub(f)
+    while params.hasMore:
+      let param = takeLocal(params, SkipFinalParRi)
+      var typ = param.typ
+      if typevarInType(typ, v): return true
+    skip f
+    if f.hasMore:
+      var ret = f
+      if typevarInType(ret, v): return true
+  false
+
+proc rejectUninferableTypevars(m: var Match) =
+  ## Drop generic candidates whose remaining typevars never appear in the
+  ## callable surface (params or return type). They cannot be inferred from
+  ## arguments and would otherwise tie non-generic overloads at pickBestMatch.
+  if m.err: return
+  for v in m.tvars:
+    if m.inferred.hasKey(v): continue
+    if not typevarInRoutineSignature(m.fn, v):
+      m.error0Typevar CouldNotInferTypeVar, v
+      break
+
 proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[CallArg];
                explicitTypeVars: Cursor) =
   assert fn.kind != NoSym or fn.sym == SymId(0)
@@ -2458,6 +2497,8 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[CallArg];
     f = paramsStart; skip f
     m.returnType = f # return type follows the parameters in the token stream
 
+  rejectUninferableTypevars(m)
+
 proc hasUnboundTypevars*(m: Match): bool =
   ## True if `m.fn`'s generic typevars (as collected by `matchTypevars`) still
   ## lack a binding after argument matching. Cheap: just consults the
@@ -2466,6 +2507,16 @@ proc hasUnboundTypevars*(m: Match): bool =
     if not m.inferred.hasKey(v):
       return true
   return false
+
+proc matchFailedOnlyDueToCouldNotInfer*(m: Match): bool =
+  result = m.err and m.error.kind == CouldNotInferTypeVar
+
+proc allFailedDueToCouldNotInfer*(m: openArray[Match]): bool =
+  if m.len == 0: return false
+  for i in 0..<m.len:
+    if not matchFailedOnlyDueToCouldNotInfer(m[i]):
+      return false
+  true
 
 proc buildTypeArgs*(m: var Match) =
   # check all type vars have a value:

--- a/tests/nimony/overload/tstaticgenoverload.nim
+++ b/tests/nimony/overload/tstaticgenoverload.nim
@@ -1,0 +1,24 @@
+import std/[assertions, syncio]
+
+# Orphan static type parameter on a generic overload must not compete with a
+# non-generic overload at an un-instantiated call site.
+func foo[Z: static[int]](x: float): int = Z
+func foo(x: float): int = foo[1](x)
+
+assert foo[1](1.0) == 1
+assert foo(1.0) == 1
+
+# Same rule for orphan regular type parameters.
+proc bar[T](x: int): string = "generic"
+proc bar(x: int): string = "concrete"
+
+assert bar(1) == "concrete"
+
+# Static type parameters that appear in the callable surface are still inferred.
+proc len[N: static[int]](x: array[N, int]): int = N
+
+var a: array[3, int]
+assert len(a) == 3
+assert len[3](a) == 3
+
+echo "ok"


### PR DESCRIPTION
Generic routines whose type parameters never appear in the callable signature (params or return type) were still treated as viable matches when called without explicit instantiation. That left unbound static or regular typevars until buildTypeArgs, after pickBestMatch had already tied them with non-generic overloads and reported "ambiguous call".

Reject such candidates at the end of sigmatch, and when every overload fails only for that reason, report the direct "could not infer type" diagnostic instead of the generic overload-set type mismatch wrapper.

Add `tests/nimony/overload/tstaticgenoverload.nim`

Fixes https://github.com/nim-lang/nimony/issues/2392