### PR TITLE
nifcoreparse: put a non-finite float's line info on its tag

### DIFF
--- a/src/lib/nifcoreparse.nim
+++ b/src/lib/nifcoreparse.nim
@@ -17,7 +17,7 @@
 ## Note: NIF `#comment#` decorations are not carried into the token buffer —
 ## the codegen path has no use for them.
 
-import std / assertions
+import std / [assertions, math]
 import nifcore
 import nifreader as rd
 import nifbuilder
@@ -288,6 +288,23 @@ proc emitRelLineInfo(bld: var Builder; abs, parent: NifLineInfo; pool: Pool;
   if emitComment and uint32(abs.comment) != 0'u32:
     bld.attachComment(pool.strings[abs.comment])
 
+proc emitFloatLit(bld: var Builder; v: float64; abs, parent: NifLineInfo;
+                  pool: Pool) =
+  ## `nifbuilder` spells a non-finite float as a compound -- `(inf)`, `(nan)`,
+  ## `(neginf)` -- and a line-info suffix may only follow an atom or a tag
+  ## *name*. Attached after the closing `)` it is not NIF: the reader stops
+  ## there and the rest of the module is lost. So the compound is written
+  ## here, with the suffix on its tag.
+  let fc = classify(v)
+  case fc
+  of fcInf, fcNan, fcNegInf:
+    bld.addTree(if fc == fcInf: "inf" elif fc == fcNan: "nan" else: "neginf")
+    emitRelLineInfo(bld, abs, parent, pool)
+    bld.endTree()
+  else:
+    bld.addFloatLit(v)
+    emitRelLineInfo(bld, abs, parent, pool)
+
 proc emitValueWithLineInfo(bld: var Builder; c: var Cursor;
                            cur: var NifLineInfo;
                            parents: var seq[NifLineInfo];
@@ -343,8 +360,7 @@ proc emitValueWithLineInfo(bld: var Builder; c: var Cursor;
     emitRelLineInfo(bld, abs, parents[^1], pool)
     c.inc
   of FloatLit:
-    bld.addFloatLit(floatVal(c))
-    emitRelLineInfo(bld, abs, parents[^1], pool)
+    emitFloatLit(bld, floatVal(c), abs, parents[^1], pool)
     c.inc
   of ExtendedSuffix, LineInfoLit, UnknownToken, EofToken, ParLe, ParRi:
     assert false, "suffix token is not a value head"
@@ -484,7 +500,7 @@ proc emitValueIndexed(bld: var Builder; c: var Cursor; cur: var NifLineInfo;
   of UIntLit:
     bld.addUIntLit(uintVal(c)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
   of FloatLit:
-    bld.addFloatLit(floatVal(c)); emitRelLineInfo(bld, abs, parents[^1], pool); c.inc
+    emitFloatLit(bld, floatVal(c), abs, parents[^1], pool); c.inc
   of ExtendedSuffix, LineInfoLit, UnknownToken, EofToken, ParLe, ParRi:
     assert false, "suffix token is not a value head"
 

--- a/tests/nimony/nifcore/tnifcoreparse.nim
+++ b/tests/nimony/nifcore/tnifcoreparse.nim
@@ -72,6 +72,24 @@ proc main =
     assert child.rawLineInfo.isValid
     child.skip()
 
+  # A non-finite float is written as a compound, `(inf)`, and its line info
+  # has to go on the tag name. Attached after the `)` the text was not NIF, and
+  # the reader stopped there, silently dropping everything after the literal.
+  var specials = createTokenBuf()
+  let specialsFile = specials.pool.filenames.getOrIncl("floats.nim")
+  specials.openTag(specials.tags.registerTag("consts"))
+  specials.appendLineInfo(specialsFile, 1, 0)
+  for v in [Inf, NaN, -Inf, 1.5]:
+    specials.addFloatLit(v)
+    specials.appendLineInfo(specialsFile, 2, 12)
+  specials.addIdent("after")
+  specials.appendLineInfo(specialsFile, 3, 4)
+  specials.closeTag()
+  let specialsText = toString(specials)
+  var reread = parseFromBuffer(specialsText, "floats")
+  assert toString(reread, includeLineInfo = false) ==
+    "(consts\n (inf)\n (nan)\n (neginf)1.5 after)"
+
   var unusedName = ""
   var hinted = parseFromBuffer(
     "(.unusedname tmp.14)\n(stmts)", "hinted", unusedName)


### PR DESCRIPTION
The NIF text writer emitted a non-finite float as `nifbuilder.addFloatLit` spells it -- a compound, `(inf)`, `(nan)`, `(neginf)` -- and then appended the literal's line-info suffix *after* the closing paren: `(inf)@D,25`. A suffix may only follow an atom or a tag name, so that is not NIF; the reader stops at it and everything after the literal is silently dropped (re-parsing the module then asserts "beginRead with unclosed tags").

Both writers that carry line info (`emitValueWithLineInfo` and the indexed module writer) now go through `emitFloatLit`, which writes the compound itself with the suffix on the tag: `(inf@D,25)`. Finite floats are written exactly as before.

Found with a `0x7FF0000000000000'f64` literal in
tests/nimony/nosystem/t1.nim. tnifcoreparse gains a regression case that fails without the fix.
