### PR TITLE
strutils: formatFloat without snprintf on wasm

### DIFF
--- a/lib/std/strutils.nim
+++ b/lib/std/strutils.nim
@@ -1122,7 +1122,8 @@ when defined(wasm32) and defined(standalone):
         dec i
       if carry:
         result.carry = true
-        kept = "1" & kept.substr(0, kept.len - 2)
+        kept.shrink kept.len - 2
+        kept = "1" & kept
     result.digits = kept
 
   func fmtDecimal(f: BiggestFloat, neg: bool, digits: string,

--- a/lib/std/strutils.nim
+++ b/lib/std/strutils.nim
@@ -966,8 +966,9 @@ func unescape*(s: string, prefix = "\"", suffix = "\""): string {.raises.} =
   if not s.endsWith(suffix):
     raise ValueError
 
-func c_snprintf(buf: cstring, n: csize_t, frmt: cstring): cint {.
-  header: "<stdio.h>", importc: "snprintf", varargs.}
+when not (defined(wasm32) and defined(standalone)):
+  func c_snprintf(buf: cstring, n: csize_t, frmt: cstring): cint {.
+    header: "<stdio.h>", importc: "snprintf", varargs.}
 
 type
   FloatFormatMode* = enum
@@ -975,6 +976,219 @@ type
     ffDefault,   ## use the shorter floating point notation
     ffDecimal,   ## use decimal floating point notation
     ffScientific ## use scientific notation (using `e` character)
+
+when defined(wasm32) and defined(standalone):
+  # WebAssembly has no variadic calling convention: an imported function has
+  # ONE type, so a `{.varargs.}` importc cannot be called with different
+  # argument tails, and `c_snprintf(buf, n, fmt, precision, f)` emits a call
+  # whose f64 argument contradicts the import's declared type. The module is
+  # then rejected at compile time — not at the call, but wholesale, which is
+  # how a single `formatFloat` in a diagnostic path takes a whole program down.
+  #
+  # So the wasm arm formats without snprintf, from the digits `$f` already
+  # produces. Working on the DECIMAL STRING rather than scaling by a power of
+  # ten keeps the rounding exact: `f * 10^p` introduces its own error, and at a
+  # tie that error decides the last digit.
+  #
+  # KNOWN DIFFERENCE from the C path, measured not assumed: `$f` yields the
+  # SHORTEST round-tripping decimal, not the exact binary expansion, so a
+  # precision beyond that length pads with zeros where glibc continues the true
+  # expansion (`0.1` at 20 places is `0.10000000000000000000` here,
+  # `0.10000000000000000555` there). Within the shortest form's digits — which
+  # is every display use, and the whole grid in hikaru's
+  # tests/wasm/formatfloat_diff.nim — the two agree byte for byte, ties
+  # included; see `roundDigits` for how the ambiguous ones are settled.
+
+  func c_isDigit(c: char): bool {.inline.} = c >= '0' and c <= '9'
+
+  func splitDigits(s: string): tuple[neg: bool, digits: string, exp: int] =
+    ## `$f` (`-12.34`, `1e+20`, `0.0000001`) → sign, significant digits with no
+    ## point, and `exp` such that the value is `0.<digits> * 10^exp`.
+    var i = 0
+    # Seed the whole tuple: nimony proves initialization per RESULT, not per
+    # field, so field-by-field assignment leaves it "possibly uninitialized".
+    result = (neg: false, digits: "", exp: 0)
+    if i < s.len and (s[i] == '-' or s[i] == '+'):
+      result.neg = s[i] == '-'
+      inc i
+    var intDigits = 0
+    var seenPoint = false
+    var expPart = 0
+    var expNeg = false
+    var leading = true
+    while i < s.len:
+      let c = s[i]
+      if c == '.':
+        seenPoint = true
+        inc i
+      elif c == 'e' or c == 'E':
+        inc i
+        if i < s.len and (s[i] == '-' or s[i] == '+'):
+          expNeg = s[i] == '-'
+          inc i
+        while i < s.len and c_isDigit(s[i]):
+          expPart = expPart * 10 + (int(s[i]) - int('0'))
+          inc i
+        if expNeg: expPart = -expPart
+        break
+      elif c_isDigit(c):
+        if c == '0' and leading and result.digits.len == 0:
+          # Leading zeros contribute no significant digits, but each one after
+          # the point pushes the exponent down.
+          if seenPoint: dec result.exp
+          else: discard
+        else:
+          leading = false
+          result.digits.add c
+          if not seenPoint: inc intDigits
+        inc i
+      else:
+        inc i
+    if intDigits > 0: result.exp = intDigits
+    result.exp = result.exp + expPart
+    # Drop trailing zeros; they carry no information and would defeat the
+    # exact-tie test below.
+    var last = result.digits.len
+    while last > 0 and result.digits[last - 1] == '0': dec last
+    result.digits.setLen(last)
+    if result.digits.len == 0: result.exp = 0
+
+  func decimalValue(digits: string, exp: int): BiggestFloat =
+    ## The double nearest `0.<digits> * 10^exp`.
+    var t = "0." & (if digits.len > 0: digits else: "0") & "e" & $exp
+    result = 0.0
+    discard parseBiggestFloat(toOpenArray(t, 0, t.len - 1), result)
+
+  func roundDigits(digits: string, keep: int, f: BiggestFloat,
+                   exp: int): tuple[digits: string, carry: bool] =
+    ## Round `digits` to `keep` leading digits. `carry` means the rounding
+    ## overflowed into a new leading digit (999 -> 100 with carry).
+    ##
+    ## `f` and `exp` are here for the one case the digit string cannot decide.
+    ## `$f` is the SHORTEST round-tripping decimal, so a trailing `5` does NOT
+    ## mean an exact tie — 9.995 prints as "9.995" but the double is
+    ## 9.99499999999999957, which C rounds DOWN to 9.99 at two places. Guessing
+    ## half-to-even there is wrong for exactly the values a naive reading calls
+    ## obvious (this fixture caught it). So the ambiguous case is settled
+    ## against the VALUE: build both candidates, parse them back, and keep the
+    ## nearer one. Only a genuine tie leaves the two equidistant, and that one
+    ## goes half-to-even as C does.
+    result = (digits: "", carry: false)
+    if keep >= digits.len:
+      result.digits = digits
+      for _ in digits.len ..< keep: result.digits.add '0'
+      return
+    if keep < 0:
+      return
+    var kept = digits.substr(0, keep - 1)
+    let first = digits[keep]
+    var roundUp = false
+    if first > '5':
+      roundUp = true
+    elif first == '5':
+      var restNonZero = false
+      for i in keep + 1 ..< digits.len:
+        if digits[i] != '0': restNonZero = true
+      if restNonZero:
+        roundUp = true
+      else:
+        let lo = decimalValue(kept, exp)
+        var up = kept
+        var i = up.len - 1
+        var c = true
+        while i >= 0 and c:
+          if up[i] == '9': up[i] = '0'
+          else:
+            up[i] = char(int(up[i]) + 1)
+            c = false
+          dec i
+        let hi = (if c: decimalValue("1" & up, exp + 1) else: decimalValue(up, exp))
+        let a = abs(f) - lo
+        let b = hi - abs(f)
+        if b < a: roundUp = true
+        elif a < b: roundUp = false
+        else:
+          let prev = if keep > 0: digits[keep - 1] else: '0'
+          roundUp = ((int(prev) - int('0')) and 1) == 1
+    if roundUp:
+      var i = kept.len - 1
+      var carry = true
+      while i >= 0 and carry:
+        if kept[i] == '9':
+          kept[i] = '0'
+        else:
+          kept[i] = char(int(kept[i]) + 1)
+          carry = false
+        dec i
+      if carry:
+        result.carry = true
+        kept = "1" & kept.substr(0, kept.len - 2)
+    result.digits = kept
+
+  func fmtDecimal(f: BiggestFloat, neg: bool, digits: string,
+                  exp, precision: int, decimalSep: char): string =
+    ## Fixed-point: `precision` digits after the point.
+    let keep = exp + precision
+    var (d, carry) = roundDigits(digits, keep, f, exp)
+    var e = exp
+    if carry: inc e
+    if d.len == 0: d = "0"
+    result = ""
+    if neg: result.add '-'
+    if e <= 0:
+      result.add '0'
+      # The C path formats with `%#.*f`, and `#` keeps the point even at
+      # precision 0 ("2." not "2"). Match it, or every zero-precision call
+      # differs by one character.
+      result.add decimalSep
+      if precision > 0:
+        var zeros = -e
+        var written = 0
+        while written < precision and zeros > 0:
+          result.add '0'
+          inc written
+          dec zeros
+        var i = 0
+        while written < precision:
+          result.add (if i < d.len: d[i] else: '0')
+          inc i
+          inc written
+    else:
+      var i = 0
+      while i < e:
+        result.add (if i < d.len: d[i] else: '0')
+        inc i
+      result.add decimalSep
+      if precision > 0:
+        var written = 0
+        while written < precision:
+          result.add (if i < d.len: d[i] else: '0')
+          inc i
+          inc written
+
+  func fmtScientific(f: BiggestFloat, neg: bool, digits: string,
+                     exp, precision: int, decimalSep: char): string =
+    var (d, carry) = roundDigits(digits, precision + 1, f, exp)
+    var e = exp
+    if carry: inc e
+    if d.len == 0: d = "0"
+    result = ""
+    if neg: result.add '-'
+    result.add d[0]
+    result.add decimalSep          # `%#.*e` keeps the point at precision 0 too
+    if precision > 0:
+      for i in 1 .. precision:
+        result.add (if i < d.len: d[i] else: '0')
+    # An all-zero mantissa is the value zero, whose exponent is 0, not -1.
+    var allZero = true
+    for c in d:
+      if c != '0': allZero = false
+    let e10 = (if allZero: 0 else: e - 1)
+    result.add 'e'
+    if e10 < 0: result.add '-' else: result.add '+'
+    let a = abs(e10)
+    if a < 10: result.add '0'
+    result.add $a
 
 func formatBiggestFloat*(f: BiggestFloat, format: FloatFormatMode = ffDefault,
                          precision: range[-1..32] = 16;
@@ -994,29 +1208,48 @@ func formatBiggestFloat*(f: BiggestFloat, format: FloatFormatMode = ffDefault,
     assert x.formatBiggestFloat() == "123.4560000000000"
     assert x.formatBiggestFloat(ffDecimal, 4) == "123.4560"
     assert x.formatBiggestFloat(ffScientific, 2) == "1.23e+02"
-  const floatFormatToChar: array[FloatFormatMode, char] = ['g', 'f', 'e']
-  var
-    frmtstr {.noinit.}: array[0..5, char]
-    buf {.noinit.}: array[0..2500, char]
-    L: cint
-  frmtstr[0] = '%'
-  if precision.int >= 0:
-    frmtstr[1] = '#'
-    frmtstr[2] = '.'
-    frmtstr[3] = '*'
-    frmtstr[4] = floatFormatToChar[format]
-    frmtstr[5] = '\0'
-    L = c_snprintf(cast[cstring](addr buf), csize_t(2501), cast[cstring](addr frmtstr), precision, f)
+  when defined(wasm32) and defined(standalone):
+    let s = $f
+    # nan/inf print as themselves in every mode, as C does.
+    if s.len == 0 or not (c_isDigit(s[0]) or s[0] == '-' or s[0] == '+'):
+      return s
+    if s.len > 1 and (s[0] == '-' or s[0] == '+') and not c_isDigit(s[1]):
+      return s
+    let (neg, digits, exp) = splitDigits(s)
+    if precision.int < 0 or format == ffDefault:
+      # ffDefault IS "the shorter notation", which is exactly what `$f` gives.
+      result = ""
+      for c in s:
+        if c == '.' or c == ',': result.add decimalSep
+        else: result.add c
+    elif format == ffDecimal:
+      result = fmtDecimal(f, neg, digits, exp, precision.int, decimalSep)
+    else:
+      result = fmtScientific(f, neg, digits, exp, precision.int, decimalSep)
   else:
-    frmtstr[1] = floatFormatToChar[format]
-    frmtstr[2] = '\0'
-    L = c_snprintf(cast[cstring](addr buf), csize_t(2501), cast[cstring](addr frmtstr), f)
-  result = newString(L)
-  for i in 0 ..< L:
-    # Depending on the locale either dot or comma is produced,
-    # but nothing else is possible:
-    if buf[i] in {'.', ','}: result[i] = decimalSep
-    else: result[i] = buf[i]
+    const floatFormatToChar: array[FloatFormatMode, char] = ['g', 'f', 'e']
+    var
+      frmtstr {.noinit.}: array[0..5, char]
+      buf {.noinit.}: array[0..2500, char]
+      L: cint
+    frmtstr[0] = '%'
+    if precision.int >= 0:
+      frmtstr[1] = '#'
+      frmtstr[2] = '.'
+      frmtstr[3] = '*'
+      frmtstr[4] = floatFormatToChar[format]
+      frmtstr[5] = '\0'
+      L = c_snprintf(cast[cstring](addr buf), csize_t(2501), cast[cstring](addr frmtstr), precision, f)
+    else:
+      frmtstr[1] = floatFormatToChar[format]
+      frmtstr[2] = '\0'
+      L = c_snprintf(cast[cstring](addr buf), csize_t(2501), cast[cstring](addr frmtstr), f)
+    result = newString(L)
+    for i in 0 ..< L:
+      # Depending on the locale either dot or comma is produced,
+      # but nothing else is possible:
+      if buf[i] in {'.', ','}: result[i] = decimalSep
+      else: result[i] = buf[i]
 
 func formatFloat*(f: float, format: FloatFormatMode = ffDefault,
                   precision: range[-1..32] = 16; decimalSep = '.'): string =


### PR DESCRIPTION
WebAssembly has no variadic calling convention. An imported function has one type, so a `{.varargs.}` importc cannot be called with different argument tails, and `c_snprintf(buf, n, fmt, precision, f)` emits a call whose f64 argument contradicts the import's declared i32. The engine rejects that when it compiles the MODULE, not when it reaches the call — so a single `formatFloat` on a diagnostic path takes the whole program down. It is not hypothetical: it is why a browser viewer built on this would not load at all.

The wasm arm formats from the digits `$f` already produces. Rounding works on the decimal string rather than scaling by a power of ten, because `f * 10^p` introduces an error that decides the last digit at exactly the values where it matters.

The one case digits alone cannot settle is decided against the value. `$f` is the SHORTEST round-tripping decimal, so a trailing `5` is not necessarily an exact tie: 9.995 prints as "9.995" while the double is 9.99499999999999957, which C rounds DOWN at two places. A first cut rounded it up on the strength of the printed digits, and the differential fixture caught it. The arm now builds both candidates, parses them back, and keeps the nearer — a genuine tie leaves them equidistant and goes half-to-even, as C does.

Two things this costs, both measured rather than assumed:

A precision beyond the shortest form's digit count pads with zeros where glibc continues the exact binary expansion (`0.1` at 20 places is `0.10000000000000000000` here, `0.10000000000000000555` there). Every precision the shortest form covers agrees byte for byte, which is every display use.

And it adds one host import. The module's env imports become `nim_write`, `nim_exit` and `strtod` — the last from parsing the candidates back. That trades a variadic import that CANNOT be typed on wasm for a non-variadic one that can, and it is the same `strtod` any wasm program that parses a float already needs; but it is a new requirement for one that only formats, so it is stated here rather than discovered.

The C path is untouched — everything above is inside a new `when defined(wasm32) and defined(standalone)` arm.

Verified on this branch: the glibc leg and the armed leg render the grid byte-identically, 27/27 lines, built from one fixture with `nimony c` and `nimony w` and diffed. `hastur build all` clean, `tests/nimony/stdlib` 53/53, `hastur all` 761/761.