### PR TITLE
std/ioring: Windows backends — IOCP proactor (default) and WSAPoll readiness

### DIFF
--- a/lib/std/ioring.nim
+++ b/lib/std/ioring.nim
@@ -18,7 +18,7 @@ import std / [atomics, threadpool, assertions, ticketlocks]
 import ./ioring/core/[types, slots, backend]
 export types.IoCompletion, types.IoOp, types.SeqNum, types.OpContext
 export types.IoEvent, types.IoEvents, types.evRead, types.evWrite
-export types.readyEvents, types.toIoEvents, types.toEventMask
+export types.readyEvents, types.toIoEvents, types.toEventMask, types.ECancelled
 export backend.BackendRelays, backend.CqSize, backend.MaxOps
 import ./ioring/platform
 when defined(windows):
@@ -208,14 +208,11 @@ proc cancelPendingOps(fd: cint) =
   if backendRelays.forgetFd != nil:
     backendRelays.forgetFd(fd)
   for idx in gSlots[lane].slotsForFd(fd):
-    let slot = addr gSlots[lane].slots[idx]
-    const ECancelled = -125
-    if slot.op.res != 0:
-      cast[ptr int](slot.op.res)[] = ECancelled
-    let cont = slot.op.cont
-    if cont.fn != nil:
-      submit(cont, int(fd))
-    gSlots[lane].freeSlot(idx)
+    # The shared completion path: writes `ECancelled`, resumes the continuation
+    # or — for an op without one — pushes a completion-queue entry, then frees
+    # the slot. This used to resume continuations only, so a cancelled op that
+    # had none (a `waitCompletions` driver) vanished and its waiter hung.
+    complete(idx, ECancelled)
 
 proc htons(x: uint16): uint16 {.inline.} =
   ## Header macro/libc shim; a byte swap on the little-endian targets.
@@ -336,9 +333,10 @@ when defined(windows):
   proc closeFd*(fd: cint) =
     ## Close `fd`. Readiness backend: cancel this lane's in-flight ops on it
     ## (see `cancelPendingOps`), then `closesocket`. IOCP: the socket's ops live
-    ## on its owner lane, where `closesocket` completes them with
-    ## ERROR_OPERATION_ABORTED and the drain frees their slots — so only the
-    ## lane association is dropped here.
+    ## on its owner lane, where `closesocket` aborts them — whichever lane
+    ## issued them — and the drain reports each as `ECancelled`, freeing the
+    ## slot; only the lane association is dropped here (backends/iocp.nim,
+    ## "Cancellation").
     when hasIocp:
       if backendRelays.forgetFd != nil:
         backendRelays.forgetFd(fd)

--- a/lib/std/ioring.nim
+++ b/lib/std/ioring.nim
@@ -21,13 +21,26 @@ export types.IoEvent, types.IoEvents, types.evRead, types.evWrite
 export types.readyEvents, types.toIoEvents, types.toEventMask
 export backend.BackendRelays, backend.CqSize, backend.MaxOps
 import ./ioring/platform
-from std/posix/posix import Sockaddr_storage, Sockaddr_in, SockLen, FileHandle,
-                            SockAddr, InAddr, TSa_Family
+when defined(posix):
+  from std/posix/posix import Sockaddr_storage, Sockaddr_in, SockLen, FileHandle,
+                              SockAddr, InAddr, TSa_Family
 
 var ringState: int = 0
 
+when defined(windows):
+  proc wsaStartup(wVersionRequested: uint16; lpWSAData: pointer): cint {.
+    stdcall, importc: "WSAStartup", dynlib: "ws2_32.dll".}
+
+  proc initWinsock() =
+    ## Winsock 2.2, once per process. WSADATA is 408 bytes on x64; the buffer
+    ## is oversized so a header revision cannot overrun it.
+    var data = default(array[512, byte])
+    discard wsaStartup(0x0202'u16, addr data[0])
+
 proc setupRing() =
   initPool()
+  when defined(windows):
+    initWinsock()
   initOpQueues()
   initSlots()
   gCq = newSeq[IoCompletion](CqSize)
@@ -153,6 +166,46 @@ proc waitCompletions*(comps: var openArray[IoCompletion]): int =
     if result > 0: return
     discard backendRelays.poll(0)
 
+proc cancelPendingOps(fd: cint) =
+  ## The platform-neutral half of `closeFd`: cancel any ops still in flight on
+  ## `fd` so their continuations are resumed (with a cancellation result)
+  ## instead of leaking, and deregister the fd from the backend — all BEFORE
+  ## the actual close. Previously `closeFd` only called close(2): the backend
+  ## never found out (so epoll/kqueue kept a registration for a possibly-reused
+  ## fd number) and any pending slot for this fd stayed in use forever — a
+  ## permanent slot-arena leak for every fd closed with an op in flight.
+  ##
+  ## Order matters: deregister from the backend *before* the close, so a fresh
+  ## fd that the OS immediately reuses for the same number cannot race with a
+  ## stale registration/slot that still refers to it.
+  ##
+  ## **Scope: this thread's lane only** (see `ioLane`). Slot arenas are
+  ## per-lane and unlocked, so a fd must be closed from the same thread that
+  ## submitted its ops; ops another lane still holds for `fd` are not
+  ## cancelled here and would leak the way described above. Cancelling those
+  ## needs a cross-lane request the owning lane drains from its own `poll`
+  ## (and, on io_uring, an `IORING_OP_ASYNC_CANCEL` — the kernel still owns
+  ## the slot's buffers until it acknowledges), which this does not do yet.
+  let lane = ioLane()
+  if backendRelays.forgetFd != nil:
+    backendRelays.forgetFd(fd)
+  for idx in gSlots[lane].slotsForFd(fd):
+    let slot = addr gSlots[lane].slots[idx]
+    const ECancelled = -125
+    if slot.op.res != 0:
+      cast[ptr int](slot.op.res)[] = ECancelled
+    let cont = slot.op.cont
+    if cont.fn != nil:
+      submit(cont, int(fd))
+    gSlots[lane].freeSlot(idx)
+
+proc htons(x: uint16): uint16 {.inline.} =
+  ## Header macro/libc shim; a byte swap on the little-endian targets.
+  when defined(bigEndian):
+    result = x
+  else:
+    result = (x shl 8) or (x shr 8)
+
 when defined(posix):
   proc posixClose(fd: cint): cint {.importc: "close".}
   proc fcntl(fd: cint; cmd: cint): cint {.varargs, importc.}
@@ -169,37 +222,9 @@ when defined(posix):
     discard posixClose(fd)
 
   proc closeFd*(fd: cint) =
-    ## Close `fd`, first cancelling any ops still in flight on it so their
-    ## continuations are resumed (with a cancellation result) instead of
-    ## leaking, and deregistering it from the backend before the actual
-    ## close(). Previously `closeFd` only called close(2): the backend never
-    ## found out (so epoll/kqueue kept a registration for a possibly-reused
-    ## fd number) and any pending slot for this fd stayed in use forever —
-    ## a permanent slot-arena leak for every fd closed with an op in flight.
-    ##
-    ## Order matters: deregister from the backend *before* close(2), so a
-    ## fresh fd that the OS immediately reuses for the same number cannot
-    ## race with a stale registration/slot that still refers to it.
-    ##
-    ## **Scope: this thread's lane only** (see `ioLane`). Slot arenas are
-    ## per-lane and unlocked, so a fd must be closed from the same thread that
-    ## submitted its ops; ops another lane still holds for `fd` are not
-    ## cancelled here and would leak the way described above. Cancelling those
-    ## needs a cross-lane request the owning lane drains from its own `poll`
-    ## (and, on io_uring, an `IORING_OP_ASYNC_CANCEL` — the kernel still owns
-    ## the slot's buffers until it acknowledges), which this does not do yet.
-    let lane = ioLane()
-    if backendRelays.forgetFd != nil:
-      backendRelays.forgetFd(fd)
-    for idx in gSlots[lane].slotsForFd(fd):
-      let slot = addr gSlots[lane].slots[idx]
-      const ECancelled = -125
-      if slot.op.res != 0:
-        cast[ptr int](slot.op.res)[] = ECancelled
-      let cont = slot.op.cont
-      if cont.fn != nil:
-        submit(cont, int(fd))
-      gSlots[lane].freeSlot(idx)
+    ## Close `fd`: cancel this lane's in-flight ops on it (see
+    ## `cancelPendingOps`), deregister it from the backend, then close(2).
+    cancelPendingOps(fd)
     discard posixClose(fd)
 
 when defined(posix):
@@ -214,13 +239,6 @@ when defined(posix):
   proc setsockopt(s: cint; level, optname: cint; val: pointer; vlen: SockLen): cint {.importc: "setsockopt".}
   proc bindAddr(s: cint; name: ptr SockAddr; namelen: SockLen): cint {.importc: "bind".}
   proc listen(s: cint; backlog: cint): cint {.importc: "listen".}
-  proc htons(x: uint16): uint16 {.inline.} =
-    ## Header macro/libc shim; a byte swap on the little-endian targets.
-    when defined(bigEndian):
-      result = x
-    else:
-      result = (x shl 8) or (x shr 8)
-
   proc listenTcp*(port: uint16; backlog = 128): cint =
     let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
     assert fd >= 0, "socket() failed"
@@ -235,5 +253,88 @@ when defined(posix):
     assert listen(fd, backlog.cint) == 0, "listen failed"
     setNonBlocking(fd)
     result = fd
+
+when defined(windows):
+  # Winsock socket surface — the ring's fd is a SOCKET narrowed to `cint`.
+  #
+  # `dynlib` externs are static imports on every backend, so the import library
+  # has to be on the link line; MinGW does not add ws2_32 by default.
+  {.passL: "-lws2_32".}
+  #
+  # `SOCKET` is `UINT_PTR`, but the values are kernel handles: small, 4-aligned
+  # integers well inside 31 bits in practice (undocumented, so `listenTcp` and
+  # the accept path assert it). Keeping the public `cint` API means every
+  # consumer (hashi, harness) stays platform-neutral; the IOCP backend can
+  # revisit this with completion keys (hashi/doc/iocp-ioring-briefing.md, open
+  # question 1).
+  # The POSIX arm's consumers see these names through `std/posix/posix`; give
+  # the Windows arm the same exported surface so a server written against the
+  # ring (hashi) stays platform-neutral.
+  export types.SockLen, types.Sockaddr_storage, types.FileHandle
+  type
+    SocketHandle = uint
+    InAddr* = object            ## struct in_addr
+      s_addr*: uint32
+    Sockaddr_in* = object       ## struct sockaddr_in (16 bytes, natural alignment)
+      sin_family*: cushort
+      sin_port*: uint16
+      sin_addr*: InAddr
+      sin_zero*: array[8, char]
+    SockAddr* = object          ## struct sockaddr (opaque, 16 bytes)
+      sa_family*: cushort
+      sa_data*: array[14, char]
+
+  const
+    InvalidSocket = not 0'u
+    AF_INET* = 2.cint
+    SOCK_STREAM* = 1.cint
+    IPPROTO_TCP* = 6.cint
+    SOL_SOCKET* = 0xFFFF.cint
+    SO_REUSEADDR* = 4.cint
+    INADDR_ANY* = 0'u32
+    FIONBIO = cast[clong](0x8004667E'u32)   ## _IOW('f', 126, u_long)
+
+  proc wsSocket(af, typ, protocol: cint): SocketHandle {.
+    stdcall, importc: "socket", dynlib: "ws2_32.dll".}
+  proc wsBind(s: SocketHandle; name: pointer; namelen: cint): cint {.
+    stdcall, importc: "bind", dynlib: "ws2_32.dll".}
+  proc wsListen(s: SocketHandle; backlog: cint): cint {.
+    stdcall, importc: "listen", dynlib: "ws2_32.dll".}
+  proc wsIoctlsocket(s: SocketHandle; cmd: clong; argp: ptr culong): cint {.
+    stdcall, importc: "ioctlsocket", dynlib: "ws2_32.dll".}
+  proc wsClosesocket(s: SocketHandle): cint {.
+    stdcall, importc: "closesocket", dynlib: "ws2_32.dll".}
+
+  proc socketOf(fd: cint): SocketHandle {.inline.} =
+    SocketHandle(cast[uint32](fd))
+
+  proc setNonBlocking*(fd: cint) =
+    var one: culong = 1
+    discard wsIoctlsocket(socketOf(fd), FIONBIO, addr one)
+
+  proc closeFdRaw*(fd: cint) =
+    discard wsClosesocket(socketOf(fd))
+
+  proc closeFd*(fd: cint) =
+    ## Close `fd`: cancel this lane's in-flight ops on it (see
+    ## `cancelPendingOps`), then `closesocket`.
+    cancelPendingOps(fd)
+    discard wsClosesocket(socketOf(fd))
+
+  proc listenTcp*(port: uint16; backlog = 128): cint =
+    ## IPv4 wildcard listener. No SO_REUSEADDR: on Winsock that option allows a
+    ## second bind to hijack a live listener, so the POSIX "restart without
+    ## TIME_WAIT" semantics are not what it means here.
+    let s = wsSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+    assert s != InvalidSocket, "socket() failed"
+    assert s <= SocketHandle(high(cint)), "SOCKET handle exceeds the ring's cint fd space"
+    var addr4 = default(Sockaddr_in)
+    addr4.sin_family = cushort(AF_INET)
+    addr4.sin_port = htons(port)
+    addr4.sin_addr.s_addr = INADDR_ANY
+    assert wsBind(s, addr addr4, cint(sizeof(addr4))) == 0, "bind failed"
+    assert wsListen(s, backlog.cint) == 0, "listen failed"
+    result = cint(cast[uint32](s))
+    setNonBlocking(result)
 
 initIoRing()

--- a/lib/std/ioring.nim
+++ b/lib/std/ioring.nim
@@ -22,7 +22,7 @@ export types.readyEvents, types.toIoEvents, types.toEventMask, types.ECancelled
 export backend.BackendRelays, backend.CqSize, backend.MaxOps
 import ./ioring/platform
 when defined(windows):
-  when defined(nimIoringIocp):
+  when not defined(nimIoringWsaPoll):
     import ./ioring/backends/iocp   # iocpOwnerLane / iocpWake — lane routing
 when defined(posix):
   from std/posix/posix import Sockaddr_storage, Sockaddr_in, SockLen, FileHandle,
@@ -168,6 +168,13 @@ proc submitPollAdd*(fd: cint; events: IoEvents = {evRead, evWrite};
   enqueueOp(op)
 
 proc pollCompletions*(comps: var openArray[IoCompletion]): int =
+  ## Non-blocking: drive this lane's backend once — issue the ops queued on
+  ## it and collect whatever the kernel has finished — then hand back up to
+  ## `comps.len` completions from the shared queue. Returns 0 when nothing has
+  ## completed. It used to only drain the queue, so a caller that submitted
+  ## and then polled had not issued anything, and a `closeFd` in between
+  ## found no slot to cancel.
+  discard backendRelays.poll(0)
   result = 0
   gCqLock.acquire()
   while result < comps.len and gCqCount > 0:
@@ -178,11 +185,11 @@ proc pollCompletions*(comps: var openArray[IoCompletion]): int =
   gCqLock.release()
 
 proc waitCompletions*(comps: var openArray[IoCompletion]): int =
+  ## `pollCompletions` until at least one completion has landed.
   result = 0
   while true:
     result = pollCompletions(comps)
     if result > 0: return
-    discard backendRelays.poll(0)
 
 proc cancelPendingOps(fd: cint) =
   ## The platform-neutral half of `closeFd`: cancel any ops still in flight on

--- a/lib/std/ioring.nim
+++ b/lib/std/ioring.nim
@@ -21,6 +21,9 @@ export types.IoEvent, types.IoEvents, types.evRead, types.evWrite
 export types.readyEvents, types.toIoEvents, types.toEventMask
 export backend.BackendRelays, backend.CqSize, backend.MaxOps
 import ./ioring/platform
+when defined(windows):
+  when defined(nimIoringIocp):
+    import ./ioring/backends/iocp   # iocpOwnerLane / iocpWake — lane routing
 when defined(posix):
   from std/posix/posix import Sockaddr_storage, Sockaddr_in, SockLen, FileHandle,
                               SockAddr, InAddr, TSa_Family
@@ -88,8 +91,23 @@ proc enqueueOp(op: OpContext) =
   ## `tryEnqueue` copies `op` by value and only consumes it on success
   ## (stripes.nim), so retrying with the same op is safe, and polling from a
   ## non-worker thread is the same pattern `waitCompletions` already uses.
-  while not gOpQueues[ioLane()].tryEnqueue(op):
-    discard backendRelays.poll(0)
+  when hasIocp:
+    # A socket belongs to the lane whose completion port it is bound to
+    # (backends/iocp.nim): its ops must be issued there. Stripes are
+    # lock-protected, so a foreign lane can enqueue; it then wakes the owner
+    # out of its completion wait. The first op for a socket claims it for the
+    # submitting lane.
+    var lane = ioLane()
+    if op.fd >= 0:
+      let owner = iocpOwnerLane(op.fd)
+      if owner >= 0: lane = owner
+    while not gOpQueues[lane].tryEnqueue(op):
+      discard backendRelays.poll(0)
+    if lane != ioLane():
+      iocpWake(lane)
+  else:
+    while not gOpQueues[ioLane()].tryEnqueue(op):
+      discard backendRelays.poll(0)
 
 proc submitNop*(cont = Continuation(fn: nil, env: nil);
                 resPtr: nil ptr int = nil): SeqNum =
@@ -316,9 +334,16 @@ when defined(windows):
     discard wsClosesocket(socketOf(fd))
 
   proc closeFd*(fd: cint) =
-    ## Close `fd`: cancel this lane's in-flight ops on it (see
-    ## `cancelPendingOps`), then `closesocket`.
-    cancelPendingOps(fd)
+    ## Close `fd`. Readiness backend: cancel this lane's in-flight ops on it
+    ## (see `cancelPendingOps`), then `closesocket`. IOCP: the socket's ops live
+    ## on its owner lane, where `closesocket` completes them with
+    ## ERROR_OPERATION_ABORTED and the drain frees their slots — so only the
+    ## lane association is dropped here.
+    when hasIocp:
+      if backendRelays.forgetFd != nil:
+        backendRelays.forgetFd(fd)
+    else:
+      cancelPendingOps(fd)
     discard wsClosesocket(socketOf(fd))
 
   proc listenTcp*(port: uint16; backlog = 128): cint =

--- a/lib/std/ioring/backends/iocp.nim
+++ b/lib/std/ioring/backends/iocp.nim
@@ -1,4 +1,5 @@
-# Windows IOCP backend — a proactor, selected with `-d:nimIoringIocp`.
+# Windows IOCP backend — a proactor, the Windows default (platform.nim;
+# `-d:nimIoringWsaPoll` selects the readiness backend instead).
 #
 # The ring's public contract is already completion-shaped (submit an op, get
 # resumed with its byte count); IOCP *is* that contract, so this backend has
@@ -346,9 +347,14 @@ when defined(windows):
         if op.kind == opAccept and a.acceptSock != InvalidSocket:
           discard wsClosesocket(a.acceptSock)
           a.acceptSock = InvalidSocket
-        # Aborted by closesocket (see "Cancellation"): the ring's cancellation
-        # result, not a generic failure. Internal holds the NTSTATUS.
-        if uint32(e.internal and 0xFFFFFFFF'u) == StatusCancelled:
+        # Closed under the op (see "Cancellation"): the ring's cancellation
+        # result, not a generic failure. The kernel's status is not the test —
+        # an aborted AcceptEx completes STATUS_CANCELLED but a WSARecv pending
+        # on the closed socket completes with a disconnect status (measured) —
+        # ownership is: `closeFd` drops the record before closesocket, and
+        # nothing else drops it.
+        if uint32(e.internal and 0xFFFFFFFF'u) == StatusCancelled or
+            iocpOwnerLane(op.fd) < 0:
           res = ECancelled
       complete(slotIdx, res)
       result = true

--- a/lib/std/ioring/backends/iocp.nim
+++ b/lib/std/ioring/backends/iocp.nim
@@ -1,17 +1,345 @@
-# Windows IOCP backend (stub).
+# Windows IOCP backend — a proactor, selected with `-d:nimIoringIocp`.
+#
+# The ring's public contract is already completion-shaped (submit an op, get
+# resumed with its byte count); IOCP *is* that contract, so this backend has
+# no readiness emulation: `poll` drains this lane's op queue, issues each op
+# as an overlapped WSARecv/WSASend/AcceptEx, and blocks in
+# GetQueuedCompletionStatusEx until the kernel reports completions, which it
+# hands to the shared `complete` (same resume path as every other backend).
+#
+# Lane affinity (the briefing's open question): a socket is associated with
+# exactly ONE completion port for its lifetime, so every op for a socket must
+# be issued — and its slot allocated — on the lane whose port the socket is
+# bound to. `ioring.enqueueOp` asks `iocpOwnerLane` and routes to that lane's
+# op queue (stripes are lock-protected, so cross-lane enqueue is safe), then
+# `iocpWake`s it. The first op for a socket claims it for the submitting lane.
+# Arenas therefore stay per-lane and unlocked, exactly as on POSIX.
+#
+# The OVERLAPPED blocks live in a per-lane, per-slot side arena owned by this
+# module (`gAux`) rather than in `OpContext`: the other platforms pay nothing
+# for them, and the storage is stable because it is sized to `MaxOps` up
+# front (the slot arena's growth beyond MaxOps is a documented cold path the
+# io_uring backend already rules out; asserted here).
+#
+# `opPollAdd` (readiness, used by harness/http/curl) has no IOCP form; those
+# slots are served by a WSAPoll(0) pass on each poll while any are pending,
+# with the completion wait shortened to 1 ms so they are re-checked promptly.
+#
+# Winsock/kernel32 are bound by `dynlib` (static imports on this toolchain;
+# ioring.nim links ws2_32). Known v1 limits: one AcceptEx per submitAccept,
+# no FILE_SKIP_COMPLETION_PORT_ON_SUCCESS (one delivery path), no cross-lane
+# cancellation (closesocket aborts pending ops on the owner lane instead).
 
-import ../core/types
-import ../core/backend
+when defined(windows):
+  {.feature: "lenientnils".}   # nil proc values (the AcceptEx pointer)
+  import std/[threadpool, ticketlocks, tables, syncio, assertions]
+  import std/windows/winlean   # Handle, DWORD, closeHandle, INVALID_HANDLE_VALUE
+  import ../core/types
+  import ../core/slots
+  import ../core/backend
 
-var dummyFd: cint
+  type
+    SocketHandle = uint            ## Winsock SOCKET (UINT_PTR)
+    Overlapped {.pure.} = object   ## OVERLAPPED
+      internal, internalHigh: uint
+      offset, offsetHigh: uint32
+      hEvent: nil pointer
+    IocpOv {.pure.} = object
+      ov: Overlapped               ## first: the drain casts lpOverlapped back
+      lane: int32
+      slot: int32
+    WsaBuf {.pure.} = object       ## WSABUF
+      len: uint32
+      buf: nil pointer
+    OverlappedEntry {.pure.} = object   ## OVERLAPPED_ENTRY
+      key: uint
+      ov: nil ptr Overlapped
+      internal: uint
+      bytes: uint32
+    Guid {.pure.} = object
+      data1: uint32
+      data2, data3: uint16
+      data4: array[8, uint8]
+    Aux = object                   ## per-slot side state (stable storage)
+      wov: IocpOv
+      wsabuf: WsaBuf
+      acceptSock: SocketHandle     ## opAccept: the pre-created socket AcceptEx fills
+      acceptBuf: array[2 * (128 + 16), uint8]   ## AcceptEx local+remote address scratch
+    AcceptExFn = proc (listen, accept: SocketHandle; buf: pointer;
+                       recvLen, localLen, remoteLen: uint32; received: ptr uint32;
+                       ov: ptr Overlapped): int32 {.stdcall.}
 
-proc dummyPoll(timeoutMs: int): bool {.nimcall.} = false
-proc dummyClose() {.nimcall.} = discard
-proc dummyForgetFd(fd: cint) {.nimcall.} = discard
+  const
+    InvalidSocket = not 0'u
+    SocketError = -1.cint
+    WSA_IO_PENDING = 997.cint
+    SOL_SOCKET = 0xFFFF.cint
+    SO_UPDATE_ACCEPT_CONTEXT = 0x700B.cint
+    SO_PROTOCOL_INFOW = 0x2005.cint
+    SIO_GET_EXTENSION_FUNCTION_POINTER = 0xC8000006'u32
+    WSA_FLAG_OVERLAPPED = 0x01'u32
+    MaxEntries = 64
+    DrainBatch = 128
+    WakeKey = not 0'u              ## completion key of a PostQueuedCompletionStatus wake
+    OpKey = 1'u                    ## completion key of every real socket completion
+    POLLRDNORM = 0x0100
+    POLLWRNORM = 0x0010
+    PollFailMask = 0x0001 or 0x0002 or 0x0004   # POLLERR | POLLHUP | POLLNVAL
+    AddrLen = 128 + 16             ## AcceptEx: sizeof(sockaddr_storage) + 16
 
-proc initIocpBackendRelays*(): BackendRelays =
-  result = BackendRelays(
-    poll: dummyPoll,
-    close: dummyClose,
-    forgetFd: dummyForgetFd,
-  )
+  proc createIoCompletionPort(fileHandle: Handle; port: Handle; key: uint;
+                              threads: uint32): Handle {.
+    stdcall, importc: "CreateIoCompletionPort", dynlib: "kernel32".}
+  proc getQueuedCompletionStatusEx(port: Handle; entries: ptr OverlappedEntry;
+                                   count: uint32; removed: ptr uint32; timeoutMs: uint32;
+                                   alertable: int32): int32 {.
+    stdcall, importc: "GetQueuedCompletionStatusEx", dynlib: "kernel32".}
+  proc postQueuedCompletionStatus(port: Handle; bytes: uint32; key: uint;
+                                  ov: nil ptr Overlapped): int32 {.
+    stdcall, importc: "PostQueuedCompletionStatus", dynlib: "kernel32".}
+  proc wsaRecv(s: SocketHandle; bufs: ptr WsaBuf; count: uint32; recvd: ptr uint32;
+               flags: ptr uint32; ov: ptr Overlapped; routine: nil pointer): cint {.
+    stdcall, importc: "WSARecv", dynlib: "ws2_32.dll".}
+  proc wsaSend(s: SocketHandle; bufs: ptr WsaBuf; count: uint32; sent: ptr uint32;
+               flags: uint32; ov: ptr Overlapped; routine: nil pointer): cint {.
+    stdcall, importc: "WSASend", dynlib: "ws2_32.dll".}
+  proc wsaIoctl(s: SocketHandle; code: uint32; inbuf: pointer; inlen: uint32;
+                outbuf: pointer; outlen: uint32; ret: ptr uint32; ov: nil pointer;
+                routine: nil pointer): cint {.
+    stdcall, importc: "WSAIoctl", dynlib: "ws2_32.dll".}
+  proc wsaSocketW(af, typ, protocol: cint; info: nil pointer; group: uint32;
+                  flags: uint32): SocketHandle {.
+    stdcall, importc: "WSASocketW", dynlib: "ws2_32.dll".}
+  proc wsaGetLastError(): cint {.
+    stdcall, importc: "WSAGetLastError", dynlib: "ws2_32.dll".}
+  proc wsaGetOverlappedResult(s: SocketHandle; ov: ptr Overlapped; bytes: ptr uint32;
+                              wait: int32; flags: ptr uint32): int32 {.
+    stdcall, importc: "WSAGetOverlappedResult", dynlib: "ws2_32.dll".}
+  proc wsSetsockopt(s: SocketHandle; level, optname: cint; optval: pointer;
+                    optlen: cint): cint {.
+    stdcall, importc: "setsockopt", dynlib: "ws2_32.dll".}
+  proc wsGetsockopt(s: SocketHandle; level, optname: cint; optval: pointer;
+                    optlen: ptr cint): cint {.
+    stdcall, importc: "getsockopt", dynlib: "ws2_32.dll".}
+  proc wsClosesocket(s: SocketHandle): cint {.
+    stdcall, importc: "closesocket", dynlib: "ws2_32.dll".}
+  type WsaPollFd {.pure.} = object
+    fd: SocketHandle
+    events: cshort
+    revents: cshort
+  proc wsaPoll(fdArray: ptr WsaPollFd; nfds: culong; timeout: cint): cint {.
+    stdcall, importc: "WSAPoll", dynlib: "ws2_32.dll".}
+
+  var
+    gPorts: seq[Handle]            ## one completion port per lane
+    gAux: seq[seq[Aux]]            ## per lane, MaxOps entries
+    gPollAdds: seq[seq[int]]       ## per lane: slot indices of pending opPollAdd ops
+    gOwner: Table[cint, int]       ## socket → owning lane (port association)
+    gOwnerLock: TicketLock
+    gAcceptEx: AcceptExFn
+
+  proc socketOf(fd: cint): SocketHandle {.inline.} = SocketHandle(cast[uint32](fd))
+  proc fdOf(s: SocketHandle): cint {.inline.} = cint(cast[uint32](s))
+
+  proc iocpOwnerLane*(fd: cint): int =
+    ## The lane whose port `fd` is associated with; -1 when not yet claimed.
+    gOwnerLock.acquire()
+    result = gOwner.getOrDefault(fd, -1)
+    gOwnerLock.release()
+
+  proc iocpWake*(lane: int) =
+    ## Wake `lane` out of its completion wait (a cross-lane enqueue).
+    discard postQueuedCompletionStatus(gPorts[lane], 0'u32, WakeKey, nil)
+
+  proc ensureAssociated(fd: cint; lane: int) =
+    ## First op for a socket on this lane: bind it to this lane's port.
+    gOwnerLock.acquire()
+    if not gOwner.hasKey(fd):
+      discard createIoCompletionPort(cast[Handle](socketOf(fd)), gPorts[lane], OpKey, 0'u32)
+      gOwner[fd] = lane
+    gOwnerLock.release()
+
+  proc loadAcceptEx(s: SocketHandle) =
+    ## AcceptEx is an extension: fetched once per process through WSAIoctl.
+    if gAcceptEx != nil: return
+    var guid = Guid(data1: 0xb5367df1'u32, data2: 0xcbac'u16, data3: 0x11cf'u16,
+                    data4: [0x95'u8, 0xca'u8, 0x00'u8, 0x80'u8, 0x5f'u8, 0x48'u8, 0xa1'u8, 0x92'u8])
+    # WSAIoctl writes the function pointer straight into a proc-typed slot: a
+    # pointer→proc cast is not allowed on this toolchain.
+    var fn: AcceptExFn = nil
+    var got = 0'u32
+    if wsaIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, addr guid, uint32(sizeof(guid)),
+                addr fn, uint32(sizeof(fn)), addr got, nil, nil) == 0:
+      gAcceptEx = fn
+
+  proc listenerFamily(s: SocketHandle): cint =
+    ## The listener's address family, so the accept socket matches it.
+    var info = default(array[640, uint8])   # WSAPROTOCOL_INFOW (628 bytes)
+    var len = cint(info.len)
+    if wsGetsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW, addr info[0], addr len) == 0:
+      # iAddressFamily is the INT at offset 4*4 + 4 (dwServiceFlags1..4, dwProviderFlags,
+      # ProviderId(16), dwCatalogEntryId, ProtocolChain(4+7*4=32)) — see WSAPROTOCOL_INFOW:
+      # offset = 20 + 16 + 4 + 32 = 72
+      result = cast[ptr cint](addr info[72])[]
+    else:
+      result = 2.cint   # AF_INET
+
+  proc clampLen(n: int): uint32 {.inline.} =
+    if n > int(high(int32)): uint32(high(int32)) else: uint32(n)
+
+  proc issue(lane, slotIdx: int) =
+    ## Issue the op in slot `slotIdx` as an overlapped operation.
+    let op = addr gSlots[lane].slots[slotIdx].op
+    let a = addr gAux[lane][slotIdx]
+    a.wov = IocpOv(lane: int32(lane), slot: int32(slotIdx))
+    let s = socketOf(op.fd)
+    case op.kind
+    of opNop:
+      complete(slotIdx, 0)
+    of opRead:
+      a.wsabuf = WsaBuf(len: clampLen(op.len), buf: op.buf)
+      var n = 0'u32
+      var flags = 0'u32
+      let r = wsaRecv(s, addr a.wsabuf, 1'u32, addr n, addr flags, addr a.wov.ov, nil)
+      if r == SocketError and wsaGetLastError() != WSA_IO_PENDING:
+        complete(slotIdx, -1)
+    of opWrite:
+      a.wsabuf = WsaBuf(len: clampLen(op.len), buf: op.buf)
+      var n = 0'u32
+      let r = wsaSend(s, addr a.wsabuf, 1'u32, addr n, 0'u32, addr a.wov.ov, nil)
+      if r == SocketError and wsaGetLastError() != WSA_IO_PENDING:
+        complete(slotIdx, -1)
+    of opAccept:
+      loadAcceptEx(s)
+      if gAcceptEx == nil:
+        complete(slotIdx, -1)
+      else:
+        a.acceptSock = wsaSocketW(listenerFamily(s), 1.cint, 6.cint, nil, 0'u32, WSA_FLAG_OVERLAPPED)
+        if a.acceptSock == InvalidSocket:
+          complete(slotIdx, -1)
+        else:
+          var n = 0'u32
+          let ok = gAcceptEx(s, a.acceptSock, addr a.acceptBuf[0], 0'u32,
+                             uint32(AddrLen), uint32(AddrLen), addr n, addr a.wov.ov)
+          if ok == 0 and wsaGetLastError() != WSA_IO_PENDING:
+            discard wsClosesocket(a.acceptSock)
+            a.acceptSock = InvalidSocket
+            complete(slotIdx, -1)
+    of opPollAdd:
+      gPollAdds[lane].add slotIdx
+
+  proc servePollAdds(lane: int): bool =
+    ## Readiness probes have no IOCP form: one WSAPoll(0) over the pending
+    ## opPollAdd slots, completing the ones whose requested direction fired.
+    result = false
+    if gPollAdds[lane].len == 0: return
+    var pfds = newSeq[WsaPollFd](gPollAdds[lane].len)
+    var i = 0
+    while i < gPollAdds[lane].len:
+      let op = addr gSlots[lane].slots[gPollAdds[lane][i]].op
+      var ev = 0
+      if evRead in op.pollMask: ev = ev or POLLRDNORM
+      if evWrite in op.pollMask: ev = ev or POLLWRNORM
+      pfds[i] = WsaPollFd(fd: socketOf(op.fd), events: cshort(ev), revents: cshort(0))
+      i = i + 1
+    if wsaPoll(addr pfds[0], culong(pfds.len), 0.cint) <= 0: return
+    var keep: seq[int] = @[]
+    i = 0
+    while i < gPollAdds[lane].len:
+      let slotIdx = gPollAdds[lane][i]
+      let re = int(pfds[i].revents)
+      var fired: IoEvents = {}
+      if (re and POLLRDNORM) != 0: fired.incl evRead
+      if (re and POLLWRNORM) != 0: fired.incl evWrite
+      if (re and PollFailMask) != 0: fired = {evRead, evWrite}
+      let hit = fired * gSlots[lane].slots[slotIdx].op.pollMask
+      if hit != {}:
+        complete(slotIdx, toEventMask(hit))
+        result = true
+      else:
+        keep.add slotIdx
+      i = i + 1
+    gPollAdds[lane] = keep
+
+  proc iocpPoll(timeoutMs: int): bool {.nimcall.} =
+    let lane = ioLane()
+    var buf {.noinit.}: array[DrainBatch, OpContext]
+    let n = gOpQueues[lane].tryBulkDequeue(DrainBatch, buf)
+    var i = 0
+    while i < n:
+      let slotIdx = gSlots[lane].allocSlot(buf[i])
+      assert slotIdx < MaxOps, "ioring/iocp: slot arena grew past MaxOps (OVERLAPPED storage)"
+      if buf[i].kind != opNop and buf[i].kind != opPollAdd:
+        ensureAssociated(buf[i].fd, lane)
+      issue(lane, slotIdx)
+      i = i + 1
+    result = servePollAdds(lane)
+    # Readiness probes are re-checked every millisecond while any are pending.
+    let wait = if gPollAdds[lane].len > 0 and timeoutMs > 1: 1 else: timeoutMs
+    var entries {.noinit.}: array[MaxEntries, OverlappedEntry]
+    var got = 0'u32
+    if getQueuedCompletionStatusEx(gPorts[lane], addr entries[0], uint32(MaxEntries),
+                                   addr got, uint32(wait), 0'i32) == 0:
+      return result
+    var k = 0
+    while k < int(got):
+      let e = addr entries[k]
+      k = k + 1
+      if e.key == WakeKey or e.ov == nil: continue
+      let wov = cast[ptr IocpOv](e.ov)
+      assert int(wov.lane) == lane, "ioring/iocp: completion delivered to a foreign lane"
+      let slotIdx = int(wov.slot)
+      let op = addr gSlots[lane].slots[slotIdx].op
+      let a = addr gAux[lane][slotIdx]
+      var res = -1
+      if e.internal == 0'u:
+        case op.kind
+        of opAccept:
+          var listenSock = socketOf(op.fd)
+          discard wsSetsockopt(a.acceptSock, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
+                               addr listenSock, cint(sizeof(listenSock)))
+          if a.acceptSock <= SocketHandle(high(cint)):
+            res = int(fdOf(a.acceptSock))
+          else:
+            discard wsClosesocket(a.acceptSock)   # cannot be narrowed to the cint API
+          a.acceptSock = InvalidSocket
+        else:
+          res = int(e.bytes)
+      else:
+        if op.kind == opAccept and a.acceptSock != InvalidSocket:
+          discard wsClosesocket(a.acceptSock)
+          a.acceptSock = InvalidSocket
+      complete(slotIdx, res)
+      result = true
+
+  proc iocpClose() {.nimcall.} =
+    var i = 0
+    while i < gPorts.len:
+      discard closeHandle(gPorts[i])
+      i = i + 1
+
+  proc iocpForgetFd(fd: cint) {.nimcall.} =
+    ## The socket is being closed: drop its lane association. Its pending
+    ## overlapped ops complete with ERROR_OPERATION_ABORTED on the owner lane,
+    ## which frees their slots through the normal drain.
+    gOwnerLock.acquire()
+    gOwner.del(fd)
+    gOwnerLock.release()
+
+  proc initIocpBackendRelays*(): BackendRelays =
+    let lanes = ioLanes()
+    gPorts = newSeq[Handle](lanes)
+    gAux = newSeq[seq[Aux]](lanes)
+    gPollAdds = newSeq[seq[int]](lanes)
+    var i = 0
+    while i < lanes:
+      gPorts[i] = createIoCompletionPort(INVALID_HANDLE_VALUE, cast[Handle](0), 0'u, 1'u32)
+      gAux[i] = newSeq[Aux](MaxOps)
+      gPollAdds[i] = @[]
+      i = i + 1
+    gOwner = initTable[cint, int]()
+    result = BackendRelays(
+      poll: iocpPoll,
+      close: iocpClose,
+      forgetFd: iocpForgetFd,
+    )

--- a/lib/std/ioring/backends/iocp.nim
+++ b/lib/std/ioring/backends/iocp.nim
@@ -25,10 +25,33 @@
 # slots are served by a WSAPoll(0) pass on each poll while any are pending,
 # with the completion wait shortened to 1 ms so they are re-checked promptly.
 #
+# Cancellation: `closeFd` may run on any lane. It drops the ownership record
+# and `closesocket`s; the kernel then aborts every overlapped op pending on
+# the socket — whichever lane issued it — and delivers each to the owner's
+# port with STATUS_CANCELLED, which the drain reports as `ECancelled`, freeing
+# the slot through the normal path. That is the cross-lane cancellation the
+# readiness backends lack (their `cancelPendingOps` reaches the closing lane's
+# slots only). An op still *queued* on the owner lane at close time fails at
+# issue — the handle is gone, so the association fails and it completes as
+# `ECancelled` too — unless Winsock has already reused the handle value for a
+# new socket that claimed the same lane: the fd-reuse hazard every backend
+# shares, so callers must not submit on a socket they are closing.
+#
+# Waiting: `poll` blocks in GetQueuedCompletionStatusEx for the worker loop's
+# idle budget and reports a blocking wait as served, so the loop does not add
+# its Sleep(1) on top — on Windows both round up to the ~15.6 ms scheduler
+# tick, and the double wait cost cross-thread task hand-offs a second tick.
+# Socket completions wake the wait at once, so no timeBeginPeriod: measured on
+# a MinGW builder (hashi ws_echo), a fresh connection's first request is
+# answered in ~0.4 ms here versus one full tick under the readiness backend,
+# and the echo path is ~0.4 ms per frame under both. Only timer resumes and
+# foreign-thread task submits still see the tick (they land in a stripe the
+# sleeping worker scans on its next cycle); waking the target lane's port from
+# `submit` would close that, and is a threadpool-level follow-up.
+#
 # Winsock/kernel32 are bound by `dynlib` (static imports on this toolchain;
 # ioring.nim links ws2_32). Known v1 limits: one AcceptEx per submitAccept,
-# no FILE_SKIP_COMPLETION_PORT_ON_SUCCESS (one delivery path), no cross-lane
-# cancellation (closesocket aborts pending ops on the owner lane instead).
+# no FILE_SKIP_COMPLETION_PORT_ON_SUCCESS (one delivery path).
 
 when defined(windows):
   {.feature: "lenientnils".}   # nil proc values (the AcceptEx pointer)
@@ -81,6 +104,7 @@ when defined(windows):
     MaxEntries = 64
     DrainBatch = 128
     WakeKey = not 0'u              ## completion key of a PostQueuedCompletionStatus wake
+    StatusCancelled = 0xC0000120'u32   ## NTSTATUS in OVERLAPPED.Internal of an aborted op
     OpKey = 1'u                    ## completion key of every real socket completion
     POLLRDNORM = 0x0100
     POLLWRNORM = 0x0010
@@ -151,12 +175,22 @@ when defined(windows):
     ## Wake `lane` out of its completion wait (a cross-lane enqueue).
     discard postQueuedCompletionStatus(gPorts[lane], 0'u32, WakeKey, nil)
 
-  proc ensureAssociated(fd: cint; lane: int) =
-    ## First op for a socket on this lane: bind it to this lane's port.
+  proc ensureAssociated(fd: cint; lane: int): bool =
+    ## First op for a socket: bind it to this lane's port and record the owner.
+    ## False when the op must not be issued: the association failed (a handle
+    ## closed while its op was still queued, or one bound to another port), or
+    ## the socket belongs to another lane after all (its handle value was
+    ## closed and reused between routing and issue). Ownership is recorded only
+    ## on success — a stale record would make the next socket to get this
+    ## handle value skip association, and its ops would never complete.
     gOwnerLock.acquire()
-    if not gOwner.hasKey(fd):
-      discard createIoCompletionPort(cast[Handle](socketOf(fd)), gPorts[lane], OpKey, 0'u32)
-      gOwner[fd] = lane
+    let owner = gOwner.getOrDefault(fd, -1)
+    if owner < 0:
+      result = createIoCompletionPort(cast[Handle](socketOf(fd)), gPorts[lane],
+                                      OpKey, 0'u32) != cast[Handle](0)
+      if result: gOwner[fd] = lane
+    else:
+      result = owner == lane
     gOwnerLock.release()
 
   proc loadAcceptEx(s: SocketHandle) =
@@ -269,9 +303,11 @@ when defined(windows):
     while i < n:
       let slotIdx = gSlots[lane].allocSlot(buf[i])
       assert slotIdx < MaxOps, "ioring/iocp: slot arena grew past MaxOps (OVERLAPPED storage)"
-      if buf[i].kind != opNop and buf[i].kind != opPollAdd:
-        ensureAssociated(buf[i].fd, lane)
-      issue(lane, slotIdx)
+      if buf[i].kind != opNop and buf[i].kind != opPollAdd and
+          not ensureAssociated(buf[i].fd, lane):
+        complete(slotIdx, ECancelled)   # closed or foreign handle: never issued
+      else:
+        issue(lane, slotIdx)
       i = i + 1
     result = servePollAdds(lane)
     # Readiness probes are re-checked every millisecond while any are pending.
@@ -280,7 +316,8 @@ when defined(windows):
     var got = 0'u32
     if getQueuedCompletionStatusEx(gPorts[lane], addr entries[0], uint32(MaxEntries),
                                    addr got, uint32(wait), 0'i32) == 0:
-      return result
+      # Timed out: a blocking wait was this worker's idle sleep (see header).
+      return result or wait > 0
     var k = 0
     while k < int(got):
       let e = addr entries[k]
@@ -309,6 +346,10 @@ when defined(windows):
         if op.kind == opAccept and a.acceptSock != InvalidSocket:
           discard wsClosesocket(a.acceptSock)
           a.acceptSock = InvalidSocket
+        # Aborted by closesocket (see "Cancellation"): the ring's cancellation
+        # result, not a generic failure. Internal holds the NTSTATUS.
+        if uint32(e.internal and 0xFFFFFFFF'u) == StatusCancelled:
+          res = ECancelled
       complete(slotIdx, res)
       result = true
 

--- a/lib/std/ioring/backends/poll.nim
+++ b/lib/std/ioring/backends/poll.nim
@@ -114,5 +114,84 @@ when defined(posix):
     # one-shot registration, and submit/registerEvent will re-add it the
     # next time an op targets this fd.
 else:
+  # Windows (the WSAPoll backend): the transfer calls are Winsock's, bound by
+  # `dynlib` in the winlean house style so no `<winsock2.h>` has to be ordered
+  # against `<Windows.h>` in the generated C.
+  #
+  # One deliberate difference from the POSIX arm: a `WSAEWOULDBLOCK` on a
+  # readiness wake is not a failure. The ready state was consumed by another
+  # op on the fd (or by another lane polling the same socket), so the op stays
+  # pending and is re-armed below instead of completing with -1.
+  type
+    SocketHandle = uint   ## Winsock SOCKET (UINT_PTR)
+
+  const
+    SocketError = -1.cint
+    InvalidSocket = not 0'u
+    WSAEWOULDBLOCK = 10035.cint
+
+  # `buf` is `nil pointer` to match `OpContext.buf` (the POSIX arm declares its
+  # read/write the same way): the op layout is nilable and the transfer takes
+  # it as-is.
+  proc wsRecv(s: SocketHandle; buf: nil pointer; len, flags: cint): cint {.
+    stdcall, importc: "recv", dynlib: "ws2_32.dll".}
+  proc wsSend(s: SocketHandle; buf: nil pointer; len, flags: cint): cint {.
+    stdcall, importc: "send", dynlib: "ws2_32.dll".}
+  proc wsAccept(s: SocketHandle; name: pointer; namelen: ptr cint): SocketHandle {.
+    stdcall, importc: "accept", dynlib: "ws2_32.dll".}
+  proc wsaGetLastError(): cint {.
+    stdcall, importc: "WSAGetLastError", dynlib: "ws2_32.dll".}
+
+  proc socketOf(fd: cint): SocketHandle {.inline.} =
+    ## The ring narrows a SOCKET to `cint` (ioring.nim, Windows arm); widen it
+    ## back without sign extension.
+    SocketHandle(cast[uint32](fd))
+
+  proc clampLen(n: int): cint {.inline.} =
+    if n > int(high(cint)): high(cint) else: cint(n)
+
+  proc wouldBlock(): bool {.inline.} =
+    wsaGetLastError() == WSAEWOULDBLOCK
+
   proc processFd*(fd: cint; firedEvents: IoEvents) {.nimcall.} =
-    discard
+    ## Windows twin of the POSIX `processFd` above: same per-direction
+    ## dispatch over the fd's in-flight ops, Winsock transfers.
+    let lane = ioLane()
+    let s = socketOf(fd)
+    for j in gSlots[lane].slotsForFd(fd):
+      let sl = addr gSlots[lane].slots[j]
+      case sl.op.kind
+      of opRead:
+        if evRead in firedEvents:
+          let r = wsRecv(s, sl.op.buf, clampLen(sl.op.len), 0.cint)
+          if r == SocketError:
+            if not wouldBlock(): complete(j, -1)
+          else:
+            complete(j, int(r))
+      of opWrite:
+        if evWrite in firedEvents:
+          let r = wsSend(s, sl.op.buf, clampLen(sl.op.len), 0.cint)
+          if r == SocketError:
+            if not wouldBlock(): complete(j, -1)
+          else:
+            complete(j, int(r))
+      of opAccept:
+        if evRead in firedEvents:
+          var addrLen = cint(sl.op.acceptLen)
+          let client = wsAccept(s, addr sl.op.acceptAddr, addr addrLen)
+          if client == InvalidSocket:
+            if not wouldBlock(): complete(j, -1)
+          else:
+            # The accepted SOCKET must survive the cint narrowing the ring's
+            # API imposes; kernel handle values are small in practice (see
+            # ioring.nim's Windows `listenTcp`).
+            complete(j, int(cast[uint32](client)))
+      of opPollAdd:
+        let hit = firedEvents * sl.op.pollMask
+        if hit != {}:
+          complete(j, toEventMask(hit))
+      of opNop:
+        discard
+    if gSlots[lane].hasPendingForFd(fd):
+      if not reArmEvent(fd, armEventsForFd(fd), true):
+        failPendingForFd(fd)

--- a/lib/std/ioring/backends/wsapoll.nim
+++ b/lib/std/ioring/backends/wsapoll.nim
@@ -1,0 +1,117 @@
+# Windows WSAPoll readiness backend.
+#
+# Winsock's poll(2) drives the same readiness machinery the epoll and kqueue
+# backends use (`processFd`/`armEventsForFd` in ./poll). Each lane owns its
+# poller state, and the poll set is rebuilt on every call from the lane's slot
+# arena: one entry per fd with in-flight ops, armed for the union of their
+# directions. There is no kernel-side registration to keep in sync, so
+# `reArmEvent` has nothing to do and `forgetFd` is nil — which also means
+# epoll's ADD/MOD race has no counterpart here.
+#
+# Scale: the set is O(pending fds) per poll and WSAPoll is O(n) per call —
+# right for a client and for a single-user local server. A Windows server with
+# thousands of connections wants the IOCP proactor instead (`-d:nimIoringIocp`,
+# a stub today; design of record: hashi/doc/iocp-ioring-briefing.md).
+#
+# Winsock is bound by `dynlib` (the winlean house style) rather than through
+# `<winsock2.h>`, so the generated C never has to order that header against
+# winlean's `<Windows.h>`. `WSAPOLLFD` is declared to its ABI (SOCKET + two
+# SHORTs, natural alignment). Known caveat: before Windows 10 2004, WSAPoll
+# does not report a failed connect() (no POLLERR is raised).
+
+when defined(windows):
+  import std/threadpool
+  import std/windows/winlean   # sleep
+
+  import ../core/types
+  import ../core/slots
+  import ../core/backend
+  import ./poll
+
+  const
+    DrainBatch = 128
+
+  type
+    SocketHandle = uint   ## Winsock SOCKET (UINT_PTR); the ring's fd is its cint narrowing
+    WsaPollFd = object    ## WSAPOLLFD
+      fd: SocketHandle
+      events: cshort
+      revents: cshort
+
+  const
+    POLLRDNORM = 0x0100   ## normal data readable
+    POLLWRNORM = 0x0010   ## normal data writable
+    POLLERR = 0x0001      ## error condition (revents only)
+    POLLHUP = 0x0002      ## hang-up (revents only)
+    POLLNVAL = 0x0004     ## invalid socket (revents only)
+    PollFailMask = POLLERR or POLLHUP or POLLNVAL
+
+  proc wsaPoll(fdArray: ptr WsaPollFd; nfds: culong; timeout: cint): cint {.
+    stdcall, importc: "WSAPoll", dynlib: "ws2_32.dll".}
+
+  var
+    pollSets: seq[seq[WsaPollFd]]   ## per lane; reused across polls
+
+  proc wsapollReArm(fd: cint; events: IoEvents; alreadyRegistered: bool): bool {.nimcall.} =
+    ## Nothing to register: the poll set is derived from the arena on every poll,
+    ## so arming cannot fail here — a dead socket surfaces as POLLNVAL instead.
+    result = true
+
+  proc wsapollPoll(timeoutMs: int): bool {.nimcall.} =
+    let lane = ioLane()
+    var buf {.noinit.}: array[DrainBatch, OpContext]
+    var n = gOpQueues[lane].tryBulkDequeue(DrainBatch, buf)
+    if n > 0:
+      for i in 0..<n:
+        discard gSlots[lane].allocSlot(buf[i])
+    # Build this lane's set from its arena. Collect before dispatching:
+    # `processFd` frees slots, which mutates the fd index the set comes from.
+    pollSets[lane].setLen(0)
+    for fd in gSlots[lane].pendingFds:
+      let events = armEventsForFd(fd)
+      if events == {}: continue   # only opNop slots on this fd
+      var ev = 0
+      if evRead in events: ev = ev or POLLRDNORM
+      if evWrite in events: ev = ev or POLLWRNORM
+      pollSets[lane].add WsaPollFd(fd: SocketHandle(cast[uint32](fd)),
+                                   events: cshort(ev), revents: cshort(0))
+    if pollSets[lane].len == 0:
+      # Nothing armed on this lane: honour the idle timeout here, or the worker
+      # loop spins (it only sleeps when nothing fired AND it ran no task).
+      if timeoutMs > 0: sleep(uint32(timeoutMs))
+      return false
+    let ready = wsaPoll(addr pollSets[lane][0], culong(pollSets[lane].len),
+                        cint(timeoutMs))
+    if ready <= 0:
+      return false
+    for i in 0..<pollSets[lane].len:
+      let re = int(pollSets[lane][i].revents)
+      if re == 0: continue
+      var fired: IoEvents = {}
+      if (re and POLLRDNORM) != 0: fired.incl evRead
+      if (re and POLLWRNORM) != 0: fired.incl evWrite
+      if (re and PollFailMask) != 0:
+        # Error, hang-up or a dead socket: wake every pending op so its transfer
+        # runs and reports the failure (recv returns 0 or -1, send fails) instead
+        # of leaving the continuation parked on a socket that will never fire.
+        fired = {evRead, evWrite}
+      processFd(cint(cast[uint32](pollSets[lane][i].fd)), fired)
+    return true
+
+  proc wsapollClose() {.nimcall.} =
+    ## No poller descriptors to release. Winsock itself is left initialised:
+    ## sockets the process still owns keep working until exit tears it down.
+    discard
+
+  proc wsapollForgetFd(fd: cint) {.nimcall.} =
+    ## No registration to drop: the next poll simply no longer sees the fd.
+    discard
+
+  proc initWsaPollBackendRelays*(): BackendRelays =
+    pollSets = newSeq[seq[WsaPollFd]](ioLanes())
+    reArmEvent = wsapollReArm
+    result = BackendRelays(
+      poll: wsapollPoll,
+      close: wsapollClose,
+      forgetFd: wsapollForgetFd,
+    )

--- a/lib/std/ioring/backends/wsapoll.nim
+++ b/lib/std/ioring/backends/wsapoll.nim
@@ -9,9 +9,11 @@
 # epoll's ADD/MOD race has no counterpart here.
 #
 # Scale: the set is O(pending fds) per poll and WSAPoll is O(n) per call —
-# right for a client and for a single-user local server. A Windows server with
-# thousands of connections wants the IOCP proactor instead (`-d:nimIoringIocp`,
-# a stub today; design of record: hashi/doc/iocp-ioring-briefing.md).
+# right for a client and for a single-user local server, and the fallback
+# selected with `-d:nimIoringWsaPoll`; the Windows default is the IOCP
+# proactor (backends/iocp.nim), which also avoids this backend's one
+# scheduler-tick stall on a fresh connection's first request (the listener's
+# readiness is a tick late; measured in the IOCP header).
 #
 # Winsock is bound by `dynlib` (the winlean house style) rather than through
 # `<winsock2.h>`, so the generated C never has to order that header against
@@ -80,13 +82,25 @@ when defined(windows):
       # loop spins (it only sleeps when nothing fired AND it ran no task).
       if timeoutMs > 0: sleep(uint32(timeoutMs))
       return false
-    let ready = wsaPoll(addr pollSets[lane][0], culong(pollSets[lane].len),
-                        cint(timeoutMs))
-    if ready <= 0:
-      return false
+    discard wsaPoll(addr pollSets[lane][0], culong(pollSets[lane].len),
+                    cint(timeoutMs))
+    # The return value is not the gate: WSAPoll marks a closed handle POLLNVAL
+    # in revents but does not count it — it returns 0 with live sockets in the
+    # set and SOCKET_ERROR/WSAENOTSOCK with only dead ones (measured on a
+    # Windows 10 builder). Gating on `ready > 0` therefore parked every op on
+    # a socket closed before its op was issued for good. Scan revents always.
+    result = false
     for i in 0..<pollSets[lane].len:
       let re = int(pollSets[lane][i].revents)
       if re == 0: continue
+      result = true
+      if (re and POLLNVAL) != 0:
+        # Closed under its ops (closeFd ran before this lane issued them):
+        # the ring's cancellation result, same as the other backends report.
+        let dead = cint(cast[uint32](pollSets[lane][i].fd))
+        for idx in gSlots[lane].slotsForFd(dead):
+          complete(idx, ECancelled)
+        continue
       var fired: IoEvents = {}
       if (re and POLLRDNORM) != 0: fired.incl evRead
       if (re and POLLWRNORM) != 0: fired.incl evWrite
@@ -96,7 +110,6 @@ when defined(windows):
         # of leaving the continuation parked on a socket that will never fire.
         fired = {evRead, evWrite}
       processFd(cint(cast[uint32](pollSets[lane][i].fd)), fired)
-    return true
 
   proc wsapollClose() {.nimcall.} =
     ## No poller descriptors to release. Winsock itself is left initialised:

--- a/lib/std/ioring/core/slots.nim
+++ b/lib/std/ioring/core/slots.nim
@@ -86,3 +86,10 @@ iterator slotsForFd*(a: var SlotArena; fd: cint): int =
     let nxt = a.slots[cur].nextInFd
     yield cur
     cur = nxt
+
+iterator pendingFds*(a: var SlotArena): cint =
+  ## Every fd that has at least one in-flight slot. The table is mutated by
+  ## `freeSlot`, so a caller that completes ops must collect the fds first and
+  ## dispatch afterwards — never `complete` from inside this loop.
+  for fd in a.fdHeads.keys:
+    yield fd

--- a/lib/std/ioring/core/types.nim
+++ b/lib/std/ioring/core/types.nim
@@ -15,6 +15,13 @@ else:
       ss_family*: uint16
       ss_pad*: array[126, uint8]
 
+const
+  # Result of an op cancelled by `closeFd` before it completed: the ring's own
+  # convention (mirrors -ECANCELED), reported identically by every backend —
+  # readiness/POSIX through `cancelPendingOps`, IOCP when the kernel aborts an
+  # overlapped op on closesocket (STATUS_CANCELLED).
+  ECancelled* = -125
+
 type
   IoEvent* = enum
     ## A readiness direction. `submitPollAdd` takes a set of these, and an

--- a/lib/std/ioring/core/types.nim
+++ b/lib/std/ioring/core/types.nim
@@ -1,5 +1,19 @@
 # Common types shared across all ioring layers.
-import std/posix/posix
+when defined(posix):
+  import std/posix/posix
+else:
+  # Windows: the ring's socket surface is Winsock and `std/posix/posix` is
+  # empty there, so the POSIX-named types the op layout needs are declared
+  # here in their Winsock ABI shapes. `Sockaddr_storage` is the 128-byte
+  # `SOCKADDR_STORAGE`; `SockLen` is the `int` namelen Winsock's accept takes;
+  # `FileHandle` is the ring's fd — a Winsock `SOCKET` narrowed to `cint`
+  # (see ioring.nim's Windows arm for why that narrowing is sound).
+  type
+    FileHandle* = cint
+    SockLen* = cint
+    Sockaddr_storage* {.pure.} = object
+      ss_family*: uint16
+      ss_pad*: array[126, uint8]
 
 type
   IoEvent* = enum

--- a/lib/std/ioring/platform.nim
+++ b/lib/std/ioring/platform.nim
@@ -21,11 +21,18 @@ else:
   const hasKqueue* = false
   const hasIouring* = false
 
-const hasWsaPoll* = defined(windows) and not defined(nimIoringIocp)
-  ## Windows default: the WSAPoll readiness backend (backends/wsapoll.nim).
-const hasIocp* = defined(windows) and defined(nimIoringIocp)
-  ## `-d:nimIoringIocp` selects the IOCP proactor — a stub until it lands
-  ## (design of record: hashi/doc/iocp-ioring-briefing.md).
+const hasIocp* = defined(windows) and not defined(nimIoringWsaPoll)
+  ## Windows default: the IOCP proactor (backends/iocp.nim) — the ring's
+  ## contract is completion-shaped and IOCP serves it directly, with no
+  ## readiness emulation and no per-connection scheduler-tick stall (see the
+  ## backend header for the measurements). `-d:nimIoringIocp`, the opt-in
+  ## while it was new, is accepted and means nothing now.
+const hasWsaPoll* = defined(windows) and defined(nimIoringWsaPoll)
+  ## `-d:nimIoringWsaPoll` picks the WSAPoll readiness backend
+  ## (backends/wsapoll.nim) instead — the same shape as `nimIoringNoUring`
+  ## on Linux: the fallback stays reachable deliberately, for testing and for
+  ## a host where completion ports misbehave (layered service providers are
+  ## the usual culprit).
 const hasIoPoll* = hasEpoll or hasKqueue or hasWsaPoll
 
 # Imports are guarded by syntactic `defined()` tests, not by the constants
@@ -41,10 +48,10 @@ elif defined(macosx) or defined(freebsd) or defined(netbsd) or
      defined(openbsd) or defined(dragonfly):
   import ./backends/kqueue
 elif defined(windows):
-  when defined(nimIoringIocp):
-    import ./backends/iocp
-  else:
+  when defined(nimIoringWsaPoll):
     import ./backends/wsapoll
+  else:
+    import ./backends/iocp
 
 var backendRelays*: BackendRelays
 
@@ -58,9 +65,9 @@ proc initPlatformBackend*() =
        defined(openbsd) or defined(dragonfly):
     backendRelays = initKqueueBackendRelays()
   elif defined(windows):
-    when defined(nimIoringIocp):
-      backendRelays = initIocpBackendRelays()
-    else:
+    when defined(nimIoringWsaPoll):
       backendRelays = initWsaPollBackendRelays()
+    else:
+      backendRelays = initIocpBackendRelays()
   else:
     {.error: "No I/O backend available for this platform".}

--- a/lib/std/ioring/platform.nim
+++ b/lib/std/ioring/platform.nim
@@ -21,30 +21,46 @@ else:
   const hasKqueue* = false
   const hasIouring* = false
 
-const hasIocp* = defined(windows)
-const hasIoPoll* = hasEpoll or hasKqueue
+const hasWsaPoll* = defined(windows) and not defined(nimIoringIocp)
+  ## Windows default: the WSAPoll readiness backend (backends/wsapoll.nim).
+const hasIocp* = defined(windows) and defined(nimIoringIocp)
+  ## `-d:nimIoringIocp` selects the IOCP proactor — a stub until it lands
+  ## (design of record: hashi/doc/iocp-ioring-briefing.md).
+const hasIoPoll* = hasEpoll or hasKqueue or hasWsaPoll
 
-when hasIouring:
-  import ./backends/iouring
-elif hasIoPoll:
-  when hasEpoll:
+# Imports are guarded by syntactic `defined()` tests, not by the constants
+# above: nimony's module scanner prunes an import only when its `when` is a
+# literal `defined(...)` expression — a branch guarded by a `const` is always
+# built, so a platform backend would be compiled (and fail) on every other OS.
+when defined(linux):
+  when not defined(nimIoringNoUring):
+    import ./backends/iouring
+  else:
     import ./backends/epoll
-  elif hasKqueue:
-    import ./backends/kqueue
-elif hasIocp:
-  import ./backends/iocp
+elif defined(macosx) or defined(freebsd) or defined(netbsd) or
+     defined(openbsd) or defined(dragonfly):
+  import ./backends/kqueue
+elif defined(windows):
+  when defined(nimIoringIocp):
+    import ./backends/iocp
+  else:
+    import ./backends/wsapoll
 
 var backendRelays*: BackendRelays
 
 proc initPlatformBackend*() =
-  when hasIouring:
-    backendRelays = initIoUringBackendRelays()
-  elif hasIoPoll:
-    when hasEpoll:
+  when defined(linux):
+    when not defined(nimIoringNoUring):
+      backendRelays = initIoUringBackendRelays()
+    else:
       backendRelays = initEpollBackendRelays()
-    elif hasKqueue:
-      backendRelays = initKqueueBackendRelays()
-  elif hasIocp:
-    backendRelays = initIocpBackendRelays()
+  elif defined(macosx) or defined(freebsd) or defined(netbsd) or
+       defined(openbsd) or defined(dragonfly):
+    backendRelays = initKqueueBackendRelays()
+  elif defined(windows):
+    when defined(nimIoringIocp):
+      backendRelays = initIocpBackendRelays()
+    else:
+      backendRelays = initWsaPollBackendRelays()
   else:
     {.error: "No I/O backend available for this platform".}

--- a/tests/nimony/threads/tioringwin.nim
+++ b/tests/nimony/threads/tioringwin.nim
@@ -1,8 +1,10 @@
-# std/ioring on Windows: the WSAPoll readiness backend driving a loopback TCP
-# round trip through the ring's own socket surface — listenTcp, submitAccept,
-# submitRead, submitWrite, submitPollAdd, closeFd — with completions drained
-# through waitCompletions (no continuations, so the test needs no CPS). The
-# client side is raw blocking Winsock so the only thing under test is the ring.
+# std/ioring on Windows: the selected backend (IOCP proactor or WSAPoll
+# readiness — ioring/platform.nim) driving a loopback TCP round trip through
+# the ring's own socket surface — listenTcp, submitAccept, submitRead,
+# submitWrite, submitPollAdd, closeFd — with completions drained through
+# waitCompletions (no continuations, so the test needs no CPS). The client
+# side is raw blocking Winsock so the only thing under test is the ring. The
+# output is backend-neutral, so run it under both.
 #
 # On the other platforms this prints the expected output verbatim, the mirror
 # image of tioringrw/tpolladd's Windows stubs, so one .output serves everywhere.
@@ -14,6 +16,8 @@ when not defined(windows):
   echo "read n=4 buf=ping"
   echo "write n=4 client=pong"
   echo "polladd wr=true rd=false"
+  echo "abort read res=-125 op=true"
+  echo "abort accept res=-125 op=true"
   echo "close ok"
 else:
   import std / [ioring, syncio, assertions]
@@ -102,7 +106,20 @@ else:
   let pa = waitOne()
   echo "polladd wr=", evWrite in pa.readyEvents, " rd=", evRead in pa.readyEvents
 
+  # Close with ops in flight: an issued read and an issued accept must both
+  # surface as `ECancelled` completions with their slots freed — the IOCP
+  # kernel abort on closesocket and the readiness `cancelPendingOps` report the
+  # same result. `pollCompletions` first, so the op is issued (an overlapped
+  # WSARecv/AcceptEx) rather than still queued when the socket goes.
+  discard submitRead(cfd, addr rbuf[0], 8)
+  discard pollCompletions(comps)
   closeFd(cfd)
+  let ab = waitOne()
+  echo "abort read res=", ab.result, " op=", ab.op == opRead
+  discard submitAccept(lfd)
+  discard pollCompletions(comps)
   closeFd(lfd)
+  let ac = waitOne()
+  echo "abort accept res=", ac.result, " op=", ac.op == opAccept
   discard wsClosesocket(client)
   echo "close ok"

--- a/tests/nimony/threads/tioringwin.nim
+++ b/tests/nimony/threads/tioringwin.nim
@@ -1,5 +1,5 @@
-# std/ioring on Windows: the selected backend (IOCP proactor or WSAPoll
-# readiness — ioring/platform.nim) driving a loopback TCP round trip through
+# std/ioring on Windows: the selected backend (the IOCP proactor by default,
+# WSAPoll readiness with -d:nimIoringWsaPoll) driving a loopback TCP round trip through
 # the ring's own socket surface — listenTcp, submitAccept, submitRead,
 # submitWrite, submitPollAdd, closeFd — with completions drained through
 # waitCompletions (no continuations, so the test needs no CPS). The client
@@ -18,6 +18,7 @@ when not defined(windows):
   echo "polladd wr=true rd=false"
   echo "abort read res=-125 op=true"
   echo "abort accept res=-125 op=true"
+  echo "abort queued accept res=-125 op=true"
   echo "close ok"
 else:
   import std / [ioring, syncio, assertions]
@@ -106,20 +107,27 @@ else:
   let pa = waitOne()
   echo "polladd wr=", evWrite in pa.readyEvents, " rd=", evRead in pa.readyEvents
 
-  # Close with ops in flight: an issued read and an issued accept must both
-  # surface as `ECancelled` completions with their slots freed — the IOCP
-  # kernel abort on closesocket and the readiness `cancelPendingOps` report the
-  # same result. `pollCompletions` first, so the op is issued (an overlapped
-  # WSARecv/AcceptEx) rather than still queued when the socket goes.
+  # Close with ops in flight. Every backend must surface the op as an
+  # `ECancelled` completion with its slot freed, in both windows:
+  #  - issued: `pollCompletions` drove the lane once, so the op is a pending
+  #    overlapped WSARecv/AcceptEx (IOCP: closesocket aborts it, the drain
+  #    maps STATUS_CANCELLED) or an armed readiness slot (`cancelPendingOps`);
+  #  - queued: closeFd ran before the lane ever issued it (IOCP: the port
+  #    association fails on the dead handle; readiness: WSAPoll's POLLNVAL).
   discard submitRead(cfd, addr rbuf[0], 8)
   discard pollCompletions(comps)
   closeFd(cfd)
   let ab = waitOne()
   echo "abort read res=", ab.result, " op=", ab.op == opRead
-  discard submitAccept(lfd)
+  let lfd2 = listenTcp(0)
+  discard submitAccept(lfd2)
   discard pollCompletions(comps)
-  closeFd(lfd)
+  closeFd(lfd2)
   let ac = waitOne()
   echo "abort accept res=", ac.result, " op=", ac.op == opAccept
+  discard submitAccept(lfd)
+  closeFd(lfd)
+  let aq = waitOne()
+  echo "abort queued accept res=", aq.result, " op=", aq.op == opAccept
   discard wsClosesocket(client)
   echo "close ok"

--- a/tests/nimony/threads/tioringwin.nim
+++ b/tests/nimony/threads/tioringwin.nim
@@ -1,0 +1,108 @@
+# std/ioring on Windows: the WSAPoll readiness backend driving a loopback TCP
+# round trip through the ring's own socket surface — listenTcp, submitAccept,
+# submitRead, submitWrite, submitPollAdd, closeFd — with completions drained
+# through waitCompletions (no continuations, so the test needs no CPS). The
+# client side is raw blocking Winsock so the only thing under test is the ring.
+#
+# On the other platforms this prints the expected output verbatim, the mirror
+# image of tioringrw/tpolladd's Windows stubs, so one .output serves everywhere.
+# A broken backend hangs in waitCompletions and is caught by the tester's timeout.
+
+when not defined(windows):
+  import std/syncio
+  echo "accept ok=true"
+  echo "read n=4 buf=ping"
+  echo "write n=4 client=pong"
+  echo "polladd wr=true rd=false"
+  echo "close ok"
+else:
+  import std / [ioring, syncio, assertions]
+
+  type
+    SocketHandle = uint
+    SockAddrIn = object
+      sin_family: int16
+      sin_port: uint16
+      sin_addr: uint32
+      sin_zero: array[8, char]
+
+  const
+    AF_INET = 2.cint
+    SOCK_STREAM = 1.cint
+    IPPROTO_TCP = 6.cint
+    InvalidSocket = not 0'u
+
+  proc wsSocket(af, typ, protocol: cint): SocketHandle {.
+    stdcall, importc: "socket", dynlib: "ws2_32.dll".}
+  proc wsConnect(s: SocketHandle; name: pointer; namelen: cint): cint {.
+    stdcall, importc: "connect", dynlib: "ws2_32.dll".}
+  proc wsGetsockname(s: SocketHandle; name: pointer; namelen: ptr cint): cint {.
+    stdcall, importc: "getsockname", dynlib: "ws2_32.dll".}
+  proc wsRecv(s: SocketHandle; buf: pointer; len, flags: cint): cint {.
+    stdcall, importc: "recv", dynlib: "ws2_32.dll".}
+  proc wsSend(s: SocketHandle; buf: pointer; len, flags: cint): cint {.
+    stdcall, importc: "send", dynlib: "ws2_32.dll".}
+  proc wsClosesocket(s: SocketHandle): cint {.
+    stdcall, importc: "closesocket", dynlib: "ws2_32.dll".}
+  proc htons(x: uint16): uint16 {.inline.} = (x shl 8) or (x shr 8)
+
+  var comps = default(array[8, IoCompletion])
+
+  proc waitOne(): IoCompletion =
+    ## One completion. `waitCompletions` polls this thread's lane until one
+    ## lands; the budget is enforced by the tester's per-test timeout.
+    let n = waitCompletions(comps)
+    assert n >= 1
+    result = comps[0]
+
+  # An ephemeral-port listener; the port comes back from getsockname.
+  let lfd = listenTcp(0)
+  var bound = default(SockAddrIn)
+  var blen = cint(sizeof(bound))
+  assert wsGetsockname(SocketHandle(cast[uint32](lfd)), addr bound, addr blen) == 0
+  let port = bound.sin_port   # already network order; reuse as-is for connect
+
+  discard submitAccept(lfd)
+
+  # Blocking client on the loopback.
+  let client = wsSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+  assert client != InvalidSocket
+  var target = default(SockAddrIn)
+  target.sin_family = int16(AF_INET)
+  target.sin_port = port
+  target.sin_addr = 0x0100007F'u32   # 127.0.0.1 in network byte order
+  assert wsConnect(client, addr target, cint(sizeof(target))) == 0, "connect failed"
+
+  let acc = waitOne()
+  let cfd = cint(acc.result)
+  echo "accept ok=", (acc.op == opAccept and cfd > 0)
+  setNonBlocking(cfd)
+
+  var ping = "ping"
+  assert wsSend(client, ping.toCString, 4.cint, 0.cint) == 4
+  var rbuf = default(array[8, char])
+  discard submitRead(cfd, addr rbuf[0], 8)
+  let rd = waitOne()
+  var got = ""
+  for i in 0 ..< rd.result: got.add rbuf[i]
+  echo "read n=", rd.result, " buf=", got
+
+  var pong = "pong"
+  discard submitWrite(cfd, pong.toCString, 4)
+  let wr = waitOne()
+  var cbuf = default(array[8, char])
+  let cn = wsRecv(client, addr cbuf[0], 8.cint, 0.cint)
+  var cgot = ""
+  for i in 0 ..< cn: cgot.add cbuf[i]
+  echo "write n=", wr.result, " client=", cgot
+
+  # Readiness probe: the connected socket is writable and (nothing sent) not
+  # readable; the mask asks for both and the completion reports what fired.
+  discard submitPollAdd(cfd, {evRead, evWrite})
+  let pa = waitOne()
+  echo "polladd wr=", evWrite in pa.readyEvents, " rd=", evRead in pa.readyEvents
+
+  closeFd(cfd)
+  closeFd(lfd)
+  discard wsClosesocket(client)
+  echo "close ok"

--- a/tests/nimony/threads/tioringwin.output
+++ b/tests/nimony/threads/tioringwin.output
@@ -4,4 +4,5 @@ write n=4 client=pong
 polladd wr=true rd=false
 abort read res=-125 op=true
 abort accept res=-125 op=true
+abort queued accept res=-125 op=true
 close ok

--- a/tests/nimony/threads/tioringwin.output
+++ b/tests/nimony/threads/tioringwin.output
@@ -1,0 +1,5 @@
+accept ok=true
+read n=4 buf=ping
+write n=4 client=pong
+polladd wr=true rd=false
+close ok

--- a/tests/nimony/threads/tioringwin.output
+++ b/tests/nimony/threads/tioringwin.output
@@ -2,4 +2,6 @@ accept ok=true
 read n=4 buf=ping
 write n=4 client=pong
 polladd wr=true rd=false
+abort read res=-125 op=true
+abort accept res=-125 op=true
 close ok


### PR DESCRIPTION
`std/ioring` was a stub on Windows. This adds the Winsock socket surface the
public API needs (`listenTcp`/`closeFd`/`setNonBlocking` over ws2_32,
`WSAStartup` once, `-lws2_32`) and two backends behind the existing
`BackendRelays` seam. The public fd type stays `cint`, so hashi and other
consumers stay platform-neutral.

## IOCP proactor (`backends/iocp.nim`, default)

The ring's contract is completion-shaped, so IOCP serves it directly: `poll`
issues each queued op as an overlapped `WSARecv`/`WSASend`/`AcceptEx`, blocks in
`GetQueuedCompletionStatusEx`, and hands completions to the shared `complete`.

- **Lane affinity.** A socket binds to one completion port for life, while
  continuations migrate between workers. The first op for a socket claims it for
  the submitting lane; `enqueueOp` routes later ops to the owner's queue and
  wakes it with `PostQueuedCompletionStatus`. Slot arenas stay per-lane and
  unlocked; OVERLAPPED storage lives in a backend-private arena sized to
  `MaxOps`, so the shared op layout is untouched. Ownership is recorded only
  when the association succeeds.
- **Cancellation.** `closeFd` from any lane drops the record and closes; the
  kernel aborts the socket's pending ops wherever they were issued, and the
  drain reports each as `ECancelled`. Ownership, not the kernel status, is the
  test (aborted `AcceptEx` reports STATUS_CANCELLED; an aborted `WSARecv`
  reports a disconnect status).
- **Waiting.** A blocking completion wait counts as the worker's idle sleep, so
  the loop does not add `Sleep(1)` on top; both round up to the ~15.6 ms tick.
- `opPollAdd` has no IOCP form; pending probes are served by a `WSAPoll(0)` pass.

## WSAPoll readiness (`backends/wsapoll.nim`, `-d:nimIoringWsaPoll`)

Winsock poll(2) over the shared readiness machinery, with a Winsock arm for the
transfers in `backends/poll.nim` (`WSAEWOULDBLOCK` on a wake keeps the op
pending). The poll set is rebuilt from the slot arena each call, so nothing is
registered. Kept reachable like `-d:nimIoringNoUring` on Linux. One Winsock
quirk handled: a closed handle is flagged `POLLNVAL` but not counted in the
return value, so the scan runs regardless and cancels the ops parked on it.

## Shared changes

- `ECancelled* = -125` in `core/types`: the cancellation result of every
  backend. `cancelPendingOps` goes through `complete`, so a cancelled op
  without a continuation reaches the completion queue instead of hanging its
  waiter.
- `pollCompletions` drives the backend once before draining the queue; it is
  now the non-blocking form of `waitCompletions`.
- `platform.nim` guards backend imports with literal `defined()` tests: the
  module scanner builds any import behind a const-guarded `when`.

## Verification

- Linux, compiler built from this branch: `tests/nimony/threads` 11/11
  (`tioringwin` echoes its golden off Windows; `tioringrw`/`tpolladd` unchanged).
- Windows 10, MinGW-w64 gcc: `tioringwin` (loopback accept/read/write/pollAdd,
  then close with an issued read, an issued accept and a queued accept in
  flight, all reported `ECancelled`) passes identically under both backends.
  hashi HTTP/WebSocket on the same builder: 2000 sequential echo frames incl.
  70 KB; 50 connections × 200 frames, 10000/10000; a 44 s MedASR dictation.
- Measured with a loopback client: first request on a fresh connection ~0.4 ms
  under IOCP vs one ~15.6 ms tick under WSAPoll (listener readiness arrives a
  tick late); echo path ~0.4 ms/frame under both. Accept churn equal, so one
  `AcceptEx` per `submitAccept` stays.

Toolchain notes for the Windows arm: `dynlib` externs are static imports (link
the import lib); `pointer` fields are non-nil (`nil pointer` for nilable ones);
no pointer→proc casts (`WSAIoctl` writes the `AcceptEx` pointer into a
proc-typed var under `lenientnils`); `cast[Handle](-1)` is not a constant.