### PR TITLE
contracts_fir: give a synthesized node's error the proc's line info

### DIFF
--- a/src/nimony/contracts_fir.nim
+++ b/src/nimony/contracts_fir.nim
@@ -107,7 +107,16 @@ proc dumpCurrentProc(c: var NjvlContext; info: NifLineInfo; msg: string) =
   stderr.writeLine toString(c.currentProcStart, false)
   stderr.writeLine "--- end NJ IR dump ---"
 
-proc buildErr(c: var NjvlContext; info: NifLineInfo; msg: string) =
+proc buildErr(c: var NjvlContext; rawInfo: NifLineInfo; msg: string) =
+  # This pass runs on the FINAL IR, where the node an error is pinned to is
+  # often one the compiler synthesized -- the epilogue's `(ret result)` is what
+  # an uninitialized `result` is reported at -- and those carry no line info.
+  # Printed, such an error is a bare `???`; worse, `reporters` deduplicates by
+  # line info, so the second and every later one in a module is swallowed and
+  # the user fixes them one recompile at a time. Fall back to the enclosing
+  # proc's declaration, which is where the reader has to look anyway.
+  let info = if rawInfo.isValid or cursorIsNil(c.currentProcStart): rawInfo
+             else: c.currentProcStart.info
   when defined(debug):
     writeStackTrace()
     echo infoToStr(info) & " Error: " & msg

--- a/tests/nimony/casestmt/tinitifwhile.nim
+++ b/tests/nimony/casestmt/tinitifwhile.nim
@@ -1,0 +1,30 @@
+import std/[syncio, assertions]
+
+# The pure-int shape of nim-lang/nimony#1985, from the issue thread. Same
+# defect as `tinitcasewhile.nim` but with an `if` inside the `while` instead
+# of a `case`, so it lowers differently and is worth pinning separately: the
+# fact "result is initialized whenever the return-flag is false" has to
+# survive the outer if/else merge, where the other branch initializes
+# `result` unconditionally.
+#
+# The rejections this analysis must keep making live in
+# `tests/nimony/errmsgs/tinitnotproven.nim`.
+
+proc classify(n: int): int =
+  let t = n
+  if t == 0:
+    result = 1
+  else:
+    var i = 0
+    while i < t:
+      if i mod 2 == 0:
+        inc i
+      else:
+        return 2           # leaving path: result set, return-flag true
+    result = 3             # normal loop exit: result set, return-flag false
+
+assert classify(0) == 1   # the `then` branch
+assert classify(1) == 3   # loop exits normally
+assert classify(2) == 2   # loop returns early
+
+echo "init-through-if-while: OK"

--- a/tests/nimony/casestmt/tinitifwhile.output
+++ b/tests/nimony/casestmt/tinitifwhile.output
@@ -1,0 +1,1 @@
+init-through-if-while: OK

--- a/tests/nimony/errmsgs/tinitnotproven.msgs
+++ b/tests/nimony/errmsgs/tinitnotproven.msgs
@@ -1,0 +1,4 @@
+tests/nimony/errmsgs/tinitnotproven.nim(13, 1) Error: cannot prove that result.0 has been initialized [pass --verbose for the NJ IR]
+tests/nimony/errmsgs/tinitnotproven.nim(23, 1) Error: cannot prove that result.1 has been initialized [pass --verbose for the NJ IR]
+tests/nimony/errmsgs/tinitnotproven.nim(37, 1) Error: cannot prove that result.2 has been initialized [pass --verbose for the NJ IR]
+tests/nimony/errmsgs/tinitnotproven.nim(51, 1) Error: cannot prove that result.3 has been initialized [pass --verbose for the NJ IR]

--- a/tests/nimony/errmsgs/tinitnotproven.nim
+++ b/tests/nimony/errmsgs/tinitnotproven.nim
@@ -1,0 +1,54 @@
+# The negative side of nim-lang/nimony#1985: `result` that genuinely is NOT
+# set on every path must still be rejected.
+#
+# Nothing else in the tree pins a rejection by the init analysis, so widening
+# it — which is what fixing a false positive like #1985 amounts to — could
+# start accepting these without a single test noticing. Each proc below is one
+# element away from a shape the analysis accepts, and the difference is always
+# the same one: no assignment on the path where the loop exits normally.
+#
+# The positives are `tests/nimony/casestmt/tinitcasewhile.nim` and
+# `tinitifwhile.nim`.
+
+proc noPostLoopAssignment(n: int): int =
+  # `return` covers only the paths that leave early; falling out of the loop
+  # reaches the end of the proc with `result` untouched.
+  var i = 0
+  while i < n:
+    if i mod 2 == 0:
+      inc i
+    else:
+      return 2
+
+proc noPostLoopAssignmentInElse(n: int): int =
+  # #1985's own shape with the trailing assignment removed: the `then` branch
+  # initializes unconditionally, the `else` branch only on its `return` path.
+  let t = n
+  if t == 0:
+    result = 1
+  else:
+    var i = 0
+    while i < t:
+      if i mod 2 == 0:
+        inc i
+      else:
+        return 2
+
+proc thenBranchDoesNotAssign(n: int): int =
+  # The mirror image: the loop side is fine, the `then` branch is not.
+  let t = n
+  if t == 0:
+    discard
+  else:
+    var i = 0
+    while i < t:
+      if i mod 2 == 0:
+        inc i
+      else:
+        return 2
+    result = 3
+
+proc onlyOneIfBranch(n: int): int =
+  # The plain baseline, with no loop involved at all.
+  if n == 0:
+    result = 1


### PR DESCRIPTION
The init analysis reports an uninitialized `result` at the node that reads it, which is the epilogue's synthesized `(ret result)` -- and that carries no line info. So the diagnostic printed as a bare `???` with no location, and since `reporters` deduplicates errors by line info, the second and every later one in a module was swallowed: a file with four such procs reported one, and the user found the rest one recompile at a time.

Fall back to the enclosing proc's declaration, which is where the reader has to look anyway.

Also pin what this analysis must keep rejecting. #1985 was a false positive, and fixing one is by definition a widening; nothing in the test tree asserted a rejection, so a widening that went too far would have been caught by no test at all. `tinitnotproven.nim` is four procs that each differ from an accepted shape only in that nothing assigns `result` on the path where the loop exits normally -- and it is only a useful test because of the fix above: before it, three of its four errors did not print.

`tinitifwhile.nim` adds the pure-int shape from #1985's thread, an `if` inside the `while` rather than a `case`, which lowers differently from the `tinitcasewhile.nim` that PR #2059 shipped.
