### PR TITLE
Fold template-expanded values in FIR range checking

### DIFF
--- a/src/nimony/contracts_fir.nim
+++ b/src/nimony/contracts_fir.nim
@@ -43,7 +43,7 @@ import ".." / finalir / [finalir_model, finalir]
 import flowtracker
 import ".." / hexer / passes
 import nimony_model, programs, decls, typenav, sembasics, reporters,
-  renderer, typeprops, inferle, xints, builtintypes, features
+  renderer, typeprops, inferle, xints, builtintypes, features, expreval
 
 type
   BorrowableCheck = enum
@@ -81,6 +81,7 @@ type
     activeBorrows: seq[BorrowInfo]
     verbose: bool                      # --verbose: dump final IR on init/contract
                                        # failures for easier debugging
+    bits: int                          # target `int` width for compile-time folding
     currentProcStart: Cursor           # cursor at the start of the proc whose
                                        # body we are currently analysing (used
                                        # for the --verbose dump)
@@ -444,9 +445,14 @@ proc checkRangeAssign(c: var FirContext; targetType, value: Cursor) =
     of IntLit: off = createXint(value.intVal); isLit = true
     of UIntLit: off = createXint(value.uintVal); isLit = true
     else:
-      # A value we cannot model cannot be proven in range, so we reject it.
-      buildErr c, value.info, "cannot prove value is in range " & $lo & ".." & $hi
-      return
+      let folded = tryEvalOrdinal(c.bits, value)
+      if not folded.isNaN:
+        off = folded
+        isLit = true
+      else:
+        # A value we cannot model cannot be proven in range, so we reject it.
+        buildErr c, value.info, "cannot prove value is in range " & $lo & ".." & $hi
+        return
 
   # lo <= v + off   <=>   0 <= v + (off - lo)
   let lower = query(VarId(0), v, off - lo)
@@ -1847,7 +1853,8 @@ proc analyzeContractsFinalIr*(input: var TokenBuf; moduleSuffix: string; feature
     flow: initFlowState(),
     loopExitLabels: initHashSet[SymId](),
     verbose: verbose,
-    features: features
+    features: features,
+    bits: bits
   )
   c.typeCache.openScope()
 

--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -1150,6 +1150,18 @@ proc evalOrdinal(c: ptr SemContext, n: Cursor; bits = 0): xint =
 proc evalOrdinal*(c: var SemContext, n: Cursor): xint =
   evalOrdinal(addr c, n)
 
+proc tryEvalOrdinal*(bits: int; n: Cursor): xint =
+  ## Fold a compile-time ordinal without a `SemContext` (hexer/FIR callers).
+  ## Returns NaN when the expression is not foldable; never shells out to
+  ## sub-compile.
+  var ec = initEvalContext(nil, noExecute = true, bits = bits)
+  var cur = n
+  let val = eval(ec, cur)
+  if val.isTagLit and val.cursorTagId == nifpools.ErrT:
+    result = createNaN()
+  else:
+    result = getConstOrdinalValue(val)
+
 proc getConstStringValue*(val: Cursor): StrId =
   if val.isStringLit:
     result = val.strId

--- a/tests/nimony/generics/tstatictemplate.nim
+++ b/tests/nimony/generics/tstatictemplate.nim
@@ -45,5 +45,9 @@ type
   Composite[A, B: static[int]] = object
     s: Span[bump(A)]
 
-func foo[A, B: static[int]](): Span[bump(A)] = B
-assert foo[2, 3]() == 3
+func foo[A, B: static[int]](): Span[bump(A)] = bump(B)
+
+let f = foo[2, 1]()
+assert typeof(f) is Span[3]
+assert typeof(f) is range[0..3]
+assert f == 2


### PR DESCRIPTION
The range prover in contracts_fir only accepted bare `IntLit`/`UIntLit` or inferle-tracked symbols, so substituted template arithmetic such as `bump(B)` → `1 + 1` was rejected even when the result is provably in range.

Add `tryEvalOrdinal` to expreval for callers without a `SemContext` (same nil-context + noExecute pattern as hexer/desugar), and use it in `checkRangeAssign` before reporting "cannot prove value is in range".

Extended unit test with range checks