### PR TITLE
float <-> string without libc, on every target

### DIFF
--- a/lib/std/parseutils.nim
+++ b/lib/std/parseutils.nim
@@ -220,262 +220,262 @@ func parseBiggestUInt*(s: openArray[char], number: var BiggestUInt): int {.
 
 # Following parseBiggestFloat code is copied from `lib/system/strmantle.nim` in Nim 2.
 
-when defined(nimNoLibc):
-  # ── freestanding, CORRECTLY ROUNDED decimal → float64 ────────────────────
-  #
-  # Only `parseBiggestFloat`'s slow path reaches this, and it always hands us a
-  # normalized, NUL-terminated `[-]<digits>E<sign><exp>` buffer. The obvious
-  # implementation — accumulate the mantissa in a uint64 and scale by 10^exp in
-  # floating point — is off by up to a few ulp because each scaling step rounds:
-  # `1e300` came back as `1.0000000000000002e+300` and `2.225073858507201e-308`
-  # as `2.2250738585072004e-308`, which is visible as float literals that differ
-  # between the native and the C (`strtod`) backend.
-  #
-  # This is instead Go's `strconv` big-decimal algorithm (`decimal.go`/`atof.go`):
-  # hold the value as an EXACT decimal digit string plus a decimal-point position
-  # and shift it by powers of two — exactly, in decimal — until the binary
-  # mantissa is normalized, then round exactly once. Every intermediate step is
-  # exact, so that single rounding is the correctly-rounded result. It is much
-  # slower than a float multiply, which does not matter: the fast paths above
-  # already take every literal that fits 15-16 digits with |exponent| <= 22.
-  const
-    MaxDecDigits = 800   ## enough for any float64 shift chain (Go's bound too)
-    MaxShift = 60        ## keeps `leftShift`'s per-digit accumulator in uint64
-    Pow2Digits = [       ## decimal digits of 2^k — an upper bound on the digits
-                         ## a `leftShift(k)` adds (it adds this or one less; the
-                         ## code detects which instead of carrying Go's cutoff
-                         ## table of 61 decimal strings)
-      1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4,
-      4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7,
-      8, 8, 8, 9, 9, 9, 10, 10, 10, 10, 11, 11,
-      11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15,
-      15, 15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18,
-      19]
-    Log2Pow10 = [1, 3, 6, 9, 13, 16, 19, 23, 26]
-      ## How far the value may be shifted in one step without overshooting the
-      ## [0.5, 1) target, indexed by the decimal-point position (`floor(log2(10^i))`,
-      ## except entry 0, which must be >= 1 so the normalization loop terminates).
-    Log2Pow10Len = 9
+# ── libc-free, CORRECTLY ROUNDED decimal → float64 ───────────────────────
+#
+# This replaces `strtod` on EVERY target, not just the freestanding ones. The
+# wasm and `nimony n` backends have no libc to call, and running one decimal
+# reader everywhere is also what keeps a float literal from depending on which
+# backend compiled it — the divergence that motivated this code in the first
+# place.
+#
+# Only `parseBiggestFloat`'s slow path reaches it, and it always hands us a
+# normalized, NUL-terminated `[-]<digits>E<sign><exp>` buffer. The obvious
+# implementation — accumulate the mantissa in a uint64 and scale by 10^exp in
+# floating point — is off by up to a few ulp because each scaling step rounds:
+# `1e300` came back as `1.0000000000000002e+300` and `2.225073858507201e-308`
+# as `2.2250738585072004e-308`.
+#
+# This is instead Go's `strconv` big-decimal algorithm (`decimal.go`/`atof.go`):
+# hold the value as an EXACT decimal digit string plus a decimal-point position
+# and shift it by powers of two — exactly, in decimal — until the binary
+# mantissa is normalized, then round exactly once. Every intermediate step is
+# exact, so that single rounding is the correctly-rounded result. It is much
+# slower than a float multiply, which does not matter: the fast paths above
+# already take every literal that fits 15-16 digits with |exponent| <= 22.
+const
+  MaxDecDigits = 800   ## enough for any float64 shift chain (Go's bound too)
+  MaxShift = 60        ## keeps `leftShift`'s per-digit accumulator in uint64
+  Pow2Digits = [       ## decimal digits of 2^k — an upper bound on the digits
+                       ## a `leftShift(k)` adds (it adds this or one less; the
+                       ## code detects which instead of carrying Go's cutoff
+                       ## table of 61 decimal strings)
+    1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4,
+    4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7,
+    8, 8, 8, 9, 9, 9, 10, 10, 10, 10, 11, 11,
+    11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15,
+    15, 15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18,
+    19]
+  Log2Pow10 = [1, 3, 6, 9, 13, 16, 19, 23, 26]
+    ## How far the value may be shifted in one step without overshooting the
+    ## [0.5, 1) target, indexed by the decimal-point position (`floor(log2(10^i))`,
+    ## except entry 0, which must be >= 1 so the normalization loop terminates).
+  Log2Pow10Len = 9
 
-  type
-    BigDec = object
-      ## value = 0.d[0..nd-1] * 10^dp  (sign in `neg`)
-      d: array[MaxDecDigits, char]
-      nd: int
-      dp: int
-      neg: bool
-      trunc: bool     ## a nonzero digit fell off the end — the stored value is
-                      ## slightly LOW, which `shouldRoundUp` needs to know
+type
+  BigDec = object
+    ## value = 0.d[0..nd-1] * 10^dp  (sign in `neg`)
+    d: array[MaxDecDigits, char]
+    nd: int
+    dp: int
+    neg: bool
+    trunc: bool     ## a nonzero digit fell off the end — the stored value is
+                    ## slightly LOW, which `shouldRoundUp` needs to know
 
-  func trimBig(a: var BigDec) =
-    while a.nd > 0 and a.d[a.nd-1] == '0': dec a.nd
-    if a.nd == 0: a.dp = 0
+func trimBig(a: var BigDec) =
+  while a.nd > 0 and a.d[a.nd-1] == '0': dec a.nd
+  if a.nd == 0: a.dp = 0
 
-  func rightShiftBig(a: var BigDec; k: int) =
-    ## a = a / 2^k, exactly (digits are produced until they run out).
-    var r = 0            # read cursor
-    var w = 0            # write cursor
-    var n = 0'u64
-    # Pick up enough leading digits to cover the first shift.
-    while (n shr k) == 0'u64:
-      if r >= a.nd:
-        if n == 0'u64:
-          a.nd = 0
-          return
-        while (n shr k) == 0'u64:
-          n = n * 10'u64
-          inc r
-        break
-      n = n * 10'u64 + uint64(ord(a.d[r]) - ord('0'))
-      inc r
-    a.dp = a.dp - (r - 1)
-    let mask = (1'u64 shl k) - 1'u64
-    # Pick up a digit, put down a digit.
-    while r < a.nd:
-      let c = uint64(ord(a.d[r]) - ord('0'))
-      let dig = n shr k
-      n = n and mask
+func rightShiftBig(a: var BigDec; k: int) =
+  ## a = a / 2^k, exactly (digits are produced until they run out).
+  var r = 0            # read cursor
+  var w = 0            # write cursor
+  var n = 0'u64
+  # Pick up enough leading digits to cover the first shift.
+  while (n shr k) == 0'u64:
+    if r >= a.nd:
+      if n == 0'u64:
+        a.nd = 0
+        return
+      while (n shr k) == 0'u64:
+        n = n * 10'u64
+        inc r
+      break
+    n = n * 10'u64 + uint64(ord(a.d[r]) - ord('0'))
+    inc r
+  a.dp = a.dp - (r - 1)
+  let mask = (1'u64 shl k) - 1'u64
+  # Pick up a digit, put down a digit.
+  while r < a.nd:
+    let c = uint64(ord(a.d[r]) - ord('0'))
+    let dig = n shr k
+    n = n and mask
+    a.d[w] = chr(int(dig) + ord('0'))
+    inc w
+    n = n * 10'u64 + c
+    inc r
+  # Put down the extra digits the division produced.
+  while n > 0'u64:
+    let dig = n shr k
+    n = n and mask
+    if w < MaxDecDigits:
       a.d[w] = chr(int(dig) + ord('0'))
       inc w
-      n = n * 10'u64 + c
-      inc r
-    # Put down the extra digits the division produced.
-    while n > 0'u64:
-      let dig = n shr k
-      n = n and mask
-      if w < MaxDecDigits:
-        a.d[w] = chr(int(dig) + ord('0'))
-        inc w
-      elif dig > 0'u64:
-        a.trunc = true
-      n = n * 10'u64
-    a.nd = w
-    trimBig(a)
+    elif dig > 0'u64:
+      a.trunc = true
+    n = n * 10'u64
+  a.nd = w
+  trimBig(a)
 
-  func leftShiftBig(a: var BigDec; k: int) =
-    ## a = a * 2^k, exactly. Digits are produced right to left into the region
-    ## `[0, nd+delta)`; `delta` over-estimates by at most one, and the surplus
-    ## shows up as unwritten leading slots, which the compaction below removes.
-    let delta = Pow2Digits[k]
-    var r = a.nd - 1
-    var w = a.nd + delta        # exclusive: the next digit goes to w-1
-    var n = 0'u64
-    while r >= 0:
-      n = n + (uint64(ord(a.d[r]) - ord('0')) shl k)
-      let quo = n div 10'u64
-      let rem = n - 10'u64 * quo
-      dec w
-      if w < MaxDecDigits: a.d[w] = chr(int(rem) + ord('0'))
-      elif rem != 0'u64: a.trunc = true
-      n = quo
-      dec r
-    while n > 0'u64:
-      let quo = n div 10'u64
-      let rem = n - 10'u64 * quo
-      dec w
-      if w < MaxDecDigits: a.d[w] = chr(int(rem) + ord('0'))
-      elif rem != 0'u64: a.trunc = true
-      n = quo
-    # `w` is the index of the most significant digit actually written: 0 when the
-    # estimate was exact, 1 when it was one too generous.
-    let stored = min(a.nd + delta, MaxDecDigits)
-    if w > 0:
-      var j = 0
-      while w + j < stored:
-        a.d[j] = a.d[w + j]
-        inc j
-      a.nd = j
-    else:
-      a.nd = stored
-    a.dp = a.dp + delta - w
-    trimBig(a)
+func leftShiftBig(a: var BigDec; k: int) =
+  ## a = a * 2^k, exactly. Digits are produced right to left into the region
+  ## `[0, nd+delta)`; `delta` over-estimates by at most one, and the surplus
+  ## shows up as unwritten leading slots, which the compaction below removes.
+  let delta = Pow2Digits[k]
+  var r = a.nd - 1
+  var w = a.nd + delta        # exclusive: the next digit goes to w-1
+  var n = 0'u64
+  while r >= 0:
+    n = n + (uint64(ord(a.d[r]) - ord('0')) shl k)
+    let quo = n div 10'u64
+    let rem = n - 10'u64 * quo
+    dec w
+    if w < MaxDecDigits: a.d[w] = chr(int(rem) + ord('0'))
+    elif rem != 0'u64: a.trunc = true
+    n = quo
+    dec r
+  while n > 0'u64:
+    let quo = n div 10'u64
+    let rem = n - 10'u64 * quo
+    dec w
+    if w < MaxDecDigits: a.d[w] = chr(int(rem) + ord('0'))
+    elif rem != 0'u64: a.trunc = true
+    n = quo
+  # `w` is the index of the most significant digit actually written: 0 when the
+  # estimate was exact, 1 when it was one too generous.
+  let stored = min(a.nd + delta, MaxDecDigits)
+  if w > 0:
+    var j = 0
+    while w + j < stored:
+      a.d[j] = a.d[w + j]
+      inc j
+    a.nd = j
+  else:
+    a.nd = stored
+  a.dp = a.dp + delta - w
+  trimBig(a)
 
-  func shiftBig(a: var BigDec; k: int) =
-    ## a = a * 2^k for k > 0, a / 2^-k for k < 0. Chunked so no single step
-    ## exceeds `MaxShift`.
-    if a.nd == 0: return
-    var k = k
-    while k > MaxShift:
-      leftShiftBig(a, MaxShift); k = k - MaxShift
-    if k > 0: leftShiftBig(a, k)
-    while k < -MaxShift:
-      rightShiftBig(a, MaxShift); k = k + MaxShift
-    if k < 0: rightShiftBig(a, -k)
+func shiftBig(a: var BigDec; k: int) =
+  ## a = a * 2^k for k > 0, a / 2^-k for k < 0. Chunked so no single step
+  ## exceeds `MaxShift`.
+  if a.nd == 0: return
+  var k = k
+  while k > MaxShift:
+    leftShiftBig(a, MaxShift); k = k - MaxShift
+  if k > 0: leftShiftBig(a, k)
+  while k < -MaxShift:
+    rightShiftBig(a, MaxShift); k = k + MaxShift
+  if k < 0: rightShiftBig(a, -k)
 
-  func shouldRoundUpBig(a: BigDec; nd: int): bool =
-    if nd < 0 or nd >= a.nd:
-      result = false
-    elif a.d[nd] == '5' and nd+1 == a.nd:
-      # Exactly halfway — unless digits were dropped, in which case the true
-      # value is above halfway and rounds up regardless.
-      if a.trunc: result = true
-      else: result = nd > 0 and ((ord(a.d[nd-1]) - ord('0')) mod 2) != 0
-    else:
-      result = a.d[nd] >= '5'
+func shouldRoundUpBig(a: BigDec; nd: int): bool =
+  if nd < 0 or nd >= a.nd:
+    result = false
+  elif a.d[nd] == '5' and nd+1 == a.nd:
+    # Exactly halfway — unless digits were dropped, in which case the true
+    # value is above halfway and rounds up regardless.
+    if a.trunc: result = true
+    else: result = nd > 0 and ((ord(a.d[nd-1]) - ord('0')) mod 2) != 0
+  else:
+    result = a.d[nd] >= '5'
 
-  func roundedIntegerBig(a: BigDec): uint64 =
-    if a.dp > 20:
-      result = 0xFFFFFFFFFFFFFFFF'u64
-    else:
-      var i = 0
-      var n = 0'u64
-      while i < a.dp and i < a.nd:
-        n = n * 10'u64 + uint64(ord(a.d[i]) - ord('0'))
-        inc i
-      while i < a.dp:
-        n = n * 10'u64
-        inc i
-      if shouldRoundUpBig(a, a.dp): n = n + 1'u64
-      result = n
-
-  func floatBitsBig(a: var BigDec): uint64 =
-    ## IEEE-754 binary64 bit pattern of `a`, correctly rounded (ties to even).
-    const
-      MantBits = 52
-      ExpBits = 11
-      Bias = -1023
-    var exp = 0
-    var mant = 0'u64
-    var overflow = false
-    if a.nd == 0:
-      exp = Bias
-    elif a.dp > 310:
-      overflow = true
-    elif a.dp < -330:
-      exp = Bias                      # underflows to zero
-    else:
-      # Scale by powers of two until the value is in [0.5, 1).
-      while a.dp > 0:
-        let n = if a.dp >= Log2Pow10Len: 27 else: Log2Pow10[a.dp]
-        shiftBig(a, -n)
-        exp = exp + n
-      while a.dp < 0 or (a.dp == 0 and a.nd > 0 and a.d[0] < '5'):
-        let n = if -a.dp >= Log2Pow10Len: 27 else: Log2Pow10[-a.dp]
-        shiftBig(a, n)
-        exp = exp - n
-      # Binary floats are normalized to [1, 2), not [0.5, 1).
-      dec exp
-      # Below the smallest normal exponent the mantissa loses bits instead.
-      if exp < Bias+1:
-        let n = Bias + 1 - exp
-        shiftBig(a, -n)
-        exp = exp + n
-      if exp - Bias >= (1 shl ExpBits) - 1:
-        overflow = true
-      else:
-        shiftBig(a, 1 + MantBits)     # extract 1+MantBits significant bits
-        mant = roundedIntegerBig(a)
-        if mant == (2'u64 shl MantBits):
-          # rounding carried into a new leading bit
-          mant = mant shr 1
-          inc exp
-          if exp - Bias >= (1 shl ExpBits) - 1: overflow = true
-        if not overflow and (mant and (1'u64 shl MantBits)) == 0'u64:
-          exp = Bias                  # subnormal
-    if overflow:
-      mant = 0'u64
-      exp = (1 shl ExpBits) - 1 + Bias
-    result = mant and ((1'u64 shl MantBits) - 1'u64)
-    result = result or (uint64((exp - Bias) and ((1 shl ExpBits) - 1)) shl MantBits)
-    if a.neg: result = result or (1'u64 shl (MantBits + ExpBits))
-
-  func c_strtod(buf: cstring, endptr: ptr cstring): float64 {.noSideEffect.} =
-    ## Freestanding (`nimony n`, libc-free) decimal→float64, correctly rounded.
-    ## The input is `parseBiggestFloat`'s normalized `[-]<digits>E<sign><exp>`
-    ## buffer; `endptr` is ignored (the only caller passes nil).
-    var a = BigDec(nd: 0, dp: 0, neg: false, trunc: false)
+func roundedIntegerBig(a: BigDec): uint64 =
+  if a.dp > 20:
+    result = 0xFFFFFFFFFFFFFFFF'u64
+  else:
     var i = 0
-    if buf[i] == '-':
-      a.neg = true; inc i
-    elif buf[i] == '+':
+    var n = 0'u64
+    while i < a.dp and i < a.nd:
+      n = n * 10'u64 + uint64(ord(a.d[i]) - ord('0'))
       inc i
-    while buf[i] == '0': inc i           # leading zeros carry no information
-    var nd = 0
+    while i < a.dp:
+      n = n * 10'u64
+      inc i
+    if shouldRoundUpBig(a, a.dp): n = n + 1'u64
+    result = n
+
+func floatBitsBig(a: var BigDec): uint64 =
+  ## IEEE-754 binary64 bit pattern of `a`, correctly rounded (ties to even).
+  const
+    MantBits = 52
+    ExpBits = 11
+    Bias = -1023
+  var exp = 0
+  var mant = 0'u64
+  var overflow = false
+  if a.nd == 0:
+    exp = Bias
+  elif a.dp > 310:
+    overflow = true
+  elif a.dp < -330:
+    exp = Bias                      # underflows to zero
+  else:
+    # Scale by powers of two until the value is in [0.5, 1).
+    while a.dp > 0:
+      let n = if a.dp >= Log2Pow10Len: 27 else: Log2Pow10[a.dp]
+      shiftBig(a, -n)
+      exp = exp + n
+    while a.dp < 0 or (a.dp == 0 and a.nd > 0 and a.d[0] < '5'):
+      let n = if -a.dp >= Log2Pow10Len: 27 else: Log2Pow10[-a.dp]
+      shiftBig(a, n)
+      exp = exp - n
+    # Binary floats are normalized to [1, 2), not [0.5, 1).
+    dec exp
+    # Below the smallest normal exponent the mantissa loses bits instead.
+    if exp < Bias+1:
+      let n = Bias + 1 - exp
+      shiftBig(a, -n)
+      exp = exp + n
+    if exp - Bias >= (1 shl ExpBits) - 1:
+      overflow = true
+    else:
+      shiftBig(a, 1 + MantBits)     # extract 1+MantBits significant bits
+      mant = roundedIntegerBig(a)
+      if mant == (2'u64 shl MantBits):
+        # rounding carried into a new leading bit
+        mant = mant shr 1
+        inc exp
+        if exp - Bias >= (1 shl ExpBits) - 1: overflow = true
+      if not overflow and (mant and (1'u64 shl MantBits)) == 0'u64:
+        exp = Bias                  # subnormal
+  if overflow:
+    mant = 0'u64
+    exp = (1 shl ExpBits) - 1 + Bias
+  result = mant and ((1'u64 shl MantBits) - 1'u64)
+  result = result or (uint64((exp - Bias) and ((1 shl ExpBits) - 1)) shl MantBits)
+  if a.neg: result = result or (1'u64 shl (MantBits + ExpBits))
+
+func decimalToFloat(buf: cstring): float64 {.noSideEffect.} =
+  ## Correctly rounded decimal→float64. The input is `parseBiggestFloat`'s
+  ## normalized, NUL-terminated `[-]<digits>E<sign><exp>` buffer.
+  var a = BigDec(nd: 0, dp: 0, neg: false, trunc: false)
+  var i = 0
+  if buf[i] == '-':
+    a.neg = true; inc i
+  elif buf[i] == '+':
+    inc i
+  while buf[i] == '0': inc i           # leading zeros carry no information
+  var nd = 0
+  while buf[i] in {'0'..'9'}:
+    if nd < MaxDecDigits:
+      a.d[nd] = buf[i]
+      inc nd
+    elif buf[i] != '0':
+      a.trunc = true
+    inc i
+  a.nd = nd
+  var se = nd                          # digits are integral: value = D * 10^exp
+  if buf[i] == 'E' or buf[i] == 'e':
+    inc i
+    var eneg = false
+    if buf[i] == '-': (eneg = true; inc i)
+    elif buf[i] == '+': inc i
+    var e = 0
     while buf[i] in {'0'..'9'}:
-      if nd < MaxDecDigits:
-        a.d[nd] = buf[i]
-        inc nd
-      elif buf[i] != '0':
-        a.trunc = true
+      if e < 100000: e = e * 10 + (ord(buf[i]) - ord('0'))
       inc i
-    a.nd = nd
-    var se = nd                          # digits are integral: value = D * 10^exp
-    if buf[i] == 'E' or buf[i] == 'e':
-      inc i
-      var eneg = false
-      if buf[i] == '-': (eneg = true; inc i)
-      elif buf[i] == '+': inc i
-      var e = 0
-      while buf[i] in {'0'..'9'}:
-        if e < 100000: e = e * 10 + (ord(buf[i]) - ord('0'))
-        inc i
-      se = se + (if eneg: -e else: e)
-    a.dp = se
-    trimBig(a)
-    result = cast[float64](floatBitsBig(a))
-else:
-  func c_strtod(buf: cstring, endptr: ptr cstring): float64 {.
-    importc: "strtod", header: "<stdlib.h>", noSideEffect.}
+    se = se + (if eneg: -e else: e)
+  a.dp = se
+  trimBig(a)
+  result = cast[float64](floatBitsBig(a))
 
 func parseBiggestFloat*(s: openArray[char]; number: var BiggestFloat): int {.
   noSideEffect.} =
@@ -487,7 +487,7 @@ func parseBiggestFloat*(s: openArray[char]; number: var BiggestFloat): int {.
   # i.e. whose integer part can fit inside a 53bits integer.
   # their real exponent must also be <= 22. If the float doesn't follow
   # these restrictions, transform the float into this form:
-  #  INTEGER * 10 ^ exponent and leave the work to standard `strtod()`.
+  #  INTEGER * 10 ^ exponent and leave the work to `decimalToFloat`.
   # This avoid the problems of decimal character portability.
   # see: https://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
 
@@ -617,7 +617,7 @@ func parseBiggestFloat*(s: openArray[char]; number: var BiggestFloat): int {.
       number = sign * integer.float * powtens[slop] * powtens[absExponent-slop]
       return i
 
-  # if failed: slow path with strtod.
+  # if failed: slow path with the exact decimal reader.
   var t {.noinit.}: array[500, char] # flaviu says: 325 is the longest reasonable literal
   var ti = 0
   let maxlen = t.len - 1 - "e+000".len # reserve enough space for exponent
@@ -648,7 +648,7 @@ func parseBiggestFloat*(s: openArray[char]; number: var BiggestFloat): int {.
   t[ti-3] = ('0'.ord + absExponent mod 10).char
   # array not zeroed out:
   t[ti] = '\0'
-  number = c_strtod(cast[cstring](addr t), nil)
+  number = decimalToFloat(cast[cstring](addr t))
 
 func skipIgnoreCase*(s, token: openArray[char]): int =
   ## Same as `skip` but case is ignored for token matching.

--- a/lib/std/strutils.nim
+++ b/lib/std/strutils.nim
@@ -966,10 +966,6 @@ func unescape*(s: string, prefix = "\"", suffix = "\""): string {.raises.} =
   if not s.endsWith(suffix):
     raise ValueError
 
-when not (defined(wasm32) and defined(standalone)):
-  func c_snprintf(buf: cstring, n: csize_t, frmt: cstring): cint {.
-    header: "<stdio.h>", importc: "snprintf", varargs.}
-
 type
   FloatFormatMode* = enum
     ## The different modes of floating point formatting.
@@ -977,219 +973,249 @@ type
     ffDecimal,   ## use decimal floating point notation
     ffScientific ## use scientific notation (using `e` character)
 
-when defined(wasm32) and defined(standalone):
-  # WebAssembly has no variadic calling convention: an imported function has
-  # ONE type, so a `{.varargs.}` importc cannot be called with different
-  # argument tails, and `c_snprintf(buf, n, fmt, precision, f)` emits a call
-  # whose f64 argument contradicts the import's declared type. The module is
-  # then rejected at compile time — not at the call, but wholesale, which is
-  # how a single `formatFloat` in a diagnostic path takes a whole program down.
-  #
-  # So the wasm arm formats without snprintf, from the digits `$f` already
-  # produces. Working on the DECIMAL STRING rather than scaling by a power of
-  # ten keeps the rounding exact: `f * 10^p` introduces its own error, and at a
-  # tie that error decides the last digit.
-  #
-  # KNOWN DIFFERENCE from the C path, measured not assumed: `$f` yields the
-  # SHORTEST round-tripping decimal, not the exact binary expansion, so a
-  # precision beyond that length pads with zeros where glibc continues the true
-  # expansion (`0.1` at 20 places is `0.10000000000000000000` here,
-  # `0.10000000000000000555` there). Within the shortest form's digits — which
-  # is every display use, and the whole grid in hikaru's
-  # tests/wasm/formatfloat_diff.nim — the two agree byte for byte, ties
-  # included; see `roundDigits` for how the ambiguous ones are settled.
+# Float formatting reproduces C's `%f`, `%e` and `%g` from the EXACT decimal
+# expansion of the double instead of calling `snprintf`. Three reasons:
+#
+# * WebAssembly has no variadic calling convention. An imported function has
+#   ONE type, so a `{.varargs.}` importc cannot be called with different
+#   argument tails, and `c_snprintf(buf, n, fmt, precision, f)` emits a call
+#   whose f64 argument contradicts the import's declared type. The engine
+#   rejects the whole MODULE, not the call, which is how a single
+#   `formatFloat` on a diagnostic path takes a program down before it starts.
+# * The freestanding targets and `nimony n` have no libc to call.
+# * `snprintf` produces the digit separator of the current C locale, which
+#   then has to be patched back to `decimalSep`.
+#
+# A double is `m * 2^e` with `m < 2^53`, so its decimal expansion is finite:
+# for `e >= 0` it is the integer `m * 2^e`, and for `e < 0` it is `m * 5^-e`
+# read with the point moved `-e` places to the left. Both are computed exactly
+# with a small base-10^9 bignum on the stack, and that exactness is what makes
+# the rounding agree with C digit for digit: the digit after the cut and
+# everything behind it are the true expansion, so a tie is RECOGNIZED rather
+# than guessed at, and goes half-to-even like the default rounding mode.
+# (Rounding the shortest round-tripping form from `$f` instead would get
+# 9.995 wrong at two places: it prints as "9.995" but the double is
+# 9.99499999999999957, which rounds DOWN.)
 
-  func c_isDigit(c: char): bool {.inline.} = c >= '0' and c <= '9'
+const
+  DecBase = 1_000_000_000'u64
+    ## One limb holds nine decimal digits.
+  DecMaxLimbs = 96
+    ## `2^-1074 * (2^53-1)` needs 767 digits, the largest expansion there is.
+  Pow5: array[0..12, uint32] = [1'u32, 5, 25, 125, 625, 3125, 15625, 78125,
+    390625, 1953125, 9765625, 48828125, 244140625]
+    ## `5^12` is the largest power of five below `DecBase`.
 
-  func splitDigits(s: string): tuple[neg: bool, digits: string, exp: int] =
-    ## `$f` (`-12.34`, `1e+20`, `0.0000001`) → sign, significant digits with no
-    ## point, and `exp` such that the value is `0.<digits> * 10^exp`.
-    var i = 0
-    # Seed the whole tuple: nimony proves initialization per RESULT, not per
-    # field, so field-by-field assignment leaves it "possibly uninitialized".
-    result = (neg: false, digits: "", exp: 0)
-    if i < s.len and (s[i] == '-' or s[i] == '+'):
-      result.neg = s[i] == '-'
-      inc i
-    var intDigits = 0
-    var seenPoint = false
-    var expPart = 0
-    var expNeg = false
-    var leading = true
-    while i < s.len:
-      let c = s[i]
-      if c == '.':
-        seenPoint = true
-        inc i
-      elif c == 'e' or c == 'E':
-        inc i
-        if i < s.len and (s[i] == '-' or s[i] == '+'):
-          expNeg = s[i] == '-'
-          inc i
-        while i < s.len and c_isDigit(s[i]):
-          expPart = expPart * 10 + (int(s[i]) - int('0'))
-          inc i
-        if expNeg: expPart = -expPart
-        break
-      elif c_isDigit(c):
-        if c == '0' and leading and result.digits.len == 0:
-          # Leading zeros contribute no significant digits, but each one after
-          # the point pushes the exponent down.
-          if seenPoint: dec result.exp
-          else: discard
-        else:
-          leading = false
-          result.digits.add c
-          if not seenPoint: inc intDigits
-        inc i
-      else:
-        inc i
-    if intDigits > 0: result.exp = intDigits
-    result.exp = result.exp + expPart
-    # Drop trailing zeros; they carry no information and would defeat the
-    # exact-tie test below.
-    var last = result.digits.len
-    while last > 0 and result.digits[last - 1] == '0': dec last
-    result.digits.setLen(last)
-    if result.digits.len == 0: result.exp = 0
+type
+  DecInt = object ## Non-negative integer, base `DecBase`, least significant limb first.
+    limbs: array[DecMaxLimbs, uint32]
+    len: int
 
-  func decimalValue(digits: string, exp: int): BiggestFloat =
-    ## The double nearest `0.<digits> * 10^exp`.
-    var t = "0." & (if digits.len > 0: digits else: "0") & "e" & $exp
-    result = 0.0
-    discard parseBiggestFloat(toOpenArray(t, 0, t.len - 1), result)
+func mulSmall(x: var DecInt; factor: uint32) =
+  var carry = 0'u64
+  var i = 0
+  while i < x.len:
+    let cur = uint64(x.limbs[i]) * uint64(factor) + carry
+    x.limbs[i] = uint32(cur mod DecBase)
+    carry = cur div DecBase
+    inc i
+  while carry > 0'u64 and x.len < DecMaxLimbs:
+    x.limbs[x.len] = uint32(carry mod DecBase)
+    carry = carry div DecBase
+    inc x.len
 
-  func roundDigits(digits: string, keep: int, f: BiggestFloat,
-                   exp: int): tuple[digits: string, carry: bool] =
-    ## Round `digits` to `keep` leading digits. `carry` means the rounding
-    ## overflowed into a new leading digit (999 -> 100 with carry).
-    ##
-    ## `f` and `exp` are here for the one case the digit string cannot decide.
-    ## `$f` is the SHORTEST round-tripping decimal, so a trailing `5` does NOT
-    ## mean an exact tie — 9.995 prints as "9.995" but the double is
-    ## 9.99499999999999957, which C rounds DOWN to 9.99 at two places. Guessing
-    ## half-to-even there is wrong for exactly the values a naive reading calls
-    ## obvious (this fixture caught it). So the ambiguous case is settled
-    ## against the VALUE: build both candidates, parse them back, and keep the
-    ## nearer one. Only a genuine tie leaves the two equidistant, and that one
-    ## goes half-to-even as C does.
-    result = (digits: "", carry: false)
-    if keep >= digits.len:
-      result.digits = digits
-      for _ in digits.len ..< keep: result.digits.add '0'
-      return
-    if keep < 0:
-      return
-    var kept = digits.substr(0, keep - 1)
-    let first = digits[keep]
-    var roundUp = false
-    if first > '5':
+func toDigits(x: DecInt): string =
+  ## Decimal digits of `x`, without leading zeros.
+  result = ""
+  var i = x.len - 1
+  while i > 0 and x.limbs[i] == 0'u32: dec i
+  if i < 0 or (i == 0 and x.limbs[0] == 0'u32):
+    result = "0"
+  else:
+    result.add $x.limbs[i]
+    dec i
+    while i >= 0:
+      let limb = $x.limbs[i]
+      for _ in limb.len ..< 9: result.add '0'
+      result.add limb
+      dec i
+
+func exactDigits(f: BiggestFloat): tuple[neg: bool, digits: string, exp: int] =
+  ## `f` as `0.<digits> * 10^exp`, `digits` exact and free of leading and
+  ## trailing zeros. Zero yields no digits and `exp = 1`, which is the
+  ## exponent `%e` and `%g` print for it (`0.000e+00`, not `0.000e-01`).
+  let bits = cast[uint64](f)
+  # Seed the whole tuple: nimony proves initialization per RESULT, not per
+  # field, so field-by-field assignment leaves it "possibly uninitialized".
+  result = (neg: (bits shr 63) != 0'u64, digits: "", exp: 1)
+  let biasedExp = int((bits shr 52) and 0x7FF'u64)
+  var mant = bits and 0xF_FFFF_FFFF_FFFF'u64
+  var e2 = 0
+  if biasedExp == 0:
+    if mant == 0'u64: return                  # +-0.0
+    e2 = -1074                                # subnormal: no hidden bit
+  else:
+    mant = mant or (1'u64 shl 52)
+    e2 = biasedExp - 1075
+  var x = default(DecInt)
+  while mant > 0'u64:
+    x.limbs[x.len] = uint32(mant mod DecBase)
+    mant = mant div DecBase
+    inc x.len
+  var pointPos = 0                            # digits to the right of the point
+  if e2 > 0:
+    var k = e2
+    while k > 0:
+      let step = if k > 29: 29 else: k        # 2^29 is the largest power of two below the base
+      mulSmall(x, 1'u32 shl step)
+      k = k - step
+  elif e2 < 0:
+    # `m * 2^-k` is `(m * 5^k) / 10^k`: the same digits, the point moved.
+    var k = -e2
+    pointPos = k
+    while k > 0:
+      let step = if k > 12: 12 else: k
+      mulSmall(x, Pow5[step])
+      k = k - step
+  var d = toDigits(x)
+  result.exp = d.len - pointPos
+  var last = d.len
+  while last > 0 and d[last-1] == '0': dec last
+  d.setLen last
+  result.digits = d
+
+func roundDigits(digits: string; keep: int): tuple[digits: string, carry: bool] =
+  ## Round the exact `digits` to `keep` leading digits, half-to-even. `carry`
+  ## reports an overflow into a new leading digit, so `999` kept at two digits
+  ## is `("10", true)`: the caller reads it with the exponent raised by one.
+  result = (digits: "", carry: false)
+  if keep < 0: return
+  if keep >= digits.len:
+    result.digits = digits
+    for _ in digits.len ..< keep: result.digits.add '0'
+    return
+  var kept = if keep == 0: "" else: digits.substr(0, keep-1)
+  let first = digits[keep]
+  var roundUp = false
+  if first > '5':
+    roundUp = true
+  elif first == '5':
+    var restNonZero = false
+    for i in keep+1 ..< digits.len:
+      if digits[i] != '0': restNonZero = true
+    if restNonZero:
       roundUp = true
-    elif first == '5':
-      var restNonZero = false
-      for i in keep + 1 ..< digits.len:
-        if digits[i] != '0': restNonZero = true
-      if restNonZero:
-        roundUp = true
-      else:
-        let lo = decimalValue(kept, exp)
-        var up = kept
-        var i = up.len - 1
-        var c = true
-        while i >= 0 and c:
-          if up[i] == '9': up[i] = '0'
-          else:
-            up[i] = char(int(up[i]) + 1)
-            c = false
-          dec i
-        let hi = (if c: decimalValue("1" & up, exp + 1) else: decimalValue(up, exp))
-        let a = abs(f) - lo
-        let b = hi - abs(f)
-        if b < a: roundUp = true
-        elif a < b: roundUp = false
-        else:
-          let prev = if keep > 0: digits[keep - 1] else: '0'
-          roundUp = ((int(prev) - int('0')) and 1) == 1
-    if roundUp:
-      var i = kept.len - 1
-      var carry = true
-      while i >= 0 and carry:
-        if kept[i] == '9':
-          kept[i] = '0'
-        else:
-          kept[i] = char(int(kept[i]) + 1)
-          carry = false
-        dec i
-      if carry:
-        result.carry = true
-        kept.shrink kept.len - 2
-        kept = "1" & kept
-    result.digits = kept
-
-  func fmtDecimal(f: BiggestFloat, neg: bool, digits: string,
-                  exp, precision: int, decimalSep: char): string =
-    ## Fixed-point: `precision` digits after the point.
-    let keep = exp + precision
-    var (d, carry) = roundDigits(digits, keep, f, exp)
-    var e = exp
-    if carry: inc e
-    if d.len == 0: d = "0"
-    result = ""
-    if neg: result.add '-'
-    if e <= 0:
-      result.add '0'
-      # The C path formats with `%#.*f`, and `#` keeps the point even at
-      # precision 0 ("2." not "2"). Match it, or every zero-precision call
-      # differs by one character.
-      result.add decimalSep
-      if precision > 0:
-        var zeros = -e
-        var written = 0
-        while written < precision and zeros > 0:
-          result.add '0'
-          inc written
-          dec zeros
-        var i = 0
-        while written < precision:
-          result.add (if i < d.len: d[i] else: '0')
-          inc i
-          inc written
     else:
-      var i = 0
-      while i < e:
-        result.add (if i < d.len: d[i] else: '0')
-        inc i
-      result.add decimalSep
-      if precision > 0:
-        var written = 0
-        while written < precision:
-          result.add (if i < d.len: d[i] else: '0')
-          inc i
-          inc written
+      # An exact tie, because the digits are the exact expansion: half-to-even.
+      let prev = if keep > 0: digits[keep-1] else: '0'
+      roundUp = ((int(prev) - int('0')) and 1) == 1
+  if roundUp:
+    var i = kept.len - 1
+    var carry = true
+    while i >= 0 and carry:
+      if kept[i] == '9':
+        kept[i] = '0'
+      else:
+        kept[i] = char(int(kept[i]) + 1)
+        carry = false
+      dec i
+    if carry:
+      # All nines: the leading 1 takes the place of the last digit and the
+      # caller lifts the exponent, `999` -> `10` at exponent+1.
+      if kept.len > 0: kept.setLen kept.len - 1
+      kept = "1" & kept
+      result.carry = true
+  result.digits = kept
 
-  func fmtScientific(f: BiggestFloat, neg: bool, digits: string,
-                     exp, precision: int, decimalSep: char): string =
-    var (d, carry) = roundDigits(digits, precision + 1, f, exp)
-    var e = exp
-    if carry: inc e
-    if d.len == 0: d = "0"
-    result = ""
-    if neg: result.add '-'
-    result.add d[0]
-    result.add decimalSep          # `%#.*e` keeps the point at precision 0 too
-    if precision > 0:
-      for i in 1 .. precision:
-        result.add (if i < d.len: d[i] else: '0')
-    # An all-zero mantissa is the value zero, whose exponent is 0, not -1.
-    var allZero = true
-    for c in d:
-      if c != '0': allZero = false
-    let e10 = (if allZero: 0 else: e - 1)
-    result.add 'e'
-    if e10 < 0: result.add '-' else: result.add '+'
-    let a = abs(e10)
-    if a < 10: result.add '0'
-    result.add $a
+func fmtDecimal(neg: bool; digits: string; exp, precision: int;
+                decimalSep: char; forcePoint: bool): string =
+  ## `%.*f`: `precision` digits after the point. `forcePoint` is the `#` flag,
+  ## which keeps the point at precision 0 ("2." rather than "2").
+  let (d, carry) = roundDigits(digits, exp + precision)
+  var e = exp
+  if carry: inc e
+  result = ""
+  if neg: result.add '-'
+  if e <= 0:
+    result.add '0'
+  else:
+    var i = 0
+    while i < e:
+      result.add (if i < d.len: d[i] else: '0')
+      inc i
+  if precision > 0 or forcePoint:
+    result.add decimalSep
+    # The k-th digit after the point sits at index `e + k - 1`; a negative
+    # index is a leading zero of the fraction, one past the end a trailing one.
+    var k = 1
+    while k <= precision:
+      let idx = e + k - 1
+      result.add (if idx >= 0 and idx < d.len: d[idx] else: '0')
+      inc k
+
+func fmtScientific(neg: bool; digits: string; exp, precision: int;
+                   decimalSep: char; forcePoint: bool): string =
+  ## `%.*e`: one digit before the point, `precision` after it.
+  let (d, carry) = roundDigits(digits, precision + 1)
+  var e = exp
+  if carry: inc e
+  result = ""
+  if neg: result.add '-'
+  result.add (if d.len > 0: d[0] else: '0')
+  if precision > 0 or forcePoint:
+    result.add decimalSep
+    var i = 1
+    while i <= precision:
+      result.add (if i < d.len: d[i] else: '0')
+      inc i
+  let e10 = e - 1
+  result.add 'e'
+  if e10 < 0: result.add '-' else: result.add '+'
+  let a = abs(e10)
+  if a < 10: result.add '0'                   # C pads the exponent to two digits
+  result.add $a
+
+func stripTrailingZeros(s: string; decimalSep: char): string =
+  ## `%g` without `#` drops the trailing zeros of the fraction, and the point
+  ## with them when nothing is left behind it.
+  var mantEnd = s.len
+  var i = 0
+  while i < s.len:
+    if s[i] == 'e':
+      mantEnd = i
+      break
+    inc i
+  var pointAt = -1
+  i = 0
+  while i < mantEnd:
+    if s[i] == decimalSep:
+      pointAt = i
+      break
+    inc i
+  if pointAt < 0:
+    result = s
+  else:
+    var last = mantEnd
+    while last > pointAt+1 and s[last-1] == '0': dec last
+    if last == pointAt+1: last = pointAt
+    result = s.substr(0, last-1) & s.substr(mantEnd, s.len-1)
+
+func fmtDefault(neg: bool; digits: string; exp, precision: int;
+                decimalSep: char; forcePoint: bool): string =
+  ## `%.*g`: `p` significant digits, printed in `%e` style when the exponent
+  ## falls outside `[-4, p)` and in `%f` style otherwise. C reads a precision
+  ## of 0 as 1.
+  let p = if precision == 0: 1 else: precision
+  let (d, carry) = roundDigits(digits, p)
+  var e = exp
+  if carry: inc e
+  let x = e - 1                               # the exponent `%e` would print
+  # `d` is already rounded to `p` digits, so the re-rounding below is a no-op.
+  let s = if x < -4 or x >= p:
+            fmtScientific(neg, d, e, p-1, decimalSep, forcePoint)
+          else:
+            fmtDecimal(neg, d, e, p-1-x, decimalSep, forcePoint)
+  result = if forcePoint: s else: stripTrailingZeros(s, decimalSep)
 
 func formatBiggestFloat*(f: BiggestFloat, format: FloatFormatMode = ffDefault,
                          precision: range[-1..32] = 16;
@@ -1209,48 +1235,19 @@ func formatBiggestFloat*(f: BiggestFloat, format: FloatFormatMode = ffDefault,
     assert x.formatBiggestFloat() == "123.4560000000000"
     assert x.formatBiggestFloat(ffDecimal, 4) == "123.4560"
     assert x.formatBiggestFloat(ffScientific, 2) == "1.23e+02"
-  when defined(wasm32) and defined(standalone):
-    let s = $f
-    # nan/inf print as themselves in every mode, as C does.
-    if s.len == 0 or not (c_isDigit(s[0]) or s[0] == '-' or s[0] == '+'):
-      return s
-    if s.len > 1 and (s[0] == '-' or s[0] == '+') and not c_isDigit(s[1]):
-      return s
-    let (neg, digits, exp) = splitDigits(s)
-    if precision.int < 0 or format == ffDefault:
-      # ffDefault IS "the shorter notation", which is exactly what `$f` gives.
-      result = ""
-      for c in s:
-        if c == '.' or c == ',': result.add decimalSep
-        else: result.add c
-    elif format == ffDecimal:
-      result = fmtDecimal(f, neg, digits, exp, precision.int, decimalSep)
-    else:
-      result = fmtScientific(f, neg, digits, exp, precision.int, decimalSep)
+  let bits = cast[uint64](f)
+  if int((bits shr 52) and 0x7FF'u64) == 0x7FF:
+    result = $f                               # inf, -inf, nan print as themselves
   else:
-    const floatFormatToChar: array[FloatFormatMode, char] = ['g', 'f', 'e']
-    var
-      frmtstr {.noinit.}: array[0..5, char]
-      buf {.noinit.}: array[0..2500, char]
-      L: cint
-    frmtstr[0] = '%'
-    if precision.int >= 0:
-      frmtstr[1] = '#'
-      frmtstr[2] = '.'
-      frmtstr[3] = '*'
-      frmtstr[4] = floatFormatToChar[format]
-      frmtstr[5] = '\0'
-      L = c_snprintf(cast[cstring](addr buf), csize_t(2501), cast[cstring](addr frmtstr), precision, f)
-    else:
-      frmtstr[1] = floatFormatToChar[format]
-      frmtstr[2] = '\0'
-      L = c_snprintf(cast[cstring](addr buf), csize_t(2501), cast[cstring](addr frmtstr), f)
-    result = newString(L)
-    for i in 0 ..< L:
-      # Depending on the locale either dot or comma is produced,
-      # but nothing else is possible:
-      if buf[i] in {'.', ','}: result[i] = decimalSep
-      else: result[i] = buf[i]
+    let (neg, digits, exp) = exactDigits(f)
+    # Without an explicit precision C uses its default of 6 and no `#` flag;
+    # with one it used `%#.*g` and friends, whose point is never dropped.
+    let p = if precision.int < 0: 6 else: precision.int
+    let forcePoint = precision.int >= 0
+    case format
+    of ffDefault: result = fmtDefault(neg, digits, exp, p, decimalSep, forcePoint)
+    of ffDecimal: result = fmtDecimal(neg, digits, exp, p, decimalSep, forcePoint)
+    of ffScientific: result = fmtScientific(neg, digits, exp, p, decimalSep, forcePoint)
 
 func formatFloat*(f: float, format: FloatFormatMode = ffDefault,
                   precision: range[-1..32] = 16; decimalSep = '.'): string =

--- a/tests/ithaqua/format_float.nim
+++ b/tests/ithaqua/format_float.nim
@@ -1,0 +1,17 @@
+# `strutils.formatFloat`. The C library's `%f`/`%e`/`%g` is reproduced from the
+# exact decimal expansion of the double, so this path has no `snprintf` to call
+# — which is what makes it usable here at all: wasm has no variadic calling
+# convention, so a `{.varargs.}` import cannot be typed and the MODULE is
+# rejected before it runs. Both legs must agree on every digit, ties included.
+import std/[syncio, strutils]
+
+const values: array[14, float] = [
+  0.0, -0.0, 1.0, 0.5, 2.5, 9.995, 0.1, 123.456, 1234.567,
+  0.00000000001, 1e20, 1e-7, 3.141592653589793, 1.7976931348623157e308
+]
+
+for v in values:
+  for p in [-1, 0, 1, 2, 6, 16, 20]:
+    echo formatFloat(v, ffDefault, p), "|", formatFloat(v, ffDecimal, p), "|",
+         formatFloat(v, ffScientific, p)
+echo formatFloat(Inf), " ", formatFloat(-Inf, ffDecimal, 3), " ", formatFloat(NaN, ffScientific, 3)

--- a/tests/nimony/stdlib/tparseutils.nim
+++ b/tests/nimony/stdlib/tparseutils.nim
@@ -169,3 +169,36 @@ block:
   assert ret.classify == fcInf
   assert parseBiggestFloat("-inf", ret) == 4
   assert ret.classify == fcNegInf
+
+block: # correctly rounded decimal -> float64, no `strtod`
+  # The slow path is a big-decimal reader, so these must come out bit for bit
+  # as the C library reads them: an exact halfway between two doubles goes
+  # half-to-even, and digits past the 17th still decide the result.
+  var ret: float64 = 3.0
+  assert parseBiggestFloat("2.2250738585072011e-308", ret) == 23
+  assert cast[int64](ret) == 0x000FFFFFFFFFFFFF'i64   # the largest subnormal
+  assert parseBiggestFloat("2.2250738585072012e-308", ret) == 23
+  assert cast[int64](ret) == 0x0010000000000000'i64   # rounds up to the smallest normal
+  assert parseBiggestFloat("9007199254740993", ret) == 16        # 2^53 + 1
+  assert cast[int64](ret) == 0x4340000000000000'i64
+  assert parseBiggestFloat("9007199254740992.5", ret) == 18      # a tie, to even
+  assert cast[int64](ret) == 0x4340000000000000'i64
+  assert parseBiggestFloat("2.4703282292062327e-324", ret) == 23 # just under half of
+  assert cast[int64](ret) == 0x0000000000000000'i64              # the smallest subnormal
+  assert parseBiggestFloat("2.4703282292062328e-324", ret) == 23
+  assert cast[int64](ret) == 0x0000000000000001'i64
+  assert parseBiggestFloat("7.8459735791271921e65", ret) == 21
+  assert cast[int64](ret) == 0x4D9DCD0089C1314E'i64
+  assert parseBiggestFloat("123456789012345678901234567890", ret) == 30
+  assert cast[int64](ret) == 0x45F8EE90FF6C373E'i64
+  # The exact expansion of the double nearest 0.1, and one digit past it.
+  assert parseBiggestFloat("0.1000000000000000055511151231257827021181583404541015625", ret) == 57
+  assert cast[int64](ret) == 0x3FB999999999999A'i64
+  assert parseBiggestFloat("0.10000000000000000555111512312578270211815834045410156251", ret) == 58
+  assert cast[int64](ret) == 0x3FB999999999999A'i64
+  assert parseBiggestFloat("1e-323", ret) == 6
+  assert cast[int64](ret) == 0x0000000000000002'i64
+  assert parseBiggestFloat("1.7976931348623158e308", ret) == 22  # still finite
+  assert cast[int64](ret) == 0x7FEFFFFFFFFFFFFF'i64
+  assert parseBiggestFloat("1e309", ret) == 5
+  assert ret.classify == fcInf

--- a/tests/nimony/stdlib/tstrutils.nim
+++ b/tests/nimony/stdlib/tstrutils.nim
@@ -729,6 +729,42 @@ block: # formatBiggestFloat
 block: # formatFloat
   assert formatFloat(1234.567, ffDecimal, 1) == "1234.6"
 
+block: # formatBiggestFloat without snprintf
+  # The C library's `%#.*g`, `%#.*f` and `%#.*e` are reproduced from the exact
+  # decimal expansion of the double; every expectation here is what glibc and
+  # macOS libc print for the same call.
+  assert formatBiggestFloat(123.456) == "123.4560000000000"    # ffDefault keeps
+  assert formatBiggestFloat(0.5, ffDefault, 3) == "0.500"      # the trailing zeros
+  assert formatBiggestFloat(1e-5, ffDefault, 3) == "1.00e-05"  # of `%#g`
+  assert formatBiggestFloat(123.456, ffDefault, 0) == "1.e+02" # precision 0 means 1
+  # Without a precision C uses its default of 6, and `%g` DROPS trailing zeros.
+  assert formatBiggestFloat(1234.567, ffDefault, -1) == "1234.57"
+  assert formatBiggestFloat(0.0001, ffDefault, -1) == "0.0001"
+  assert formatBiggestFloat(0.00001, ffDefault, -1) == "1e-05"
+  assert formatBiggestFloat(1e20, ffDefault, -1) == "1e+20"
+  assert formatBiggestFloat(1234.567, ffScientific, -1) == "1.234567e+03"
+  # Exact ties round half-to-even, as the hardware's rounding mode does.
+  assert formatBiggestFloat(0.5, ffDecimal, 0) == "0."
+  assert formatBiggestFloat(1.5, ffDecimal, 0) == "2."
+  assert formatBiggestFloat(2.5, ffDecimal, 0) == "2."
+  assert formatBiggestFloat(3.5, ffDecimal, 0) == "4."
+  assert formatBiggestFloat(0.125, ffDecimal, 2) == "0.12"
+  assert formatBiggestFloat(0.375, ffDecimal, 2) == "0.38"
+  # 9.995 is NOT a tie: the double is 9.99499999999999957, so it rounds down.
+  assert formatBiggestFloat(9.995, ffDecimal, 2) == "9.99"
+  assert formatBiggestFloat(9.995, ffScientific, 2) == "9.99e+00"
+  # Beyond the shortest round-tripping form the true expansion continues.
+  assert formatBiggestFloat(0.1, ffDecimal, 20) == "0.10000000000000000555"
+  # Rounding that overflows into a new leading digit.
+  assert formatBiggestFloat(9.99, ffDecimal, 1) == "10.0"
+  assert formatBiggestFloat(999.9, ffDecimal, 0) == "1000."
+  assert formatBiggestFloat(1e20, ffDecimal, 2) == "100000000000000000000.00"
+  assert formatBiggestFloat(1e300, ffScientific, 2) == "1.00e+300"
+  assert formatBiggestFloat(-0.0, ffDecimal, 2) == "-0.00"
+  assert formatBiggestFloat(Inf) == "inf"
+  assert formatBiggestFloat(-Inf, ffDecimal, 3) == "-inf"
+  assert formatBiggestFloat(NaN, ffScientific, 3) == "nan"
+
 block: # `%`
   try:
     assert "" % ["a"] == ""


### PR DESCRIPTION
`formatFloat` reached `snprintf` and `parseBiggestFloat`'s slow path reached `strtod` on every target that had a libc, with libc-free stand-ins gated behind `when defined(wasm32) and defined(standalone)` and `when defined(nimNoLibc)`. Both gates are gone: the stand-ins are now the implementation everywhere, and the two libc imports with them.

The reason to do this at all is that the gates were the wrong shape. A float that renders differently depending on which backend compiled the module is a bug the C path cannot see, and `snprintf` was never callable on wasm anyway: WebAssembly has no variadic calling convention, an imported function has ONE type, and a `{.varargs.}` importc called with different argument tails is rejected when the engine compiles the MODULE — so one `formatFloat` on a diagnostic path took a whole program down before it started.

Formatting is rewritten rather than merely ungated. The wasm arm rounded the SHORTEST round-tripping decimal from `$f`, which has two consequences: a precision past that length padded with zeros where C continues the true binary expansion (`0.1` at 20 places), and a trailing `5` was not necessarily a tie, so the ambiguous case had to be settled by building both candidates and parsing them back — which cost a `strtod` import on a program that only formats. This computes the EXACT decimal expansion instead, with a base-10^9 bignum on the stack: a double is `m * 2^e`, so the expansion is the integer `m * 2^e` for `e >= 0` and `m * 5^-e` with the point moved for `e < 0`. The digit after the cut and everything behind it are then exact, so a tie is recognized rather than guessed at and goes half-to-even, as the hardware's rounding mode does. Both warts and the extra import go away.

Serving every target also meant filling in what the wasm arm never covered: `%#.*g` for `ffDefault` with a precision (which is where the documented `formatBiggestFloat(123.456) == "123.4560000000000"` comes from), and C's default precision of 6 — plus `%g`'s trailing-zero stripping — when `precision == -1`.

The parse side needed no rewrite, only the gate removed and `c_strtod` renamed to `decimalToFloat`, which is what it is now that it stands in for nothing.

Output is byte-identical to the platform libc, verified differentially (a C program against the same grid compiled by nimony), not argued:

  formatting   1,920 curated + 45,600 random-bit-pattern + 51,300
               ties/powers/carries/inf/nan cases, 3 modes, precisions -1..32
  parsing      723 hard literals + 1,025 exact ties and their neighbours,
               compared as raw bit patterns
  truncation   300 inputs of 400-1500 digits, new against pre-change, since
               those run past `parseBiggestFloat`'s own 500-char buffer

all with zero mismatches. `nimony n` and the C backend also agree with each other on the new `tests/ithaqua/format_float.nim` fixture, which puts the formatter under the wasmdiff oracle where the original bug lived.