### PR TITLE
ioring: wait for completions in the kernel, not in a nanosleep

### DIFF
--- a/lib/std/ioring/backends/iouring.nim
+++ b/lib/std/ioring/backends/iouring.nim
@@ -92,10 +92,21 @@ proc iouringPoll(timeoutMs: int): bool {.nimcall.} =
       # `addr op.acceptAddr`/`addr op.acceptLen` and the kernel writes through
       # those at completion time, long after this stack frame is gone.
       fillSqe(sqe, addr gSlots[lane].slots[idx].op)
-    try:
-      discard localQueues[lane].submit()
-    except ErrorCode as e:
-      quit "fatal: bug: submit cannot fail: " & $e
+  # ONE enter per poll: flush whatever was just filled and, when the caller
+  # gave us a time budget, wait for a completion inside it.
+  #
+  # Waiting here is the whole point. Peeking at the CQ and returning empty
+  # leaves the caller to spend its budget in `nanosleep` (see
+  # `threadpool.workerLoop`) — a sleep no completion can interrupt, so every
+  # completion picks up latency bounded by the poll interval rather than being
+  # delivered when the kernel has it. epoll never had that problem because its
+  # wait IS `epoll_wait(timeoutMs)`. Measured on a write-heavy WebSocket
+  # workload before this: ~3.2x the control-reply latency of the epoll backend,
+  # uniformly across rates.
+  #
+  # Called unconditionally, not just when SQEs were filled: with nothing new to
+  # submit there is still a budget to spend waiting for work already in flight.
+  discard localQueues[lane].submitAndWait(1'u, timeoutMs.int64 * 1_000_000'i64)
   if localQueues[lane].cqReady > 0:
     var cqes {.noinit.}: array[DrainBatch, Cqe]
     try:

--- a/lib/std/ioring/backends/iouring.nim
+++ b/lib/std/ioring/backends/iouring.nim
@@ -116,14 +116,16 @@ proc iouringPoll(timeoutMs: int): bool {.nimcall.} =
   # delivered when the kernel has it. epoll never had that problem because its
   # wait IS `epoll_wait(timeoutMs)`.
   #
-  # Not conditional on having just filled SQEs: with nothing new to submit there
-  # is still a budget to spend waiting on work already in flight. But with
-  # NOTHING in flight either, no completion can arrive, so the enter is a
-  # syscall that can only ever time out — skip it and let the caller idle in its
-  # own sleep, which is the pre-io_uring behaviour for a lane with no work.
-  var waited = false
-  if inFlight[lane] > 0:
-    waited = timeoutMs > 0 and localQueues[lane].canTimedWait
+  # With a budget the wait happens whether or not anything is in flight. On an
+  # empty ring the timed enter can only time out — and that timeout IS the
+  # caller's idle sleep, at the same syscall cost as the `nanosleep` it would
+  # otherwise do, so skipping it (as this backend first did) only moved the
+  # sleep onto the caller: a loop that just pumps (`while running: pumpIo(100)`)
+  # spun a full core once its lane went idle. Only a budget-less poll on an idle
+  # lane skips the enter; with work in flight and no budget, `submitAndWait`
+  # still decides whether a syscall is needed.
+  var waited = timeoutMs > 0 and localQueues[lane].canTimedWait
+  if waited or inFlight[lane] > 0:
     let waitNr = if waited: 1'u else: 0'u
     discard localQueues[lane].submitAndWait(waitNr,
                                             timeoutMs.int64 * 1_000_000'i64)

--- a/lib/std/ioring/backends/iouring.nim
+++ b/lib/std/ioring/backends/iouring.nim
@@ -23,9 +23,22 @@ const
 var
   sqEntries: int
   localQueues: seq[Queue]
+  inFlight: seq[int]
+    ## Ops submitted on this lane and not yet completed. Owned by the lane's own
+    ## thread — `iouringPoll` is the only writer and is the only place either
+    ## end of an op's life is observed.
+    ##
+    ## It exists to answer "can a completion possibly arrive?", which the ring
+    ## itself cannot: `sqReady` counts SQEs the KERNEL has yet to consume, and
+    ## drops to zero the moment it does, while the op is still outstanding.
+    ## Reading it instead would skip the wait exactly when there is work to wait
+    ## for. Drift is one-directional by construction — an op that is cancelled
+    ## without a CQE leaves the count high, which costs a syscall and never a
+    ## missed completion.
 
 proc tryInitLocalQueues(): bool =
   localQueues = @[]
+  inFlight = newSeq[int](ioLanes())
   try:
     for i in 0..<ioLanes():
       localQueues.add newQueue(sqEntries)
@@ -92,21 +105,28 @@ proc iouringPoll(timeoutMs: int): bool {.nimcall.} =
       # `addr op.acceptAddr`/`addr op.acceptLen` and the kernel writes through
       # those at completion time, long after this stack frame is gone.
       fillSqe(sqe, addr gSlots[lane].slots[idx].op)
-  # ONE enter per poll: flush whatever was just filled and, when the caller
-  # gave us a time budget, wait for a completion inside it.
+      inFlight[lane] = inFlight[lane] + 1
+  # ONE enter per poll: flush whatever was just filled and, when the caller gave
+  # us a time budget, wait for a completion inside the same syscall.
   #
   # Waiting here is the whole point. Peeking at the CQ and returning empty
   # leaves the caller to spend its budget in `nanosleep` (see
   # `threadpool.workerLoop`) — a sleep no completion can interrupt, so every
   # completion picks up latency bounded by the poll interval rather than being
   # delivered when the kernel has it. epoll never had that problem because its
-  # wait IS `epoll_wait(timeoutMs)`. Measured on a write-heavy WebSocket
-  # workload before this: ~3.2x the control-reply latency of the epoll backend,
-  # uniformly across rates.
+  # wait IS `epoll_wait(timeoutMs)`.
   #
-  # Called unconditionally, not just when SQEs were filled: with nothing new to
-  # submit there is still a budget to spend waiting for work already in flight.
-  discard localQueues[lane].submitAndWait(1'u, timeoutMs.int64 * 1_000_000'i64)
+  # Not conditional on having just filled SQEs: with nothing new to submit there
+  # is still a budget to spend waiting on work already in flight. But with
+  # NOTHING in flight either, no completion can arrive, so the enter is a
+  # syscall that can only ever time out — skip it and let the caller idle in its
+  # own sleep, which is the pre-io_uring behaviour for a lane with no work.
+  var waited = false
+  if inFlight[lane] > 0:
+    waited = timeoutMs > 0 and localQueues[lane].canTimedWait
+    let waitNr = if waited: 1'u else: 0'u
+    discard localQueues[lane].submitAndWait(waitNr,
+                                            timeoutMs.int64 * 1_000_000'i64)
   if localQueues[lane].cqReady > 0:
     var cqes {.noinit.}: array[DrainBatch, Cqe]
     try:
@@ -128,8 +148,15 @@ proc iouringPoll(timeoutMs: int): bool {.nimcall.} =
           if POLL_OUT in fired: ev.incl evWrite
           res = toEventMask(ev)
         complete(idx, res)
+      inFlight[lane] = inFlight[lane] - n
       return true
-  return false
+  # Nothing completed — but if the wait above happened, the caller's timeout has
+  # ALREADY been spent, in the kernel, where a completion could have cut it
+  # short. Saying `false` here would send it into `nanosleep` for the same
+  # interval a second time: twice the idle latency, and the second half
+  # uninterruptible, which is the exact cost this backend just stopped paying.
+  # Hence the relay's contract is "the budget is spent", not "an event fired".
+  return waited
 
 proc iouringForgetFd(fd: cint) {.nimcall.} =
   discard

--- a/lib/std/ioring/core/backend.nim
+++ b/lib/std/ioring/core/backend.nim
@@ -12,6 +12,16 @@ const MaxOps* = 8192
 type
   BackendRelays* = object
     poll*: proc (timeoutMs: int): bool {.nimcall.}
+      ## Service one lane for at most `timeoutMs`. Returns true when the
+      ## caller's time budget has been SPENT — either completions were
+      ## delivered, or this call waited for them and none came. A caller that
+      ## paces itself when idle (`threadpool.workerLoop`) must not sleep out the
+      ## same interval again on a true; doing so doubles idle latency and makes
+      ## the second half uninterruptible by a completion.
+      ##
+      ## False therefore means "nothing happened AND nothing was waited for" —
+      ## the lane had no work a wait could have produced — and the caller keeps
+      ## responsibility for its own pacing.
     close*: proc () {.nimcall.}
     forgetFd*: proc (fd: cint) {.nimcall.}
       ## Drop any backend-side per-fd registration/bookkeeping before a fd is

--- a/lib/std/ioring/core/backend.nim
+++ b/lib/std/ioring/core/backend.nim
@@ -19,9 +19,11 @@ type
       ## same interval again on a true; doing so doubles idle latency and makes
       ## the second half uninterruptible by a completion.
       ##
-      ## False therefore means "nothing happened AND nothing was waited for" —
-      ## the lane had no work a wait could have produced — and the caller keeps
-      ## responsibility for its own pacing.
+      ## False therefore means "nothing happened AND nothing was waited for":
+      ## the call had no budget, or the ring cannot wait with a deadline
+      ## (io_uring without EXT_ARG, kernel < 5.11). Only then does the caller
+      ## keep responsibility for its own pacing. A poll WITH a budget spends it
+      ## even on an idle lane, so a loop that only pumps does not spin.
     close*: proc () {.nimcall.}
     forgetFd*: proc (fd: cint) {.nimcall.}
       ## Drop any backend-side per-fd registration/bookkeeping before a fd is

--- a/lib/std/posix/io_uring.nim
+++ b/lib/std/posix/io_uring.nim
@@ -803,6 +803,54 @@ proc waitReady(queue: var Queue; waitNr: uint = 0): uint32 {.raises, tags: [], i
     discard enter(queue.fd, 0.cint, waitNr.cint, {ENTER_GETEVENTS}, nil, 0.cint)
     result = queue.cqReady
 
+proc submitAndWait*(queue: var Queue; waitNr: uint; timeoutNs: int64): int {.
+    tags: [], discardable.} =
+  ## Flush pending SQEs and, in the SAME `io_uring_enter`, wait for `waitNr`
+  ## completions or `timeoutNs`, whichever comes first. The fused form matters:
+  ## submitting and then entering again to wait is two syscalls on the very
+  ## path a poll loop runs per iteration. (liburing spells this
+  ## `io_uring_submit_and_wait_timeout`.)
+  ##
+  ## The bounded wait is the point. `submit(waitNr = 1)` blocks with no
+  ## deadline, which a worker that must also service a task queue cannot use;
+  ## submitting and not waiting at all leaves the caller to sleep out its
+  ## interval in a sleep no completion can interrupt.
+  ##
+  ## Needs `FEAT_EXT_ARG` (kernel 5.11+) for the deadline; without it there is
+  ## no way to give `io_uring_enter` one, so this falls back to a plain submit
+  ## and the caller keeps responsibility for its own pacing.
+  let submited = queue.sqFlush
+  var flags: EnterFlags = {}
+  let mayWait = waitNr > 0'u and timeoutNs > 0'i64 and
+                FEAT_EXT_ARG in queue.params.features
+  if not mayWait:
+    let cqNeedsEnter = queue.cqNeedsEnter
+    if queue.sqNeedsEnter(submited, flags) or cqNeedsEnter:
+      if cqNeedsEnter: flags.incl(ENTER_GETEVENTS)
+      try:
+        result = enter(queue.fd, submited.cint, 0.cint,
+                       flags, nil, 0.cint)
+      except:
+        result = 0
+    else:
+      result = submited
+    return
+  discard queue.sqNeedsEnter(submited, flags)   # may set the SQPOLL wakeup bit
+  flags.incl(ENTER_GETEVENTS)
+  flags.incl(ENTER_EXT_ARG)
+  var ts = Timespec(tv_sec: Time(timeoutNs div 1_000_000_000'i64),
+                    tv_nsec: clong(timeoutNs mod 1_000_000_000'i64))
+  var arg = GeteventsArg(sigmask: 0'u64, sigmaskSz: 8'u32, pad: 0'u32,
+                         ts: cast[uint64](addr ts))
+  try:
+    result = enter(queue.fd, submited.cint, waitNr.cint,
+                   flags, addr arg, sizeof(arg).cint)
+  except:
+    # -ETIME is the ordinary "deadline passed, nothing arrived" answer and
+    # -EINTR is a signal; neither is an error worth propagating, and the caller
+    # reads `cqReady` regardless.
+    result = submited
+
 proc copyCqesToSeq(queue: var Queue; cqes: openArray[Cqe]; ready: uint32) {.inline.} =
   var
     head = queue.cq.head[]

--- a/lib/std/posix/io_uring.nim
+++ b/lib/std/posix/io_uring.nim
@@ -803,6 +803,16 @@ proc waitReady(queue: var Queue; waitNr: uint = 0): uint32 {.raises, tags: [], i
     discard enter(queue.fd, 0.cint, waitNr.cint, {ENTER_GETEVENTS}, nil, 0.cint)
     result = queue.cqReady
 
+proc canTimedWait*(queue: var Queue): bool {.inline.} =
+  ## Whether `submitAndWait` can actually honour a deadline. `EXT_ARG` is what
+  ## carries a timespec into `io_uring_enter`, and it needs kernel 5.11+;
+  ## without it `submitAndWait` degrades to a plain submit and returns at once.
+  ##
+  ## Exposed because the difference is not an implementation detail to a poll
+  ## loop: a caller that would otherwise pace itself has to know whether this
+  ## ring will spend its budget for it or hand it straight back.
+  FEAT_EXT_ARG in queue.params.features
+
 proc submitAndWait*(queue: var Queue; waitNr: uint; timeoutNs: int64): int {.
     tags: [], discardable.} =
   ## Flush pending SQEs and, in the SAME `io_uring_enter`, wait for `waitNr`


### PR DESCRIPTION
`iouringPoll` accepts a `timeoutMs` and ignores it: it drains the op queue, submits, then harvests only CQEs that are ALREADY ready and returns. A caller that asks for a bounded wait therefore gets a busy loop.

It shows up most plainly for an embedder driving the ring from its own loop — ours pumps from a render frame callback, because its main thread belongs to a rendering engine and can never call the pool's own loop:

    pumpIo(1) over ~92ms      io_uring as-is:  3,509,132 iterations
                              with this patch:            93

One per millisecond, as asked, rather than a spinning core. The epoll backend was already correct here, because its wait IS `epoll_wait(timeoutMs)`.

`submitAndWait` fuses the flush and the wait into ONE `io_uring_enter` with `IORING_ENTER_GETEVENTS | IORING_ENTER_EXT_ARG` and a timespec — the shape of liburing's `io_uring_submit_and_wait_timeout`. Submitting and then entering again to wait would be two syscalls per poll iteration on the path being fixed. `iouringPoll` calls it unconditionally, so a poll with nothing new to submit still spends its budget waiting on work already in flight. 