### PR TITLE
Added support for template calls in static type slots

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1506,6 +1506,12 @@ proc semTypeExpr(c: var SemContext; dest: var TokenBuf; n: var Cursor; context: 
   var it = Item(n: n, typ: c.types.autoType)
   semExpr c, dest, it
   n = it.n
+  if context == AllowValues:
+    let emitted = cursorAt(dest, start)
+    if emitted.exprKind == ExprX and isPureTypeValueExpr(emitted):
+      var buf = createTokenBuf(4)
+      buf.addSubtree typeValueExpr(emitted)
+      dest.replace cursorAt(buf, 0), start
   exprToType c, dest, it.typ, start, context, info
   swap c.phase, phase
 

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -589,6 +589,9 @@ proc foldValueExpr(m: var Match; a: Cursor; depth = 0): xint =
       var n = a
       inc n
       result = foldValueExpr(m, n, depth+1)
+    of ExprX:
+      if not isPureTypeValueExpr(a): return
+      result = foldValueExpr(m, typeValueExpr(a), depth+1)
     else:
       if a.typeKind == RangetypeT and m.context != nil:
         result = lengthOrd(m.context[], a)

--- a/src/nimony/typeprops.nim
+++ b/src/nimony/typeprops.nim
@@ -229,8 +229,39 @@ proc containsGenericParamsAux(n: var TypeCursor): bool =
     inc n
   return false
 
+proc typeValueExpr*(n: Cursor): Cursor =
+  ## In a static type slot, a template expansion is emitted as `(expr … value)`.
+  ## Peel to `value` when present; otherwise return `n` unchanged.
+  result = n
+  if n.exprKind != ExprX: return
+  var e = n
+  inc e
+  while e.hasMore and not isLastSon(e):
+    skip e
+  if e.hasMore:
+    result = e
+
+proc isPureTypeValueExpr*(n: Cursor): bool =
+  ## True when `n` is an `(expr …)` whose prefix statements are only empty
+  ## `(stmts)` nodes — the shape produced by expanding a single-expression
+  ## template in a type context.
+  if n.exprKind != ExprX: return true
+  var e = n
+  inc e
+  while e.hasMore and not isLastSon(e):
+    if e.stmtKind == StmtsS:
+      var probe = e
+      probe.peekInto:
+        if probe.hasMore: return false
+    else:
+      return false
+    skip e
+  result = e.hasMore
+
 proc containsGenericParams*(n: TypeCursor): bool =
   var n = n
+  if n.exprKind == ExprX and isPureTypeValueExpr(n):
+    n = typeValueExpr(n)
   result = containsGenericParamsAux(n)
 
 proc nominalRoot*(t: TypeCursor; allowTypevar = false; skipPtrs = false): SymId =

--- a/src/validator/phase_validator.nim
+++ b/src/validator/phase_validator.nim
@@ -112,6 +112,8 @@ const
     "low", "high", "add", "sub", "mul", "div", "mod", "shr", "shl", "ashr",
     "bitand", "bitor", "bitxor", "bitnot", "eq", "neq", "le", "lt", "conv",
     "cast", "deref", "pat", "tupat", "arrat",
+    # template expansion in a static type slot: `(expr … value)`
+    "expr",
     # decl kinds that may appear nullary as kind markers
     "const"
   ]

--- a/tests/nimony/generics/tstatictemplate.nim
+++ b/tests/nimony/generics/tstatictemplate.nim
@@ -1,0 +1,49 @@
+import std/assertions
+
+template bump(n: int): int = n + 1
+template mix(a, b: int): int = a * 10 + b
+
+type
+  Sized[N: static[int]; T] = object
+    data: array[bump(N), T]
+
+var s: Sized[5, int]
+assert sizeof(s.data) == 48, "bump(5) == 6 -> sizeof(array[6, int]) == 48"
+
+type
+  Grid[R, C: static[int]; T] = object
+    data: array[bump(R * C), T]
+
+var g: Grid[2, 3, int]
+assert sizeof(g.data) == 56, "bump(2 * 3) == 7 -> sizeof(array[7, int]) == 56"
+
+type
+  Mixed[R, C: static[int]; T] = object
+    data: array[mix(R + 1, C * 2), T]
+
+var m: Mixed[2, 3, int]
+assert sizeof(m.data) == 288, "mix(2 + 1, 3 * 2) == mix(3, 6) == 36 -> sizeof(array[36, int]) == 288"
+
+proc takesBump[R, C: static[int]; T](x: array[bump(R * C), T]): int = x.len
+
+var flat: array[7, int]
+assert takesBump[2, 3, int](flat) == 7, "takesBump[2, 3, int] should match array[7, int]"
+
+proc takesMix[R, C: static[int]; T](x: array[mix(R + 1, C * 2), T]): int = x.len
+
+var wide: array[36, int]
+assert takesMix[2, 3, int](wide) == 36, "takesMix[2, 3, int] should match array[36, int]"
+
+type
+  Span[N: static[int]] = range[0 .. bump(N) - 1]
+
+proc lastIndex[N: static[int]](): int = high(Span[N])
+
+assert lastIndex[5]() == 5, "lastIndex[5]() == bump(5) - 1 == 5"
+
+type
+  Composite[A, B: static[int]] = object
+    s: Span[bump(A)]
+
+func foo[A, B: static[int]](): Span[bump(A)] = B
+assert foo[2, 3]() == 3


### PR DESCRIPTION
Array lengths, range bounds, and generic parameters expand to `(expr … value)` rather than bare arithmetic. Without handling that shape, sem leaves invalid NIF behind and the post-sem validator rejects `(array … (expr …))` as "got expr, expected type".

Peel pure template-expansion `(expr …)` nodes to their trailing value expression after semchecking, fold them during overload matching, and allow them in the post-sem validator's type-context overlay. Add tstatictemplate.nim covering arrays, proc signatures, range bounds, and nested generic use.

Implementation:
- typeprops: add `typeValueExpr` / `isPureTypeValueExpr`; peel `(expr …)` in `containsGenericParams` before walking the tree (avoids a cursor loop when checking range bounds like `bump(N) - 1` at instantiation)
- sem: in `semTypeExpr` with `AllowValues`, replace a pure `(expr …)` wrapper with its value so array/range type slots store `(add …)` etc.
- sigmatch: extend `foldValueExpr` to recurse through pure `(expr …)` when matching folded array lengths and static params
- phase_validator: treat `expr` as a type-context tag alongside `add` / `mul`, so deferred template expansions in generic type bodies pass validation

Implements https://github.com/nim-lang/nimony/issues/2460