### PR TITLE
sem: a candidate with unbound type parameters is not a match (fixes #2442)

### DIFF
--- a/src/nimony/semcall.nim
+++ b/src/nimony/semcall.nim
@@ -616,7 +616,7 @@ proc buildCallSource(buf: var TokenBuf; cs: CallState; callee: Cursor) =
     buf.addSubtree cs.args[valueIndex].n
   buf.addParRi()
 
-proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; fnName: StrId; args: openArray[CallArg], genericArgs: Cursor, hasNamedArgs: bool) =
+proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; fnName: StrId; args: openArray[CallArg], genericArgs: Cursor, hasNamedArgs: bool, expected: TypeCursor) =
   # scope extension: procs attached to argument types are also considered
   # If the type is Typevar and it has attached
   # a concept, use the concepts symbols too:
@@ -635,7 +635,7 @@ proc considerTypeboundOps(c: var SemContext; m: var seq[Match]; fnName: StrId; a
         addTypeboundOps c, fnName, root, candidates
     # now match them:
     for candidate in candidates.a:
-      m.add createMatch(addr c)
+      m.add createMatch(addr c, expected)
       sigmatchNamedArgs(m[^1], candidate, args, genericArgs, hasNamedArgs)
 
 proc addArgsInstConverters(c: var SemContext; dest: var TokenBuf; m: var Match; origArgs: openArray[CallArg]) =
@@ -975,26 +975,6 @@ proc runCompiledMacroPlugin(c: var SemContext; dest: var TokenBuf; it: var Item;
   else:
     buildErr c, dest, cs.callNodeInfo, "macro '" & pool.syms[finalFn] & "' not compiled"
 
-proc inferTypevarsFromExpected(c: var SemContext; m: var Match; expected: TypeCursor) =
-  ## When argument matching leaves a generic routine's typevars unbound but the
-  ## call site has a concrete expected type, unify the routine's return type with
-  ## it to bind the rest — e.g. `let r: Result[int, string] = ok(5)` infers `E`
-  ## from the target even though only `T` appears in `ok`'s argument. Runs after
-  ## overload selection, so it cannot affect which candidate is chosen; it only
-  ## fills in bindings before `buildTypeArgs` checks they are all present. Merges
-  ## only on a clean (non-converting) unify, so a conversion-to-expected (handled
-  ## later by `commonType`) is left untouched.
-  if m.err or m.fn.kind notin RoutineKinds or m.fn.sym == SymId(0): return
-  if cursorIsNil(expected) or expected.isDotToken or
-     expected.typeKind in {AutoT, VoidT} or containsGenericParams(expected): return
-  if cursorIsNil(m.returnType) or m.returnType.isDotToken: return
-  var rtMatch = createMatch(addr c)
-  rtMatch.inferred = m.inferred  # seed with the bindings already found from args
-  var rt = m.returnType
-  typematch(rtMatch, rt, Item(n: emptyNode(c), typ: expected))
-  if not rtMatch.err and classifyMatch(rtMatch) in {EqualMatch, GenericMatch}:
-    m.inferred = rtMatch.inferred
-
 proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: var CallState) =
   # Everything the candidate collection below writes to `dest` is a
   # DIAGNOSTIC ("attempt to call routine", a symchoice element that cannot be
@@ -1021,12 +1001,12 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
         let maybeProc = typ.skipModifier
         if maybeProc.typeKind in RoutineTypes:
           let candidate = FnCandidate(kind: s.kind, sym: sym, typ: maybeProc)
-          m.add createMatch(addr c)
+          m.add createMatch(addr c, it.typ)
           sigmatchNamedArgs(m[^1], candidate, cs.args, genericArgs, cs.hasNamedArgs)
       else:
         buildErr c, dest, cs.fn.n.info, "`choice` node does not contain `symbol`"
       inc f
-    considerTypeboundOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs)
+    considerTypeboundOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs, it.typ)
     if m.len == 0:
       # symchoice contained no callable symbols and no typebound ops
       assert cs.fnName != StrId(0)
@@ -1036,7 +1016,7 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
     # for dot-call desugaring and generic bodies). Still run ADL / concept
     # lookup on the argument types so e.g. `t.one()` → `one(t)` can match a
     # concept requirement without a real `one` in scope yet.
-    considerTypeboundOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs)
+    considerTypeboundOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs, it.typ)
   elif cs.fn.typ.typeKind == TypedescT and cs.args.len == 1:
     closeArgsScope c, cs
     semConvFromCall c, dest, it, cs
@@ -1056,9 +1036,9 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
     let maybeProc = typ.skipModifier
     if maybeProc.typeKind in RoutineTypes:
       let candidate = FnCandidate(kind: cs.fnKind, sym: sym, typ: maybeProc)
-      m.add createMatch(addr c)
+      m.add createMatch(addr c, it.typ)
       sigmatchNamedArgs(m[^1], candidate, cs.args, genericArgs, cs.hasNamedArgs)
-      considerTypeboundOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs)
+      considerTypeboundOps(c, m, cs.fnName, cs.args, genericArgs, cs.hasNamedArgs, it.typ)
     elif sym != SymId(0):
       # non-callable symbol, look up all overloads
       assert cs.fnName != StrId(0)
@@ -1092,7 +1072,7 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
       csArgsOrig = move cs.args
     for mi in 0 ..< L:
       if not m[mi].err: continue
-      var newMatch = createMatch(addr c)
+      var newMatch = createMatch(addr c, it.typ)
       var newArgs: seq[CallArg] = @[]
       var newArgBufs: seq[TokenBuf] = @[] # to keep alive
       var param = skipProcTypeToParams(m[mi].fn.typ)
@@ -1168,8 +1148,6 @@ proc resolveOverloads(c: var SemContext; dest: var TokenBuf; it: var Item; cs: v
         compatBundleVarargsInMatch c, m[idx], varargsElem, cs.callNodeInfo
     addArgsInstConverters(c, dest, m[idx], cs.args)
     leaveCall dest, it, cs
-    if m[idx].hasUnboundTypevars:
-      inferTypevarsFromExpected(c, m[idx], it.typ)
     buildTypeArgs(m[idx])
 
     if m[idx].err:

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -91,6 +91,12 @@ type
     pos, opened: int
     inheritanceCosts, intLitCosts, intConvCosts, convCosts: int
     returnType*: Cursor
+    expected*: TypeCursor ## the type the CALL SITE wants, or a nil/`auto`
+                          ## cursor when it wants nothing in particular. The
+                          ## last thing that can bind a leftover typevar (see
+                          ## `inferTypevarsFromExpected`), so matching needs it
+                          ## in hand to tell an uninstantiable candidate from
+                          ## one the target type still completes.
     context: ptr SemContext
     error: MatchError
     firstVarargPosition*: int
@@ -98,8 +104,9 @@ type
     genericConverter*, refineArgType*, insertedParam*: bool
     missingConstraints*: OrderedTable[string, Cursor]
 
-proc createMatch*(context: ptr SemContext): Match =
-  Match(context: context, firstVarargPosition: -1, varargsEndPosition: -1)
+proc createMatch*(context: ptr SemContext; expected: TypeCursor = default(Cursor)): Match =
+  Match(context: context, expected: expected,
+        firstVarargPosition: -1, varargsEndPosition: -1)
 
 proc bindTypevar(m: var Match; fs: SymId; a: Cursor) =
   ## Record a FRESH binding for the formal typevar `fs`. Every call site is
@@ -2535,6 +2542,40 @@ proc matchTypevars*(m: var Match; fn: FnCandidate; explicitTypeVars: Cursor) =
       m.error0 RoutineIsNotGeneric
       return
 
+proc inferTypevarsFromExpected(m: var Match) =
+  ## Last chance to bind a generic routine's leftover typevars: unify its
+  ## RETURN type with the type the call site expects — `let r: Result[int,
+  ## string] = ok(5)` infers `E` that way, as `ok`'s argument only mentions
+  ## `T`. This is part of MATCHING, not a touch-up applied to the winner
+  ## afterwards: whether the expected type completes a candidate is exactly
+  ## what separates one that can be instantiated from one that cannot, and the
+  ## latter must not reach `pickBestMatch` at all. Merges only on a clean
+  ## (non-converting) unify, so a conversion-to-expected — `commonType`'s job,
+  ## much later — is left untouched.
+  if m.fn.kind notin RoutineKinds or m.fn.sym == SymId(0): return
+  if cursorIsNil(m.expected) or m.expected.isDotToken or
+     m.expected.typeKind in {AutoT, VoidT} or containsGenericParams(m.expected): return
+  if cursorIsNil(m.returnType) or m.returnType.isDotToken: return
+  var rtMatch = createMatch(m.context)
+  rtMatch.inferred = m.inferred # seed with the bindings already found from args
+  var rt = m.returnType
+  typematch(rtMatch, rt, Item(n: emptyNode(m.context[]), typ: m.expected))
+  if not rtMatch.err and classifyMatch(rtMatch) in {EqualMatch, GenericMatch}:
+    # `bindTypevar` rather than assigning `inferred` wholesale: it is what keeps
+    # `unboundTvars` — the count the caller is about to test — honest.
+    for v, inf in rtMatch.inferred:
+      if not m.inferred.hasKey(v):
+        bindTypevar m, v, inf
+
+proc anArgIsStillUntyped(args: openArray[CallArg]): bool =
+  ## `auto` on an argument is not a type, it is "not decided yet": an empty
+  ## literal (`@[]`) whose element type only the enclosing context can supply.
+  ## A typevar the arguments left unbound is then unbound because the ARGUMENT
+  ## is unfinished, not because the candidate is uninstantiable — so the
+  ## rejection below has nothing to say about it.
+  for a in args:
+    if not cursorIsNil(a.typ) and a.typ.typeKind == AutoT: return true
+
 proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[CallArg];
                explicitTypeVars: Cursor) =
   assert fn.kind != NoSym or fn.sym == SymId(0)
@@ -2563,32 +2604,29 @@ proc sigmatch*(m: var Match; fn: FnCandidate; args: openArray[CallArg];
     f = paramsStart; skip f
     m.returnType = f # return type follows the parameters in the token stream
 
-  if m.unboundTvars > 0 and not m.err and not m.insertedParam:
-    # The arguments have had their say and the only thing that can still bind a
-    # typevar is `inferTypevarsFromExpected`, which reaches them through the
-    # return type — plus, when a parameter was left to its default,
-    # `addArgsInstConverters`, which instantiates that default expression and
-    # matches it against the formal (`proc foo6[T](x: T = 3)` called as
-    # `foo6()` infers `T` from the `3`). Hence `insertedParam` bows out here.
-    # So a typevar left over in a routine whose return type is concrete and
-    # whose parameters all got arguments is one that nothing will ever bind: an
-    # ORPHAN type parameter,
-    # like `Z` in `func foo[Z: static int](x: float)`. It cannot be
-    # instantiated, hence it is not a match at all — left in the running it
-    # ties the non-generic `foo(x: float)` at `pickBestMatch` and turns a
-    # perfectly clear call into "ambiguous call" (#2392). Walking the typevars
-    # is confined to this failure path: it only serves to name the culprit.
-    if cursorIsNil(m.returnType) or not containsGenericParams(m.returnType):
-      for v in m.tvars:
+  if m.unboundTvars > 0 and not m.err and not m.insertedParam and
+      not anArgIsStillUntyped(args):
+    # The arguments have had their say. Two things can still bind a typevar:
+    # the call site's expected type, through the return type (right below),
+    # and — when a parameter was left to its default — `addArgsInstConverters`,
+    # which instantiates that default expression and matches it against the
+    # formal (`proc foo6[T](x: T = 3)` called as `foo6()` infers `T` from the
+    # `3`). Hence `insertedParam` bows out here.
+    inferTypevarsFromExpected m
+    if m.unboundTvars > 0:
+      # A typevar still unbound now is one that NOTHING will ever bind, so the
+      # candidate cannot be instantiated — and a candidate that cannot be
+      # instantiated is not a match at all. Left in the running it either ties
+      # a viable overload at `pickBestMatch` and turns a clear call into
+      # "ambiguous call" (#2392), or outright beats it by binding fewer
+      # typevars — `matrix[R, C: static int, T](fill: T)` swallowing the call
+      # meant for `matrix(elems: array[R, array[C, T]])` and orphaning `R` and
+      # `C` (#2442). Walking the typevars is confined to this failure path: it
+      # only serves to name the culprit, in declaration order.
+      for v in typeVars(m.fn.sym):
         if not m.inferred.hasKey(v):
           m.error0Typevar CouldNotInferTypeVar, v
           break
-
-proc hasUnboundTypevars*(m: Match): bool =
-  ## True if `m.fn`'s generic typevars (as collected by `matchTypevars`) still
-  ## lack a binding after argument matching. Free: `bindTypevar` keeps the
-  ## count up to date as the bindings happen.
-  m.unboundTvars > 0
 
 proc allUninstantiable*(m: openArray[Match]): bool =
   ## Every candidate was dropped for the same reason: a type parameter nothing

--- a/tests/nimony/overload/tstaticgenoverload.nim
+++ b/tests/nimony/overload/tstaticgenoverload.nim
@@ -21,4 +21,38 @@ var a: array[3, int]
 assert len(a) == 3
 assert len[3](a) == 3
 
+# The rule holds even when the orphans appear in the RETURN type: `fill: T`
+# binds `T` to the whole array and orphans `R` and `C`, so it is not a match
+# and the structural overload wins (nim-lang/nimony#2442).
+type Matrix[R, C: static[int], T] = object
+  rows, cols: int
+
+proc matrix[R, C: static[int], T](elems: array[R, array[C, T]]): Matrix[R, C, T] =
+  result = Matrix[R, C, T](rows: R, cols: C)
+
+proc matrix[R, C: static[int], T](fill: T): Matrix[R, C, T] =
+  result = Matrix[R, C, T](rows: R, cols: C)
+
+let data: array[2, array[3, float64]] = [
+  [1.0'f64, 2.0'f64, 3.0'f64],
+  [4.0'f64, 5.0'f64, 6.0'f64]]
+let m = matrix(data)
+assert m.rows == 2
+assert m.cols == 3
+
+# ... and the orphaning overload is still callable once nothing is orphaned.
+let f = matrix[4, 5, float64](1.0'f64)
+assert f.rows == 4
+assert f.cols == 5
+
+# The other side of the rule: a typevar the arguments leave unbound is NOT an
+# orphan when the call site's expected type still binds it.
+type Res[T, E] = object
+  v: T
+
+proc ok[T, E](x: T): Res[T, E] = Res[T, E](v: x)
+
+let r: Res[int, string] = ok(5)
+assert r.v == 5
+
 echo "ok"


### PR DESCRIPTION
`sigmatch` already rejected a candidate whose type parameters nothing can bind (#2392) — but only when its return type was concrete. Any generic parameter in the return type bought a blanket exemption, on the grounds that `inferTypevarsFromExpected` might still bind something through it. So

    proc matrix[R, C: static int, T](elems: array[R, array[C, T]]): Matrix[R, C, T]
    proc matrix[R, C: static int, T](fill: T): Matrix[R, C, T]

kept the second overload in the running for `matrix(data)`: `T` swallows the whole array, `R` and `C` are orphaned, and because it binds fewer type variables it then wins `pickBestMatch` — leaving `buildTypeArgs` to report "could not infer type for R" for a call that had a perfectly good overload.

Rather than rank the orphans away afterwards, decide it where a match is decided. `inferTypevarsFromExpected` moves out of `semcall` into the tail of `sigmatch`, so the expected type is part of matching and not a touch-up applied to the winner; the `Match` carries the call site's expected type to get it there. After it has run, a leftover type parameter is one nothing will ever bind, and the candidate is dropped — return type generic or not, static or not.

The one argument shape that keeps its exemption is an `auto`-typed argument: `auto` is "not decided yet" (the empty literal in `foo(@[])`, whose element type only the enclosing call supplies), so an unbound type parameter there says nothing about the candidate.

Supersedes #2443, which filtered the orphans out in `semcall` after matching and only for static parameters.
