### PR TITLE
Fixed Arithmetic total ordering constraint

### DIFF
--- a/lib/std/math.nim
+++ b/lib/std/math.nim
@@ -9,7 +9,7 @@ type
     func `mod`(x, y: Self): Self
     func `==`(x, y: Self): bool
     func `<`(x, y: Self): bool
-    func `>`(x, y: Self): bool
+    func `<=`(x, y: Self): bool
 
   IntegerArithmetic* = concept of Arithmetic ## `Arithmetic` plus the integer-only operations.
     func `div`(x, y: Self): Self


### PR DESCRIPTION
For total ordering, `<` and `<=` are sufficient. The other comparison operators are derived from these via templates in `comparison.nim`. Requiring `>` in Arithmetic is too restrictive because built-in and user defined types generally rely on those system templates instead of implementing `>` themselves.