### PR TITLE
ioring: stop printing, fail the ops instead

### DIFF
--- a/lib/std/ioring/backends/epoll.nim
+++ b/lib/std/ioring/backends/epoll.nim
@@ -15,7 +15,6 @@ import ../core/types
 import ../core/slots
 import ../core/backend
 import ./poll
-import std/syncio
 
 const
   MaxIoEvents = 64
@@ -39,7 +38,7 @@ proc fdNotPollable(): bool {.inline.} =
   let e = errno()
   result = e == EPERM or e == EBADF
 
-proc epollReArm(fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} =
+proc epollReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} =
   let epollFd = epollFds[ioLane()]
   var ev {.noinit.}: EpollEvent
   ev.events = EPOLLONESHOT
@@ -54,25 +53,15 @@ proc epollReArm(fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} =
   ev.data.`ptr` = cast[pointer](uint(fd))
   let op = if alreadyRegistered: EPOLL_CTL_MOD else: EPOLL_CTL_ADD
   var res = epoll_ctl(epollFd, op, fd, addr ev)
-  if res != 0 and op == EPOLL_CTL_ADD:
-    # Lost the race with a concurrent submit on the same fd that already
-    # ADD'ed it (or the fd was previously registered and evicted from our
-    # bookkeeping some other way) — fall back to MOD once.
-    if not fdNotPollable():
-      # Not a stale/non-pollable fd → a genuine ADD-vs-MOD race (whether the fd
-      # is already registered is derived from the arena, one poll cycle behind
-      # a concurrent submit at worst). ADD on an already-present
-      # fd → EEXIST; fall back to MOD so the fd ends up armed with the current
-      # mask instead of staying a fired (disarmed) oneshot — that stall loses the
-      # connection. (A regular-file/closed fd is skipped above; MOD can't help it.)
-      res = epoll_ctl(epollFd, EPOLL_CTL_MOD, fd, addr ev)
-      if res != 0:
-        # Report the ERRNO, not the return value: epoll_ctl reports every
-        # failure as -1, so "failed: -1" says nothing about which failure it
-        # was — and this branch fires only when both verbs failed on a fd we
-        # believe is live, i.e. exactly when the reason matters.
-        stderr.writeLine("ioring: epoll ADD+MOD both failed on fd " & $fd &
-                         " (errno " & $errno() & ")")
+  if res != 0 and op == EPOLL_CTL_ADD and not fdNotPollable():
+    # ADD on an already-present fd → EEXIST (the arena is one poll cycle behind
+    # a concurrent submit at worst); fall back to MOD so the fd ends up armed
+    # rather than staying a fired, disarmed oneshot.
+    res = epoll_ctl(epollFd, EPOLL_CTL_MOD, fd, addr ev)
+  # Still failing → this fd will not deliver readiness (both verbs failed, a MOD
+  # on a registered fd failed, or it is not pollable at all: EPERM/EBADF).
+  # `submitForPoll` fails the ops waiting on it.
+  result = res == 0
 
 proc epollPoll(timeoutMs: int): bool {.nimcall.} =
   let lane = ioLane()

--- a/lib/std/ioring/backends/iouring.nim
+++ b/lib/std/ioring/backends/iouring.nim
@@ -10,7 +10,7 @@
 # polled" hang.
 
 import std/[assertions, atomics, posix/posix, ticketlocks, threadpool]
-import std/syncio
+import std/syncio   # quit
 import ../../posix/io_uring
 import ../core/types
 import ../core/slots
@@ -33,9 +33,8 @@ proc tryInitLocalQueues(): bool =
   try:
     for i in 0..<ioLanes():
       localQueues.add newQueue(sqEntries)
-  except ErrorCode as e:
-    stderr.writeLine("ioring: failed to init io_uring queue: " & $e)
-    return false
+  except ErrorCode:
+    return false   # the caller falls back to the epoll backend
   return true
 
 proc fillSqe(sqe: ptr Sqe; op: ptr OpContext) {.inline.} =
@@ -78,8 +77,7 @@ proc iouringPoll(timeoutMs: int): bool {.nimcall.} =
       var sqe: nil ptr Sqe
       try:
         sqe = localQueues[lane].getSqe()
-      except ErrorCode as e:
-        stderr.writeLine("ioring: failed to get sqe: " & $e)
+      except ErrorCode:
         # Ops buf[i..<n] were dequeued but never got an SQE/slot; put them
         # back so the next poll picks them up instead of losing them forever.
         for k in i..<n:

--- a/lib/std/ioring/backends/kqueue.nim
+++ b/lib/std/ioring/backends/kqueue.nim
@@ -17,7 +17,7 @@ const
 
 var kqFds: seq[cint]
 
-proc kqueueReArm(fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} =
+proc kqueueReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} =
   # EV_ADD is idempotent in kqueue (add-or-modify), unlike epoll's ADD/MOD
   # split, so there is no separate "first time vs re-arm" bookkeeping needed
   # here. `ident` (the fd) is what `kqueuePoll` reads back on delivery, not
@@ -28,16 +28,19 @@ proc kqueueReArm(fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} =
   # bytes — or never.
   var ev = default(KEvent)
   let kq = kqFds[ioLane()]
+  # Reported, not discarded: a failed registration means no readiness, and
+  # `submitForPoll` fails the ops waiting on it.
+  result = true
   if (mask and EvRead) != 0:
     ev.ident = uint(fd)
     ev.filter = EVFILT_READ
     ev.flags = EV_ADD or EV_ONESHOT
-    discard kevent(kq, addr ev, 1, nil, 0, nil)
+    if kevent(kq, addr ev, 1, nil, 0, nil) < 0: result = false
   if (mask and EvWrite) != 0:
     ev.ident = uint(fd)
     ev.filter = EVFILT_WRITE
     ev.flags = EV_ADD or EV_ONESHOT
-    discard kevent(kq, addr ev, 1, nil, 0, nil)
+    if kevent(kq, addr ev, 1, nil, 0, nil) < 0: result = false
 
 proc kqueuePoll(timeoutMs: int): bool {.nimcall.} =
   let lane = ioLane()

--- a/lib/std/ioring/backends/poll.nim
+++ b/lib/std/ioring/backends/poll.nim
@@ -7,8 +7,8 @@ import ../core/types
 import ../core/slots
 import ../core/backend
 
-proc noopReArm(fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} = discard
-var reArmEvent*: proc (fd: cint; mask: int, alreadyRegistered: bool) {.nimcall.} = noopReArm
+proc noopReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} = true
+var reArmEvent*: proc (fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} = noopReArm
 ## Registers (or re-arms, for EPOLLONESHOT-style backends) readiness
 ## interest for `fd`. Takes only `fd` and the direction mask — never a
 ## specific slot index: a fd can have several ops in flight (e.g. a
@@ -39,10 +39,22 @@ proc armMaskForFd*(fd: cint): int =
     of opNop:
       discard
 
+const ArmFailed* = -1
+  ## Completion result for an op on a fd that could not be armed — the same
+  ## value a failed read or write reports.
+
+proc failPendingForFd*(fd: cint) =
+  ## Complete every op pending on `fd`. Nothing will make them ready once the
+  ## fd cannot be armed, so otherwise they park forever.
+  let lane = ioLane()
+  for j in gSlots[lane].slotsForFd(fd):
+    complete(j, ArmFailed)
+
 proc submitForPoll*(fd: cint; alreadyRegistered: bool = false) {.nimcall.} =
   ## Arm `fd` for every op pending on it, including the one just allocated by
   ## the caller (`allocSlot` has already linked it into the fd's list).
-  reArmEvent(fd, armMaskForFd(fd), alreadyRegistered)
+  if not reArmEvent(fd, armMaskForFd(fd), alreadyRegistered):
+    failPendingForFd(fd)
 
 when defined(posix):
   import std / assertions
@@ -96,7 +108,8 @@ when defined(posix):
     # Re-arm for whatever directions still have an op pending on this fd
     # (completions above may have freed some slots already).
     if gSlots[lane].hasPendingForFd(fd):
-      reArmEvent(fd, armMaskForFd(fd), true)
+      if not reArmEvent(fd, armMaskForFd(fd), true):
+        failPendingForFd(fd)
     # else: nothing left for this fd; the backend already consumed the
     # one-shot registration, and submit/registerEvent will re-add it the
     # next time an op targets this fd.


### PR DESCRIPTION
Removes the three `stderr.writeLine`s in `std/ioring`. Two of them were noise; the third was standing in for an error path that did not exist.

`iouring`'s "failed to get sqe" already re-enqueues the dequeued ops so the next poll picks them up — and the `sqe == nil` branch four lines below recovers identically without announcing it, so the module was inconsistent with itself. "failed to init io_uring queue" likewise: the caller falls back to the epoll backend, and that fallback IS the handling. Both prints just go.

`epoll`'s "ADD+MOD both failed" is the different one. There is no recovery there: the fd ends up unarmed, so nothing will ever make its pending ops ready, their continuations stay parked, and the caller waits on a read that will never return and never fail. No error, no timeout, no crash — just a task that never wakes while the process runs on normally. That message was the only evidence the failure had happened at all.

So report it instead. `reArmEvent` returns whether the fd is armed, and `submitForPoll`/`processFd` complete that fd's pending ops with `ArmFailed` when it is not — the same thing `closeFd` already does when it cancels, and the same value a failed read or write reports, so callers need no new case.

Why completion and not `raise`: the arm runs inside `poll`, under `gReactor`, so the throw would land on whichever worker (or whichever embedder frame calling `pumpIo`) happened to be polling — a thread that owns none of the affected ops and can do nothing with it. It would not release them either, the slot's continuation being parked regardless, so the completion is needed anyway. And since `submit` is caller-runs under saturation, user continuations execute inside `processFd`, so an exception would unwind through those frames. The per-op result already reaches the owner; this path simply was not using it.

Two behaviour changes worth calling out. A MOD that fails on an already-registered fd was previously ignored outright — same silent stall, now reported. And the EPERM/EBADF "not pollable" case is no longer skipped silently: skipping was safe only while nothing was waiting on the fd, and `submitForPoll` runs immediately after `allocSlot`, so something always is.

kqueue's registration failures were likewise discarded; it now reports them.

Verified: `hastur build all` clean, `tests/nimony/threads` 10/10 on io_uring, `tpolladd` matches its golden on the epoll arm too, `hastur all` 761/761.