### PR TITLE
ioring/io_uring: enums and sets of enum for the flag APIs

### DIFF
--- a/lib/std/ioring.nim
+++ b/lib/std/ioring.nim
@@ -17,7 +17,8 @@
 import std / [atomics, threadpool, assertions, ticketlocks]
 import ./ioring/core/[types, slots, backend]
 export types.IoCompletion, types.IoOp, types.SeqNum, types.OpContext
-export types.EvRead, types.EvWrite
+export types.IoEvent, types.IoEvents, types.evRead, types.evWrite
+export types.readyEvents, types.toIoEvents, types.toEventMask
 export backend.BackendRelays, backend.CqSize, backend.MaxOps
 import ./ioring/platform
 from std/posix/posix import Sockaddr_storage, Sockaddr_in, SockLen, FileHandle,
@@ -110,17 +111,16 @@ proc submitAccept*(listenFd: cint;
   op.acceptLen = SockLen(sizeof(op.acceptAddr))
   enqueueOp(op)
 
-proc submitPollAdd*(fd: cint; mask = EvRead or EvWrite;
+proc submitPollAdd*(fd: cint; events: IoEvents = {evRead, evWrite};
                     cont = Continuation(fn: nil, env: nil);
                     resPtr: nil ptr int = nil): SeqNum =
   ## Register oneshot readiness interest in `fd` without issuing any I/O.
-  ## When the fd becomes ready in one of the `mask` directions a single
-  ## completion fires whose `op` is `opPollAdd` and whose `result` holds the
-  ## ready-direction mask (bits `EvRead` and/or `EvWrite`). Unlike
-  ## `submitRead`/`submitWrite`, no transfer is performed — the caller decides
-  ## what to do with the ready fd (e.g. libcurl's multi-socket engine). This
-  ## is oneshot: `complete` frees the slot, so re-arm by calling
-  ## `submitPollAdd` again after handling the event.
+  ## When the fd becomes ready in one of the `events` directions a single
+  ## completion fires whose `op` is `opPollAdd` and whose `readyEvents` are the
+  ## directions that fired. Unlike `submitRead`/`submitWrite`, no transfer is
+  ## performed — the caller decides what to do with the ready fd (e.g.
+  ## libcurl's multi-socket engine). This is oneshot: `complete` frees the
+  ## slot, so re-arm by calling `submitPollAdd` again after handling the event.
   ##
   ## **Pass the direction you actually want.** The default watches both, which
   ## is right for a probe with no preference — but a caller waiting to *read*
@@ -128,9 +128,12 @@ proc submitPollAdd*(fd: cint; mask = EvRead or EvWrite;
   ## writable nearly always), and because the op is oneshot its re-arm then
   ## spins as fast as the loop can poll. libcurl's multi-socket engine always
   ## states its direction (`CURL_POLL_IN`/`CURL_POLL_OUT`); pass it through.
+  ##
+  ## A `resPtr` receives the same directions as a bit mask instead of a set,
+  ## being a `ptr int`; decode it with `toIoEvents`.
   result = nextSeqNum()
   var op = OpContext(kind: opPollAdd, fd: fd, seqnum: result,
-    cont: cont, res: cast[int](resPtr), pollMask: mask)
+    cont: cont, res: cast[int](resPtr), pollMask: events)
   enqueueOp(op)
 
 proc pollCompletions*(comps: var openArray[IoCompletion]): int =

--- a/lib/std/ioring/backends/epoll.nim
+++ b/lib/std/ioring/backends/epoll.nim
@@ -38,13 +38,13 @@ proc fdNotPollable(): bool {.inline.} =
   let e = errno()
   result = e == EPERM or e == EBADF
 
-proc epollReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} =
+proc epollReArm(fd: cint; events: IoEvents, alreadyRegistered: bool): bool {.nimcall.} =
   let epollFd = epollFds[ioLane()]
   var ev {.noinit.}: EpollEvent
   ev.events = EPOLLONESHOT
-  if (mask and EvRead) != 0:
+  if evRead in events:
     ev.events = ev.events or EPOLLIN
-  if (mask and EvWrite) != 0:
+  if evWrite in events:
     ev.events = ev.events or EPOLLOUT
   # Store the fd itself (not a slot index) as user data: a slot can be freed
   # and its index reused for a *different* fd between registration and the
@@ -79,11 +79,11 @@ proc epollPoll(timeoutMs: int): bool {.nimcall.} =
   for i in 0..<n:
     let fd = cint(cast[uint](ioEvents[i].data.`ptr`))
     let events = ioEvents[i].events
-    var firedEvents = 0
+    var firedEvents: IoEvents = {}
     if (events and EPOLLIN) != 0:
-      firedEvents = firedEvents or EvRead
+      firedEvents.incl evRead
     if (events and EPOLLOUT) != 0:
-      firedEvents = firedEvents or EvWrite
+      firedEvents.incl evWrite
     processFd(fd, firedEvents)
   return true
 

--- a/lib/std/ioring/backends/iouring.nim
+++ b/lib/std/ioring/backends/iouring.nim
@@ -19,10 +19,6 @@ from ./epoll import initEpollBackendRelays
 
 const
   DrainBatch = 128  ## Max deferred entries drained per poll() call.
-  # Standard poll(2) mask bits used by io_uring's OP_POLL_ADD (distinct from
-  # the internal EvRead/EvWrite flags, which never cross into the kernel).
-  POLLIN = uint32(0x0001)
-  POLLOUT = uint32(0x0004)
 
 var
   sqEntries: int
@@ -53,10 +49,13 @@ proc fillSqe(sqe: ptr Sqe; op: ptr OpContext) {.inline.} =
     # re-arms with a new submitPollAdd (matching the epoll/kqueue oneshot
     # behaviour). Watching both regardless would spin a read-waiter on a
     # writable socket — see submitPollAdd's docstring.
-    var pollFlags = 0'u32
-    if (op.pollMask and EvRead) != 0: pollFlags = pollFlags or POLLIN
-    if (op.pollMask and EvWrite) != 0: pollFlags = pollFlags or POLLOUT
-    discard sqe.poll_add(op.fd, pollFlags)
+    # The kernel speaks poll(2) events, the ring speaks `IoEvents`; the two
+    # never share a representation, so translate in both directions here and
+    # in the completion loop below.
+    var pollEvents: PollEvents = {}
+    if evRead in op.pollMask: pollEvents.incl POLL_IN
+    if evWrite in op.pollMask: pollEvents.incl POLL_OUT
+    discard sqe.poll_add(op.fd, pollEvents)
   of opNop:
     discard sqe.nop()
 
@@ -107,17 +106,16 @@ proc iouringPoll(timeoutMs: int): bool {.nimcall.} =
       for i in 0..<n:
         let idx = int(cqes[i].userData)
         # For OP_POLL_ADD the kernel reports the fired mask in poll(2) form;
-        # translate it to the same internal EvRead/EvWrite flags the epoll/
-        # kqueue backends use, so the completion's `result` is consistent no
+        # translate it to the same internal `IoEvents` the epoll/kqueue
+        # backends report, so the completion's `readyEvents` are consistent no
         # matter which backend is in use.
         var res = int(cqes[i].res)
         if gSlots[lane].slots[idx].op.kind == opPollAdd:
-          var ev = 0
-          if (uint32(res) and POLLIN) != 0:
-            ev = ev or EvRead
-          if (uint32(res) and POLLOUT) != 0:
-            ev = ev or EvWrite
-          res = ev
+          var fired = toPollEvents(uint32(res))
+          var ev: IoEvents = {}
+          if POLL_IN in fired: ev.incl evRead
+          if POLL_OUT in fired: ev.incl evWrite
+          res = toEventMask(ev)
         complete(idx, res)
       return true
   return false

--- a/lib/std/ioring/backends/kqueue.nim
+++ b/lib/std/ioring/backends/kqueue.nim
@@ -17,7 +17,7 @@ const
 
 var kqFds: seq[cint]
 
-proc kqueueReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} =
+proc kqueueReArm(fd: cint; events: IoEvents, alreadyRegistered: bool): bool {.nimcall.} =
   # EV_ADD is idempotent in kqueue (add-or-modify), unlike epoll's ADD/MOD
   # split, so there is no separate "first time vs re-arm" bookkeeping needed
   # here. `ident` (the fd) is what `kqueuePoll` reads back on delivery, not
@@ -31,12 +31,12 @@ proc kqueueReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.}
   # Reported, not discarded: a failed registration means no readiness, and
   # `submitForPoll` fails the ops waiting on it.
   result = true
-  if (mask and EvRead) != 0:
+  if evRead in events:
     ev.ident = uint(fd)
     ev.filter = EVFILT_READ
     ev.flags = EV_ADD or EV_ONESHOT
     if kevent(kq, addr ev, 1, nil, 0, nil) < 0: result = false
-  if (mask and EvWrite) != 0:
+  if evWrite in events:
     ev.ident = uint(fd)
     ev.filter = EVFILT_WRITE
     ev.flags = EV_ADD or EV_ONESHOT
@@ -50,38 +50,37 @@ proc kqueuePoll(timeoutMs: int): bool {.nimcall.} =
     for i in 0..<n:
       discard gSlots[lane].allocSlot(buf[i])
       submitForPoll(buf[i].fd)
-  var events {.noinit.}: array[64, KEvent]
+  var kevents {.noinit.}: array[64, KEvent]
   var ts = Timespec(
     tv_sec: Time(timeoutMs div 1000),
     tv_nsec: clong((timeoutMs mod 1000) * 1_000_000))
-  n = int(kevent(kqFds[lane], nil, 0, addr events[0], 64, addr ts))
+  n = int(kevent(kqFds[lane], nil, 0, addr kevents[0], 64, addr ts))
   if n <= 0:
     return false
   # A poll-add registers two kevents (EVFILT_READ and EVFILT_WRITE); when the
   # fd is ready in both directions both fire in the same batch. Deliver the
   # union per fd so a oneshot poll-add on a socket that is simultaneously
-  # readable and writable reports EvRead or EvWrite like io_uring's
+  # readable and writable reports {evRead, evWrite} like io_uring's
   # IORING_OP_POLL_ADD does, instead of completing on whichever event comes
   # first. Per-direction matching for read/write ops still happens inside
   # processFd.
   var firedFds {.noinit.}: array[64, cint]
-  var firedMasks {.noinit.}: array[64, int]
+  var firedEvents {.noinit.}: array[64, IoEvents]
   var m = 0
   for i in 0..<n:
-    let fd = cint(events[i].ident)
+    let fd = cint(kevents[i].ident)
+    let dir = if kevents[i].filter == EVFILT_READ: evRead else: evWrite
     var k = 0
     while k < m and firedFds[k] != fd:
       inc k
     if k == m:
       firedFds[m] = fd
-      firedMasks[m] = if events[i].filter == EVFILT_READ: EvRead else: EvWrite
+      firedEvents[m] = {dir}
       inc m
-    elif events[i].filter == EVFILT_READ:
-      firedMasks[k] = firedMasks[k] or EvRead
     else:
-      firedMasks[k] = firedMasks[k] or EvWrite
+      firedEvents[k].incl dir
   for i in 0..<m:
-    processFd(firedFds[i], firedMasks[i])
+    processFd(firedFds[i], firedEvents[i])
   return true
 
 proc kqueueClose() {.nimcall.} =

--- a/lib/std/ioring/backends/poll.nim
+++ b/lib/std/ioring/backends/poll.nim
@@ -7,15 +7,15 @@ import ../core/types
 import ../core/slots
 import ../core/backend
 
-proc noopReArm(fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} = true
-var reArmEvent*: proc (fd: cint; mask: int, alreadyRegistered: bool): bool {.nimcall.} = noopReArm
+proc noopReArm(fd: cint; events: IoEvents, alreadyRegistered: bool): bool {.nimcall.} = true
+var reArmEvent*: proc (fd: cint; events: IoEvents, alreadyRegistered: bool): bool {.nimcall.} = noopReArm
 ## Registers (or re-arms, for EPOLLONESHOT-style backends) readiness
-## interest for `fd`. Takes only `fd` and the direction mask — never a
+## interest for `fd`. Takes only `fd` and the directions — never a
 ## specific slot index: a fd can have several ops in flight (e.g. a
 ## pending read *and* a pending write) sharing one epoll/kqueue
 ## registration, so the registration is keyed by fd, not by any one op.
-  
-proc armMaskForFd*(fd: cint): int =
+
+proc armEventsForFd*(fd: cint): IoEvents =
   ## The union of the directions every op currently pending on `fd` waits for.
   ##
   ## It has to be the union, never one op's own direction: the registration is
@@ -23,19 +23,19 @@ proc armMaskForFd*(fd: cint): int =
   ## with just the newest op's direction therefore silently disarms the others —
   ## `submitWrite(fd)` followed by `submitRead(fd)` would leave the fd watched
   ## for EPOLLIN only and the pending write would never be woken.
-  result = 0
+  result = {}
   let lane = ioLane()
   for j in gSlots[lane].slotsForFd(fd):
     case gSlots[lane].slots[j].op.kind
     of opRead, opAccept:
-      result = result or EvRead
+      result.incl evRead
     of opWrite:
-      result = result or EvWrite
+      result.incl evWrite
     of opPollAdd:
       # Pure readiness probe: exactly the direction(s) the caller asked for.
       # Arming both regardless would wake a read-waiter on writability, and a
       # oneshot op re-armed on every spurious wake is a busy loop.
-      result = result or gSlots[lane].slots[j].op.pollMask
+      result = result + gSlots[lane].slots[j].op.pollMask
     of opNop:
       discard
 
@@ -53,7 +53,7 @@ proc failPendingForFd*(fd: cint) =
 proc submitForPoll*(fd: cint; alreadyRegistered: bool = false) {.nimcall.} =
   ## Arm `fd` for every op pending on it, including the one just allocated by
   ## the caller (`allocSlot` has already linked it into the fd's list).
-  if not reArmEvent(fd, armMaskForFd(fd), alreadyRegistered):
+  if not reArmEvent(fd, armEventsForFd(fd), alreadyRegistered):
     failPendingForFd(fd)
 
 when defined(posix):
@@ -64,14 +64,14 @@ when defined(posix):
   proc posixWrite(fd: cint; buf: nil pointer; count: int): int {.importc: "write".}
   proc posixAccept(s: cint; `addr`: pointer; addrlen: ptr SockLen): cint {.importc: "accept".}
 
-  proc processFd*(fd: cint; firedEvents: int) {.nimcall.} =
+  proc processFd*(fd: cint; firedEvents: IoEvents) {.nimcall.} =
     ## Dispatch every pending op on `fd` whose direction actually matches the
-    ## readiness that just fired. `firedEvents` (EvRead/EvWrite, as delivered
-    ## by the poller) is authoritative: a write-readiness wakeup must not
-    ## drive a still-pending *read* op (and vice versa) — the fd may be
-    ## registered for both directions at once (e.g. a socket with an
-    ## in-flight read and an in-flight write), and only the direction that
-    ## actually fired has data ready / a free send buffer.
+    ## readiness that just fired. `firedEvents` (as delivered by the poller)
+    ## is authoritative: a write-readiness wakeup must not drive a
+    ## still-pending *read* op (and vice versa) — the fd may be registered for
+    ## both directions at once (e.g. a socket with an in-flight read and an
+    ## in-flight write), and only the direction that actually fired has data
+    ## ready / a free send buffer.
     # O(k) in the number of ops on this fd, via the intrusive per-fd list,
     # instead of an O(MaxOps) scan of the whole arena.
     let lane = ioLane()
@@ -79,15 +79,15 @@ when defined(posix):
       let s = addr gSlots[lane].slots[j]
       case s.op.kind
       of opRead:
-        if (firedEvents and EvRead) != 0:
+        if evRead in firedEvents:
           let r = posixRead(fd, s.op.buf, s.op.len)
           complete(j, if r >= 0: r else: -1)
       of opWrite:
-        if (firedEvents and EvWrite) != 0:
+        if evWrite in firedEvents:
           let r = posixWrite(fd, s.op.buf, s.op.len)
           complete(j, if r >= 0: r else: -1)
       of opAccept:
-        if (firedEvents and EvRead) != 0:
+        if evRead in firedEvents:
           var addrLen = s.op.acceptLen
           let clientFd = posixAccept(fd, addr s.op.acceptAddr, addr addrLen)
           complete(j, if clientFd >= 0: clientFd else: -1)
@@ -100,19 +100,19 @@ when defined(posix):
         # Only the directions this op asked for count. A wake for a direction
         # it did not request leaves the slot pending, and the re-arm below
         # keeps watching for the one it did.
-        let hit = firedEvents and s.op.pollMask
-        if hit != 0:
-          complete(j, hit)
+        let hit = firedEvents * s.op.pollMask
+        if hit != {}:
+          complete(j, toEventMask(hit))
       of opNop:
         discard
     # Re-arm for whatever directions still have an op pending on this fd
     # (completions above may have freed some slots already).
     if gSlots[lane].hasPendingForFd(fd):
-      if not reArmEvent(fd, armMaskForFd(fd), true):
+      if not reArmEvent(fd, armEventsForFd(fd), true):
         failPendingForFd(fd)
     # else: nothing left for this fd; the backend already consumed the
     # one-shot registration, and submit/registerEvent will re-add it the
     # next time an op targets this fd.
 else:
-  proc processFd*(fd: cint; firedEvents: int) {.nimcall.} =
+  proc processFd*(fd: cint; firedEvents: IoEvents) {.nimcall.} =
     discard

--- a/lib/std/ioring/core/types.nim
+++ b/lib/std/ioring/core/types.nim
@@ -1,11 +1,15 @@
 # Common types shared across all ioring layers.
 import std/posix/posix
 
-const
-  EvRead* = 1
-  EvWrite* = 2
-
 type
+  IoEvent* = enum
+    ## A readiness direction. `submitPollAdd` takes a set of these, and an
+    ## `opPollAdd` completion reports the set that actually fired.
+    evRead   ## readable — data is available, or a listener has a pending connection
+    evWrite  ## writable — the send buffer has room
+
+  IoEvents* = set[IoEvent]
+
   IoOp* = enum
     opNop, opRead, opWrite, opAccept, opPollAdd
 
@@ -16,6 +20,9 @@ type
     op*: IoOp
     fd*: FileHandle
     result*: int
+      ## Op-dependent: a byte count for `opRead`/`opWrite`, the accepted fd for
+      ## `opAccept`, -1 on failure — and for `opPollAdd` the fired directions
+      ## encoded as a bit mask, which `readyEvents` decodes into `IoEvents`.
 
   OpContext* = object
     kind*: IoOp
@@ -25,11 +32,30 @@ type
     len*: int
     cont*: Continuation
     res*: int
-    pollMask*: int
-      ## opPollAdd only: the direction(s) the caller actually waits for
-      ## (EvRead / EvWrite / both). Without it a readiness probe has to arm
-      ## both directions, and a caller waiting to READ is woken every time the
-      ## fd is merely WRITABLE — which, for a socket, is almost always. Since
-      ## the op is oneshot, that caller's re-arm turns into a hot spin.
+    pollMask*: IoEvents
+      ## opPollAdd only: the direction(s) the caller actually waits for.
+      ## Without it a readiness probe has to arm both directions, and a caller
+      ## waiting to READ is woken every time the fd is merely WRITABLE — which,
+      ## for a socket, is almost always. Since the op is oneshot, that caller's
+      ## re-arm turns into a hot spin.
     acceptAddr*: Sockaddr_storage
     acceptLen*: SockLen
+
+proc toEventMask*(events: IoEvents): int {.inline.} =
+  ## Encode `events` for the plain `int` channels a completion travels through
+  ## (`IoCompletion.result` and the `resPtr` out-parameter), neither of which
+  ## can carry a set.
+  result = 0
+  if evRead in events: result = result or (1 shl ord(evRead))
+  if evWrite in events: result = result or (1 shl ord(evWrite))
+
+proc toIoEvents*(mask: int): IoEvents {.inline.} =
+  ## Inverse of `toEventMask`.
+  result = {}
+  if (mask and (1 shl ord(evRead))) != 0: result.incl evRead
+  if (mask and (1 shl ord(evWrite))) != 0: result.incl evWrite
+
+proc readyEvents*(c: IoCompletion): IoEvents {.inline.} =
+  ## The direction(s) that fired, for an `opPollAdd` completion. Empty for
+  ## every other op, whose `result` is a byte count or an error instead.
+  if c.op == opPollAdd: toIoEvents(c.result) else: {}

--- a/lib/std/posix/io_uring.nim
+++ b/lib/std/posix/io_uring.nim
@@ -29,12 +29,106 @@ type
     TIMEOUT_ETIME_SUCCESS
   TimeoutFlags* = set[TimeoutFlag]
 
-  PollFlag* {.size: sizeof(uint16).} = enum
+  PollFlag* {.size: sizeof(uint32).} = enum
+    ## `IORING_POLL_*`. These do *not* travel in the SQE's event field: the
+    ## kernel reads them from `len`, which is a `__u32` — hence the size.
     POLL_ADD_MULTI
     POLL_UPDATE_EVENTS
     POLL_UPDATE_USER_DATA
     POLL_ADD_LEVEL
   PollFlags* = set[PollFlag]
+
+  PollEvent* {.size: sizeof(uint32).} = enum
+    ## A poll(2) event, which is what `OP_POLL_ADD` arms on and reports back.
+    ## Distinct from `PollFlag`: these are the `POLL*` bits every poll-style
+    ## interface uses, the other set is io_uring's own arming modes.
+    POLL_IN         ## POLLIN
+    POLL_PRI        ## POLLPRI
+    POLL_OUT        ## POLLOUT
+    POLL_ERR        ## POLLERR (reported only, never requested)
+    POLL_HUP        ## POLLHUP (reported only, never requested)
+    POLL_NVAL       ## POLLNVAL (reported only, never requested)
+    POLL_RDNORM     ## POLLRDNORM
+    POLL_RDBAND     ## POLLRDBAND
+    POLL_WRNORM     ## POLLWRNORM
+    POLL_WRBAND     ## POLLWRBAND
+    POLL_MSG        ## POLLMSG
+    POLL_RESERVED11 ## unused by the kernel; holds the bit positions in place
+    POLL_REMOVE     ## POLLREMOVE
+    POLL_RDHUP      ## POLLRDHUP
+  PollEvents* = set[PollEvent]
+
+  MsgFlag* {.size: sizeof(uint32).} = enum
+    ## Socket message flags, as passed to send(2)/recv(2) and their io_uring
+    ## equivalents. Stops at `MSG_WAITFORONE`: the kernel's remaining flags
+    ## (MSG_ZEROCOPY and friends) sit far up the word behind unnamed gaps.
+    MSG_OOB
+    MSG_PEEK
+    MSG_DONTROUTE
+    MSG_CTRUNC
+    MSG_PROXY
+    MSG_TRUNC
+    MSG_DONTWAIT
+    MSG_EOR
+    MSG_WAITALL
+    MSG_FIN
+    MSG_SYN
+    MSG_CONFIRM
+    MSG_RST
+    MSG_ERRQUEUE
+    MSG_NOSIGNAL
+    MSG_MORE
+    MSG_WAITFORONE
+  MsgFlags* = set[MsgFlag]
+
+  SyncFileRangeFlag* {.size: sizeof(uint32).} = enum
+    SYNC_FILE_RANGE_WAIT_BEFORE
+    SYNC_FILE_RANGE_WRITE
+    SYNC_FILE_RANGE_WAIT_AFTER
+  SyncFileRangeFlags* = set[SyncFileRangeFlag]
+
+  SpliceFlag* {.size: sizeof(uint32).} = enum
+    SPLICE_F_MOVE
+    SPLICE_F_NONBLOCK
+    SPLICE_F_MORE
+    SPLICE_F_GIFT
+  SpliceFlags* = set[SpliceFlag]
+
+  RenameFlag* {.size: sizeof(uint32).} = enum
+    RENAME_NOREPLACE
+    RENAME_EXCHANGE
+    RENAME_WHITEOUT
+  RenameFlags* = set[RenameFlag]
+
+  StatxField* {.size: sizeof(uint32).} = enum
+    ## `STATX_*`: which fields `statx` should fill in. `STATX_BASIC_STATS` and
+    ## `STATX_ALL` below name the usual combinations.
+    STATX_TYPE
+    STATX_MODE
+    STATX_NLINK
+    STATX_UID
+    STATX_GID
+    STATX_ATIME
+    STATX_MTIME
+    STATX_CTIME
+    STATX_INO
+    STATX_SIZE
+    STATX_BLOCKS
+    STATX_BTIME
+    STATX_MNT_ID
+    STATX_DIOALIGN
+  StatxFields* = set[StatxField]
+
+  XattrFlag* {.size: sizeof(uint32).} = enum
+    XATTR_CREATE
+    XATTR_REPLACE
+  XattrFlags* = set[XattrFlag]
+
+  ShutdownHow* {.size: sizeof(uint32).} = enum
+    ## `how` for shutdown(2): not a flag set, a choice of one.
+    SHUT_RD
+    SHUT_WR
+    SHUT_RDWR
 
   AsyncCancelFlag* {.size: sizeof(uint32).} = enum
     ASYNC_CANCEL_ALL
@@ -62,21 +156,24 @@ type
   InnerSqeFlags* {.union.} = object
     rwFlags*: KernelRwfT
     fsyncFlags*: FsyncFlags
-    pollEvents*: PollFlags
-    poll32Events*: uint32
-    syncRangeFlags*: uint32
-    msgFlags*: uint32
+    poll32Events*: PollEvents
+      ## The kernel's `poll32_events`. Its `poll_events` alias is the low half
+      ## of these same bytes, so there is nothing separate to declare.
+    syncRangeFlags*: SyncFileRangeFlags
+    msgFlags*: MsgFlags
     timeoutFlags*: TimeoutFlags
     acceptFlags*: uint32
-    cancelFlags*: uint32
+    cancelFlags*: AsyncCancelFlags
     openFlags*: uint32
     statxFlags*: uint32
     fadviseAdvice*: uint32
     spliceFlags*: uint32
-    renameFlags*: uint32
+      ## Untyped on purpose: `SpliceFlags` covers the low four bits, but
+      ## `SPLICE_F_FD_IN_FIXED` is io_uring's own bit high up the same word.
+    renameFlags*: RenameFlags
     unlinkFlags*: uint32
     hardlinkFlags*: uint32
-    xattrFlags*: uint32
+    xattrFlags*: XattrFlags
     msgRingFlags*: MsgRingOpFlags
     uringCmdFlags*: uint32
 
@@ -390,7 +487,7 @@ type
   SyncCancelReg* = object
     `addr`*: uint64
     fd*: int32
-    flags*: uint32
+    flags*: AsyncCancelFlags
     timeout*: Timespec
     pad*: array[4, uint64]
   
@@ -403,9 +500,13 @@ type
     namelen*: uint32
     controllen*: uint32
     payloadlen*: uint32
-    flags*: uint32
+    flags*: MsgFlags
 
 const
+  STATX_BASIC_STATS* = {STATX_TYPE, STATX_MODE, STATX_NLINK, STATX_UID,
+                        STATX_GID, STATX_ATIME, STATX_MTIME, STATX_CTIME,
+                        STATX_INO, STATX_SIZE, STATX_BLOCKS}
+  STATX_ALL* = STATX_BASIC_STATS + {STATX_BTIME}
   FILE_INDEX_ALLOC* = not 0u
   URING_CMD_FIXED* = not 0u
   TIMEOUT_CLOCK_MASK* = {TIMEOUT_BOOTTIME, TIMEOUT_REALTIME}
@@ -438,14 +539,16 @@ proc setup*(entries: cint, params: ptr Params): FileHandle {.raises, tags: [].} 
     raiseOSError(osLastError(), "io_uring setup syscall failed")
 
 proc enter*(fd: cint, toSubmit: cint, minComplete: cint,
-            flags: cint, sig: nil pointer, sz: cint): cint {.raises, tags: [].} =
+            flags: EnterFlags, sig: nil pointer, sz: cint): cint {.raises, tags: [].} =
   ## `sig` points to a kernel sigset (8 bytes on Linux) or is nil.
-  result = syscall(SYS_io_uring_enter, fd, toSubmit, minComplete, flags, sig, sz)
+  var f = flags
+  result = syscall(SYS_io_uring_enter, fd, toSubmit, minComplete,
+                   cast[ptr cint](f.addr)[], sig, sz)
   if result < 0:
     raiseOSError(osLastError(), "io_uring enter syscall failed")
 
-proc register*(fd: cint, op: cint, arg: nil pointer, nr_args: cint): cint {.raises, tags: [].} =
-  result = syscall(SYS_io_uring_register, fd, op, arg, nr_args, 0, 0)
+proc register*(fd: cint, op: RegisterOp, arg: nil pointer, nr_args: cint): cint {.raises, tags: [].} =
+  result = syscall(SYS_io_uring_register, fd, cint(op), arg, nr_args, 0, 0)
   if result < 0:
     raiseOSError(osLastError(), "io_uring register syscall failed")
 
@@ -673,7 +776,7 @@ proc submit*(queue: var Queue; waitNr: uint = 0): int {.raises, tags: [], discar
   if queue.sqNeedsEnter(submited, flags) or cqNeedsEnter:
     if cqNeedsEnter:
       flags.incl(ENTER_GETEVENTS)
-    result = enter(queue.fd, submited.cint, waitNr.cint, cast[ptr cint](flags.addr)[], nil, 0.cint)
+    result = enter(queue.fd, submited.cint, waitNr.cint, flags, nil, 0.cint)
   else:
     result = submited
 
@@ -697,8 +800,7 @@ proc cqReady*(queue: var Queue): uint32 =
 proc waitReady(queue: var Queue; waitNr: uint = 0): uint32 {.raises, tags: [], inline.} =
   result = queue.cqReady
   if result == 0 and (queue.cqNeedsFlush or waitNr > 0):
-    var flags = {ENTER_GETEVENTS}
-    discard enter(queue.fd, 0.cint, waitNr.cint, cast[ptr cint](flags.addr)[], nil, 0.cint)
+    discard enter(queue.fd, 0.cint, waitNr.cint, {ENTER_GETEVENTS}, nil, 0.cint)
     result = queue.cqReady
 
 proc copyCqesToSeq(queue: var Queue; cqes: openArray[Cqe]; ready: uint32) {.inline.} =
@@ -756,7 +858,7 @@ proc registerFiles*(q: var Queue; fds: seq[FileHandle]): int {.raises, tags: [],
   ## Registering file descriptors will wait for the ring to idle.
   ## Files are automatically unregistered by the kernel when the ring is torn down.
   ## An application need unregister only if it wants to register a new array of file descriptors.
-  return register(q.fd.cint, REGISTER_FILES.cint, fds[0].addr, fds.len.cint)
+  return register(q.fd.cint, REGISTER_FILES, fds[0].addr, fds.len.cint)
 
 proc registerFilesUpdate*(q: var Queue; offset: Off; fds: seq[FileHandle]): int {.raises, tags: [], discardable.} =
   ## Updates registered file descriptors.
@@ -771,28 +873,28 @@ proc registerFilesUpdate*(q: var Queue; offset: Off; fds: seq[FileHandle]): int 
     offset: offset.uint32,
     data: cast[uint64](fds[0].addr)
   )
-  return register(q.fd.cint, REGISTER_FILES_UPDATE.cint, update.addr, fds.len.cint)
+  return register(q.fd.cint, REGISTER_FILES_UPDATE, update.addr, fds.len.cint)
 
 proc unregisterFiles*(q: var Queue;): int {.raises, tags: [], discardable.} =
   ## Unregisters all registered file descriptors previously associated with the ring.
-  return register(q.fd.cint, UNREGISTER_FILES.cint, nil, 0)
+  return register(q.fd.cint, UNREGISTER_FILES, nil, 0)
 
 proc registerEventFd*(q: var Queue; fd: FileHandle): int {.raises, tags: [], discardable.} =
   ## Registers the file descriptor for an eventfd that will be notified of completion events on
   ##  an io_uring instance.
   ## Only a single a eventfd can be registered at any given point in time.
-  return register(q.fd.cint, REGISTER_EVENTFD.cint, fd.addr, 1)
+  return register(q.fd.cint, REGISTER_EVENTFD, fd.addr, 1)
 
 proc registerEventFdAsync*(q: var Queue; fd: FileHandle): int {.raises, tags: [], discardable.} =
   ## Registers the file descriptor for an eventfd that will be notified of completion events on
   ## an io_uring instance. Notifications are only posted for events that complete in an async manner.
   ## This means that events that complete inline while being submitted do not trigger a notification event.
   ## Only a single eventfd can be registered at any given point in time.
-  return register(q.fd.cint, REGISTER_EVENTFD_ASYNC.cint, fd.addr, 1)
+  return register(q.fd.cint, REGISTER_EVENTFD_ASYNC, fd.addr, 1)
 
 proc unregisterEventFd*(q: var Queue;): int {.raises, tags: [], discardable.} =
   ## Unregister the registered eventfd file descriptor.
-  return register(q.fd.cint, UNREGISTER_EVENTFD.cint, nil, 0)
+  return register(q.fd.cint, UNREGISTER_EVENTFD, nil, 0)
 
 proc registerBuffers*(q: var Queue; buffers: seq[IOVec]): int {.raises, tags: [], discardable.} =
   ## Registers an array of buffers for use with `read_fixed` and `write_fixed`.
@@ -801,11 +903,11 @@ proc registerBuffers*(q: var Queue; buffers: seq[IOVec]): int {.raises, tags: []
   ##   User buffers point to file-backed memory.
   ##   error occured then you try to pass pointer allocated on stack
   ##   use alloc or alloc0
-  return register(q.fd.cint, REGISTER_BUFFERS.cint, buffers[0].addr, buffers.len.cint)
+  return register(q.fd.cint, REGISTER_BUFFERS, buffers[0].addr, buffers.len.cint)
 
 proc unregisterBuffers*(q: var Queue;): int {.raises, tags: [], discardable.} =
   ## Unregister the registered buffers.
-  return register(q.fd.cint, UNREGISTER_BUFFERS.cint, nil, 0)
+  return register(q.fd.cint, UNREGISTER_BUFFERS, nil, 0)
 
 # ============= OPS ==================
 
@@ -848,9 +950,14 @@ proc fsync*(sqe: ptr Sqe; fd: FileHandle; flags: FsyncFlags = {}): ptr Sqe =
 proc fallocate*(sqe: ptr Sqe; fd: FileHandle; mode: FileMode; offset: Off; len: int): ptr Sqe =
   sqe.prepRw(OP_FALLOCATE, fd, len, mode.int, offset)
 
-proc statx*(sqe: ptr Sqe; fd: FileHandle; path: var string; flags: uint32; mask: uint32; buf: ptr Stat): ptr Sqe =
+proc statx*(sqe: ptr Sqe; fd: FileHandle; path: var string; flags: uint32;
+            mask: StatxFields; buf: ptr Stat): ptr Sqe =
+  ## `flags` stays a raw `AT_*` word: those bits start at `AT_SYMLINK_NOFOLLOW`
+  ## (0x100) with nothing below them, so they do not form a set of enum.
+  var m = mask
   sqe.opFlags.statxFlags = flags
-  sqe.prepRw(OP_STATX, fd, cast[pointer](path.toCString), mask, cast[pointer](buf))
+  sqe.prepRw(OP_STATX, fd, cast[pointer](path.toCString),
+             cast[ptr uint32](m.addr)[], cast[pointer](buf))
 
 proc read*(sqe: ptr Sqe; fd: FileHandle; buffer: pointer; len: int; offset: int = 0): ptr Sqe =
   sqe.prepRw(OP_READ, fd, buffer, len, offset)
@@ -898,19 +1005,26 @@ proc connect*(sqe: ptr Sqe; sock: SocketHandle, `addr`: ptr SockAddr, addrLen: S
 proc epoll_ctl*(sqe: ptr Sqe; epfd: FileHandle; fd: FileHandle; op: uint32; ev: ptr EpollEvent): ptr Sqe =
   sqe.prepRw(OP_EPOLL_CTL, epfd, cast[pointer](ev), op, fd)
 
-proc poll_add*(sqe: ptr Sqe; fd: FileHandle; pollMask: uint32): ptr Sqe =
-  ## Single-shot `OP_POLL_ADD`: completes once with the fired poll mask, then
-  ## disarms until re-armed. `pollMask` is a standard poll(2) mask (POLLIN/
-  ## POLLOUT, ...). Matches liburing's io_uring_prep_poll_add, which stores the
-  ## mask in the poll32_events field.
-  sqe.opFlags.poll32Events = pollMask
+proc toPollEvents*(mask: uint32): PollEvents {.inline.} =
+  ## Reinterpret a raw poll(2) mask — such as the `res` an `OP_POLL_ADD`
+  ## completion reports — as a set. Bits above `POLL_RDHUP` are dropped: the
+  ## kernel does not set them for a poll, and keeping them would leave the set
+  ## holding values that are not `PollEvent`s.
+  var m = mask and ((1'u32 shl (ord(POLL_RDHUP) + 1)) - 1)
+  result = cast[ptr PollEvents](m.addr)[]
+
+proc poll_add*(sqe: ptr Sqe; fd: FileHandle; events: PollEvents): ptr Sqe =
+  ## Single-shot `OP_POLL_ADD`: completes once with the fired poll events, then
+  ## disarms until re-armed. Matches liburing's io_uring_prep_poll_add, which
+  ## stores the mask in the poll32_events field.
+  sqe.opFlags.poll32Events = events
   sqe.prepRw(OP_POLL_ADD, fd, cast[pointer](nil), 0, 0)
 
 
-proc poll_multi*(sqe: ptr Sqe; fd: FileHandle; pollMask: uint32): ptr Sqe =
+proc poll_multi*(sqe: ptr Sqe; fd: FileHandle; events: PollEvents): ptr Sqe =
   ## Multishot `OP_POLL_ADD`: stays armed and completes on every readiness edge.
   var flags = PollFlags({POLL_ADD_MULTI})
-  result = sqe.poll_add(fd, pollMask)
+  result = sqe.poll_add(fd, events)
   # After `poll_add`, not before: it goes through `prepRw`, which writes
   # `len = 0` — and `len` is exactly where the multishot flag lives, so setting
   # it first left the SQE a plain one-shot poll.
@@ -919,46 +1033,49 @@ proc poll_multi*(sqe: ptr Sqe; fd: FileHandle; pollMask: uint32): ptr Sqe =
 proc poll_remove*[UserData: SomeNumber | pointer](sqe: ptr Sqe; target_user_data: UserData): ptr Sqe =
   sqe.prepRw(OP_POLL_REMOVE, -1, target_user_data, 0, 0)
 
-proc poll_update*[UserData: SomeNumber | pointer](sqe: ptr Sqe; oldUserData: UserData; newUserData: UserData; pollMask: uint32, flags: uint32): ptr Sqe =
-  sqe.opFlags.poll32Events = pollMask
-  sqe.prepRw(OP_POLL_REMOVE, -1, oldUserData, int flags, cast[int](newUserData))
+proc poll_update*[UserData: SomeNumber | pointer](sqe: ptr Sqe; oldUserData: UserData; newUserData: UserData; events: PollEvents, flags: PollFlags): ptr Sqe =
+  ## `flags` says *what* to update (`POLL_UPDATE_EVENTS` / `POLL_UPDATE_USER_DATA`);
+  ## it travels in `len`, which is where the kernel reads the `IORING_POLL_*` bits.
+  var f = flags
+  sqe.opFlags.poll32Events = events
+  sqe.prepRw(OP_POLL_REMOVE, -1, oldUserData, cast[ptr int32](f.addr)[], cast[int](newUserData))
 
 
-proc recv*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: cint = 0): ptr Sqe =
-  sqe.opFlags.msgFlags = flags.uint32
+proc recv*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: MsgFlags = {}): ptr Sqe =
+  sqe.opFlags.msgFlags = flags
   sqe.prepRw(OP_RECV, sock, buffer, len, 0)
 
-proc recv_multishot*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: cint): ptr Sqe =
+proc recv_multishot*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: MsgFlags): ptr Sqe =
   sqe.ioprio.incl(RECV_MULTISHOT)
   sqe.recv(sock, buffer, len, flags)
 
-proc send*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: cint = 0): ptr Sqe =
-  sqe.opFlags.msgFlags = flags.uint32
+proc send*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: MsgFlags = {}): ptr Sqe =
+  sqe.opFlags.msgFlags = flags
   sqe.prepRw(OP_SEND, sock, buffer, len, 0)
 
-proc send*(sqe: ptr Sqe; sock: SocketHandle; str: var string; flags: cint = 0): ptr Sqe =
-  sqe.send(sock, cast[pointer](str.toCString), str.len, 0)
+proc send*(sqe: ptr Sqe; sock: SocketHandle; str: var string; flags: MsgFlags = {}): ptr Sqe =
+  sqe.send(sock, cast[pointer](str.toCString), str.len, flags)
 
-proc send_zc*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: uint32; zc_flags: uint; buf_index: uint): ptr Sqe =
+proc send_zc*(sqe: ptr Sqe; sock: SocketHandle; buffer: pointer; len: int; flags: MsgFlags; zcFlags: IoprioFlags; buf_index: uint): ptr Sqe =
   sqe.opFlags.msgFlags = flags
-  sqe.ioprio = cast[ptr IoprioFlags](zc_flags.addr)[]
+  sqe.ioprio = zcFlags
   sqe.prepRw(OP_SEND_ZC, sock, buffer, len, 0)
 
 
-proc recvmsg*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: cint): ptr Sqe =
-  sqe.opFlags.msgFlags = flags.uint32
+proc recvmsg*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: MsgFlags = {}): ptr Sqe =
+  sqe.opFlags.msgFlags = flags
   sqe.prepRw(OP_RECVMSG, sock, cast[pointer](msghdr), 1, 0)
 
-proc recvmsg_multishot*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: cint): ptr Sqe =
+proc recvmsg_multishot*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: MsgFlags): ptr Sqe =
   sqe.ioprio.incl(RECV_MULTISHOT)
   sqe.recvmsg(sock, msghdr, flags)
 
-proc sendmsg*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: cint): ptr Sqe =
-  sqe.opFlags.msgFlags = flags.uint32
+proc sendmsg*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: MsgFlags = {}): ptr Sqe =
+  sqe.opFlags.msgFlags = flags
   sqe.prepRw(OP_SENDMSG, sock, cast[pointer](msghdr), 1, 0)
 
-proc sendmsg_zc*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: cint): ptr Sqe =
-  sqe.opFlags.msgFlags = flags.uint32
+proc sendmsg_zc*(sqe: ptr Sqe; sock: SocketHandle; msghdr: ptr Tmsghdr; flags: MsgFlags = {}): ptr Sqe =
+  sqe.opFlags.msgFlags = flags
   sqe.prepRw(OP_SENDMSG_ZC, sock, cast[pointer](msghdr), 1, 0)
 
 
@@ -971,7 +1088,7 @@ proc close*[T: FileHandle | SocketHandle](sqe: ptr Sqe; fd: T): ptr Sqe =
   sqe.fd = cast[int32](fd)
   return sqe
 
-proc renameat*(sqe: ptr Sqe; oldDirFd: FileHandle; oldPath: var string; newDirFd: FileHandle; newPath: var string; flags: uint32): ptr Sqe =
+proc renameat*(sqe: ptr Sqe; oldDirFd: FileHandle; oldPath: var string; newDirFd: FileHandle; newPath: var string; flags: RenameFlags = {}): ptr Sqe =
   sqe.opFlags.renameFlags = flags
   sqe.prepRw(OP_RENAMEAT, oldDirFd, cast[pointer](oldPath.toCString), newDirFd.int, cast[int](newPath.toCString))
 
@@ -1003,7 +1120,7 @@ proc link_timeout*(sqe: ptr Sqe; ts: Timespec; flags: TimeoutFlags): ptr Sqe =
   sqe.prepRw(OP_LINK_TIMEOUT, -1.cint, cast[pointer](ts.addr), 1, 0)
 
 
-proc cancel*[T: SomeNumber | pointer](sqe: ptr Sqe; cancelUserData: T; flags: uint32): ptr Sqe =
+proc cancel*[T: SomeNumber | pointer](sqe: ptr Sqe; cancelUserData: T; flags: AsyncCancelFlags = {}): ptr Sqe =
   sqe.opFlags.cancelFlags = flags
   sqe.prepRw(OP_ASYNC_CANCEL, -1.cint, cancelUserData, 0, 0)
 
@@ -1012,11 +1129,11 @@ proc cancelFd*(sqe: ptr Sqe; fd: FileHandle): ptr Sqe =
   ## as opposed to `cancel`, which matches a single op by its user_data. Used
   ## when a fd is being closed so the kernel does not later complete into a
   ## slot index that the arena has since freed and reused for something else.
-  sqe.opFlags.cancelFlags = 1'u32 shl ord(ASYNC_CANCEL_FD)
+  sqe.opFlags.cancelFlags = {ASYNC_CANCEL_FD}
   sqe.prepRw(OP_ASYNC_CANCEL, fd, 0, 0, 0)
 
-proc shutdown*(sqe: ptr Sqe; sockfd: FileHandle; how: uint32): ptr Sqe =
-  sqe.prepRw(OP_SHUTDOWN, sockfd, 0, how.int, 0)
+proc shutdown*(sqe: ptr Sqe; sockfd: FileHandle; how: ShutdownHow): ptr Sqe =
+  sqe.prepRw(OP_SHUTDOWN, sockfd, 0, ord(how), 0)
 
 
 proc provide_buffers*(sqe: ptr Sqe; buffers: pointer; bufferSize: int; buffersCount: int; groupId: uint; bufferId: uint): ptr Sqe =
@@ -1027,7 +1144,7 @@ proc remove_buffers*(sqe: ptr Sqe; buffersCount: int; groupId: uint;): ptr Sqe =
   sqe.buf.bufIndex = groupId.uint16
   sqe.prepRw(OP_REMOVE_BUFFERS, cast[FileHandle](buffersCount), 0, 0, 0)
 
-proc sync_file_range*(sqe: ptr Sqe; fd: FileHandle; len: int; flags: uint32; offset: Off = 0): ptr Sqe =
+proc sync_file_range*(sqe: ptr Sqe; fd: FileHandle; len: int; flags: SyncFileRangeFlags; offset: Off = 0): ptr Sqe =
   sqe.opFlags.syncRangeFlags = flags
   sqe.prepRw(OP_SYNC_FILE_RANGE, fd, 0, len, offset)
 
@@ -1042,45 +1159,43 @@ proc madvice*(sqe: ptr Sqe; `addr`: pointer; len: int; advice: int): ptr Sqe =
   sqe.opFlags.fadviseAdvice = advice.uint32
   sqe.prepRw(OP_MADVISE, -1.cint, `addr`, len, 0)
 
-proc splice*(sqe: ptr Sqe; fd_in: FileHandle; off_in: int; fd_out: FileHandle; off_out: int; len: int; flags: int = 0, fixed: bool = false): ptr Sqe =
+proc splice*(sqe: ptr Sqe; fd_in: FileHandle; off_in: int; fd_out: FileHandle; off_out: int; len: int; flags: SpliceFlags = {}, fixed: bool = false): ptr Sqe =
   sqe.opcode = OP_SPLICE
   sqe.fd = fd_out
   sqe.len = len.int32
   sqe.off = cast[ptr InnerSqeOffset](off_out.addr)[]
   sqe.splice.spliceFdIn = fd_in.uint32
   sqe.`addr`.spliceOffIn = off_in
-  var spliceFlags = 
-    if fixed:
-      flags.uint32 or SPLICE_F_FD_IN_FIXED.uint32
-    else:
-      flags.uint32
+  var f = flags
+  var spliceFlags = cast[ptr uint32](f.addr)[]
+  if fixed:
+    spliceFlags = spliceFlags or SPLICE_F_FD_IN_FIXED.uint32
   sqe.opFlags.spliceFlags = spliceFlags
   return sqe
 
-proc tee*(sqe: ptr Sqe, fd_in: FileHandle, fd_out: FileHandle; len: int; flags: int = 0, fixed: bool = false): ptr Sqe =
+proc tee*(sqe: ptr Sqe, fd_in: FileHandle, fd_out: FileHandle; len: int; flags: SpliceFlags = {}, fixed: bool = false): ptr Sqe =
   sqe.opcode = OP_TEE
   sqe.fd = fd_out
   sqe.len = len.int32
   sqe.splice.spliceFdIn = fd_in.uint32
-  var spliceFlags = 
-    if fixed:
-      flags.uint32 or SPLICE_F_FD_IN_FIXED.uint32
-    else:
-      flags.uint32
+  var f = flags
+  var spliceFlags = cast[ptr uint32](f.addr)[]
+  if fixed:
+    spliceFlags = spliceFlags or SPLICE_F_FD_IN_FIXED.uint32
   sqe.opFlags.spliceFlags = spliceFlags
   return sqe
 
-proc msg_ring*(sqe: ptr Sqe; ring_fd: FileHandle; res: int; user_data: uint64; user_flags: uint32 = 0; opcode_flags: uint32 = 0): ptr Sqe =
-  sqe.opFlags.msgRingFlags = cast[ptr MsgRingOpFlags](opcode_flags.addr)[]
+proc msg_ring*(sqe: ptr Sqe; ring_fd: FileHandle; res: int; user_data: uint64; user_flags: uint32 = 0; opcode_flags: MsgRingOpFlags = {}): ptr Sqe =
+  sqe.opFlags.msgRingFlags = opcode_flags
   sqe.prepRw(OP_MSG_RING, ring_fd, MSG_DATA.cint, res, user_data)
 
-proc fsetxattr*(sqe: ptr Sqe; fd: FileHandle; name: var string; value: var string; flags: int = 0): ptr Sqe =
-  sqe.opFlags.xattrFlags = flags.uint32
+proc fsetxattr*(sqe: ptr Sqe; fd: FileHandle; name: var string; value: var string; flags: XattrFlags = {}): ptr Sqe =
+  sqe.opFlags.xattrFlags = flags
   # TODO: which len?
   sqe.prepRw(OP_FSETXATTR, fd, cast[pointer](name.toCString), name.len, cast[pointer](value.toCString))
 
-proc setxattr*(sqe: ptr Sqe, name: var string; value: var string; path: var string; flags: int = 0): ptr Sqe =
-  sqe.opFlags.xattrFlags = flags.uint32
+proc setxattr*(sqe: ptr Sqe, name: var string; value: var string; path: var string; flags: XattrFlags = {}): ptr Sqe =
+  sqe.opFlags.xattrFlags = flags
   sqe.cmd.addr3 = cast[pointer](path.toCString)
   sqe.prepRw(OP_SETXATTR, 0.cint, cast[pointer](name.toCString), name.len, cast[pointer](value.toCString))
 

--- a/tests/nimony/threads/tpolladd.nim
+++ b/tests/nimony/threads/tpolladd.nim
@@ -1,9 +1,9 @@
 when defined(windows):
   import std/syncio
-  echo "n=1 op=opPollAdd result=3 rd=true wr=true"
-  echo "m=1 op=opPollAdd result=2 wr=true"
-  echo "k=1 fd_is_a=true result=1"
-  echo "j=1 fd_is_b=true result=1 rd=true"
+  echo "n=1 op=opPollAdd rd=true wr=true"
+  echo "m=1 op=opPollAdd wr=true"
+  echo "k=1 fd_is_a=true rd=true wr=false"
+  echo "j=1 fd_is_b=true rd=true wr=false"
 else:
   import std / [ioring, assertions, syncio]
   import std/posix/posix
@@ -32,15 +32,15 @@ else:
   var comps: array[8, IoCompletion]
   discard submitPollAdd(a)
   let n = waitCompletions(comps)
-  echo "n=", n, " op=", comps[0].op, " result=", comps[0].result,
-       " rd=", (comps[0].result and EvRead) != 0,
-       " wr=", (comps[0].result and EvWrite) != 0
+  echo "n=", n, " op=", comps[0].op,
+       " rd=", evRead in comps[0].readyEvents,
+       " wr=", evWrite in comps[0].readyEvents
 
   # Oneshot: re-arm on `b`, which is writable.
   discard submitPollAdd(b)
   let m = waitCompletions(comps)
-  echo "m=", m, " op=", comps[0].op, " result=", comps[0].result,
-       " wr=", (comps[0].result and EvWrite) != 0
+  echo "m=", m, " op=", comps[0].op,
+       " wr=", evWrite in comps[0].readyEvents
 
   # The mask is honoured: `b` is writable but has nothing to read, so a
   # read-only probe on it must NOT complete. Asserting a negative without a
@@ -48,20 +48,23 @@ else:
   # still readable (nothing has consumed the byte above — a poll does no I/O).
   # Exactly one completion must come back, and it must be `a`'s.
   #
-  # Before the mask existed, opPollAdd always armed EvRead or EvWrite, so this
+  # Before the mask existed, opPollAdd always armed both directions, so this
   # probe fired immediately on writability — and since the op is oneshot, a
   # caller that re-armed after each wake spun as fast as it could poll.
-  discard submitPollAdd(b, EvRead)
-  discard submitPollAdd(a, EvRead)
+  discard submitPollAdd(b, {evRead})
+  discard submitPollAdd(a, {evRead})
   let k = waitCompletions(comps)
-  echo "k=", k, " fd_is_a=", cint(comps[0].fd) == a, " result=", comps[0].result
+  echo "k=", k, " fd_is_a=", cint(comps[0].fd) == a,
+       " rd=", evRead in comps[0].readyEvents,
+       " wr=", evWrite in comps[0].readyEvents
 
   # …and the probe left pending on `b` fires as soon as `b` really is readable,
-  # reporting EvRead and nothing else.
+  # reporting evRead and nothing else.
   discard send(a, msg.toCString, len(msg), MSG_NOSIGNAL)
   let j = waitCompletions(comps)
-  echo "j=", j, " fd_is_b=", cint(comps[0].fd) == b, " result=", comps[0].result,
-       " rd=", (comps[0].result and EvRead) != 0
+  echo "j=", j, " fd_is_b=", cint(comps[0].fd) == b,
+       " rd=", evRead in comps[0].readyEvents,
+       " wr=", evWrite in comps[0].readyEvents
 
   closeFd(a)
   closeFd(b)

--- a/tests/nimony/threads/tpolladd.output
+++ b/tests/nimony/threads/tpolladd.output
@@ -1,4 +1,4 @@
-n=1 op=opPollAdd result=3 rd=true wr=true
-m=1 op=opPollAdd result=2 wr=true
-k=1 fd_is_a=true result=1
-j=1 fd_is_b=true result=1 rd=true
+n=1 op=opPollAdd rd=true wr=true
+m=1 op=opPollAdd wr=true
+k=1 fd_is_a=true rd=true wr=false
+j=1 fd_is_b=true rd=true wr=false


### PR DESCRIPTION
The io_uring work introduced public APIs that pass flags as bare ints, which the type system cannot check and the reader cannot name.

std/ioring: `EvRead`/`EvWrite` become `IoEvent`/`IoEvents`. `submitPollAdd` takes `{evRead}` rather than an `or` of two untyped consts, `OpContext.pollMask` and the whole backend seam (`reArmEvent`, `armEventsForFd`, `processFd`) carry the set, and `IoCompletion.readyEvents` decodes what fired. `IoCompletion.result` stays an int — it also carries byte counts and errors — so `toEventMask` / `toIoEvents` bridge it and the `resPtr` channel, which is a `ptr int` and cannot hold a set either.

std/posix/io_uring: the SQE ops now take the enum sets the module already defined instead of raw words — `AsyncCancelFlags` for `cancel`/`cancelFd`, `IoprioFlags` for `send_zc`, `MsgRingOpFlags` for `msg_ring`, `PollFlags` for `poll_update`, `EnterFlags` for `enter`, `RegisterOp` for `register` — which also removes the reinterpreting casts at each call site. New sets cover the flag words that had none: `PollEvents` (poll_add/poll_multi/poll_update), `MsgFlags`, `SyncFileRangeFlags`, `SpliceFlags`, `RenameFlags`, `XattrFlags`, `StatxFields`, plus `ShutdownHow` for shutdown(2)'s three-way choice. The matching `InnerSqeFlags` union members are typed to match.

Two bugs fall out of the typing:

- `PollFlag` was `{.size: sizeof(uint16).}`, but the kernel reads those bits from `len`, a `__u32`. `poll_multi` casts the set through `ptr int32`, so it was reading two bytes past it and OR-ing whatever followed into `len`.
- `send(sqe, sock, str, flags)` forwarded a literal `0` instead of `flags`, silently dropping the caller's message flags.

Left as raw words on purpose: `openat`, `unlinkat`, `linkat`, `accept` and statx's `flags` take `O_*`/`AT_*`/`SOCK_*` bits, which start high in the word with nothing below them and so do not form a set of enum; `fadvice`/`madvice` advice values differ per architecture.

Verified: the enum bit positions were checked against the kernel values by running them (POLLIN=1 … POLLRDHUP=0x2000, MSG_NOSIGNAL=0x4000, STATX_BASIC_STATS=0x7ff, IORING_ASYNC_CANCEL_FD=2, …). The Linux-only paths — io_uring backend, epoll fallback — were type-checked with `nimony check --os:linux` over a probe exercising every changed signature. tests/nimony is green on macOS/kqueue: 56 directories, 681/681 (sysbasics excluded; it wedges on the known macOS tdynlibs hang with or without this change).