### PR TITLE
fix(macros): a macro could not receive or return a `proc` declaration

### DIFF
--- a/lib/std/private/macros_nif.nim
+++ b/lib/std/private/macros_nif.nim
@@ -67,6 +67,7 @@ proc tagToNimNodeKind(tag: string): NimNodeKind =
   of "asm": nnkAsm
   of "comment": nnkCommentStmt
   # Declarations
+  of "proc": nnkProcDef
   of "func": nnkFuncDef
   of "method": nnkMethodDef
   of "iterator": nnkIteratorDef
@@ -167,7 +168,7 @@ proc nimNodeKindToTag(k: NimNodeKind): string =
   of nnkYieldStmt: "yld"
   of nnkRaiseStmt: "raise"
   of nnkDiscardStmt: "discard"
-  of nnkProcDef: "func"
+  of nnkProcDef: "proc"
   of nnkFuncDef: "func"
   of nnkMethodDef: "method"
   of nnkIteratorDef: "iterator"

--- a/tests/nimony/macros/tprocdef_roundtrip.nim
+++ b/tests/nimony/macros/tprocdef_roundtrip.nim
@@ -1,0 +1,19 @@
+# A macro must be able to receive a `proc` declaration and return it.
+#
+# The NIF <-> NimNode codec (lib/std/private/macros_nif.nim) had no `"proc"`
+# case, so the declaration arrived as `nnkNone` and was re-serialized as an
+# empty node: the routine vanished, and the only symptom was an unrelated
+# "undeclared identifier" at the call site.
+#
+# The identity macro below exercises BOTH directions of the codec in one go —
+# `(proc ...)` -> nnkProcDef on the way in, nnkProcDef -> `(proc ...)` on the
+# way out — so either mapping regressing fails this test.
+import std / [syncio, macros]
+
+macro identity(prc: untyped): untyped =
+  result = prc
+
+proc greet(name: string) {.identity.} =
+  echo "hello, " & name
+
+greet("world")

--- a/tests/nimony/macros/tprocdef_roundtrip.nojoin
+++ b/tests/nimony/macros/tprocdef_roundtrip.nojoin
@@ -1,0 +1,4 @@
+# Imports a plugin-backed stdlib module (macros/json/typetraits/smartcli/parfor).
+# Compiling two such tests in one nifmake run lets its parallel jobs launch the
+# same plugin build twice into the same nimcache and clobber each other. Until
+# that race is fixed these keep separate runs.

--- a/tests/nimony/macros/tprocdef_roundtrip.output
+++ b/tests/nimony/macros/tprocdef_roundtrip.output
@@ -1,0 +1,1 @@
+hello, world


### PR DESCRIPTION
A proc-pragma macro silently deleted the routine it was applied to:

    macro identity(prc: untyped): untyped = prc

    proc greet(name: string) {.identity.} =
      echo "hello, " & name

    greet("world")

    ??? Error: expression expected
    t.nim(9, 1) Error: undeclared identifier: 'greet'

Note the `???` — the first error has no position, because by then the declaration is gone rather than malformed.

Cause: the NIF <-> NimNode codec in lib/std/private/macros_nif.nim was missing `proc` in both directions. `tagToNimNodeKind` had cases for func/method/ iterator/converter/template/macro but not `proc`, so a `(proc ...)` tree deserialized to `nnkNone`; and `nimNodeKindToTag` mapped nnkProcDef to `"func"`, so anything that did survive came back out mislabelled. An identity macro therefore returned `(stmts .)` — an empty statement list — which sema rejects with "expression expected", and the proc it was supposed to define no longer existed.

Fix: add `of "proc": nnkProcDef` to `tagToNimNodeKind`, and map nnkProcDef back to `"proc"` rather than `"func"`.

tests/nimony/macros/tprocdef_roundtrip.nim covers it. The identity macro exercises both directions in one test, so either mapping regressing fails it.