### PR TITLE
immutable view in hot path saves ~8% on IC Nimony build time

### DIFF
--- a/src/hexer/dce2.nim
+++ b/src/hexer/dce2.nim
@@ -59,7 +59,8 @@ proc markLive(moduleGraphs: Table[string, ModuleAnalysis]; resolved: ResolveTabl
     if not result.getOrQuit(moduleName).containsOrIncl(sym):
       # Process dependencies from the symbol's own module
       if moduleName in moduleGraphs:
-        let graph = moduleGraphs.getOrQuit(moduleName)
+        # Immutable view to avoid deepcopy of the graphs
+        let graph {.cursor.} = moduleGraphs.getOrQuit(moduleName)
         if sym in graph.uses:
           for dep in graph.uses.getOrQuit(sym):
             let s = translate(resolved, dep)

--- a/src/lib/compat2.nim
+++ b/src/lib/compat2.nim
@@ -55,14 +55,14 @@ when not defined(nimony):
     if not t.hasKey(k): quit "getOrQuit: missing key"
     result = t[k]
 
-  proc getOrQuit*[A, B](t: Table[A, B]; k: A): B =
+  proc getOrQuit*[A, B](t: Table[A, B]; k: A): lent B =
     ## Read-only variant for `let`-bound tables: nimony's `getOrQuit` takes
     ## the table by value and returns `var B`, but host Nim distinguishes
     ## mutable from immutable receivers.
     if not t.hasKey(k): quit "getOrQuit: missing key"
     result = t[k]
 
-  proc getOrQuit*[A, B](t: OrderedTable[A, B]; k: A): B =
+  proc getOrQuit*[A, B](t: OrderedTable[A, B]; k: A): lent B =
     if not t.hasKey(k): quit "getOrQuit: missing key"
     result = t[k]
 


### PR DESCRIPTION
This avoids ~70K deep copies of large objects.