### PR TITLE
semcall: replace the failed call tree with its error, don't append it

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -1182,7 +1182,12 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
         # the call this is an argument of in the case of AllowEmpty
         typeofCallIs c, dest, it, cs.beforeCall, c.types.autoType
       else:
-        buildErr c, dest, cs.callNodeInfo, getErrorMsg(m[idx])
+        # `leaveCall` has already closed the call tree at `cs.beforeCall`, so
+        # the error has to REPLACE it: appended, it would be a second child of
+        # whatever encloses the call, and a node with a fixed arity — `(ret X)`
+        # above all — then has one child too many. The next reader trips over
+        # the leftover (`defer` lowering asserted on it, nim-lang/nimony#2400).
+        buildErrAt c, dest, cs.beforeCall, getErrorMsg(m[idx])
     elif finalFn.kind == TemplateY:
       if c.templateInstCounter <= MaxNestedTemplates:
         c.expanded.addSymUse finalFn.sym, cs.callNodeInfo
@@ -1191,7 +1196,8 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
           semTemplateCall c, dest, it, finalFn.sym, cs.beforeCall, m[idx], cs.flags
         dec c.templateInstCounter
       else:
-        buildErr c, dest, cs.callNodeInfo, "recursion limit exceeded for template expansions"
+        # same as above: replace the closed call tree, never append to it
+        buildErrAt c, dest, cs.beforeCall, "recursion limit exceeded for template expansions"
     elif finalFn.kind == MacroY:
       # Run compiled macro plugin
       runCompiledMacroPlugin(c, dest, it, cs, finalFn.sym)

--- a/tests/nimony/errmsgs/tundeclaredrettype_defer.msgs
+++ b/tests/nimony/errmsgs/tundeclaredrettype_defer.msgs
@@ -1,0 +1,2 @@
+tests/nimony/errmsgs/tundeclaredrettype_defer.nim(25, 5) Error: undeclared identifier: NotAType
+tests/nimony/errmsgs/tundeclaredrettype_defer.nim(27, 18) Error: could not infer type for T.0.tunmf12sg1

--- a/tests/nimony/errmsgs/tundeclaredrettype_defer.nim
+++ b/tests/nimony/errmsgs/tundeclaredrettype_defer.nim
@@ -1,0 +1,27 @@
+# An undeclared return type, a `defer`, and a `return` whose type has to be
+# INFERRED used to crash the compiler instead of diagnosing the source:
+#
+#   nifcore.nim(895) `c.rem == 0` into: body did not consume all N children
+#     deferstmts.nim(97) trReturn
+#
+# `semcall` matched the callee and `leaveCall` closed the call tree, and the
+# "could not infer type" diagnostic was then APPENDED beside it — leaving a
+# `(ret X (err …))` with two children where the grammar allows one. `defer`
+# lowering was simply the first pass to walk that tree and notice
+# (nim-lang/nimony#2400).
+#
+# All three properties have to meet: without the `defer` nothing walks the
+# tree, without the `return` there is no fixed-arity node to overfill, and a
+# concretely typed `return 1` reports a plain type mismatch instead of going
+# through the failed inference. Those neighbours are in
+# `tundeclaredrettype_variants.nim`, and each of them already behaved.
+#
+# Reported as `return @[]`, which fails inference the same way through
+# `system.@`; spelled with a local generic here so the golden does not name a
+# typevar of `system`, whose numbering shifts whenever `system.nim` does.
+
+proc emptySeq[T](): seq[T] = @[]
+
+proc brokenProc(): NotAType =
+  defer: discard
+  return emptySeq()

--- a/tests/nimony/errmsgs/tundeclaredrettype_variants.msgs
+++ b/tests/nimony/errmsgs/tundeclaredrettype_variants.msgs
@@ -1,0 +1,6 @@
+tests/nimony/errmsgs/tundeclaredrettype_variants.nim(8, 5) Error: undeclared identifier: NotAType
+tests/nimony/errmsgs/tundeclaredrettype_variants.nim(9, 18) Error: could not infer type for T.0.tunyag5ck
+tests/nimony/errmsgs/tundeclaredrettype_variants.nim(11, 5) Error: undeclared identifier: NotAType
+tests/nimony/errmsgs/tundeclaredrettype_variants.nim(14, 5) Error: undeclared identifier: NotAType
+tests/nimony/errmsgs/tundeclaredrettype_variants.nim(18, 5) Error: undeclared identifier: NotAType
+tests/nimony/errmsgs/tundeclaredrettype_variants.nim(20, 10) Error: type mismatch: got: int64 but wanted: NotAType

--- a/tests/nimony/errmsgs/tundeclaredrettype_variants.nim
+++ b/tests/nimony/errmsgs/tundeclaredrettype_variants.nim
@@ -1,0 +1,20 @@
+# The neighbours of `tundeclaredrettype_defer.nim`: each keeps the undeclared
+# return type and varies one of the other two properties. All of them reported
+# an ordinary diagnostic before nim-lang/nimony#2400 was fixed and must keep
+# doing so, unchanged.
+
+proc emptySeq[T](): seq[T] = @[]
+
+proc noDefer(): NotAType =
+  return emptySeq()
+
+proc noReturn(): NotAType =
+  defer: discard
+
+proc bareReturn(): NotAType =
+  defer: discard
+  return
+
+proc typedReturn(): NotAType =
+  defer: discard
+  return 1


### PR DESCRIPTION
When a candidate matched but adding its arguments or type arguments errored, `leaveCall` had already closed the call tree in `dest` and the diagnostic was then appended beside it. That leaves two trees where the enclosing node expects one, so any node of fixed arity ends up with a child too many: `return emptySeq()` in a proc whose return type is an undeclared identifier produced `(ret X (err …))`.

Nothing noticed until a pass walked the tree. `defer` lowering does, and asserted deep in the NIF layer -- `nifcore.nim(895) c.rem == 0, into: body did not consume all N children` -- naming neither the mistake in the source nor a place near it. Without the `defer` the same malformed tree was built and simply never read.

Replace the closed call tree with `(err <that tree> "msg")` via `buildErrAt`, the way `semtypes` already does for a bad `set` element type. The template recursion limit right below it appended in the same way and gets the same treatment.

The reported spelling is `return @[]`; it fails inference through `system.@`, so a local generic stands in for it in the test to keep the golden from naming a typevar of `system`.

Fixes #2400
