### PR TITLE
lengc: unblock the `lengc` bootstrap tier

### DIFF
--- a/src/lengc/llvmdebug.nim
+++ b/src/lengc/llvmdebug.nim
@@ -522,7 +522,7 @@ proc genDITypeForSymbol(c: var LLVMCode; symId: SymId): int =
 
 # ---- Composite type (struct / union) ----------------------------------
 
-proc genDIUnionType(c: var LLVMCode; n: var Cursor; selectorType = default(Cursor)): int
+proc genDIUnionType(c: var LLVMCode; n: var Cursor; selectorType: Cursor = default(Cursor)): int
 proc genDIAnonObject(c: var LLVMCode; n: var Cursor; name = ""): int
 
 proc enumFieldName(c: var LLVMCode; enumType: Cursor; value: int64): string =
@@ -662,7 +662,7 @@ proc genDIAnonObject(c: var LLVMCode; n: var Cursor; name = ""): int =
     ", align: " & $oAlign & ")"
   result = c.addMetadata(s)
 
-proc genDIUnionType(c: var LLVMCode; n: var Cursor; selectorType = default(Cursor)): int =
+proc genDIUnionType(c: var LLVMCode; n: var Cursor; selectorType: Cursor = default(Cursor)): int =
   ## Generate an anonymous DICompositeType union for an inline union body.
   ## Each branch (nested object / field) becomes an overlapping member.
   ##

--- a/src/lib/nifcdecl.nim
+++ b/src/lib/nifcdecl.nim
@@ -155,7 +155,14 @@ proc takeUnionBranch*(n: var Cursor): UnionBranch =
   ## Read a `(of RANGES BODY)` / `(else BODY)` branch and advance past it.
   ## Callers that only need the fields use `result.body`; debug info also reads
   ## `result.ranges` to name the branch after its discriminant values.
+  ##
+  ## Start from the nil-cursor default: an `else` branch has no ranges, so
+  ## without this `result.ranges` is whatever the stack held — and
+  ## `cursorIsNil(branch.ranges)` is exactly how `contracts_fir` and
+  ## `llvmdebug` tell the two shapes apart. `strictdefs` rejects the field
+  ## write into an uninitialized `result` for that reason.
   let isOf = n.substructureKind == OfU
+  result = default(UnionBranch)
   n.into:
     if isOf:
       result.ranges = n


### PR DESCRIPTION
`hastur tiers` has been failing on `src/lengc/lengc.nim` with

  src/lib/nifcdecl.nim(161, 7) Error: cannot prove that result.15 has been initialized

Two independent causes, both in code that only Nim compiles today, so nothing noticed:

* `takeUnionBranch` writes `result.ranges` only on the `of` path and `result.body` unconditionally, never assigning `result` as a whole. That is a real defect, not just a `strictdefs` complaint: an `else` branch leaves `ranges` holding whatever the stack held, and `cursorIsNil(branch.ranges)` is exactly how `contracts_fir` and `llvmdebug` tell an `of` branch from an `else` one. Nim's zero-initialized `result` hid it. Start from `default(UnionBranch)`.

* `genDIUnionType`'s `selectorType = default(Cursor)` parameter infers as `auto` under Nimony, so the call at llvmdebug.nim(620) had no matching overload. Spell the type, as `typenav` and the shoggoth passes already do.

`hastur tiers` is now 0 / 27; suite 794 / 794, llvmdebug 2 / 2.