### PR TITLE
sigmatch: prefer concept requirements on scope ties in generic bodies

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -1189,8 +1189,9 @@ No new ranking category is introduced; the existing rules do the work:
 
   func doBar[T: Foo](x: T): int = bar(x)
 
-  doBar(1.0'f64) # 2, not ambiguous: deferred at definition time,
-                 # then `bar(x: float64)` wins at instantiation
+  doBar(1.0'f64) # 2, not ambiguous: inside `doBar`, `bar` is bound to the
+                 # Foo concept requirement (ConceptScope wins the tie), which
+                 # defers resolution; at instantiation, `bar(x: float64)` wins
   ```
 
   ```nim

--- a/doc/language.md
+++ b/doc/language.md
@@ -1143,15 +1143,26 @@ Conceptually, every routine has one extra implicit parameter of type
 `Scope`. The compiler synthesizes the corresponding argument at every
 call site:
 
+- when the routine is a **concept requirement** — a phantom declaration
+  taken from a concept body, with no implementation of its own — the
+  argument has type `ConceptScope`;
 - when the routine is declared in the calling module, the argument has
-  type `Scope` and the parameter matches **exactly**;
+  type `Scope`, where `Scope = object of ConceptScope`, and the
+  parameter matches as a **subtype** (depth 1);
 - when the routine is imported from another module, the argument has
   type `ImportScope`, where `ImportScope = object of Scope`, and the
-  parameter matches as a **subtype** (depth 1).
+  parameter matches as a **subtype** (depth 2).
 
 So `import` is treated as a form of inheritance between scopes, in the
-same spirit as Eiffel's inheritance between classes. No new ranking
-category is introduced; the existing rules do the work:
+same spirit as Eiffel's inheritance between classes. Concept requirements
+likewise participate in this hierarchy: they are the most specific scope,
+so they win ties against same-module and imported candidates when every
+real-argument metric is equal. A call that selects a concept requirement
+is not executed as written — the compiler defers it and **re-resolves**
+the call at generic instantiation time, when concrete argument types can
+pick a real overload.
+
+No new ranking category is introduced; the existing rules do the work:
 
 - two candidates that tie on real-argument matches → the local one wins
   because the imported one carries one extra unit of subtype distance;
@@ -1162,7 +1173,25 @@ category is introduced; the existing rules do the work:
 - a local candidate that matches via subtyping on a real argument vs.
   an imported candidate that matches exactly on its real arguments →
   ambiguous, because each side contributes one unit of subtype distance
-  and the categories tie.
+  and the categories tie;
+- inside a generic body whose type parameter is constrained by a concept,
+  a concept requirement that ties with real overloads on every other
+  metric wins the tie via `ConceptScope` and is re-resolved once the
+  generic is instantiated with a concrete type.
+
+  ```nim
+  type
+    Foo = concept
+      func bar(x: Self): int
+
+  func bar[T](x: T): int = 1
+  func bar(x: float64): int = 2
+
+  func doBar[T: Foo](x: T): int = bar(x)
+
+  doBar(1.0'f64) # 2, not ambiguous: deferred at definition time,
+                 # then `bar(x: float64)` wins at instantiation
+  ```
 
   ```nim
   # module m:
@@ -3660,7 +3689,7 @@ Some consequences of this rule:
 - A `var Self` parameter is only met by a candidate that takes a `var` parameter, and a plain `Self` parameter cannot be passed to a `var` parameter.
 - A `func` requirement is met by a `func`, by a `proc` marked `noSideEffect`, or by a `template`; a `proc` requirement is met by any of these plus a `proc`.
 - An `iterator` requirement is only met by an iterator.
-- If several candidates match the call, the requirement is satisfied; whether the call is ambiguous is decided at instantiation.
+- If several candidates match the call, the requirement is satisfied; whether the call is ambiguous is decided at instantiation. (This leniency applies only while **checking** that a type satisfies a concept. A call inside an instantiated generic body uses ordinary overload resolution, including the `ConceptScope` preference described under [Module-of-origin](#module-of-origin).)
 - A candidate whose own constraint is the concept being checked, such as `proc <=[T: Orderable](x, y: T)` while checking `Orderable`, does not count: a type satisfies a concept only through a derivation that does not assume the conclusion.
 - Candidates are looked up by name where a call would find them: in the module that declares the concept, in the module that declares the checked type (operations are attached to their type by living in its module), and in every module visible where the check happens.
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -139,8 +139,13 @@ proc scopeBump(m: Match): int =
   ## Models an implicit `Scope` parameter on every routine. Same-module
   ## calls pass `Scope` (exact match); cross-module calls pass
   ## `ImportScope`, where `ImportScope = object of Scope` (subtype match,
-  ## depth 1). Returns the phantom parameter's contribution to
-  ## `inheritanceCosts`: 0 for a same-module candidate, 1 otherwise.
+  ## depth 1). Concept requirement stubs are phantom declarations with no
+  ## body; they are modeled as `ConceptScope`, where `Scope = object of
+  ## ConceptScope`, so they beat same-module candidates when everything
+  ## else ties and `addFn`'s `fromConcept` path can defer the call to
+  ## instantiation. Returns the phantom parameter's contribution to
+  ## `inheritanceCosts`: -1 for a concept requirement, 0 for same-module,
+  ## 1 for cross-module.
   ##
   ## Treating module-of-origin as a subtyping dimension makes overload
   ## resolution prefer locally defined routines over imported ones
@@ -152,6 +157,7 @@ proc scopeBump(m: Match): int =
   ## Evaluated lazily by `cmpMatches`, so unique-resolution call sites
   ## pay nothing: only candidates that actually compete with another
   ## successful match are inspected.
+  if m.fn.fromConcept: return -1
   if m.context == nil or m.fn.sym == SymId(0): return 0
   let s = pool.syms[m.fn.sym]
   # Locate the dot that introduces the module suffix without allocating

--- a/tests/nimony/concepts/tconceptoverloadpriority.nim
+++ b/tests/nimony/concepts/tconceptoverloadpriority.nim
@@ -1,0 +1,16 @@
+import std/assertions
+
+## Concept requirement stubs must win ties against equally-good real
+## overloads inside a generic body so the call is deferred and re-resolved
+## at instantiation with concrete argument types.
+
+type
+  Foo* = concept
+    func bar(x: Self): int
+
+func bar[T](x: T): int = 1
+func bar(x: float64): int = 2
+
+func doBar[T: Foo](x: T): int = bar(x)
+
+assert doBar(1.0'f64) == 2


### PR DESCRIPTION
Model concept requirement stubs as ConceptScope so they beat same-module and imported overloads when all else ties, deferring the call to instantiation. Add regression test and document the scope hierarchy.

Fixes https://github.com/nim-lang/nimony/issues/2452