### PR TITLE
semcheck statement-level `{.error.}` pragmas

### DIFF
--- a/src/nimony/sempragmas.nim
+++ b/src/nimony/sempragmas.nim
@@ -1082,6 +1082,18 @@ proc semPragmaLine*(c: var SemContext; dest: var TokenBuf; it: var Item; isPragm
     semBoolExpr c, dest, it.n
     dest.addParRi()
     closePragmaLine()
+  of ErrorP:
+    # Statement-level `{.error: "msg".}` — distinct from `{.error.}` on a routine
+    # decl (handled in `semPragma`). Classic Nim calls `localError` here; dead
+    # branches (`when false: ... else: {.error.}`) never reach this.
+    let info = it.n.info
+    toPragmaArgs()
+    let start = dest.len
+    let s = evalConstStrExpr(c, dest, it.n, c.types.stringType)
+    closePragmaLine()
+    if s != StrId(0):
+      dest.shrink start
+      buildErr c, dest, info, pool.strings[s]
   of KeepOverflowFlagP:
     if not isPragmaBlock:
       buildErr c, dest, it.n.info, "`keepOverflowFlag` pragma must be used in a pragma block"


### PR DESCRIPTION
`ErrorP` was handled in `semPragma` for routine and type declarations, but statement pragmas in `semPragmaLine` fell through to "unsupported pragma". Evaluate the message string and report it via `buildErr`, matching classic Nim's statement-level `{.error: "msg".}` behavior. Dead `when`/`else` branches still skip semchecking as before.

Fixes https://github.com/nim-lang/nimony/issues/2391