### PR TITLE
fix(notnil) for array of ref objects

### DIFF
--- a/src/nimony/contracts_fir.nim
+++ b/src/nimony/contracts_fir.nim
@@ -1212,6 +1212,12 @@ proc cannotBeNil(c: var FirContext; n: Cursor): bool {.inline.} =
   let t = getType(c.typeCache, n)
   result = markedAs(t, NotnilU) or isNonNilExpr(c, n)
 
+proc storeTargetType(c: var FirContext, n: Cursor): Cursor {.inline.} =
+  var target = n
+  if target.exprKind in {AddrX, HaddrX}:
+    inc target
+  result = getType(c.typeCache, target)
+
 # --- Final-IR-specific traversal ---
 
 proc traverseStore(c: var FirContext; n: var Cursor) =
@@ -1256,7 +1262,7 @@ proc traverseStore(c: var FirContext; n: var Cursor) =
     markInit(c, symId)
 
     # Check for not-nil type match
-    let expected = getType(c.typeCache, n)
+    let expected = storeTargetType(c, n)
     checkNilMatch c, valueStart, expected
     checkRangeAssign c, expected, valueStart
 
@@ -1286,7 +1292,9 @@ proc traverseStore(c: var FirContext; n: var Cursor) =
 
     skip n
   else:
-    checkRangeAssign c, getType(c.typeCache, n), valueStart
+    let expected = storeTargetType(c, n)
+    checkNilMatch c, valueStart, expected
+    checkRangeAssign c, expected, valueStart
     traverseExpr c, n
 
   n = storeStart; skip n

--- a/tests/nimony/notnil/tarray_entry.msgs
+++ b/tests/nimony/notnil/tarray_entry.msgs
@@ -1,0 +1,1 @@
+tests/nimony/notnil/tarray_entry.nim(7, 8) Error: expected non-nil value [pass --verbose for the Final IR]

--- a/tests/nimony/notnil/tarray_entry.nim
+++ b/tests/nimony/notnil/tarray_entry.nim
@@ -1,0 +1,7 @@
+type Foo = object
+  x: int
+
+var a: array[8, ref Foo]
+
+a[0] = (ref Foo)(x: 3)
+a[1] = nil

--- a/tests/nimony/notnil/tarray_refentry.msgs
+++ b/tests/nimony/notnil/tarray_refentry.msgs
@@ -1,0 +1,1 @@
+tests/nimony/notnil/tarray_refentry.nim(7, 8) Error: expected non-nil value [pass --verbose for the Final IR]

--- a/tests/nimony/notnil/tarray_refentry.nim
+++ b/tests/nimony/notnil/tarray_refentry.nim
@@ -1,0 +1,7 @@
+type Foo = ref object
+  x: int
+
+var a: array[8, Foo]
+
+a[0] = Foo(x: 3)
+a[1] = nil


### PR DESCRIPTION
The compiler did not report any error when assigning a nil to an entry in an array of ref objects; also no executable was generated. I created two tests that exhibit the issue.  Now, the compiler reports the error and the tests pass.

Only tested on array.  I haven't tested seq or other containers.

I do not have any experience with this repository.  I'm following the "spend some tokens to generate a fix and submit a PR" model.