### PR TITLE
fix(sem): defer default() when the type still has generic params

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -3986,6 +3986,16 @@ proc callDefault(c: var SemContext; dest: var TokenBuf; typ: Cursor; info: NifLi
   discard buildSymChoice(c, callBuf, pool.strings.getOrIncl("default"), info, FindAll)
   callBuf.addSubtree typ
   callBuf.addParRi()
+  if containsGenericParams(typ):
+    # In a generic body the default's overloads (e.g. `default[I: Ordinal;
+    # T: HasDefault](array[I, T])`) cannot be matched against a type that
+    # still carries generic params: a symbolic array length like `bump(N)`
+    # is no ordinal index type, and an abstract element `T` satisfies no
+    # concrete `default` overload. Defer the call unresolved; instantiation
+    # re-`semExpr`s it with a concrete type, where the array length folds
+    # (`semArrayType`) and the proper overload matches.
+    dest.addSubtree cursorAt(callBuf, 0)
+    return
   var it = Item(n: cursorAt(callBuf, 0), typ: c.types.autoType)
   semCall c, dest, it, {}
 

--- a/tests/nimony/generics/tstatictemplate.nim
+++ b/tests/nimony/generics/tstatictemplate.nim
@@ -51,3 +51,13 @@ let f = foo[2, 1]()
 assert typeof(f) is Span[3]
 assert typeof(f) is range[0..3]
 assert f == 2
+
+proc makeSized[N: static[int]; T: HasDefault](): Sized[N, T] = Sized[N, T]()
+
+let s2 = makeSized[5, int]()
+assert sizeof(s2.data) == 48, "makeSized[5, int]() default-constructs array[6, int]"
+
+proc makeGrid[R, C: static[int]; T](): Grid[R, C, T] = Grid[R, C, T]()
+
+let g2 = makeGrid[2, 3, int]()
+assert sizeof(g2.data) == 56, "makeGrid[2, 3, int]() default-constructs array[7, int]"


### PR DESCRIPTION
Generic object constructors like Sized[N, T]() no longer fail at definition time on default(array[bump(N), T]); instantiation folds the array length and resolves the overload. Extend tstatictemplate.

Improves https://github.com/nim-lang/nimony/issues/2460