### PR TITLE
concepts: a requirement must be anchored to `Self` (fixes #2430)

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -3727,6 +3727,17 @@ type
 ```
 
 
+Inference of a generic parameter is anchored to `Self`: it is `Self` that ties a requirement to the type being checked. A requirement may leave `Self` out, but only once every generic parameter it names is already bound by an earlier requirement:
+
+```nim
+type
+  Findable[T] = concept
+    iterator items(x: Self): T   # the first usage binds `T`
+    proc `==`(a, b: T): bool     # no `Self`, but `T` is bound by now
+```
+
+A requirement that neither names `Self` nor has all its parameters bound states nothing about the checked type and is never satisfied — otherwise a candidate would bind the open parameter to whatever type it happens to name, and every type would satisfy the concept.
+
 ## Generics
 
 Generics are a means to parametrize procs, iterators or types with `type parameters`:idx:. Depending on the context, the brackets are used either to introduce type parameters or to instantiate a generic proc, iterator, or type.

--- a/src/nimony/sigconcepts.nim
+++ b/src/nimony/sigconcepts.nim
@@ -68,24 +68,6 @@ proc collectSelfSymsInType(typ: Cursor; headerSelf: SymId; result: var seq[SymId
   else:
     discard
 
-proc conceptSelfSyms*(body: Cursor; routine: Cursor): seq[SymId] =
-  ## Every `Self` sym a requirement signature refers to, plus the header's.
-  result = @[]
-  let headerSelf = conceptSelfSymFromSlot(body)
-  var n = routine
-  skipToParams n
-  if n.substructureKind == ParamsU:
-    # `into` advances `n` past the params subtree, landing on the return type.
-    n.into ParamsU:
-      while n.hasMore:
-        let param = takeLocal(n, SkipFinalParRi)
-        collectSelfSymsInType(param.typ, headerSelf, result)
-  else:
-    skip n # void params slot
-  collectSelfSymsInType(n, headerSelf, result) # n now at the return type
-  if headerSelf != SymId(0) and headerSelf notin result:
-    result.add headerSelf
-
 proc collectOpenTypevars*(typ: Cursor; result: var HashSet[SymId]) =
   ## Every typevar symbol referenced inside a type tree.
   var typ = typ
@@ -100,6 +82,39 @@ proc collectOpenTypevars*(typ: Cursor; result: var HashSet[SymId]) =
   else:
     discard
 
+proc scanSignature(body: Cursor; routine: Cursor;
+                   selfSyms: var seq[SymId]; openTvs: var HashSet[SymId]) =
+  ## One walk over a requirement's parameter types and its return type,
+  ## collecting the `Self` syms it names and every typevar it names.
+  let headerSelf = conceptSelfSymFromSlot(body)
+  var n = routine
+  skipToParams n
+  if n.substructureKind == ParamsU:
+    # `into` advances `n` past the params subtree, landing on the return type.
+    n.into ParamsU:
+      while n.hasMore:
+        let param = takeLocal(n, SkipFinalParRi)
+        collectSelfSymsInType(param.typ, headerSelf, selfSyms)
+        collectOpenTypevars(param.typ, openTvs)
+  else:
+    skip n # void params slot
+  collectSelfSymsInType(n, headerSelf, selfSyms) # n now at the return type
+  collectOpenTypevars(n, openTvs)
+
+proc conceptSelfSymsInSignature(body: Cursor; routine: Cursor): seq[SymId] =
+  ## The `Self` syms the requirement's own signature refers to. Empty means the
+  ## requirement says nothing about the checked type.
+  result = @[]
+  var openTvs = initHashSet[SymId]()
+  scanSignature(body, routine, result, openTvs)
+
+proc conceptSelfSyms*(body: Cursor; routine: Cursor): seq[SymId] =
+  ## Every `Self` sym a requirement signature refers to, plus the header's.
+  result = conceptSelfSymsInSignature(body, routine)
+  let headerSelf = conceptSelfSymFromSlot(body)
+  if headerSelf != SymId(0) and headerSelf notin result:
+    result.add headerSelf
+
 proc conceptRequirementOwnTypevars*(routine: Cursor): seq[SymId] =
   ## The generic parameters a requirement declares for itself, as in
   ## `proc sample[G: HasNext](s: Self; g: var G)`.
@@ -113,6 +128,25 @@ proc conceptRequirementOwnTypevars*(routine: Cursor): seq[SymId] =
         if name.isSymbolDef:
           result.add name.symId
       skip tv
+
+proc conceptRoutineUsesSelf*(body: Cursor; routine: Cursor): bool {.inline.} =
+  ## Does the requirement's signature mention `Self`? That is what ties a
+  ## requirement to the type being checked; one that does not says nothing
+  ## about it.
+  conceptSelfSymsInSignature(body, routine).len > 0
+
+proc conceptRoutineTypevars*(body: Cursor; routine: Cursor): seq[SymId] =
+  ## The typevars a requirement's signature names, minus the generic parameters
+  ## the requirement declares for itself: those are universally quantified and
+  ## are never inferred. What is left are the concept's container parameters and
+  ## an enclosing generic's.
+  var selfSyms: seq[SymId] = @[]
+  var open = initHashSet[SymId]()
+  scanSignature(body, routine, selfSyms, open)
+  for own in conceptRequirementOwnTypevars(routine):
+    open.excl own
+  result = @[]
+  for tv in open: result.add tv
 
 proc substituteTypevars*(dest: var TokenBuf; typ: Cursor; bindings: Table[SymId, Cursor]) =
   ## Copies the type tree `typ` into `dest`, replacing every symbol that has a

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -844,6 +844,17 @@ proc conceptRoutineAvailable(m: var Match; conceptSym: SymId; body: Cursor; rout
   var bindings = m.inferred
   for selfSym in conceptSelfSyms(body, routine):
     bindings[selfSym] = a
+  if not conceptRoutineUsesSelf(body, routine):
+    # `Self` is what ties a requirement to the checked type. A requirement that
+    # never names it may still be checked — but only once every typevar it names
+    # is bound, which an earlier requirement does under the "first use infers
+    # `T`" rule. While one is still open nothing relates the requirement to `a`,
+    # and candidate matching would bind that typevar to whatever type the
+    # candidate happens to name, so *every* type would satisfy the concept
+    # (issue #2430).
+    for tv in conceptRoutineTypevars(body, routine):
+      if not bindings.hasKey(tv):
+        return false
   var argBuf = createTokenBuf(32)
   var retBuf = createTokenBuf(16)
   substituteTypevars(retBuf, asRoutine(routine).retType, bindings)

--- a/tests/nimony/concepts/tandconstraintconceptcrash.msgs
+++ b/tests/nimony/concepts/tandconstraintconceptcrash.msgs
@@ -1,0 +1,3 @@
+tests/nimony/concepts/tandconstraintconceptcrash.nim(16, 24) Error: Type mismatch at [position]
+abs(y)
+[1] T does not match constraint ComparableAndNegatable (declared in lib/std/system.nim(248, 1))

--- a/tests/nimony/concepts/tandconstraintconceptcrash.nim
+++ b/tests/nimony/concepts/tandconstraintconceptcrash.nim
@@ -1,0 +1,16 @@
+## `T: SomeInteger and IntegerArithmetic` reaching the constraint-mismatch
+## diagnostic. Minimal input (reduced from `lib/std/math.nim`) for a native
+## backend miscompile: a nimsem built by `nimony n` segfaults here instead of
+## reporting the error as soon as `sigmatch.conceptRoutineAvailable` gains a
+## seventh parameter, so that one of its arguments is passed on the stack.
+## The requirement-free `concept of` child and the `and` constraint are both
+## needed to reach it.
+
+type
+  Arithmetic* = concept
+    func `+`(x, y: Self): Self
+
+  IntegerArithmetic* = concept of Arithmetic
+
+func euclDiv*[T: SomeInteger and IntegerArithmetic](x, y: T): T {.inline.} =
+  result = result + abs(y)

--- a/tests/nimony/concepts/tconceptcontainerselfless.nim
+++ b/tests/nimony/concepts/tconceptcontainerselfless.nim
@@ -1,0 +1,41 @@
+## `Self` is what ties a concept requirement to the type being checked. A
+## requirement that never names it must not be allowed to infer the concept's
+## container parameter from a candidate, or every type satisfies the concept
+## (issue #2430).
+
+import std/assertions
+
+type
+  SparseColor = enum
+    red = 0
+    green = 2
+    blue = 4
+
+  HasFoo*[T] = concept
+    proc foo(_: typedesc[T], ordinal: uint64): T
+
+proc foo*(_: typedesc[uint8], ordinal: uint64): uint8 =
+  uint8(ordinal)
+
+# The requirement mentions no `Self` and leaves `T` open, so it states nothing
+# about the checked type. Before the fix the free `T` bound to the builtin's
+# `uint8` and *every* type satisfied `HasFoo`.
+assert not (SparseColor is HasFoo)
+assert not (int is HasFoo)
+assert not (uint8 is HasFoo)
+
+# and the call site agrees with the concept probe
+assert not compiles(foo(SparseColor, 0'u64))
+assert compiles(foo(uint8, 0'u64))
+
+type
+  # A requirement may omit `Self` once its typevars are bound: the first one
+  # here binds `T`, so the second is checked against that binding.
+  Findable*[T] = concept
+    proc first(x: Self): T
+    proc `==`(a, b: T): bool
+
+proc first*(x: seq[int]): int = x[0]
+
+assert seq[int] is Findable
+assert not (seq[string] is Findable)

--- a/tests/nimony/concepts/tconceptgenericinherit.nim
+++ b/tests/nimony/concepts/tconceptgenericinherit.nim
@@ -4,10 +4,10 @@ import std/assertions
 
 type
   Foo*[T] = concept
-    func foo(x: T): T
+    func foo(x: Self): T
 
   Bar*[T] = concept of Foo[T]
-    func bar(x: T): T
+    func bar(x: Self): T
 
 func foo*(x: int): int = x
 func bar*(x: int): int = x


### PR DESCRIPTION
`HasFoo[T] = concept: proc foo(_: typedesc[T], ordinal: uint64): T` names `Self` nowhere, so probing it left `T` open: `collectOpenTypevars` put `T` in `req.inferable` and `linearMatchTree` bound it to the builtin `foo(_: typedesc[uint8], ...)`'s `uint8`. The checked type was never used, so every type satisfied the concept.

`Self` is what ties a requirement to the type being checked. A requirement may leave it out, but only once every typevar it names is already bound -- an earlier requirement binds them under the "first use infers `T`" rule. While one is still open nothing relates the requirement to the checked type, so it is not satisfied.

The rule is per-requirement rather than "every requirement must name `Self`" because `doc/language.md`'s own `Findable[T]` relies on the weaker form: `iterator items(x: Self): T` binds `T`, then `proc ==(a, b: T): bool` legitimately has no `Self`.

`tconceptgenericinherit.nim` was the only thing relying on the old accident -- it wrote `func foo(x: T): T` where it meant `func foo(x: Self): T`, and `int is Bar` was true only because the candidate happened to bind the free `T` to the checked type.