### PR TITLE
cps: the const-ref temporaries of a coroutine belong in the frame

### DIFF
--- a/src/hexer/constparams.nim
+++ b/src/hexer/constparams.nim
@@ -46,9 +46,54 @@ when not defined(nimony):
   proc tr(c: var Context; dest: var TokenBuf; n: var Cursor)
     {.ensuresNif: addedAny(dest).}
 
-proc passByConstRef(c: var Context; typ, pragmas: Cursor): bool =
-  result = sizeof.passByConstRef(typ, pragmas, c.ptrSize, c.sizeofCache) or
+proc passByConstRef(typ, pragmas: Cursor; ptrSize: int;
+                    cache: var SizeofCache): bool =
+  result = sizeof.passByConstRef(typ, pragmas, ptrSize, cache) or
            typeprops.isInheritable(typ, false)
+
+proc passByConstRef(c: var Context; typ, pragmas: Cursor): bool =
+  result = passByConstRef(typ, pragmas, c.ptrSize, c.sizeofCache)
+
+type
+  ArgRole* = enum
+    argPlain        ## nothing to do here beyond walking into it
+    argConstRef     ## has to arrive as an address
+    argCompileTime  ## `typedesc`/`static`: a value with no runtime existence
+
+proc nextArgRole*(fnType: var Cursor; ptrSize: int; cache: var SizeofCache): ArgRole =
+  ## Classify the next actual against the formal parameter list, advancing
+  ## `fnType` past the formal it consumed.
+  ##
+  ## Answers "how does this actual reach the callee?" — and `argConstRef` is
+  ## the interesting one: the callee gets an ADDRESS, so the actual needs
+  ## storage to have an address of.
+  ##
+  ## Two walkers need this and must agree exactly, because both walk formals
+  ## and actuals in step: `trCall` below, and `coro_transform`'s lifetime
+  ## extension, which asks the same question a pass earlier to find out what a
+  ## coroutine has to keep in its frame. A rule one of them has and the other
+  ## lacks does not fail — it silently pairs an argument with the wrong
+  ## parameter from that point on. So the rules live here once: a `varargs`
+  ## formal serves every remaining actual and must not be advanced past; a
+  ## closure's environment actual has no formal at all; and the const-ref
+  ## question is asked before the compile-time one. What the two walkers *do*
+  ## with a role is where they are allowed to differ.
+  if not fnType.hasMore: return argPlain
+  assert fnType.isTagLit
+  let previousFormalParam = fnType
+  let param = takeLocal(fnType, SkipFinalParRi)
+  let pk = param.typ.typeKind
+  if pk in {MutT, OutT, LentT}:
+    result = argPlain
+  elif pk == VarargsT:
+    fnType = previousFormalParam
+    result = argPlain
+  elif passByConstRef(param.typ, param.pragmas, ptrSize, cache):
+    result = argConstRef
+  elif pk in {TypedescT, StaticT}:
+    result = argCompileTime
+  else:
+    result = argPlain
 
 proc rememberConstRefParams(c: var Context; params: Cursor) =
   if not params.isTagLit: return
@@ -94,10 +139,25 @@ proc trProcDecl(c: var Context; dest: var TokenBuf; n: var Cursor) =
   c.sizeofCache = move(c2.sizeofCache)
   c.needsXelim = c2.needsXelim
 
+proc yieldsAddress(n: Cursor): bool =
+  ## Does this expression already EVALUATE to an address? Not the same question
+  ## as "is its head an `addr`": `coro_transform`'s lifetime extension hands us
+  ## `(expr (stmts (var tmp ...)) (haddr tmp))`, whose value is an address even
+  ## though the tree it sits in is an `expr`.
+  var n = n
+  while n.exprKind == ExprX:
+    inc n
+    while not isLastSon(n): skip n
+  result = n.exprKind in {AddrX, HaddrX}
+
 proc trConstRef(c: var Context; dest: var TokenBuf; n: var Cursor) =
   let info = n.info
-  assert n.exprKind notin {AddrX, HaddrX}
-  if constructsValue(n):
+  if yieldsAddress(n):
+    # Already carries an address: this call is inside a coroutine, and
+    # `coro_transform` gave the argument storage in the FRAME rather than let
+    # us put it on a state proc's stack, which dies at the next suspension.
+    tr c, dest, n
+  elif constructsValue(n):
     # We cannot take the address of a literal so we have to copy it to a
     # temporary first:
     let argType = getType(c.typeCache, n)
@@ -230,26 +290,10 @@ proc trCall(c: var Context; dest: var TokenBuf; n: var Cursor; targetExpectsTupl
 
     fnType = sub(fnType) # peek only, never left
     while n.hasMore:
-      let previousFormalParam = fnType
-      if not fnType.hasMore:
-        tr c, dest, n # can happen for closure parameter
-      else:
-        assert fnType.isTagLit
-        let param = takeLocal(fnType, SkipFinalParRi)
-        let pk = param.typ.typeKind
-        if pk in {MutT, OutT, LentT}:
-          tr c, dest, n
-        elif pk == VarargsT:
-          # do not advance formal parameter:
-          fnType = previousFormalParam
-          tr c, dest, n
-        elif passByConstRef(c, param.typ, param.pragmas):
-          trConstRef c, dest, n
-        elif pk in {TypedescT, StaticT}:
-          # do not produce any code for this as it's a compile-time value:
-          skip n
-        else:
-          tr c, dest, n
+      case nextArgRole(fnType, c.ptrSize, c.sizeofCache)
+      of argPlain: tr c, dest, n
+      of argConstRef: trConstRef c, dest, n
+      of argCompileTime: skip n  # a compile-time value produces no code
     dest.addParRi(n.endInfo)
   if needsTuple:
     dest.addParRi() # TupconstrX

--- a/src/hexer/coro_transform.nim
+++ b/src/hexer/coro_transform.nim
@@ -40,7 +40,7 @@ include ".." / lib / compat2
 import ".." / lib / symparser
 import ".." / nimony / [nimony_model, decls, programs, typenav, sizeof, expreval, xints, builtintypes, langmodes, renderer, reporters, typeprops]
 import ".." / finalir / [finalir, finalir_model]
-import passes, defaultvalues
+import passes, defaultvalues, constparams, duplifier
 include ".." / nimony / nif_annotations
 
 ## Note: `ContinuationName` lives in `builtintypes` (re-imported via the
@@ -191,6 +191,9 @@ type
       ## nested per-coroutine Final-IR runs (treIteratorBody) — restarting at
       ## 0 re-mints `x.N SymIds that collide with still-live outer temps.
     typeCache*: TypeCache
+    sizeofCache*: SizeofCache
+      ## Memoizes the type sizes `nextArgRole` asks about while `trGoto`
+      ## decides which actuals have to arrive as an address.
     thisModuleSuffix*: string
     procStack*: seq[SymId]
     currentProc*: ProcContext
@@ -1112,6 +1115,42 @@ proc trReturn*(c: var Context; dest: var TokenBuf; n: var Cursor) =
 # Lifetime + state analysis
 # ---------------------------------------------------------------------
 
+const
+  AddressTaken = -1
+    ## A `use` state no `def` can equal — `currentState` only ever comes from a
+    ## non-negative `lab` literal — so a local marked with it always becomes a
+    ## frame field.
+
+proc markAddressTaken(c: var Context; n: Cursor) =
+  ## A local whose address is taken has to live in the FRAME, not in whichever
+  ## state proc happens to contain the `addr`. The pointer can be stored
+  ## anywhere and read in a later state, i.e. after that proc returned, and the
+  ## `def != use` rule below cannot see it: taking an address is not a use in a
+  ## different state. It is also the rule the lifetime extension below rests
+  ## on: the local it gives an escaping temporary is worth nothing unless the
+  ## `(haddr)` next to it pins that local to the frame.
+  ##
+  ## Derefs are not followed: `addr p[]` is an address of what `p` points at,
+  ## which is not `p`'s own storage and says nothing about where `p` must live.
+  var n = n
+  while true:
+    case n.exprKind
+    of DotX, TupatX, AtX, ArratX, AddrX, HaddrX:
+      inc n
+    of ConvKinds:
+      inc n
+      skip n # type part
+    of BaseobjX:
+      inc n
+      skip n # type part
+      skip n # skip intlit
+    else:
+      break
+  if n.kind == Symbol:
+    let known = c.currentProc.localToEnv.getOrDefault(n.symId, EnvField(def: -2))
+    if known.def != -2:
+      c.currentProc.localToEnv.getOrQuit(n.symId).use = AddressTaken
+
 proc escapingLocalsImpl(c: var Context; n: var Cursor; currentState: var int) =
   ## Processes the single tree/token at `n`, advancing past it.
   if n.stmtKind == LabS and n.childCursor.kind == IntLit:
@@ -1144,6 +1183,8 @@ proc escapingLocalsImpl(c: var Context; n: var Cursor; currentState: var int) =
   else:
     case n.kind
     of TagLit:
+      if n.exprKind in {AddrX, HaddrX}:
+        markAddressTaken c, n.childCursor
       n.loopInto:
         escapingLocalsImpl c, n, currentState
     of Symbol:
@@ -1187,6 +1228,102 @@ proc emitLabel*(dest: var TokenBuf; label: int; info: NifLineInfo) =
   dest.addParRi()
 
 proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor)
+
+# ---------------------------------------------------------------------
+# Lifetime extension for escaping data
+# ---------------------------------------------------------------------
+#
+# A state proc is not the coroutine's activation record. It runs, it returns,
+# and its stack is gone — while the FRAME, and everything the frame points at,
+# has to survive until the coroutine is resumed and, for a `.passive` callee,
+# until that callee has run to completion. So the coroutine has exactly one
+# kind of storage that outlives a state: the frame.
+#
+# `escapingLocals` below decides which NAMED locals go there — the `def != use`
+# rule, plus `markAddressTaken` for a local a pointer is kept to. Neither rule
+# can see data that has no name at all, and a value that is only ever an
+# argument does not get one until much later: `constparams.trConstRef` gives a
+# literal or a constructor a temporary to take the address of, and by then the
+# body has been cut and that temporary is a local of ONE state proc. The
+# pointer taken from it lives on — in an `openArray` in the frame, in the
+# `.passive` callee's own frame — so the length arrives intact and the data
+# pointer points into a dead stack slot.
+#
+# The fix is to name that data here, while there is still one body to name it
+# in: an actual that will reach its callee as an address gets a local of the
+# coroutine, `markAddressTaken` pins the local to the frame, and the later
+# `trConstRef` finds an argument that already has an address and leaves it
+# alone. `nextArgRole` is the shared classifier, so the two passes cannot
+# disagree about which actual goes with which formal.
+#
+# This rides on `trGoto`'s walk rather than adding a pass of its own: `trGoto`
+# already rewrites the whole body, already maintains the type cache this needs,
+# and runs right before `escapingLocals` — which is precisely the window in
+# which "give it a name" is still enough to mean "put it in the frame".
+
+proc trGotoValue(c: var Context; dest: var TokenBuf; n: var Cursor)
+
+proc extendLifetime(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  ## `n` is an actual the callee receives as an ADDRESS. If it has no storage
+  ## of its own to take an address of, give it some — as a local, which the
+  ## `(haddr)` below then pins to the frame.
+  if not constructsValue(n):
+    # An lvalue already has storage of its own, and whether THAT storage is
+    # durable enough is the ordinary escape question `escapingLocals` answers:
+    # a borrow which outlives the call is one the caller kept, and keeping it
+    # means an `addr` that `markAddressTaken` can see — `toOpenArray` is
+    # `.inline`, so the `(haddr local)` inside it is in this body already.
+    trGotoValue c, dest, n
+    return
+  let info = n.info
+  let argType = getType(c.typeCache, n)
+  let symId = pool.syms.getOrIncl("`coroTemp." & $c.currentProc.counter)
+  inc c.currentProc.counter
+  # The `(expr (stmts ...) v)` shape rather than a statement hoisted in front
+  # of the enclosing one: it keeps the value's evaluation exactly where it was,
+  # which matters as soon as a second argument of the same call has side
+  # effects. `xelim_final` flattens it at the end of the pipeline, the same way
+  # it flattens the temporaries `constparams` and `vtables` emit.
+  copyIntoKind dest, ExprX, info:
+    copyIntoKind dest, StmtsS, info:
+      copyIntoKind dest, VarS, info:
+        addSymDef dest, symId, info
+        dest.addEmpty2 info # export marker, pragmas
+        copyTree dest, argType
+        c.typeCache.registerLocal(symId, VarY, argType)
+        trGotoValue c, dest, n # the value
+    copyIntoKind dest, HaddrX, info:
+      dest.addSymUse symId, info
+
+proc trGotoCall(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  var fnType = skipProcTypeToParams(getType(c.typeCache, n.childCursor))
+  if not fnType.isParamsTag:
+    # Nothing with formal parameters to walk against; just recurse.
+    copyInto dest, n:
+      while n.hasMore: trGotoValue c, dest, n
+    return
+  dest.addParLe(n.cursorTagId, n.info)
+  n.into:
+    trGotoValue c, dest, n # the `fn`
+    fnType = sub(fnType)   # peek only, never left
+    while n.hasMore:
+      case nextArgRole(fnType, c.ptrSize, c.sizeofCache)
+      of argConstRef: extendLifetime c, dest, n
+      of argPlain, argCompileTime: trGotoValue c, dest, n
+  dest.addParRi(n.endInfo)
+
+proc trGotoValue(c: var Context; dest: var TokenBuf; n: var Cursor) =
+  ## Copy an expression, extending the lifetime of every escaping temporary
+  ## inside it. Used wherever `trGoto` would otherwise `takeTree` a value.
+  case n.kind
+  of TagLit:
+    if n.exprKind in CallKinds:
+      trGotoCall c, dest, n
+    else:
+      copyInto dest, n:
+        while n.hasMore: trGotoValue c, dest, n
+  else:
+    takeTree dest, n
 
 proc emitSymJump(dest: var TokenBuf; label: SymId; info: NifLineInfo) =
   dest.addParLe(JmpS, info)
@@ -1417,8 +1554,8 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
     var addLabel = false
     takeInto dest, n:
       addLabel = c.hooks.isPassiveCall(c, n)
-      dest.takeTree n
-      dest.takeTree n
+      trGotoValue c, dest, n
+      trGotoValue c, dest, n
     if addLabel:
       emitLabel dest, c.currentProc.labelCounter, info
       inc c.currentProc.labelCounter
@@ -1462,7 +1599,7 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
         inc c.currentProc.labelCounter
         dest.copyIntoKind IfS, info:
           dest.copyIntoKind ElifU, info:
-            dest.takeTree n # cond
+            trGotoValue c, dest, n # cond
             dest.copyIntoKind StmtsS, info:
               emitJump dest, lthen, info
         var thenCur = n
@@ -1490,7 +1627,7 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
     else:
       dest.addParLe(n.cursorTagId, info)
       n.into:
-        dest.takeTree n                # condition: an expression, nothing to do
+        trGotoValue c, dest, n         # condition
         trGotoScoped c, dest, n        # then
         if n.hasMore:
           if n.isTagLit: trGotoScoped c, dest, n   # else
@@ -1501,12 +1638,17 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
     let sk = n.stmtKind
     let ek = n.exprKind
     if sk == YldS or c.hooks.isPassiveCall(c, n) or ek == SuspendX:
-      takeTree dest, n
+      trGotoValue c, dest, n
       emitLabel dest, c.currentProc.labelCounter, info
       inc c.currentProc.labelCounter
     else:
       case n.kind
       of TagLit:
+        if n.exprKind in CallKinds:
+          # Also reached for a `(call ...)` in STATEMENT position: same tree,
+          # same actuals, and its arguments escape the same way.
+          trGotoCall c, dest, n
+          return
         case n.stmtKind
         of LocalDecls - {ResultS}:
           let sym = n.childCursor.symId
@@ -1520,7 +1662,7 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
             # dont change type, tr will traverse it again later
             dest.takeTree n
             addLabel = c.hooks.isPassiveCall(c, n)
-            dest.takeTree n
+            trGotoValue c, dest, n
           if addLabel:
             emitLabel dest, c.currentProc.labelCounter, info
             inc c.currentProc.labelCounter
@@ -1554,7 +1696,7 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
             var hasElse = false
             dest.addParLe(n.cursorTagId, info)      # the dispatch: jumps only
             n.into:
-              dest.takeTree n                       # selector
+              trGotoValue c, dest, n                # selector
               while n.hasMore:
                 let subK = n.substructureKind
                 if subK in {OfU, ElseU}:
@@ -1594,7 +1736,7 @@ proc trGoto*(c: var Context; dest: var TokenBuf; n: var Cursor) =
           else:
             dest.addParLe(n.cursorTagId, info)
             n.into:
-              dest.takeTree n                       # selector
+              trGotoValue c, dest, n                # selector
               while n.hasMore:
                 let subK = n.substructureKind
                 if subK in {OfU, ElseU}:

--- a/tests/nimony/valgrind/tpassive_openarray.nim
+++ b/tests/nimony/valgrind/tpassive_openarray.nim
@@ -1,0 +1,77 @@
+# Data a coroutine's frame points at has to live in the frame. A state proc is
+# not the coroutine's activation record: it runs, it returns, and its stack is
+# gone, while the frame survives until the coroutine is resumed. A literal has
+# no address of its own, so something has to give it storage to be addressed
+# through — and if that storage is a state proc's local while the `openArray`
+# built from it lives in the frame and is read from a later state, the length
+# comes through intact and the data pointer points into a dead stack slot. The
+# symptom is a right-sized string of garbage.
+#
+# It lives HERE, in the valgrind category, and not next to the other cps tests,
+# because reading a dead stack slot is only *sometimes* wrong output: whether
+# the bytes are still the ones you wrote is a matter of what has run since.
+# Built against the unfixed compiler this file prints the expected lines and
+# passes — memcheck is what turns it into a test, reporting the read of
+# uninitialised memory whatever the stale bytes happened to hold. So the
+# `.output` below says the behaviour is right and the category says the memory
+# is, and only the two together pin this bug down.
+
+import std / [syncio]
+
+func show(data: openArray[char]): string =
+  result = ""
+  for i in 0..<data.len: result.add data[i]
+
+proc take(data: openArray[char]) {.passive.} =
+  echo "[", show(data), "] len=", data.len
+
+proc chain() {.passive.} =
+  # Three in a row: the first used to survive by accident on some targets, so
+  # one call is not enough to pin this down.
+  take("aaa")
+  take("bbb")
+  take("ccc")
+
+chain()
+
+proc step() {.passive.} = discard
+
+proc borrowAcrossSuspension() {.passive.} =
+  # No passive call carries the view here: the temporary is created in one
+  # state and read in the next, which is the same bug without an argument.
+  let oa: openArray[char] = "hello"
+  step()
+  echo "[", show(oa), "]"
+
+borrowAcrossSuspension()
+
+iterator gen(): string {.closure.} =
+  # Closure iterators are cut into states by the same transform.
+  let oa: openArray[char] = "world"
+  yield "first"
+  yield show(oa)
+
+for v in gen(): echo "[", v, "]"
+
+proc borrowFromLocal() {.passive.} =
+  # The other half of the rule: an lvalue already has storage, so the pass
+  # leaves it alone and the ordinary escape analysis has to be what keeps it
+  # alive. `toOpenArray` is `.inline`, so the `addr buf` it takes is in this
+  # body before the cut and pins `buf` to the frame like any other `addr`.
+  var buf: array[5, char] = ['b', 'o', 'r', 'r', 'w']
+  let oa: openArray[char] = buf
+  step()
+  echo "[", show(oa), "]"
+
+borrowFromLocal()
+
+proc addrOfLocal() {.passive.} =
+  # The general rule the fix rests on: an address taken of a local must pin
+  # that local to the frame, whatever states the pointer is read in.
+  var x = 42
+  let p = addr x
+  step()
+  p[] = 99
+  step()
+  echo "x=", x
+addrOfLocal()

--- a/tests/nimony/valgrind/tpassive_openarray.output
+++ b/tests/nimony/valgrind/tpassive_openarray.output
@@ -1,0 +1,8 @@
+[aaa] len=3
+[bbb] len=3
+[ccc] len=3
+[hello]
+[first]
+[world]
+[borrw]
+x=99


### PR DESCRIPTION
An `openArray` argument to a `.passive` proc arrived with its length intact and its data pointer dangling. Not an `openArray` problem: a literal has no address of its own, so `constparams` gives it a temporary to borrow one from, and that temporary is a local of the routine the call appears in. Right, until `cps` cuts that routine into one proc per state — then the temporary belongs to one state proc while the view built from it lives in the coroutine frame and is read from a later state, after that proc returned. Every borrow was exposed; `openArray` is only where the shape shows, because the length is copied and the pointer is not. Closure iterators had it too.

`injectConstParamDerefs` cannot simply move ahead of `cps`: it also has to see the state procs and init wrappers `cps` GENERATES, whose const-ref params need the same derefs as everyone else's. Nor can it run early and again later — this file also carries the raise lowering (success tuples, `tupleVars`, `raise e` -> `raise (e, result)`), none of which is idempotent. So only the temporaries move, and only for the routines `cps` is about to cut up: `hoistConstRefTemps` runs on a coroutine body in the nested pipeline `treIteratorBody` already had, emitting exactly the shape `trConstRef` would have, which is now a no-op on an argument that already carries an address.

It does not live in `cps.nim`, because `cps.nim` is only one of two consumers: `.closure` iterators reach the same transform through `lambdalifting.nim`, and both point their `trCoroutine` hook at `coro_transform.transformCoroutineDecl`. That is already the one place serving both, so that is where it is called from.

That alone does not lift them: `def != use` cannot see an escape, because taking an address is not a use in a different state. So an address taken of a local now pins that local to the frame. `addr p[]` does not count — that is the pointee's address, not the local's.

The price of the split is two walkers over the same trees, and what they must agree on exactly is which actual belongs to which formal: a `varargs` formal serves every remaining actual, a closure's environment actual has no formal at all, and compile-time actuals are dropped by one walker and kept by the other. A rule one copy has and the other lacks does not fail loudly, it pairs every following argument with the wrong parameter. `nextArgRole` answers that once and each walker acts on the answer.

The regression test is in the **valgrind** category rather than next to the other cps tests, because reading a dead stack slot is only sometimes wrong output — whether the bytes are still the ones you wrote depends on what has run since. Built against the unfixed compiler the file prints its expected lines and passes; under memcheck it reports the read of uninitialised memory whatever the stale bytes held, and exits 1. Verified both ways on this base: fixed, the whole valgrind group is clean; unfixed, this test fails.