### PR TITLE
nif: replace cache files atomically, never truncate a mapped one

### DIFF
--- a/src/lib/bif.nim
+++ b/src/lib/bif.nim
@@ -371,9 +371,7 @@ proc storeToFile*(b: var TokenBuf; f: File; dottedSuffix = "") =
 
 proc store*(b: var TokenBuf; filename: string; dottedSuffix = "") =
   ## Write `b` to `filename` in binary `.bif` form (with its symbol index).
-  var f = open(filename, fmWrite)
-  storeToFile(b, f, dottedSuffix)
-  close(f)
+  vfsWrite(filename, storeToString(b, dottedSuffix))
 
 # ── load ──────────────────────────────────────────────────────────────────
 

--- a/src/lib/vfs.nim
+++ b/src/lib/vfs.nim
@@ -76,8 +76,32 @@ type
     AlwaysWrite,
     OnlyIfChanged
 
+# --- atomic replacement ---------------------------------------------------
+#
+# Never truncate a .nif or .bif that a reader may have mmap'd.
+
+import std / atomics
+
+when defined(windows):
+  proc osProcessId(): int32 {.importc: "GetCurrentProcessId", stdcall,
+                              dynlib: "kernel32".}
+else:
+  proc osProcessId(): int32 {.importc: "getpid".}
+
+when defined(nimony):
+  var atomicWriteCounter: int = 0
+  proc nextTempSeq(): int = atomicFetchAdd(atomicWriteCounter, 1)
+else:
+  var atomicWriteCounter: Atomic[int]
+  proc nextTempSeq(): int = atomicWriteCounter.fetchAdd(1)
+
+proc atomicTempPath*(target: string): string =
+  ## A sibling temp path for an atomic replacement of `target`
+  result = target & ".tmp." & $int(osProcessId()) & "." & $nextTempSeq()
+
 when defined(nimony):
   import std / [os, dirs, paths]
+  import std / private / oscommons
   # Nimony's stdlib procs are `.raises`. Wrap them so vfs.nim stays
   # non-raising (the rest of the compiler is wired that way).
   proc unixModTime(p: string): int64 =
@@ -91,8 +115,19 @@ when defined(nimony):
     try: removeFile(path(p)) except: discard
   proc readBytes(p: string): string =
     try: readFile(p) except: ""
+
   proc writeBytes(p, c: string) =
-    try: writeFile(p, c) except: quit "vfs: write failed: " & p
+    let tmp = atomicTempPath(p)
+    var ok = false
+    try:
+      writeFile(tmp, c)
+      ok = tryMoveFSObject(tmp, p, false)
+    except:
+      ok = false
+    if not ok:
+      try: removeFile(path(tmp)) except: discard   # no `.tmp.NNN` litter
+      quit "vfs: write failed: " & p
+
   proc fileMaybeExists(p: string): bool =
     try: fileExists(p) except: false
   proc openMmapImpl(p: string): MemFile =
@@ -107,7 +142,14 @@ else:
     toUnix(t) * nanosPerSec + int64(t.nanosecond)
   proc rmPath(path: string) = removeFile(path)
   proc readBytes(p: string): string = readFile(p)
-  proc writeBytes(p, c: string) = writeFile(p, c)
+  proc writeBytes(p, c: string) =
+    let tmp = atomicTempPath(p)
+    try:
+      writeFile(tmp, c)
+      moveFile(tmp, p)
+    except CatchableError:
+      try: removeFile(tmp) except CatchableError: discard   # no `.tmp.NNN` litter
+      raise
   proc fileMaybeExists(p: string): bool = fileExists(p)
   proc openMmapImpl(p: string): MemFile = memfiles.open(p)
 

--- a/tests/nifcache/setup.nim
+++ b/tests/nifcache/setup.nim
@@ -1,0 +1,130 @@
+## Custom runner: a cache write must never truncate a file a reader has MMAP'D.
+##
+## `nifreader.open` and `bif.load` both mmap the cache entry they read, and
+## `load` deliberately BORROWS the mapped token block for the process lifetime
+## rather than copying it. Any writer that replaces such a file with a
+## truncating `fmWrite` open invalidates those pages immediately — the reader
+## takes SIGBUS past the new EOF, or reads torn bytes in the window before the
+## new content lands.
+##
+## No race is needed to show it: truncation invalidates the mapping at once, so
+## one process suffices — store, mmap, store again, then touch the mapping.
+## That determinism is why this is a test and not a stress rig; against a
+## truncating writer both cases below die with SIGBUS every time.
+##
+## Two surfaces, because there are two writers: `bif.store` (binary `.bif`) and
+## `vfs.vfsWrite` (the relay behind every `.nif` / `.idx.nif` write — nifpools,
+## nifindexes, nifbuilder, nifmake).
+
+import std / [os, strutils]
+import "../../src/lib/vfs"
+import "../../src/lib/bif"
+import "../../src/lib/nifcore"
+
+var failures = 0
+
+proc fail(msg: string) =
+  echo "  FAIL: ", msg
+  inc failures
+
+proc ok(msg: string) =
+  echo "  ok: ", msg
+
+proc tempsLeft(target: string): seq[string] =
+  ## `.tmp.<pid>.<n>` siblings of `target`. The temp must be gone on the
+  ## success path AND the failure path; a leftover would also be picked up by
+  ## directory scans looking for outputs.
+  result = @[]
+  let dir = target.parentDir
+  let prefix = target.extractFilename & ".tmp."
+  for kind, p in walkDir(if dir.len > 0: dir else: "."):
+    if kind == pcFile and p.extractFilename.startsWith(prefix):
+      result.add p
+
+# ── surface 1: bif.store, whose mapping is borrowed for the process lifetime ──
+
+proc buildBuf(n: int): TokenBuf =
+  result = createTokenBuf(16)
+  let tStmts = result.tags.registerTag("stmts")
+  let tCall = result.tags.registerTag("call")
+  let f = result.pool.filenames.getOrIncl("some/where.nim")
+  result.buildTree tStmts:
+    result.appendLineInfo f, 1'i32, 0'i32
+    for i in 0 ..< n:
+      result.buildTree tCall:
+        result.addSymUse "some.long.symbol.name.0"
+        result.addIntLit int64(i)
+        result.addStrLit "a longer interned string"
+
+proc bifCase() =
+  echo "bif.store replaces a mapped .bif without truncating it"
+  let path = getTempDir() / "nifcache_bif_atomic.bif"
+  removeFile path
+
+  var big = buildBuf(50_000)
+  store(big, path)
+  let bigSize = getFileSize(path)
+
+  var m = load(path)                    # mmap + borrow the token block
+  let n = m.buf.len
+  if n == 0:
+    fail "loaded an empty token buffer"
+    return
+
+  var small = buildBuf(10)              # a second writer, a SMALLER file
+  store(small, path)
+  if getFileSize(path) >= bigSize:
+    fail "the second store did not shrink the file; the test proves nothing"
+
+  # Touch every token of the mapping taken before the rewrite. Under a
+  # truncating writer this is a SIGBUS, not a wrong answer.
+  var acc = 0'u32
+  for i in 0 ..< n: acc = acc xor uint32(m.buf[i])
+  ok "the borrowed token block survived a smaller rewrite (" & $n & " tokens)"
+
+  let leftovers = tempsLeft(path)
+  if leftovers.len > 0: fail "temp files left behind: " & $leftovers
+  else: ok "no .tmp.* residue"
+  removeFile path
+
+# ── surface 2: vfsWrite, the relay behind every .nif write ───────────────────
+
+proc vfsCase() =
+  echo "vfsWrite replaces a mapped .nif without truncating it"
+  let path = getTempDir() / "nifcache_vfs_atomic.nif"
+  removeFile path
+
+  var big = newStringOfCap(200_000)
+  for i in 0 ..< 200_000: big.add 'x'
+  vfsWrite(path, big)
+
+  let blob = vfsOpenMmap(path)
+  let size = blob.size
+  if size != 200_000:
+    fail "mmap reported " & $size & " bytes, expected 200000"
+    return
+
+  vfsWrite(path, "short\n")
+  if getFileSize(path) >= size:
+    fail "the rewrite did not shrink the file; the test proves nothing"
+
+  var sum = 0
+  let data = cast[ptr UncheckedArray[char]](blob.data)
+  for i in 0 ..< size: sum = sum + int(data[i])
+  if sum != 200_000 * int('x'):
+    fail "the mapping's bytes changed under us (sum " & $sum & ")"
+  else:
+    ok "the held mapping still reads its original bytes (" & $size & " bytes)"
+
+  let leftovers = tempsLeft(path)
+  if leftovers.len > 0: fail "temp files left behind: " & $leftovers
+  else: ok "no .tmp.* residue"
+  removeFile path
+
+bifCase()
+vfsCase()
+
+if failures > 0:
+  echo "nifcache: ", failures, " failure(s)"
+  quit 1
+echo "nifcache: all checks passed"


### PR DESCRIPTION
The `.nif`/`.bif` writers replace a cache file in place while the readers mmap it. `vfs.writeBytes` (both backends) is `writeFile`, and `bif.store` opened the target `fmWrite` — both truncate. Meanwhile `nifreader.open` mmaps and parses straight out of the mapping, and `bif.load` mmaps a `.bif` and BORROWS its token block via `adoptForeignTokens`, deliberately keeping the mapping for the process lifetime.

`ftruncate` invalidates the pages of an existing mapping immediately, so a second process rewriting a cache entry another has mapped gives that reader SIGBUS past the new EOF, torn bytes inside the write window, or `EINVAL` from mmap on the zero-length file that exists between the truncating open and the first write. Those are the three shapes parallel builds fail in — `Bus error` with no location, a compile-time error on plainly valid code, and `cannot open: <hash>.s.nif` naming no source file — and each names a different innocent module every run, because the victim is whoever was reading the entry the two processes collided on. `nifmake -j:1` makes all three go away.

Fix: write a sibling temp file and rename it over the target. POSIX rename is atomic, and an open mapping keeps the old inode alive until it is unmapped, so a reader mid-parse finishes safely against the bytes it started with while the next opener sees the new file whole. The temp is a sibling (same filesystem, so the rename really is a rename), carries pid + a per-process counter so two concurrent writers cannot collide on the temp itself, and is not suffixed `.nif` so output scans never pick a half-written one up. It is removed on the failure path too.

`bif.store` now renders with `storeToString` and hands the bytes to `vfsWrite`, which costs nothing extra — `storeToFile` already materialised the whole image before writing — and routes `.bif` through the same relay as every other write. `storeToFile` stays for API compatibility, with a note that a caller who opens the target itself owns the atomicity problem, the truncation having already happened at its open.

Windows: `MoveFileEx` refuses to replace a file with an open mapping, so the rename fails loudly there. Not a regression — the truncating `fmWrite` open it replaces fails just as loudly against a mapped target (see the "keeps the file locked on Windows" note in `nifindexes.createIndex`), so the set of failing situations is unchanged and only the error text moves. On the platforms where the current code does not fail, it corrupts silently, which is worse. A bounded retry around the rename would absorb the Windows case; that is left out rather than guessing a timeout for a lock-holder the writer cannot identify.

tests/nifcache is a custom runner covering both writers. No race is needed: truncation invalidates the mapping at once, so one process suffices — store, mmap, store something smaller, then touch the mapping. Against the truncating writer both cases die with SIGBUS every time; with this change they read their original bytes back. It also asserts no `.tmp.*` residue.