### PR TITLE
fix(cps): register locals while scanning for suspension points

### DIFF
--- a/src/hexer/coro_transform.nim
+++ b/src/hexer/coro_transform.nim
@@ -1244,11 +1244,42 @@ proc containsSuspensionPoint*(c: var Context; n: Cursor): bool =
   var n = n
   if n.stmtKind == YldS or c.hooks.isPassiveCall(c, n) or n.exprKind == SuspendX:
     return true
-  # `linearScan` visits the nested nodes; the root was checked above
+  # `linearScan` visits the nested nodes; the root was checked above.
+  #
+  # REGISTER THE LOCALS WE WALK PAST. `isPassiveCall` types the call TARGET,
+  # and this predicate reaches nodes nested arbitrarily deep BEFORE the main
+  # traversal has registered the locals declared beside them. A local declared
+  # INSIDE this subtree and used as a passive call's target therefore failed
+  # the typenav lookup outright:
+  #
+  #   proc drv() {.passive.} =
+  #     if true:
+  #       let h = arr[0]        # declared inside the branch…
+  #       discard h(5)          # …and the call target -> could not find symbol: h.0
+  #
+  # The same local declared OUTSIDE the branch was fine, because the main pass
+  # had already registered it — which is why this only ever showed up for
+  # `if`/`while` regions, and why a bare `block:` (never handed to this
+  # predicate) compiled. Registration happens in a scope of our own so nothing
+  # leaks back to the caller; the main traversal registers these again later.
+  result = false
+  c.typeCache.openScope()
   linearScan n:
-    if n.stmtKind == YldS or c.hooks.isPassiveCall(c, n) or n.exprKind == SuspendX:
-      return true
-  return false
+    let sk = n.stmtKind
+    if sk in {LetS, CursorS, PatternvarS, VarS, TvarS, TletS, GvarS, GletS}:
+      # A plain child walk, NOT `into`: `into` asserts its body consumed every
+      # child, and we only want the four leading slots (name, export marker,
+      # pragmas, type) — the init value is none of our business here.
+      var d = n.childCursor      # at the name
+      let name = d.symId
+      inc d                      # name
+      skip d, SkipExport         # export marker
+      skip d, SkipPragmas        # pragmas
+      c.typeCache.registerLocal(name, cast[SymKind](sk), d)
+    if sk == YldS or c.hooks.isPassiveCall(c, n) or n.exprKind == SuspendX:
+      result = true
+      break
+  c.typeCache.closeScope()
 
 const
   KeptLoop* = -1

--- a/tests/nimony/cps/tpassive_local_call_target.nim
+++ b/tests/nimony/cps/tpassive_local_call_target.nim
@@ -1,0 +1,65 @@
+import std / syncio
+
+# Regression: a passive call whose TARGET is a local declared inside an
+# `if`/`while` region failed to lower at all:
+#
+#   [Bug] could not find symbol: h.0
+#
+# `containsSuspensionPoint` scans a subtree asking `isPassiveCall` about every
+# nested node, and that predicate types the call TARGET. The scan reaches those
+# nodes before the main traversal has registered the locals declared beside
+# them, so the typenav lookup failed. The same local declared OUTSIDE the
+# region was fine — the main pass had already registered it — which made this
+# look like an `if`/`while` problem rather than a registration-order one.
+#
+# Shapes, all of which used to fail: a local target in an `if` (`h.0`), in a
+# `while` (`h.0`), a seq ELEMENT as the target inside a loop (a compiler temp,
+# `` `x.1 ``), and `for h in s` (the iterator's index, `` `ii.2 ``).
+
+type H = proc (x: int): int {.passive.}
+
+proc add10(x: int): int {.passive.} =
+  result = x + 10
+
+var arr: array[2, H]
+var s: seq[H] = @[]
+
+proc inIf() {.passive.} =
+  if true:
+    let h = arr[0]                    # local target declared in the branch
+    echo "inIf ", h(1)
+
+proc inWhile() {.passive.} =
+  var i = 0
+  while i < 2:
+    let h = arr[i]                    # local target declared in the loop
+    echo "inWhile ", h(i)
+    inc i
+
+proc seqInLoop() {.passive.} =
+  var i = 0
+  while i < s.len:
+    echo "seqInLoop ", s[i](i)        # seq element IS the target, in a loop
+    inc i
+
+proc forOverSeq() {.passive.} =
+  for h in s:
+    echo "forOverSeq ", h(100)
+
+proc notTheTarget() {.passive.} =
+  if true:
+    let k = 7                         # a local in the region that is NOT the
+    echo "notTheTarget ", arr[0](k)   # target — always worked, keep it so
+
+proc main() {.passive.} =
+  inIf()
+  inWhile()
+  seqInLoop()
+  forOverSeq()
+  notTheTarget()
+
+arr[0] = add10
+arr[1] = add10
+s.add add10
+s.add add10
+main()

--- a/tests/nimony/cps/tpassive_local_call_target.output
+++ b/tests/nimony/cps/tpassive_local_call_target.output
@@ -1,0 +1,8 @@
+inIf 11
+inWhile 10
+inWhile 11
+seqInLoop 10
+seqInLoop 11
+forOverSeq 110
+forOverSeq 110
+notTheTarget 17


### PR DESCRIPTION
A passive call whose TARGET is a local declared inside an `if`/`while` region failed to lower at all:

```
  proc drv() {.passive.} =
    if true:
      let h = arr[0]
      discard h(5)        # [Bug] could not find symbol: h.0
```

`containsSuspensionPoint` scans a subtree asking `isPassiveCall` about every nested node, and that predicate types the call target (`getType(n.childCursor)`). The scan is a pure predicate — it registers nothing — so it reaches those nodes before the main traversal has registered the locals declared beside them, and the typenav lookup fails outright.

Three observations that made this look like something else, all explained by the same mechanism: the identical local declared OUTSIDE the region worked (the main pass had already registered it), a local inside the region that was NOT the call target worked (nothing ever types it), and a bare `block:` worked (it is not handed to this predicate).

Fixed by registering the locals the scan walks past, in a scope of its own so nothing leaks back to the caller; the main traversal registers them again later, which is harmless. The extraction is a plain child walk rather than `into`, because `into` asserts its body consumed every child and only the four leading slots are wanted.

Shapes fixed, all of which are in the test:

  let h = arr[0]; h(x)   inside an `if`      -> was `h.0`
  let h = arr[i]; h(x)   inside a `while`    -> was `h.0`
  s[i](x)                inside a loop       -> was a temp, `x.1`
  for h in s: h(x)                           -> was the iterator index, `ii.2`

The seq-element cases are the same bug: indexing a seq introduces a temporary that becomes the call target, where an array index introduces none — which is why `arr[i](x)` in a loop always worked and `s[i](x)` did not.

Suite: 816/816. The test is mutation-checked — 47/47 in tests/nimony/cps with the fix, 46/47 without, failing on exactly this test.