### PR TITLE
sigmatch: a generic instance satisfies a concept via generic routines…

### DIFF
--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -851,9 +851,24 @@ proc conceptCandidateMatches(m: var Match; candSym: SymId; candDecl: Cursor;
     # only an expected type could bind the rest; nothing to judge here
     result = true
   else:
-    var retBuf = createTokenBuf(16)
-    substituteTypevars(retBuf, candRet, probe.inferred)
-    let instRet = typeToCursor(m.context[], retBuf, 0)
+    # Instantiate the result type the way a real call does (`semcall`'s
+    # `instantiateType`), not by textual substitution: a generic candidate
+    # `func \`+\`[T](a, b: Box[T]): Box[T]` probed for `Box[int]` yields
+    # `(at Box int)`, while the requirement's `Self` is the *instance symbol*
+    # `Box[int]` — and an instance symbol only ever matches another symbol.
+    # `semLocalType` folds the invocation back into that symbol (issue #2500).
+    var instRet: Cursor
+    # The hook goes through a local on purpose: `m.context.semInstantiateType(
+    # m.context[], …)` — the field called straight through the `ptr` — builds
+    # and passes the C backend but SEGFAULTS the natively built nimsem in
+    # `hastur boot` stage 2 (an arkham miscompile, not yet isolated).
+    let hook = m.context.semInstantiateType
+    if hook != nil:
+      instRet = hook(m.context[], candRet, probe.inferred)
+    else:
+      var retBuf = createTokenBuf(16)
+      substituteTypevars(retBuf, candRet, probe.inferred)
+      instRet = typeToCursor(m.context[], retBuf, 0)
     result = conceptReturnFits(m, req.reqRet, instRet)
   if not result:
     undoInferred(m, adopted)

--- a/tests/nimony/concepts/tconceptgenericimpl.nim
+++ b/tests/nimony/concepts/tconceptgenericimpl.nim
@@ -1,0 +1,34 @@
+## A generic instance satisfies an atomic concept through *generic* routines
+## over the generic type (issue #2500): probing `func `+`[T](a, b: Box[T])`
+## for `Box[int]` binds `T = int`, and its result `Box[T]` instantiates to the
+## same `Box[int]` the requirement's `Self` names. A candidate constrained by
+## the concept being checked still counts, because with `T = int` it asks
+## `int is Additive` — a different question, not the one under construction.
+
+import std/assertions
+
+type
+  Additive = concept
+    func `+`(a, b: Self): Self
+    func zero(_: typedesc[Self]): Self
+
+template zero*(_: typedesc[int]): int = 0
+
+assert int is Additive
+
+type
+  Box[T: Additive] = object
+    v: T
+
+func `+`*[T: Additive](a, b: Box[T]): Box[T] = Box[T](v: a.v + b.v)
+template zero*[T: Additive](_: typedesc[Box[T]]): Box[T] = Box[T](v: T.zero)
+
+assert Box[int] is Additive
+assert Box[Box[int]] is Additive
+assert not (Box[string] is Additive)
+
+proc sum[T: Additive](xs: openArray[T]): T =
+  result = T.zero
+  for x in xs: result = result + x
+
+assert sum([Box[int](v: 1), Box[int](v: 2), Box[int](v: 3)]).v == 6


### PR DESCRIPTION
… (#2500)

`Box[int] is Additive` was false although `func +[T](a, b: Box[T]): Box[T]` exists. Candidate lookup and the argument side were fine: the probe of the generic candidate matched, binding `T = int`. What failed was the result-type check: the candidate's return was built by textual substitution, yielding the invocation `(at Box int)`, while the requirement's `Self` is the *instance symbol* `Box[int]`, and `matchObjectTypes` accepts a symbol formal only against a symbol actual.

Instantiate the candidate's result through the context's `semInstantiateType` hook instead, exactly what `semcall` does for a real call: `semLocalType` folds the invocation back into the instance symbol.
