### PR TITLE
bif: fill a loaded module's pools without hashing them

### DIFF
--- a/src/lib/bif.nim
+++ b/src/lib/bif.nim
@@ -487,8 +487,8 @@ proc loadFromFile*(f: File): BifModule =
     let bytes = tokenCount * sizeof(NifToken)
     readExact(f, dest, bytes)
   # pools: append in stored (id) order so ids 1,2,… match the token refs. No
-  # hashing — `addOrdered` leaves the reverse index unbuilt, and the first
-  # `getOrIncl`/`getKeyId` on the pool builds it if one ever comes.
+  # hashing — `addOrdered` leaves the reverse index unbuilt, and `getOrIncl` (or
+  # an explicit `ensureIndexed`, for `getKeyId`) builds it if one ever comes.
   for _ in 1 .. nTags:    discard result.buf.tags.tags.addOrdered(readStr(f))
   for _ in 1 .. nStrings: discard result.buf.pool.strings.addOrdered(readStr(f))
   for _ in 1 .. nSyms:    discard result.buf.pool.syms.addOrdered(readStr(f))
@@ -571,8 +571,8 @@ proc load*(filename: string): BifModule =
   result.buf = adoptForeignTokens(cast[pointer](r.base + uint(r.pos)), tokenCount)
   r.pos += tokenBytes
   # pools: append in stored (id) order so ids 1,2,… match the token refs. No
-  # hashing — `addOrdered` leaves the reverse index unbuilt, and the first
-  # `getOrIncl`/`getKeyId` on the pool builds it if one ever comes.
+  # hashing — `addOrdered` leaves the reverse index unbuilt, and `getOrIncl` (or
+  # an explicit `ensureIndexed`, for `getKeyId`) builds it if one ever comes.
   for _ in 1 .. nTags:    discard result.buf.tags.tags.addOrdered(rStr(r))
   for _ in 1 .. nStrings: discard result.buf.pool.strings.addOrdered(rStr(r))
   for _ in 1 .. nSyms:    discard result.buf.pool.syms.addOrdered(rStr(r))

--- a/src/lib/bif.nim
+++ b/src/lib/bif.nim
@@ -486,11 +486,13 @@ proc loadFromFile*(f: File): BifModule =
     let dest = result.buf.growRawUninit(tokenCount)
     let bytes = tokenCount * sizeof(NifToken)
     readExact(f, dest, bytes)
-  # pools: re-intern in stored (id) order so ids 1,2,… match the token refs.
-  for _ in 1 .. nTags:    discard result.buf.tags.tags.getOrIncl(readStr(f))
-  for _ in 1 .. nStrings: discard result.buf.pool.strings.getOrIncl(readStr(f))
-  for _ in 1 .. nSyms:    discard result.buf.pool.syms.getOrIncl(readStr(f))
-  for _ in 1 .. nFiles:   discard result.buf.pool.filenames.getOrIncl(readStr(f))
+  # pools: append in stored (id) order so ids 1,2,… match the token refs. No
+  # hashing — `addOrdered` leaves the reverse index unbuilt, and the first
+  # `getOrIncl`/`getKeyId` on the pool builds it if one ever comes.
+  for _ in 1 .. nTags:    discard result.buf.tags.tags.addOrdered(readStr(f))
+  for _ in 1 .. nStrings: discard result.buf.pool.strings.addOrdered(readStr(f))
+  for _ in 1 .. nSyms:    discard result.buf.pool.syms.addOrdered(readStr(f))
+  for _ in 1 .. nFiles:   discard result.buf.pool.filenames.addOrdered(readStr(f))
   # symbol index (we are now positioned exactly at indexOffset).
   result.index = readIndex(f)
 
@@ -568,11 +570,13 @@ proc load*(filename: string): BifModule =
   assert r.pos + tokenBytes <= r.size, "bif: truncated token block"
   result.buf = adoptForeignTokens(cast[pointer](r.base + uint(r.pos)), tokenCount)
   r.pos += tokenBytes
-  # pools: re-intern in stored (id) order so ids 1,2,… match the token refs.
-  for _ in 1 .. nTags:    discard result.buf.tags.tags.getOrIncl(rStr(r))
-  for _ in 1 .. nStrings: discard result.buf.pool.strings.getOrIncl(rStr(r))
-  for _ in 1 .. nSyms:    discard result.buf.pool.syms.getOrIncl(rStr(r))
-  for _ in 1 .. nFiles:   discard result.buf.pool.filenames.getOrIncl(rStr(r))
+  # pools: append in stored (id) order so ids 1,2,… match the token refs. No
+  # hashing — `addOrdered` leaves the reverse index unbuilt, and the first
+  # `getOrIncl`/`getKeyId` on the pool builds it if one ever comes.
+  for _ in 1 .. nTags:    discard result.buf.tags.tags.addOrdered(rStr(r))
+  for _ in 1 .. nStrings: discard result.buf.pool.strings.addOrdered(rStr(r))
+  for _ in 1 .. nSyms:    discard result.buf.pool.syms.addOrdered(rStr(r))
+  for _ in 1 .. nFiles:   discard result.buf.pool.filenames.addOrdered(rStr(r))
   # symbol index (we are now positioned exactly at indexOffset).
   let nIndex = int rVarint(r)
   result.index = newSeq[IndexEntry](nIndex)

--- a/src/lib/bitabs.nim
+++ b/src/lib/bitabs.nim
@@ -57,7 +57,40 @@ proc enlarge[Id, T](t: var BiTable[Id, T]) =
         j = nextTry(j, maxHash(t))
       t.keys[j] = move n[i]
 
-proc getKeyId*[Id, T](t: BiTable[Id, T]; v: T): Id =
+proc rebuildIndex[Id, T](t: var BiTable[Id, T]) =
+  ## Build `keys` from `vals` for a table filled by `addOrdered`, which leaves
+  ## none. Sized as `enlarge` would have left it after that many inserts, so the
+  ## load factor matches a table that was built by interning all along.
+  var cap = 16
+  # `mustRehash` asserts `length > counter`, so the capacity has to clear
+  # `vals.len` before the load-factor question can even be asked.
+  while cap <= t.vals.len: cap = cap * 2
+  while mustRehash(cap, t.vals.len): cap = cap * 2
+  t.keys = newSeq[Id](cap)
+  for i in 0 ..< t.vals.len:
+    var j = hash(t.vals[i]) and maxHash(t)
+    while isFilled(t.keys[j]):
+      j = nextTry(j, maxHash(t))
+    t.keys[j] = Id(i + idStart)
+
+proc addOrdered*[Id, T](t: var BiTable[Id, T]; v: sink T): Id =
+  ## Append `v` under the next id WITHOUT hashing it.
+  ##
+  ## For a table deserialized in id order, every entry's id is its position, so
+  ## the reverse index costs a hash and an insert per entry to reproduce
+  ## something the file already states. `bif.load` fills four pools that way,
+  ## and on a 68-module `--ic:on` build of the Nim compiler that was 451ms of a
+  ## 637ms `load`, nearly all of it the symbol pool.
+  ##
+  ## The table is still a BiTable: the first `getOrIncl`/`getKeyId` builds the
+  ## index, so a pool that does get interned into behaves exactly as before —
+  ## it just pays for the index at the point something needs it rather than
+  ## always. Callers that only ever map id -> value never pay at all.
+  t.vals.add v
+  result = Id(t.vals.len - 1 + idStart)
+
+proc getKeyId*[Id, T](t: var BiTable[Id, T]; v: T): Id =
+  if t.keys.len == 0 and t.vals.len > 0: rebuildIndex(t)
   let origH = hash(v)
   var h = origH and maxHash(t)
   if t.keys.len != 0:
@@ -71,6 +104,7 @@ proc getKeyId*[Id, T](t: BiTable[Id, T]; v: T): Id =
 {.pragma: maybeDirty, dirty.}
 
 template getOrInclImpl() {.maybeDirty.} =
+  if t.keys.len == 0 and t.vals.len > 0: rebuildIndex(t)
   let origH = hash(v)
   var h = origH and maxHash(t)
   if t.keys.len != 0:
@@ -183,5 +217,41 @@ when isMainModule:
   discard tf.getOrIncl(16.4)
   discard tf.getOrIncl(32.4)
   assert getKeyId(tf, 32.4) == 3
+
+  # `addOrdered` must be indistinguishable from having interned all along, and
+  # the interesting part is the table it leaves BEHIND: the reverse index is
+  # unbuilt, so every lookup path has to notice and build it. A duplicate id
+  # handed out here would be silent corruption for a `bif` pool, since the
+  # token stream already refers to the first one.
+  block orderedFill:
+    var a = initBiTable[uint32, string]()
+    for i in 0 ..< 5_000:
+      assert a.addOrdered("s" & $i).idToIdx == i     # same ids getOrIncl gives
+    assert a.vals.len == 5_000
+    assert a[uint32 1] == "s0"                       # id -> value, no index yet
+    assert a[uint32 5_000] == "s4999"
+
+    # first lookup builds the index; every entry must be findable
+    assert getKeyId(a, "s0") == 1
+    assert getKeyId(a, "s4999") == 5_000
+    assert getKeyId(a, "nope") == 0
+    for i in 0 ..< 5_000:
+      assert getKeyId(a, "s" & $i).idToIdx == i
+
+    # and interning must now REUSE those ids rather than append duplicates
+    for i in 0 ..< 5_000:
+      assert a.getOrIncl("s" & $i).idToIdx == i
+    assert a.vals.len == 5_000
+    assert a.getOrIncl("fresh").idToIdx == 5_000
+    assert a.vals.len == 5_001
+
+  block orderedThenIncl:
+    # the same, but with `getOrIncl` as the FIRST call after the ordered fill —
+    # the other of the two paths that has to build the index
+    var b = initBiTable[uint32, string]()
+    for i in 0 ..< 100: discard b.addOrdered("t" & $i)
+    assert b.getOrIncl("t42").idToIdx == 42
+    assert b.vals.len == 100
+    assert getKeyId(b, "t99") == 100
 
   echo "success"

--- a/src/lib/bitabs.nim
+++ b/src/lib/bitabs.nim
@@ -73,6 +73,22 @@ proc rebuildIndex[Id, T](t: var BiTable[Id, T]) =
       j = nextTry(j, maxHash(t))
     t.keys[j] = Id(i + idStart)
 
+proc isIndexed*[Id, T](t: BiTable[Id, T]): bool {.inline.} =
+  ## Whether the reverse (value -> id) index exists. It does not, and only does
+  ## not, between an `addOrdered` fill and the first thing that needs it.
+  t.keys.len != 0 or t.vals.len == 0
+
+proc ensureIndexed*[Id, T](t: var BiTable[Id, T]) =
+  ## Build the reverse index if `addOrdered` left it unbuilt. Idempotent, and
+  ## free for a table that was interned into normally.
+  ##
+  ## `getOrIncl` calls this itself. `getKeyId` cannot — it takes the table
+  ## immutably and changing that would break every caller in the ecosystem for
+  ## the sake of the rare one — so a caller that looks up BY VALUE in a table
+  ## that might have been filled with `addOrdered` calls this first. Getting it
+  ## wrong is an assertion in `getKeyId`, not a wrong answer.
+  if not t.isIndexed: rebuildIndex(t)
+
 proc addOrdered*[Id, T](t: var BiTable[Id, T]; v: sink T): Id =
   ## Append `v` under the next id WITHOUT hashing it.
   ##
@@ -82,15 +98,17 @@ proc addOrdered*[Id, T](t: var BiTable[Id, T]; v: sink T): Id =
   ## and on a 68-module `--ic:on` build of the Nim compiler that was 451ms of a
   ## 637ms `load`, nearly all of it the symbol pool.
   ##
-  ## The table is still a BiTable: the first `getOrIncl`/`getKeyId` builds the
-  ## index, so a pool that does get interned into behaves exactly as before —
-  ## it just pays for the index at the point something needs it rather than
-  ## always. Callers that only ever map id -> value never pay at all.
+  ## The table is still a BiTable: `getOrIncl` builds the index on demand (and
+  ## `ensureIndexed` does it explicitly for `getKeyId`), so a pool that does get
+  ## interned into behaves exactly as before — it just pays for the index at the
+  ## point something needs it rather than always. Callers that only ever map
+  ## id -> value never pay at all.
   t.vals.add v
   result = Id(t.vals.len - 1 + idStart)
 
-proc getKeyId*[Id, T](t: var BiTable[Id, T]; v: T): Id =
-  if t.keys.len == 0 and t.vals.len > 0: rebuildIndex(t)
+proc getKeyId*[Id, T](t: BiTable[Id, T]; v: T): Id =
+  assert t.isIndexed,
+    "getKeyId on a table filled by addOrdered: call ensureIndexed first"
   let origH = hash(v)
   var h = origH and maxHash(t)
   if t.keys.len != 0:
@@ -104,7 +122,7 @@ proc getKeyId*[Id, T](t: var BiTable[Id, T]; v: T): Id =
 {.pragma: maybeDirty, dirty.}
 
 template getOrInclImpl() {.maybeDirty.} =
-  if t.keys.len == 0 and t.vals.len > 0: rebuildIndex(t)
+  ensureIndexed(t)
   let origH = hash(v)
   var h = origH and maxHash(t)
   if t.keys.len != 0:
@@ -231,7 +249,11 @@ when isMainModule:
     assert a[uint32 1] == "s0"                       # id -> value, no index yet
     assert a[uint32 5_000] == "s4999"
 
-    # first lookup builds the index; every entry must be findable
+    # `getKeyId` needs the index, and says so rather than answering wrongly
+    assert not a.isIndexed
+    a.ensureIndexed()
+    assert a.isIndexed
+    a.ensureIndexed()                                # idempotent
     assert getKeyId(a, "s0") == 1
     assert getKeyId(a, "s4999") == 5_000
     assert getKeyId(a, "nope") == 0
@@ -246,12 +268,23 @@ when isMainModule:
     assert a.vals.len == 5_001
 
   block orderedThenIncl:
-    # the same, but with `getOrIncl` as the FIRST call after the ordered fill —
-    # the other of the two paths that has to build the index
+    # `getOrIncl` builds the index itself, so it needs no `ensureIndexed`
     var b = initBiTable[uint32, string]()
     for i in 0 ..< 100: discard b.addOrdered("t" & $i)
+    assert not b.isIndexed
     assert b.getOrIncl("t42").idToIdx == 42
+    assert b.isIndexed
     assert b.vals.len == 100
     assert getKeyId(b, "t99") == 100
+
+  block indexedFromTheStart:
+    # a normally interned table is `isIndexed` throughout, so `ensureIndexed`
+    # costs it nothing and `getKeyId` never trips its assertion
+    var d = initBiTable[uint32, string]()
+    assert d.isIndexed                               # empty counts as indexed
+    discard d.getOrIncl("only")
+    assert d.isIndexed
+    d.ensureIndexed()
+    assert getKeyId(d, "only") == 1
 
   echo "success"


### PR DESCRIPTION
`load`/`loadFromFile` read the four pools back with `getOrIncl`, hashing every tag, string, symbol and filename into the reverse index. But both read them in STORED ID ORDER — that is the invariant the format rests on, so that ids 1,2,… line up with the token refs — which means each entry's id is already its position and the hash is being paid to reproduce something the file states.

`BiTable.addOrdered` appends under the next id and skips it. The table is still a BiTable: `getOrIncl`/`getKeyId` notice an unbuilt index and construct it, so a pool that does get interned into behaves exactly as before and merely pays for the index when something needs it. A pool that only maps id -> value — which is every `bif`-loaded module pool — never pays at all.

Measured on the Nim compiler's `--ic:on` backend, which loads a `.bif` per module per stage process (68-module target, 177 processes):

    bif.load        637ms -> 369ms
    of which syms   451ms -> 187ms   (the rest is materializing the strings)
    of which strings 26ms ->   1ms
    whole cold build 8.51s -> 8.07s

`getKeyId` takes `var BiTable` now, since a lookup may build the index. The one non-test caller in this repo (`plugins.pragmaKind`, on `pluginTags.tags`) reaches it through a `ref`, so it is unaffected.

The self-test grew a case for the ordered fill, and it earned its place immediately: the first `rebuildIndex` sized its capacity with `mustRehash` alone, which asserts `length > counter` and so tripped for any pool bigger than 16 entries. Nothing in a whole compiler build had caught that — the rebuild path never runs there, because those pools are only ever read. The test covers both entries into it (`getKeyId` first, and `getOrIncl` first), that ids after a rebuild still match what interning would have given, and that `getOrIncl` reuses them rather than appending duplicates — which for a `bif` pool would be silent corruption, the token stream already pointing at the first copy.