### PR TITLE
CLI param --base swallows -j

### DIFF
--- a/src/nifmake/nifmake.nim
+++ b/src/nifmake/nifmake.nim
@@ -658,7 +658,7 @@ Commands:
 
 Options:
   -j, --parallel[:N]    Parallel builds (for 'run'); :N caps at N processes
-  --makefile <name>     Output Makefile name (default: Makefile)
+  --makefile:<name>     Output Makefile name (default: Makefile)
   --force               Force rebuild of all targets (removes their outputs first)
   --rerun               Run every command regardless of staleness, but KEEP the
                         existing outputs, so a tool writing OnlyIfChanged can
@@ -683,7 +683,7 @@ Options:
 Examples:
   nifmake run build.nif
   nifmake makefile build.nif
-  nifmake --makefile build.mk makefile build.nif
+  nifmake --makefile:build.mk makefile build.nif
 """
   quit(0)
 
@@ -744,7 +744,8 @@ proc main() =
     progressLo = 0
     progressHi = 100
 
-  for kind, key, val in getopt():
+  var p = initOptParser(allowWhitespaceAfterColon = false)
+  for kind, key, val in p.getopt():
     case kind
     of cmdArgument:
       case key.normalize

--- a/src/nimony/deps.nim
+++ b/src/nimony/deps.nim
@@ -2098,7 +2098,7 @@ proc buildGraphForEval*(config: NifConfig; mainNifFile: string; dependencyNifFil
   # Execute the build using nifmake
   let nifmakeCmd = quoteShell(findTool("nifmake")) &
     (if ForceRebuild in flags: " --force" else: "") &
-    " --base:" & quoteShell(config.baseDir) &
+    (if config.baseDir.len > 0: " --base:" & quoteShell(config.baseDir) else: "") &
     " -j run " & quoteShell(buildFile)
   exec(nifmakeCmd)
   exec(exeFile)
@@ -2134,7 +2134,7 @@ proc buildGraph*(config: sink NifConfig; project: string;
     (if forceRebuild: " --force" else: "") &  # Use generic force flag
     (if Profile in flags: " --profile" else: "") &
     (if Report in flags: " --report" else: "") &
-    " --base:" & quoteShell(config.baseDir)
+    (if config.baseDir.len > 0: " --base:" & quoteShell(config.baseDir) else: "")
   let nifmakeCommand = nifmakeBase & " -j run "
   # A changed configuration invalidates every sem result, and now says so
   # directly instead of through a file the sem nodes pretended to read.

--- a/src/nimony/nifconfig.nim
+++ b/src/nimony/nifconfig.nim
@@ -229,7 +229,7 @@ proc parseNifConfig*(configFile: string; result: var NifConfig) =
   parseConfig(c, result)
 proc getOptionsAsOneString*(config: NifConfig): string =
   ## Returns the concatenation of options that affects generated files.
-  result = "--base:" & config.baseDir
+  result = ""
 
   for i in config.defines:
     result.add(" -d:" & i)

--- a/tests/nifmake/setup.nim
+++ b/tests/nifmake/setup.nim
@@ -1,0 +1,22 @@
+## Custom runner: an option with an empty value must not swallow the argument
+## after it. `nimony` puts `--base:<dir>` in front of the rest of nifmake's
+## command line, and the directory is empty when the project is a bare file
+## name; a parser that takes the next word as the value loses it.
+import std / [os, osproc, strutils]
+
+proc arg(name: string): string =
+  let prefix = "--" & name & ":"
+  for p in commandLineParams():
+    if p.startsWith(prefix): return p[prefix.len .. ^1]
+  result = ""
+
+let bindir = if arg("bindir").len > 0: arg("bindir") else: "bin"
+let nifmake = (bindir / "nifmake".addFileExt(ExeExt)).quoteShell
+
+let (expected, _) = execCmdEx(nifmake & " version")
+let (actual, _) = execCmdEx(nifmake & " --base: version")
+if actual == expected:
+  echo "nifmake: an empty --base: does not swallow the command after it"
+else:
+  quit "FAILURE: `nifmake --base: version` did not print what `nifmake version` " &
+       "prints; got: " & actual.splitLines[0]


### PR DESCRIPTION
When nimony is called like `nimony n main.nim` the CLI command for nifmake would be constructed as `--base: -j` since there is no directory portion for main.nim. This was swallowing the following -j param because allowWhitespaceAfterColon was enabled.

There are also a couple of doc fixes where the `:` was excluded from --makefile.