### PR TITLE
WIP: Support user-defined compile-time calls in static generic type positions

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -550,11 +550,11 @@ proc matchesConstraint*(m: var Match; f: var Cursor; a: Cursor): bool =
   result = matchesConstraintAux(m, f, a)
 
 proc foldValueExpr(m: var Match; a: Cursor; depth = 0): xint =
-  ## The tiny fixed-opcode evaluator for compile-time *values* in type
-  ## positions: folds `+ - *` over integer literals and rewrites an
-  ## array-index `rangetype` to its length. Anything else — in particular a
-  ## still-symbolic expression — yields NaN and is compared syntactically
-  ## instead; matching never solves for a value parameter backwards.
+  ## Folds a compile-time *value* expression in a type position to an integer,
+  ## when possible. Handles literals, bound value generic parameters, `+ - *`,
+  ## user-defined routine calls, and `rangetype` lengths. Anything still
+  ## symbolic yields NaN and is compared structurally instead; matching never
+  ## solves for a value parameter backwards.
   result = createNaN()
   if depth > 10: return
   case a.kind
@@ -563,8 +563,8 @@ proc foldValueExpr(m: var Match; a: Cursor; depth = 0): xint =
   of UIntLit:
     result = createXint(a.uintVal)
   of Symbol:
-    # an already-inferred value typevar (e.g. `R` in `array[R * C, T]`): fold to
-    # the value it was bound to, so array-length matching resolves once bound.
+    # an already-inferred value typevar (e.g. `R` in `R * C`): fold to the
+    # value it was bound to so length matching resolves once bound.
     if isStaticTypevar(a.symId) and m.inferred.contains(a.symId):
       let inferred = m.inferred.getOrQuit(a.symId)
       result = foldValueExpr(m, inferred, depth+1)
@@ -594,6 +594,22 @@ proc foldValueExpr(m: var Match; a: Cursor; depth = 0): xint =
         result = lengthOrd(m.context[], a)
   else:
     discard
+  if not result.isNaN or depth > 0 or m.context == nil: return
+  result = lengthOrd(m.context[], a)
+  if not result.isNaN: return
+  var err = false
+  let val = asSigned(evalOrdinal(m.context[], a), err)
+  if not err:
+    result = createXint(val)
+    return
+  if m.inferred.len == 0: return
+  var subBuf = createTokenBuf(16)
+  substituteTypevars(subBuf, a, m.inferred)
+  var sub = cursorAt(subBuf, 0)
+  err = false
+  let subVal = asSigned(evalOrdinal(m.context[], sub), err)
+  if not err:
+    result = createXint(subVal)
 
 proc foldStaticArg(m: var Match; elemType, a: Cursor): Cursor =
   ## Fold `a` to the canonical typed value a value (`static`) parameter should
@@ -1711,11 +1727,10 @@ proc matchArrayType(m: var Match; f: var Cursor; a: var Cursor) =
     inc f1
     skip a1
     skip f1
-    # fold already-bound value typevars first (`array[R * C, T]`), falling back
-    # to the plain array-length ordinal for concrete/rangetype lengths.
+    # fold already-bound value typevars first (i.e. `array[R * C, T]`
+    # or `array[foo(R, C), T]`), falling back to the plain array-length
+    # ordinal for concrete/rangetype lengths.
     var fLen = foldValueExpr(m, f1)
-    if fLen.isNaN:
-      fLen = lengthOrd(m.context[], f1)
     var aLen = foldValueExpr(m, a1)
     if aLen.isNaN:
       aLen = lengthOrd(m.context[], a1)

--- a/src/validator/phase_validator.nim
+++ b/src/validator/phase_validator.nim
@@ -112,6 +112,8 @@ const
     "low", "high", "add", "sub", "mul", "div", "mod", "shr", "shl", "ashr",
     "bitand", "bitor", "bitxor", "bitnot", "eq", "neq", "le", "lt", "conv",
     "cast", "deref", "pat", "tupat", "arrat",
+    # compile-time value expressions in type slots
+    "call",
     # decl kinds that may appear nullary as kind markers
     "const"
   ]

--- a/tests/nimony/generics/tstaticfunc.nim
+++ b/tests/nimony/generics/tstaticfunc.nim
@@ -1,4 +1,4 @@
-import std/syncio
+import std/assertions
 
 func bump(n: int): int = n + 1
 func mix(a, b: int): int = a * 10 + b
@@ -8,33 +8,33 @@ type
     data: array[bump(N), T]
 
 var s: Sized[5, int]
-echo sizeof(s.data)                 # bump(5) == 6  -> 48
+assert sizeof(s.data) == 48, "bump(5) == 6 -> sizeof(array[6, int]) == 48"
 
 type
   Grid[R, C: static[int]; T] = object
     data: array[bump(R * C), T]
 
 var g: Grid[2, 3, int]
-echo sizeof(g.data)                 # bump(2 * 3) == 7 -> 56
+assert sizeof(g.data) == 56, "bump(2 * 3) == 7 -> sizeof(array[7, int]) == 56"
 
 type
   Mixed[R, C: static[int]; T] = object
     data: array[mix(R + 1, C * 2), T]
 
 var m: Mixed[2, 3, int]
-echo sizeof(m.data)                 # mix(2 + 1, 3 * 2) == mix(3, 6) == 36 -> 288
+assert sizeof(m.data) == 288, "mix(2 + 1, 3 * 2) == mix(3, 6) == 36 -> sizeof(array[36, int]) == 288"
 
 # overload resolution folds already-bound `static[int]` params when matching an
 # array length built from a user-defined compile-time function.
 proc takesBump[R, C: static[int]; T](x: array[bump(R * C), T]): int = x.len
 
 var flat: array[7, int]
-echo takesBump[2, 3, int](flat)     # bump(2 * 3) == 7
+assert takesBump[2, 3, int](flat) == 7, "takesBump[2, 3, int] should match array[7, int]"
 
 proc takesMix[R, C: static[int]; T](x: array[mix(R + 1, C * 2), T]): int = x.len
 
 var wide: array[36, int]
-echo takesMix[2, 3, int](wide)      # mix(3, 6) == 36
+assert takesMix[2, 3, int](wide) == 36, "takesMix[2, 3, int] should match array[36, int]"
 
 # and the same in a range bound:
 type
@@ -42,4 +42,4 @@ type
 
 proc lastIndex[N: static[int]](): int = high(Span[N])
 
-echo lastIndex[5]()                 # bump(5) - 1 == 5
+assert lastIndex[5]() == 5, "lastIndex[5]() == bump(5) - 1 == 5"

--- a/tests/nimony/generics/tstaticfunc.nim
+++ b/tests/nimony/generics/tstaticfunc.nim
@@ -1,0 +1,45 @@
+import std/syncio
+
+func bump(n: int): int = n + 1
+func mix(a, b: int): int = a * 10 + b
+
+type
+  Sized[N: static[int]; T] = object
+    data: array[bump(N), T]
+
+var s: Sized[5, int]
+echo sizeof(s.data)                 # bump(5) == 6  -> 48
+
+type
+  Grid[R, C: static[int]; T] = object
+    data: array[bump(R * C), T]
+
+var g: Grid[2, 3, int]
+echo sizeof(g.data)                 # bump(2 * 3) == 7 -> 56
+
+type
+  Mixed[R, C: static[int]; T] = object
+    data: array[mix(R + 1, C * 2), T]
+
+var m: Mixed[2, 3, int]
+echo sizeof(m.data)                 # mix(2 + 1, 3 * 2) == mix(3, 6) == 36 -> 288
+
+# overload resolution folds already-bound `static[int]` params when matching an
+# array length built from a user-defined compile-time function.
+proc takesBump[R, C: static[int]; T](x: array[bump(R * C), T]): int = x.len
+
+var flat: array[7, int]
+echo takesBump[2, 3, int](flat)     # bump(2 * 3) == 7
+
+proc takesMix[R, C: static[int]; T](x: array[mix(R + 1, C * 2), T]): int = x.len
+
+var wide: array[36, int]
+echo takesMix[2, 3, int](wide)      # mix(3, 6) == 36
+
+# and the same in a range bound:
+type
+  Span[N: static[int]] = range[0 .. bump(N) - 1]
+
+proc lastIndex[N: static[int]](): int = high(Span[N])
+
+echo lastIndex[5]()                 # bump(5) - 1 == 5


### PR DESCRIPTION
Generic type bodies and routine signatures could already defer symbolic array bounds built from built-in operators, e.g. `array[M * N, T]` with `M, N: static[int]`, and fold them when the type is instantiated or when overload resolution compares array lengths. The same deferral did not work for user-defined routines such as `array[bump(N), T]` or `array[bump(R * C), T]`.

Changes:
- phase_validator: add `"call"` to `typeCtxTagsLiteral`, treating deferred routine applications in type slots like other compile-time value expressions (`mul`, `add`, …).

- sigmatch: extend `foldValueExpr` with top-level fallbacks (depth == 0) that run after the fast literal/operator path:
    1. `lengthOrd` for `rangetype` lengths
    2. `evalOrdinal` for concrete expressions, including user func calls
    3. `substituteTypevars` + `evalOrdinal` once static params are bound

  This keeps the logic generic — no array-specific helpers — while letting
  `matchArrayType` fold formal bounds such as `bump(R * C)` against
  concrete argument types.

Add tests/nimony/generics/tstaticfunc.nim covering:
- generic object types with unary and binary user funcs in array bounds
- arithmetic nested inside call arguments (`bump(R * C)`, `mix(R + 1, C * 2)`)
- proc signature matching with explicit static generic arguments
- range bounds built from a user func (`range[0 .. bump(N) - 1]`)

Instantiation-time folding in semArrayType/evalOrdinal was already sufficient for type definitions; the validator and sigmatch gaps were the missing pieces.

Implements https://github.com/nim-lang/nimony/issues/2460