### PR TITLE
fix(notnil): check stores into array entries, fields and derefs

### DIFF
--- a/bench/alloc_bench.nim
+++ b/bench/alloc_bench.nim
@@ -28,6 +28,16 @@ const
 var slots: array[MaxLive, pointer]
 var rngState: uint64 = 0x9E3779B97F4A7C15u64
 
+proc xalloc(size: int): pointer {.inline.} =
+  ## `alloc` hands back an *unchecked* pointer: it is nil when the heap is
+  ## exhausted. `slots` holds plain `pointer`s, which are not-nil, so the OOM
+  ## case has to be ruled out before one goes in. A benchmark has nothing
+  ## useful to say about a failed allocation, so it simply stops.
+  let p = alloc(size)
+  if p == nil:
+    quit(1)
+  result = p
+
 proc nextRand(): uint64 {.inline.} =
   var x = rngState
   x = x xor (x shl 13)
@@ -42,7 +52,7 @@ proc main() =
     # fill: varied small sizes (many size classes)
     for i in 0 ..< MaxLive:
       let size = int(nextRand() mod 240u64) + 16
-      let p = alloc(size)
+      let p = xalloc(size)
       cast[ptr uint8](p)[] = uint8(i and 0xFF)
       slots[i] = p
     # churn: free a pseudo-random live slot, allocate a replacement
@@ -51,7 +61,7 @@ proc main() =
       checksum = checksum + uint64(cast[ptr uint8](slots[j])[])
       dealloc(slots[j])
       let size = int(nextRand() mod 1000u64) + 8
-      let p = alloc(size)
+      let p = xalloc(size)
       cast[ptr uint8](p)[] = uint8(j and 0xFF)
       slots[j] = p
     # big chunks: page-and-above allocations, freed immediately

--- a/src/nimony/contracts_fir.nim
+++ b/src/nimony/contracts_fir.nim
@@ -68,6 +68,10 @@ type
                                        # per-exit state accumulation (journaled).
     errors: TokenBuf
     procCanRaise: bool
+    inHook: bool                       # inside a `=destroy`/`=wasMoved`/… body:
+                                       # hooks operate on raw, possibly
+                                       # moved-from memory, so a `notnil` field
+                                       # may legitimately be set to `nil` there.
     features: set[Feature]
     moduleSuffix: string
     nestedProcs: int
@@ -1219,6 +1223,32 @@ proc cannotBeNil(c: var FirContext; n: Cursor): bool {.inline.} =
   let t = getType(c.typeCache, n)
   result = markedAs(t, NotnilU) or isNonNilExpr(c, n)
 
+proc storeTargetType(c: var FirContext, n: Cursor): Cursor {.inline.} =
+  var target = n
+  if target.exprKind in {AddrX, HaddrX}:
+    inc target
+  result = getType(c.typeCache, target)
+
+const HookPrefixes = ["=destroy", "=wasMoved", "=trace", "=copy", "=sink", "=dup"]
+
+proc isHookProc(symId: SymId): bool =
+  ## A type-bound hook, hand-written (`=wasMoved.0.m`) or synthesized by the
+  ## lifter (`=dup_SFoo0m.0.m`). Their bodies run on memory that is not in a
+  ## valid state: `=wasMoved` *produces* the moved-from state, `=destroy` and
+  ## `=trace` *observe* it, and the lifter drops the nilability annotation from
+  ## a hook's own signature (see `lifter.addParamType`) so that one hook serves
+  ## both `ref T` and `ref T notnil`. Nil-checking a store inside such a body
+  ## asks the impossible of it.
+  let name = pool.symBasename(symId)
+  if name.len == 0 or name[0] != '=': return false
+  for p in HookPrefixes:
+    if name.startsWith(p): return true
+  result = false
+
+proc checkStoreNilMatch(c: var FirContext; value: Cursor; expected: Cursor) {.inline.} =
+  if not c.inHook:
+    checkNilMatch c, value, expected
+
 # --- Final-IR-specific traversal ---
 
 proc traverseStore(c: var FirContext; n: var Cursor) =
@@ -1263,8 +1293,8 @@ proc traverseStore(c: var FirContext; n: var Cursor) =
     markInit(c, symId)
 
     # Check for not-nil type match
-    let expected = getType(c.typeCache, n)
-    checkNilMatch c, valueStart, expected
+    let expected = storeTargetType(c, n)
+    checkStoreNilMatch c, valueStart, expected
     checkRangeAssign c, expected, valueStart
 
     # Try to extract facts from the value
@@ -1293,7 +1323,9 @@ proc traverseStore(c: var FirContext; n: var Cursor) =
 
     skip n
   else:
-    checkRangeAssign c, getType(c.typeCache, n), valueStart
+    let expected = storeTargetType(c, n)
+    checkStoreNilMatch c, valueStart, expected
+    checkRangeAssign c, expected, valueStart
     traverseExpr c, n
 
   n = storeStart; skip n
@@ -1683,6 +1715,7 @@ proc traverseProc(c: var FirContext; n: var Cursor) =
   let oldFlow = move c.flow
   c.flow = initFlowState()
   c.procCanRaise = false
+  let oldInHook = c.inHook
   let oldTr = move c.tr
   c.tr = initFlowTracker()
   # Seed with the enclosing init-set ONLY for genuinely nested procs (closures),
@@ -1701,6 +1734,7 @@ proc traverseProc(c: var FirContext; n: var Cursor) =
   let procStart = n
   n = sub(n)
   let symId = n.symId
+  c.inHook = isHookProc(symId)
   var isGeneric = false
   var isExternProc = false
   var outParams: seq[SymId] = @[]
@@ -1757,6 +1791,7 @@ proc traverseProc(c: var FirContext; n: var Cursor) =
   c.inlineVars = ensureMove oldInlineVars
   c.activeBorrows = ensureMove oldBorrows
   c.currentProcStart = oldProcStart
+  c.inHook = oldInHook
 
 proc traverseStmt(c: var FirContext; n: var Cursor) =
   case n.finalIrKind

--- a/tests/nimony/notnil/tarray_entry.msgs
+++ b/tests/nimony/notnil/tarray_entry.msgs
@@ -1,0 +1,1 @@
+tests/nimony/notnil/tarray_entry.nim(7, 8) Error: expected non-nil value [pass --verbose for the Final IR]

--- a/tests/nimony/notnil/tarray_entry.nim
+++ b/tests/nimony/notnil/tarray_entry.nim
@@ -1,0 +1,7 @@
+type Foo = object
+  x: int
+
+var a: array[8, ref Foo]
+
+a[0] = (ref Foo)(x: 3)
+a[1] = nil

--- a/tests/nimony/notnil/tarray_refentry.msgs
+++ b/tests/nimony/notnil/tarray_refentry.msgs
@@ -1,0 +1,1 @@
+tests/nimony/notnil/tarray_refentry.nim(7, 8) Error: expected non-nil value [pass --verbose for the Final IR]

--- a/tests/nimony/notnil/tarray_refentry.nim
+++ b/tests/nimony/notnil/tarray_refentry.nim
@@ -1,0 +1,7 @@
+type Foo = ref object
+  x: int
+
+var a: array[8, Foo]
+
+a[0] = Foo(x: 3)
+a[1] = nil


### PR DESCRIPTION
Based on #2502 by dwhall: `traverseStore` only ran `checkNilMatch` when the store destination was a bare symbol, so `a[1] = nil` on an `array[8, ref Foo]` compiled silently. Run it on the other branch too, and add `storeTargetType`, which looks through `(addr …)`/`(haddr …)` before asking `getType` for the destination's type.

That closes the hole but breaks 24 tests, from two sides of one fact: a hook body runs on memory that is not in a valid state. `=wasMoved` *produces* the moved-from (nil) state and `=destroy`/`=trace` observe it, so asking for a non-nil proof inside one asks the impossible. It showed up twice:

- Hand-written `=wasMoved` bodies clearing owner fields (`lib/std/posix/io_uring.nim`, two arc tests).
- Every `ref object` with a `ref` field, through the *generated* `=dup`. `hexer/lifter.addParamType` deliberately strips `(notnil)`/`(nil)` from a hook's own signature so one hook serves both `ref T` and `ref T notnil`, so `=dup_Aref<Obj>` returns a bare `(ref Obj)` and the enclosing object hook's `dest.field = <that>` stores a nilable value into a not-nil field. The diagnostics pointed at unrelated places (openarrays.nim, bitabs.nim) because the line info is the lifter's `c.info`.

So exempt hook bodies: an `inHook` flag set in `traverseProc` from the symbol's basename, and `checkStoreNilMatch` skipping the check while it is set.

The one genuine new diagnostic is `bench/alloc_bench.nim`: `alloc()` returns `(pointer (unchecked))` and `slots` holds not-nil `pointer`s. Master already rejected that for locals (`var q: pointer = alloc(16)` was an error), so the array store was simply the hole. An `xalloc` wrapper rules out the OOM case.
