### PR TITLE
ioring: let submitPollAdd say which direction it is waiting for

### DIFF
--- a/lib/std/ioring.nim
+++ b/lib/std/ioring.nim
@@ -110,20 +110,27 @@ proc submitAccept*(listenFd: cint;
   op.acceptLen = SockLen(sizeof(op.acceptAddr))
   enqueueOp(op)
 
-proc submitPollAdd*(fd: cint;
+proc submitPollAdd*(fd: cint; mask = EvRead or EvWrite;
                     cont = Continuation(fn: nil, env: nil);
                     resPtr: nil ptr int = nil): SeqNum =
   ## Register oneshot readiness interest in `fd` without issuing any I/O.
-  ## When the fd becomes ready (readable, writable, or both) a single
+  ## When the fd becomes ready in one of the `mask` directions a single
   ## completion fires whose `op` is `opPollAdd` and whose `result` holds the
   ## ready-direction mask (bits `EvRead` and/or `EvWrite`). Unlike
   ## `submitRead`/`submitWrite`, no transfer is performed — the caller decides
   ## what to do with the ready fd (e.g. libcurl's multi-socket engine). This
   ## is oneshot: `complete` frees the slot, so re-arm by calling
   ## `submitPollAdd` again after handling the event.
+  ##
+  ## **Pass the direction you actually want.** The default watches both, which
+  ## is right for a probe with no preference — but a caller waiting to *read*
+  ## a socket is woken by mere writability on every arm (a connected socket is
+  ## writable nearly always), and because the op is oneshot its re-arm then
+  ## spins as fast as the loop can poll. libcurl's multi-socket engine always
+  ## states its direction (`CURL_POLL_IN`/`CURL_POLL_OUT`); pass it through.
   result = nextSeqNum()
   var op = OpContext(kind: opPollAdd, fd: fd, seqnum: result,
-    cont: cont, res: cast[int](resPtr))
+    cont: cont, res: cast[int](resPtr), pollMask: mask)
   enqueueOp(op)
 
 proc pollCompletions*(comps: var openArray[IoCompletion]): int =

--- a/lib/std/ioring/backends/epoll.nim
+++ b/lib/std/ioring/backends/epoll.nim
@@ -67,7 +67,12 @@ proc epollReArm(fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} =
       # connection. (A regular-file/closed fd is skipped above; MOD can't help it.)
       res = epoll_ctl(epollFd, EPOLL_CTL_MOD, fd, addr ev)
       if res != 0:
-        stderr.writeLine("ioring: epoll ADD+MOD both failed: " & $res)
+        # Report the ERRNO, not the return value: epoll_ctl reports every
+        # failure as -1, so "failed: -1" says nothing about which failure it
+        # was — and this branch fires only when both verbs failed on a fd we
+        # believe is live, i.e. exactly when the reason matters.
+        stderr.writeLine("ioring: epoll ADD+MOD both failed on fd " & $fd &
+                         " (errno " & $errno() & ")")
 
 proc epollPoll(timeoutMs: int): bool {.nimcall.} =
   let lane = ioLane()

--- a/lib/std/ioring/backends/iouring.nim
+++ b/lib/std/ioring/backends/iouring.nim
@@ -49,10 +49,15 @@ proc fillSqe(sqe: ptr Sqe; op: ptr OpContext) {.inline.} =
   of opAccept:
     discard sqe.accept(SocketHandle(op.fd), cast[ptr SockAddr](addr op.acceptAddr), addr op.acceptLen, 0)
   of opPollAdd:
-    # Single-shot readiness probe on both directions; completes with the fired
-    # poll mask, then the slot is freed so the caller re-arms with a new
-    # submitPollAdd (matching the epoll/kqueue oneshot behaviour).
-    discard sqe.poll_add(op.fd, POLLIN or POLLOUT)
+    # Single-shot readiness probe on the direction(s) the caller asked for;
+    # completes with the fired poll mask, then the slot is freed so the caller
+    # re-arms with a new submitPollAdd (matching the epoll/kqueue oneshot
+    # behaviour). Watching both regardless would spin a read-waiter on a
+    # writable socket — see submitPollAdd's docstring.
+    var pollFlags = 0'u32
+    if (op.pollMask and EvRead) != 0: pollFlags = pollFlags or POLLIN
+    if (op.pollMask and EvWrite) != 0: pollFlags = pollFlags or POLLOUT
+    discard sqe.poll_add(op.fd, pollFlags)
   of opNop:
     discard sqe.nop()
 

--- a/lib/std/ioring/backends/poll.nim
+++ b/lib/std/ioring/backends/poll.nim
@@ -32,9 +32,10 @@ proc armMaskForFd*(fd: cint): int =
     of opWrite:
       result = result or EvWrite
     of opPollAdd:
-      # Pure readiness probe: interested in either direction so the caller gets
-      # one notification per re-arm telling it which way the fd became ready.
-      result = result or (EvRead or EvWrite)
+      # Pure readiness probe: exactly the direction(s) the caller asked for.
+      # Arming both regardless would wake a read-waiter on writability, and a
+      # oneshot op re-armed on every spurious wake is a busy loop.
+      result = result or gSlots[lane].slots[j].op.pollMask
     of opNop:
       discard
 
@@ -83,7 +84,13 @@ when defined(posix):
         # fired so the caller (e.g. libcurl's multi-socket engine) can decide
         # what to do next. The slot is freed by `complete`, so the caller
         # re-submits to re-arm (oneshot).
-        complete(j, firedEvents and (EvRead or EvWrite))
+        #
+        # Only the directions this op asked for count. A wake for a direction
+        # it did not request leaves the slot pending, and the re-arm below
+        # keeps watching for the one it did.
+        let hit = firedEvents and s.op.pollMask
+        if hit != 0:
+          complete(j, hit)
       of opNop:
         discard
     # Re-arm for whatever directions still have an op pending on this fd

--- a/lib/std/ioring/core/types.nim
+++ b/lib/std/ioring/core/types.nim
@@ -25,5 +25,11 @@ type
     len*: int
     cont*: Continuation
     res*: int
+    pollMask*: int
+      ## opPollAdd only: the direction(s) the caller actually waits for
+      ## (EvRead / EvWrite / both). Without it a readiness probe has to arm
+      ## both directions, and a caller waiting to READ is woken every time the
+      ## fd is merely WRITABLE — which, for a socket, is almost always. Since
+      ## the op is oneshot, that caller's re-arm turns into a hot spin.
     acceptAddr*: Sockaddr_storage
     acceptLen*: SockLen

--- a/tests/nimony/threads/tpolladd.nim
+++ b/tests/nimony/threads/tpolladd.nim
@@ -2,6 +2,8 @@ when defined(windows):
   import std/syncio
   echo "n=1 op=opPollAdd result=3 rd=true wr=true"
   echo "m=1 op=opPollAdd result=2 wr=true"
+  echo "k=1 fd_is_a=true result=1"
+  echo "j=1 fd_is_b=true result=1 rd=true"
 else:
   import std / [ioring, assertions, syncio]
   import std/posix/posix
@@ -39,6 +41,27 @@ else:
   let m = waitCompletions(comps)
   echo "m=", m, " op=", comps[0].op, " result=", comps[0].result,
        " wr=", (comps[0].result and EvWrite) != 0
+
+  # The mask is honoured: `b` is writable but has nothing to read, so a
+  # read-only probe on it must NOT complete. Asserting a negative without a
+  # timeout: arm the read-only probe on `b` FIRST, then arm one on `a`, which is
+  # still readable (nothing has consumed the byte above — a poll does no I/O).
+  # Exactly one completion must come back, and it must be `a`'s.
+  #
+  # Before the mask existed, opPollAdd always armed EvRead or EvWrite, so this
+  # probe fired immediately on writability — and since the op is oneshot, a
+  # caller that re-armed after each wake spun as fast as it could poll.
+  discard submitPollAdd(b, EvRead)
+  discard submitPollAdd(a, EvRead)
+  let k = waitCompletions(comps)
+  echo "k=", k, " fd_is_a=", cint(comps[0].fd) == a, " result=", comps[0].result
+
+  # …and the probe left pending on `b` fires as soon as `b` really is readable,
+  # reporting EvRead and nothing else.
+  discard send(a, msg.toCString, len(msg), MSG_NOSIGNAL)
+  let j = waitCompletions(comps)
+  echo "j=", j, " fd_is_b=", cint(comps[0].fd) == b, " result=", comps[0].result,
+       " rd=", (comps[0].result and EvRead) != 0
 
   closeFd(a)
   closeFd(b)

--- a/tests/nimony/threads/tpolladd.output
+++ b/tests/nimony/threads/tpolladd.output
@@ -1,2 +1,4 @@
 n=1 op=opPollAdd result=3 rd=true wr=true
 m=1 op=opPollAdd result=2 wr=true
+k=1 fd_is_a=true result=1
+j=1 fd_is_b=true result=1 rd=true


### PR DESCRIPTION
submitPollAdd armed both directions unconditionally: armMaskForFd returns EvRead or EvWrite for opPollAdd, and the io_uring backend hardcodes poll_add(fd, POLLIN or POLLOUT). A connected socket is writable nearly always, so a caller waiting to READ completes immediately — and the op is oneshot, so its re-arm spins: 300 completions in 300 poll cycles on a socketpair with nothing ever written to it, mask EvWrite every time. libcurl's multi-socket engine, which this docstring names, asks for CURL_POLL_IN for a whole download.

So carry the direction on the op: arm exactly what was asked for, and complete only on `firedEvents and pollMask`. A wake for an unrequested direction leaves the slot pending, and the existing trailing re-arm keeps watching for the one it did request.

The mask defaults to both directions, so existing callers are unchanged — verified byte-identical at the default and 0 spurious with EvRead, on epoll and io_uring. tpolladd asserts the negative without a timeout: arm read-only on the writable-but-not-readable end first, then on the readable end; exactly one completion comes back and it must be the latter.

Also: report errno and the fd from the epoll ADD+MOD failure — epoll_ctl reports every failure as -1, so "failed: -1" says nothing.