### PR TITLE
bif: lazy pools — a name stays in the mapped file until it is first read

### DIFF
--- a/src/lib/bif.nim
+++ b/src/lib/bif.nim
@@ -542,7 +542,21 @@ proc rStr(r: var BifReader): string =
     endStore(result)
     r.pos += n
 
-proc load*(filename: string): BifModule =
+proc rLazyStr[Id](r: var BifReader; t: var BiTable[Id, string]) {.inline.} =
+  ## `rStr`, except that the bytes stay in the mapping and the pool records
+  ## where they are (`bitabs.addLazy`). The mapping is left in place for the
+  ## buffer's lifetime already, and the pool borrows it the same way.
+  let n = int rVarint(r)
+  assert r.pos + n <= r.size, "bif: truncated string"
+  discard t.addLazy(cast[pointer](r.base), r.pos, n)
+  r.pos += n
+
+proc load*(filename: string; lazyPools = false): BifModule =
+  ## Load a `.bif`. The token block is borrowed from the mapping either way;
+  ## with `lazyPools` the string, symbol and filename pools are too — an
+  ## entry is copied out on its first read (`bitabs.LazyStrings`) — which is
+  ## what a reader that touches a fraction of a file's names wants. Tags are
+  ## few and always read, and stay eager.
   ## Read a `BifModule` from a binary `.bif` file, memory-mapping it and BORROWING
   ## the token block (zero-copy — see `adoptForeignTokens`). Mints fresh pools (the
   ## bif INVARIANT). The mapping stays resident for the process lifetime.
@@ -574,9 +588,14 @@ proc load*(filename: string): BifModule =
   # hashing — `addOrdered` leaves the reverse index unbuilt, and `getOrIncl` (or
   # an explicit `ensureIndexed`, for `getKeyId`) builds it if one ever comes.
   for _ in 1 .. nTags:    discard result.buf.tags.tags.addOrdered(rStr(r))
-  for _ in 1 .. nStrings: discard result.buf.pool.strings.addOrdered(rStr(r))
-  for _ in 1 .. nSyms:    discard result.buf.pool.syms.addOrdered(rStr(r))
-  for _ in 1 .. nFiles:   discard result.buf.pool.filenames.addOrdered(rStr(r))
+  if lazyPools:
+    for _ in 1 .. nStrings: rLazyStr(r, result.buf.pool.strings)
+    for _ in 1 .. nSyms:    rLazyStr(r, result.buf.pool.syms)
+    for _ in 1 .. nFiles:   rLazyStr(r, result.buf.pool.filenames)
+  else:
+    for _ in 1 .. nStrings: discard result.buf.pool.strings.addOrdered(rStr(r))
+    for _ in 1 .. nSyms:    discard result.buf.pool.syms.addOrdered(rStr(r))
+    for _ in 1 .. nFiles:   discard result.buf.pool.filenames.addOrdered(rStr(r))
   # symbol index (we are now positioned exactly at indexOffset).
   let nIndex = int rVarint(r)
   result.index = newSeq[IndexEntry](nIndex)
@@ -908,6 +927,21 @@ when isMainModule:
     close(ff)
     doAssert sameTokens(src, fm.buf), "loadFromFile disagrees with mmap load"
     doAssert fm.buf.pool.syms.len == src.pool.syms.len
+
+    # lazy pools: every pooled name reads back identical, and a lookup BY
+    # VALUE finds it — that lookup hashes and compares the mapped bytes, and
+    # runs before anything has copied the entry out.
+    var lm = load(tmp, lazyPools = true)
+    doAssert sameTokens(src, lm.buf), "lazy load disagrees with mmap load"
+    doAssert lm.buf.pool.syms.len == src.pool.syms.len
+    ensureIndexed(lm.buf.pool.syms)
+    for i in 0 ..< src.pool.syms.len:
+      let id = SymId(i + 1)
+      doAssert lm.buf.pool.syms.getKeyId(src.pool.syms[id]) == id, "lazy lookup"
+      doAssert lm.buf.pool.syms[id] == src.pool.syms[id], "lazy read"
+    for i in 0 ..< src.pool.strings.len:
+      let id = StrId(i + 1)
+      doAssert lm.buf.pool.strings[id] == src.pool.strings[id], "lazy string"
 
     # containsSym probes only the syms table (skipping header, pad, tokens, tags,
     # strings); it must find a pooled name and reject an absent one.

--- a/src/lib/bitabs.nim
+++ b/src/lib/bitabs.nim
@@ -17,12 +17,84 @@ else:
     import std/assertions
 
 type
+  LazyStrings* = ref object
+    ## The backing of a `BiTable[Id, string]` whose values still sit in a
+    ## mapped file: per entry a byte offset and length into `base`. An entry
+    ## is copied into `vals` the first time it is READ; hashing and
+    ## comparison work on the mapped bytes directly, so a table can be
+    ## indexed and looked up by value without materialising anything.
+    ##
+    ## Why: `bif.load` fills four pools per file, and a Nim IC backend process
+    ## opens ~800 files of which it reads names from a fraction — 222MB of
+    ## strings, 41% of the process's heap, for names it never looked at
+    ## (`--mm:refc -d:nimTypeNames` on nimbus-eth2). `base` is borrowed from
+    ## the mapping, which has to outlive the table; `bif.load` leaves its
+    ## mapping in place for the buffer's lifetime for the same reason.
+    base: ptr UncheckedArray[char]
+    offs: seq[uint32]
+    lens: seq[uint32]
+
   BiTable*[Id, T] = object # Id must be an int/uint or a distinct type thereof
                            # that is convertible to `uint32`. `Id(0)` must mean "not used".
     vals: seq[T] # indexed by LitId
     keys: seq[Id]  # indexed by hash(val)
+    lazy: LazyStrings # nil unless `T is string` and `addLazy` was used
 
 proc initBiTable*[Id, T](): BiTable[Id, T] = BiTable[Id, T](vals: @[], keys: @[])
+
+const
+  idStart = 1
+
+template idToIdx(x: untyped): int = x.int - idStart
+
+template isLazyAt(t, idx: untyped): bool =
+  ## Entry `idx` is still only in the mapped file.
+  t.lazy != nil and t.vals[idx].len == 0 and t.lazy.lens[idx] > 0'u32
+
+proc materialize[Id, T](t: var BiTable[Id, T]; idx: int) {.inline.} =
+  when T is string:
+    if isLazyAt(t, idx):
+      let n = int t.lazy.lens[idx]
+      var s = newString(n)
+      copyMem(addr s[0], addr t.lazy.base[t.lazy.offs[idx]], n)
+      t.vals[idx] = s
+
+proc hashAt[Id, T](t: BiTable[Id, T]; idx: int): Hash {.inline.} =
+  ## `hash(t.vals[idx])`, off the mapped bytes when the entry is still there.
+  ## `hash(openArray[char])` and `hash(string)` run the same algorithm.
+  when T is string:
+    if isLazyAt(t, idx):
+      let off = int t.lazy.offs[idx]
+      return hash(toOpenArray(t.lazy.base, off, off + int(t.lazy.lens[idx]) - 1))
+  result = hash(t.vals[idx])
+
+proc eqAt[Id, T, V](t: BiTable[Id, T]; idx: int; v: V): bool {.inline.} =
+  ## `v == t.vals[idx]`, off the mapped bytes when the entry is still there.
+  ## `V` is `T` or a view of it (`getOrInclFromView`); only a `string` probe
+  ## gets the no-copy comparison, a view against a lazy entry compares
+  ## against a copy — that path does not run on file-loaded pools.
+  when T is string:
+    if isLazyAt(t, idx):
+      let n = int t.lazy.lens[idx]
+      when V is string:
+        return v.len == n and (n == 0 or
+          equalMem(unsafeAddr v[0], addr t.lazy.base[t.lazy.offs[idx]], n))
+      else:
+        var tmp = newString(n)
+        if n > 0: copyMem(addr tmp[0], addr t.lazy.base[t.lazy.offs[idx]], n)
+        return v == tmp
+  result = v == t.vals[idx]
+
+proc addLazy*[Id](t: var BiTable[Id, string]; base: pointer; off, len: int): Id =
+  ## `addOrdered` for a value that stays in the mapped file at `base + off`
+  ## until it is first read. Only for a table filled in id order from a file
+  ## (see `bif.load`); mixing with `getOrIncl` afterwards is fine.
+  if t.lazy == nil: t.lazy = LazyStrings(base: cast[ptr UncheckedArray[char]](base))
+  assert cast[pointer](t.lazy.base) == base, "addLazy: one mapping per table"
+  t.lazy.offs.add uint32(off)
+  t.lazy.lens.add uint32(len)
+  t.vals.add ""
+  result = Id(t.vals.len - 1 + idStart)
 
 proc nextTry(h, maxHash: Hash): Hash {.inline.} =
   result = (h + 1) and maxHash
@@ -36,10 +108,6 @@ proc mustRehash(length, counter: int): bool {.inline.} =
   assert(length > counter)
   result = (length < counter div 2 + counter) or (length - counter < 4)
 
-const
-  idStart = 1
-
-template idToIdx(x: untyped): int = x.int - idStart
 
 proc hasId*[Id, T](t: BiTable[Id, T]; x: Id): bool {.inline.} =
   let idx = idToIdx(x)
@@ -52,7 +120,7 @@ proc enlarge[Id, T](t: var BiTable[Id, T]) =
   for i in 0..high(n):
     let eh = n[i]
     if isFilled(eh):
-      var j = hash(t.vals[idToIdx eh]) and maxHash(t)
+      var j = hashAt(t, idToIdx eh) and maxHash(t)
       while isFilled(t.keys[j]):
         j = nextTry(j, maxHash(t))
       t.keys[j] = move n[i]
@@ -68,7 +136,7 @@ proc rebuildIndex[Id, T](t: var BiTable[Id, T]) =
   while mustRehash(cap, t.vals.len): cap = cap * 2
   t.keys = newSeq[Id](cap)
   for i in 0 ..< t.vals.len:
-    var j = hash(t.vals[i]) and maxHash(t)
+    var j = hashAt(t, i) and maxHash(t)
     while isFilled(t.keys[j]):
       j = nextTry(j, maxHash(t))
     t.keys[j] = Id(i + idStart)
@@ -104,6 +172,9 @@ proc addOrdered*[Id, T](t: var BiTable[Id, T]; v: sink T): Id =
   ## point something needs it rather than always. Callers that only ever map
   ## id -> value never pay at all.
   t.vals.add v
+  if t.lazy != nil:
+    t.lazy.offs.add 0'u32
+    t.lazy.lens.add 0'u32
   result = Id(t.vals.len - 1 + idStart)
 
 proc getKeyId*[Id, T](t: BiTable[Id, T]; v: T): Id =
@@ -115,7 +186,7 @@ proc getKeyId*[Id, T](t: BiTable[Id, T]; v: T): Id =
     while true:
       let strId = t.keys[h]
       if not isFilled(strId): break
-      if v == t.vals[idToIdx strId]: return strId
+      if eqAt(t, idToIdx strId, v): return strId
       h = nextTry(h, maxHash(t))
   return Id(0)
 
@@ -129,7 +200,7 @@ template getOrInclImpl() {.maybeDirty.} =
     while true:
       let strId = t.keys[h]
       if not isFilled(strId): break
-      if v == t.vals[idToIdx strId]: return strId
+      if eqAt(t, idToIdx strId, v): return strId
       h = nextTry(h, maxHash(t))
     # not found, we need to insert it:
     if mustRehash(t.keys.len, t.vals.len):
@@ -149,6 +220,9 @@ proc getOrIncl*[Id, T](t: var BiTable[Id, T]; v: T): Id =
   result = Id(t.vals.len + idStart)
   t.keys[h] = result
   t.vals.add v
+  if t.lazy != nil:
+    t.lazy.offs.add 0'u32
+    t.lazy.lens.add 0'u32
 
 proc getOrInclFromView*[Id, T, View](t: var BiTable[Id, T]; v: View): Id =
   ## Optimized version that only materializes from the view `v` if the value does
@@ -157,6 +231,9 @@ proc getOrInclFromView*[Id, T, View](t: var BiTable[Id, T]; v: View): Id =
   result = Id(t.vals.len + idStart)
   t.keys[h] = result
   t.vals.add $v
+  if t.lazy != nil:
+    t.lazy.offs.add 0'u32
+    t.lazy.lens.add 0'u32
 
 when defined(nimony):
   proc `[]`*[Id, T](t: BiTable[Id, T]; strId: Id): var T {.inline.} =
@@ -167,11 +244,19 @@ else:
   proc `[]`*[Id, T](t: var BiTable[Id, T]; strId: Id): var T {.inline.} =
     let idx = idToIdx strId
     assert idx < t.vals.len
+    materialize(t, idx)
     result = t.vals[idx]
 
   proc `[]`*[Id, T](t: BiTable[Id, T]; strId: Id): lent T {.inline.} =
     let idx = idToIdx strId
     assert idx < t.vals.len
+    # A read materialises a lazy entry, and a read through a non-`var` table
+    # still has to: the entry's storage is the heap seq the table owns, so
+    # filling it in place is exactly what the `var` overload does — the only
+    # thing `lent` forbids is doing it through this parameter.
+    when T is string:
+      if isLazyAt(t, idx):
+        materialize(cast[ptr BiTable[Id, T]](unsafeAddr t)[], idx)
     result = t.vals[idx]
 
 proc hash*[Id, T](t: BiTable[Id, T]): Hash =


### PR DESCRIPTION
`bif.load` borrowed the token block from the mapping but copied every string, symbol and filename out of it into the four pools. A Nim IC backend process opens ~800 `.bif` files and reads names from a fraction of them: on nimbus-eth2 that was 2.9M strings, 222MB, 41% of the process's heap (`--mm:refc -d:nimTypeNames`).

`BiTable[Id, string]` can now be backed by the mapping (`LazyStrings`): `addLazy` records an entry's offset and length, the entry is copied into `vals` on its first read, and hashing and value comparison work on the mapped bytes, so a table is indexed and looked up by value without materialising anything. A read through a non-`var` table fills the entry in place — its storage is the heap seq the table owns; `lent` only forbids doing it through that parameter. `load(lazyPools = true)` fills strings, symbols and filenames that way; tags are few, always read, and stay eager. The default is unchanged.

The self-test loads the same file both ways and checks every name reads back identical and is found by value before it was ever copied.

With the compiler reading only what it needs, that nimbus process holds 1.04M strings, 117MB, and 233MB instead of 309MB after loading its closure; the compiler's own IC build is a few percent faster.